### PR TITLE
add check on maximum frame threshold in a zdx

### DIFF
--- a/tests/suite/zdx/maxframe.yaml
+++ b/tests/suite/zdx/maxframe.yaml
@@ -1,0 +1,13 @@
+script: |
+  zdx create -f 1000000000 -o index.zng -k a in.tzng
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[a:string]
+      0:[hello;]
+
+outputs:
+  - name: stderr
+    data: |
+      frame threshold too large (1000000000)

--- a/zdx/reader.go
+++ b/zdx/reader.go
@@ -15,6 +15,7 @@ const (
 	FrameThresh  = 32 * 1024
 	FrameFudge   = 1024
 	FrameBufSize = FrameThresh + FrameFudge
+	FrameMaxSize = 20 * 1024 * 1024
 )
 
 // Reader implements zbuf.Reader, io.ReadSeeker, and io.Closer.
@@ -60,6 +61,9 @@ func NewReaderFromURI(zctx *resolver.Context, uri iosrc.URI) (*Reader, error) {
 	if err != nil {
 		r.Close()
 		return nil, fmt.Errorf("%s: %w", uri, err)
+	}
+	if trailer.FrameThresh > FrameMaxSize {
+		return nil, fmt.Errorf("%s: frame threshold too large (%d)", uri, trailer.FrameThresh)
 	}
 	// We add a bit to the seeker buffer so to accommodate the usual
 	// overflow size.

--- a/zdx/writer.go
+++ b/zdx/writer.go
@@ -83,6 +83,9 @@ func NewWriter(zctx *resolver.Context, path string, keyFields []string, frameThr
 	if frameThresh == 0 {
 		return nil, errors.New("microindex frame threshold cannot be zero")
 	}
+	if frameThresh > FrameMaxSize {
+		return nil, fmt.Errorf("frame threshold too large (%d)", frameThresh)
+	}
 	uri, err := iosrc.ParseURI(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds error checks for very large frame tresholds mainly
to avoid a bad frameTresh field in a microindex trailer from causing
an OOM condition.

Fixes #1133 