### PR TITLE
Fix switch break in parallelize

### DIFF
--- a/compiler/semantic/parallelize.go
+++ b/compiler/semantic/parallelize.go
@@ -227,11 +227,12 @@ func parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortRevers
 
 	seq := ensureSequentialProc(p)
 	orderSensitiveTail := true
+loop:
 	for i := range seq.Procs {
 		switch seq.Procs[i].(type) {
 		case *ast.Sort, *ast.Summarize:
 			orderSensitiveTail = false
-			break
+			break loop
 		default:
 			continue
 		}


### PR DESCRIPTION
The break here was not causing the statement to break out of the for loop. Put
a label on it.