### PR TITLE
AST transform for parallelizing a flowgraph

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -409,11 +409,11 @@ func decomposable(rs []ast.Reducer) bool {
 	return true
 }
 
-// distributeFlowgraph takes a sequential proc AST and tries to
-// distribute it by splitting as much as possible of the sequence into
+// parallelizeFlowgraph takes a sequential proc AST and tries to
+// parallelize it by splitting as much as possible of the sequence into
 // N parallel branches. The boolean return argument indicates whether
 // distribution succeeded.
-func distributeFlowgraph(seq *ast.SequentialProc, N int, inputSortField string, inputSortReversed bool) (*ast.SequentialProc, bool) {
+func parallelizeFlowgraph(seq *ast.SequentialProc, N int, inputSortField string, inputSortReversed bool) (*ast.SequentialProc, bool) {
 	for i := range seq.Procs {
 		switch p := seq.Procs[i].(type) {
 		case *ast.CutProc, *ast.FilterProc, *ast.PassProc, *ast.PutProc, *ast.RenameProc:
@@ -464,7 +464,7 @@ func distributeFlowgraph(seq *ast.SequentialProc, N int, inputSortField string, 
 		}
 	}
 	// If we're here, the flowgraph is a chain of stateless
-	// procs. If inputs are sorted, we can distribute the entire
+	// procs. If inputs are sorted, we can parallelize the entire
 	// chain and do an ordered merge. Otherwise, no distribution.
 	if inputSortField == "" {
 		return seq, false

--- a/driver/compile_test.go
+++ b/driver/compile_test.go
@@ -180,7 +180,7 @@ func TestBooleanExpressionFields(t *testing.T) {
 	}
 }
 
-func TestDistributeFlowgraph(t *testing.T) {
+func TestParallelizeFlowgraph(t *testing.T) {
 	tests := []struct {
 		zql                     string
 		orderField              string
@@ -240,7 +240,7 @@ func TestDistributeFlowgraph(t *testing.T) {
 		t.Run(tc.zql, func(t *testing.T) {
 			query, err := zql.ParseProc(tc.zql)
 			require.NoError(t, err)
-			distributed, ok := distributeFlowgraph(query.(*ast.SequentialProc), 2, tc.orderField, false)
+			parallelized, ok := parallelizeFlowgraph(query.(*ast.SequentialProc), 2, tc.orderField, false)
 			require.Equal(t, ok, tc.zql != tc.expected)
 
 			expected, err := zql.ParseProc(tc.expected)
@@ -250,8 +250,8 @@ func TestDistributeFlowgraph(t *testing.T) {
 				// if the proc started with a parallel graph.
 				expected.(*ast.SequentialProc).Procs = expected.(*ast.SequentialProc).Procs[1:]
 
-				// if the distributed flowgraph includes a groupby, then adjust the expected AST by setting
-				// the EmitPart flag on the distributed groupbys and the ConsumePart flag on the post-merge groupby.
+				// If the parallelized flowgraph includes a groupby, then adjust the expected AST by setting
+				// the EmitPart flag on the parallelized groupbys and the ConsumePart flag on the post-merge groupby.
 				branch := expected.(*ast.SequentialProc).Procs[0].(*ast.ParallelProc).Procs[0].(*ast.SequentialProc)
 				if _, ok := branch.Procs[len(branch.Procs)-1].(*ast.GroupByProc); ok {
 					for _, b := range expected.(*ast.SequentialProc).Procs[0].(*ast.ParallelProc).Procs {
@@ -265,7 +265,7 @@ func TestDistributeFlowgraph(t *testing.T) {
 			if tc.zql != tc.expected {
 				expected.(*ast.SequentialProc).Procs[0].(*ast.ParallelProc).MergeOrderField = tc.expectedMergeOrderField
 			}
-			assert.Equal(t, expected.(*ast.SequentialProc), distributed)
+			assert.Equal(t, expected.(*ast.SequentialProc), parallelized)
 		})
 	}
 	// This needs a standalone test due to the presence of a pass
@@ -276,16 +276,17 @@ func TestDistributeFlowgraph(t *testing.T) {
 		dquery := "(filter * | cut x | put x=y | rename foo=boo; filter * | cut x | put x=y | rename foo=boo)"
 		program, err := zql.ParseProc(query)
 		require.NoError(t, err)
-		distributed, _ := distributeFlowgraph(program.(*ast.SequentialProc), 2, orderField, false)
+		parallelized, ok := parallelizeFlowgraph(program.(*ast.SequentialProc), 2, orderField, false)
+		require.True(t, ok)
 
 		expected, err := zql.ParseProc(dquery)
 		require.NoError(t, err)
 
 		// We can't express a pass proc in zql, so add it to the AST this way.
-		// (It's added by the distributed flowgraph in order to force a merge rather than having trailing leaves connected to a mux output).
+		// (It's added by the parallelized flowgraph in order to force a merge rather than having trailing leaves connected to a mux output).
 		expected.(*ast.SequentialProc).Procs = append(expected.(*ast.SequentialProc).Procs[1:], &ast.PassProc{Node: ast.Node{"PassProc"}})
 		expected.(*ast.SequentialProc).Procs[0].(*ast.ParallelProc).MergeOrderField = orderField
 
-		assert.Equal(t, expected.(*ast.SequentialProc), distributed)
+		assert.Equal(t, expected.(*ast.SequentialProc), parallelized)
 	})
 }


### PR DESCRIPTION
Add `driver.parallelizeFlowgraph()`, a function that tries to transform a sequential flowgraph into a parallel one. 

Wiring this into compilation will come in a subsequent PR (I have that working locally).

closes #1022 