### PR TITLE
make zar map use chunk file by default

### DIFF
--- a/tests/suite/zar/index-custom-input.yaml
+++ b/tests/suite/zar/index-custom-input.yaml
@@ -2,7 +2,7 @@
 script: |
   mkdir logs
   zar import -R ./logs babble.tzng
-  zar map -q -o sums.zng -R ./logs "sum(v) by s" _
+  zar map -q -o sums.zng -R ./logs "sum(v) by s"
   zar index -f 20000 -i sums.zng -q -R ./logs -o index.zng -z "put key=s | sort key"
   zdx section -t -s 1 logs/20200422/1587518620.0622373.zng.zar/index.zng
 

--- a/tests/suite/zar/map.yaml
+++ b/tests/suite/zar/map.yaml
@@ -1,11 +1,15 @@
 script: |
   mkdir logs
   zar import -s 20KiB -R ./logs babble.tzng
-  zar map -R ./logs "count()" _ | zq -t -
+  zar map -R ./logs "count()" | zq -t -
   echo ===
-  zar map -R ./logs -o count.zng "count()" _
+  zar map -R ./logs -o count.zng "count()"
   zq -t "*" ./logs/20200422/1587518620.0622373.zng.zar/count.zng
   zq -t "*" ./logs/20200421/1587509477.06313454.zng.zar/count.zng
+  echo ===
+  zar map -R ./logs -o top.zng "count() by v | sort -r count, v | head 1"
+  zar map -R ./logs -o bottom.zng "count() by v | sort count, v | head 1"
+  zar map -t -R ./logs "sort v" top.zng bottom.zng
 
 inputs:
   - name: babble.tzng
@@ -22,3 +26,10 @@ outputs:
       0:[939;]
       #0:record[count:uint64]
       0:[61;]
+      ===
+      #0:record[v:int64,count:uint64]
+      0:[2;1;]
+      0:[278;8;]
+      #0:record[v:int64,count:uint64]
+      0:[14;1;]
+      0:[407;2;]

--- a/tests/suite/zar/s3/rm.yaml
+++ b/tests/suite/zar/s3/rm.yaml
@@ -1,7 +1,7 @@
 script: |
   source minio.sh
   zar import -s 20KiB -R ./root -data s3://bucket/zartest babble.tzng
-  zar map -R ./root -o count.zng "count()" _
+  zar map -R ./root -o count.zng "count()"
   echo ===
   zar ls -l -R ./root
   echo ===

--- a/tests/suite/zar/s3/rmdirs.yaml
+++ b/tests/suite/zar/s3/rmdirs.yaml
@@ -1,7 +1,7 @@
 script: |
   source minio.sh
   zar import -s 20KiB -R ./root -data s3://bucket/zartest babble.tzng
-  zar map -R ./root -o count.zng "count()" _
+  zar map -R ./root -o count.zng "count()"
   echo ===
   zar ls -l -R ./root
   echo ===

--- a/tests/suite/zar/s3/zq.yaml
+++ b/tests/suite/zar/s3/zq.yaml
@@ -1,7 +1,7 @@
 script: |
   source minio.sh
   zar import -s 20KiB -R ./root -data s3://bucket/zartest babble.tzng
-  zar map -R ./root -o count.zng "count()" _
+  zar map -R ./root -o count.zng "count()"
   echo ===
   zar ls -l -R ./root
 

--- a/tests/suite/zar/zq.yaml
+++ b/tests/suite/zar/zq.yaml
@@ -3,7 +3,7 @@ script: |
   zar import -s 20KiB -R ./logs babble.tzng
   zar zq -R ./logs "count()" | zq -t -
   echo ===
-  zar map -R ./logs -o count.zng "count()" _
+  zar map -R ./logs -o count.zng "count()"
   zar zq -R ./logs "* | sort -r count" count.zng | zq -t -
   echo ===
   zar zq -R ./logs "sum(count)" count.zng | zq -t -


### PR DESCRIPTION
@philrz caught an error with zar map if no input file was specified, and that led to a discussion about what should occur if `zar map` is run without inputs. With this change, `zar map` will always require a ZQL query to be given, and will assume the input is only the chunk file if no files are specified. That has the nice side effect that the docs/readme will see less usages of the special name "_".

