### PR TITLE
Add ToStdio functionality to emitter

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/pkg/terminal"
-	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zio/zstio"
@@ -104,7 +103,7 @@ func (f *Flags) FileName() string {
 	return f.outputFile
 }
 
-func (f *Flags) Open(ctx context.Context) (zbuf.WriteCloser, error) {
+func (f *Flags) Open(ctx context.Context) (emitter.Emitter, error) {
 	if f.dir != "" {
 		d, err := emitter.NewDir(ctx, f.dir, f.outputFile, os.Stderr, f.WriterOpts)
 		if err != nil {

--- a/emitter/dir.go
+++ b/emitter/dir.go
@@ -17,12 +17,18 @@ var (
 	ErrNoPath = errors.New("no _path field in zng record")
 )
 
-// Dir implements the Writer interface and sends all log lines with the
+type Emitter interface {
+	zbuf.WriteCloser
+	// ToStdio returns true if the emitter is writing to stdout or stderr.
+	ToStdio() bool
+}
+
+// dir implements the Writer interface and sends all log lines with the
 // same descriptor to a file named <prefix><path>.<ext> in the directory indicated,
 // where <prefix> and <ext> are specificied and <path> is determined by the
 // _path field in the boom descriptor.  Note that more than one descriptor
 // can map to the same output file.
-type Dir struct {
+type dir struct {
 	ctx     context.Context
 	dir     iosrc.URI
 	prefix  string
@@ -34,7 +40,7 @@ type Dir struct {
 	source  iosrc.Source
 }
 
-func NewDir(ctx context.Context, dir, prefix string, stderr io.Writer, opts zio.WriterOpts) (*Dir, error) {
+func NewDir(ctx context.Context, dir, prefix string, stderr io.Writer, opts zio.WriterOpts) (Emitter, error) {
 	uri, err := iosrc.ParseURI(dir)
 	if err != nil {
 		return nil, err
@@ -46,17 +52,17 @@ func NewDir(ctx context.Context, dir, prefix string, stderr io.Writer, opts zio.
 	return NewDirWithSource(ctx, uri, prefix, stderr, opts, src)
 }
 
-func NewDirWithSource(ctx context.Context, dir iosrc.URI, prefix string, stderr io.Writer, opts zio.WriterOpts, source iosrc.Source) (*Dir, error) {
-	if err := iosrc.MkdirAll(dir, 0755); err != nil {
+func NewDirWithSource(ctx context.Context, d iosrc.URI, prefix string, stderr io.Writer, opts zio.WriterOpts, source iosrc.Source) (Emitter, error) {
+	if err := iosrc.MkdirAll(d, 0755); err != nil {
 		return nil, err
 	}
 	e := zio.Extension(opts.Format)
 	if e == "" {
 		return nil, fmt.Errorf("unknown format: %s", opts.Format)
 	}
-	return &Dir{
+	return &dir{
 		ctx:     ctx,
-		dir:     dir,
+		dir:     d,
 		prefix:  prefix,
 		ext:     e,
 		stderr:  stderr,
@@ -67,7 +73,7 @@ func NewDirWithSource(ctx context.Context, dir iosrc.URI, prefix string, stderr 
 	}, nil
 }
 
-func (d *Dir) Write(r *zng.Record) error {
+func (d *dir) Write(r *zng.Record) error {
 	out, err := d.lookupOutput(r)
 	if err != nil {
 		return err
@@ -75,7 +81,7 @@ func (d *Dir) Write(r *zng.Record) error {
 	return out.Write(r)
 }
 
-func (d *Dir) lookupOutput(rec *zng.Record) (zbuf.WriteCloser, error) {
+func (d *dir) lookupOutput(rec *zng.Record) (zbuf.WriteCloser, error) {
 	typ := rec.Type
 	w, ok := d.writers[typ]
 	if ok {
@@ -89,10 +95,14 @@ func (d *Dir) lookupOutput(rec *zng.Record) (zbuf.WriteCloser, error) {
 	return w, nil
 }
 
+func (d *dir) ToStdio() bool {
+	return false
+}
+
 // filename returns the name of the file for the specified path. This handles
 // the case of two tds one _path, adding a # in the filename for every _path that
 // has more than one td.
-func (d *Dir) filename(r *zng.Record) (iosrc.URI, string) {
+func (d *dir) filename(r *zng.Record) (iosrc.URI, string) {
 	var _path string
 	base, err := r.AccessString("_path")
 	if err == nil {
@@ -104,7 +114,7 @@ func (d *Dir) filename(r *zng.Record) (iosrc.URI, string) {
 	return d.dir.AppendPath(name), _path
 }
 
-func (d *Dir) newFile(rec *zng.Record) (zbuf.WriteCloser, error) {
+func (d *dir) newFile(rec *zng.Record) (zbuf.WriteCloser, error) {
 	filename, path := d.filename(rec)
 	if w, ok := d.paths[path]; ok {
 		return w, nil
@@ -119,7 +129,7 @@ func (d *Dir) newFile(rec *zng.Record) (zbuf.WriteCloser, error) {
 	return w, err
 }
 
-func (d *Dir) Close() error {
+func (d *dir) Close() error {
 	var cerr error
 	for _, w := range d.writers {
 		if err := w.Close(); err != nil {

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -14,7 +14,16 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-func NewFile(ctx context.Context, path string, opts zio.WriterOpts) (zbuf.WriteCloser, error) {
+type file struct {
+	zbuf.WriteCloser
+	isstdio bool
+}
+
+func (f *file) ToStdio() bool {
+	return f.isstdio
+}
+
+func NewFile(ctx context.Context, path string, opts zio.WriterOpts) (Emitter, error) {
 	if path == "" {
 		path = "stdout"
 	}
@@ -36,7 +45,7 @@ func IsTerminal(w io.Writer) bool {
 	return false
 }
 
-func NewFileWithSource(ctx context.Context, path iosrc.URI, opts zio.WriterOpts, source iosrc.Source) (zbuf.WriteCloser, error) {
+func NewFileWithSource(ctx context.Context, path iosrc.URI, opts zio.WriterOpts, source iosrc.Source) (Emitter, error) {
 	f, err := source.NewWriter(ctx, path)
 	if err != nil {
 		return nil, err
@@ -61,5 +70,5 @@ func NewFileWithSource(ctx context.Context, path iosrc.URI, opts zio.WriterOpts,
 	if err != nil {
 		return nil, err
 	}
-	return w, nil
+	return &file{w, path.Scheme == "stdio"}, nil
 }


### PR DESCRIPTION
Have emitter.NewDir and emitter.NewFile return a new Emitter interface, which
is a zbuf.WriteCloser along with a function that returns true if the emitter is
writing to stdio (i.e. stdout or stderr). This can be used to write command
line functionality that changes depending on where zng records are being output
to.