### PR TITLE
rename ZAR_ROOT to ZED_LAKE_ROOT

### DIFF
--- a/cmd/zed/lake/compact/command.go
+++ b/cmd/zed/lake/compact/command.go
@@ -33,7 +33,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.purge, "purge", false, "remove chunk files (and associated files) whose data has been combined into other chunks")
 	return c, nil
 }

--- a/cmd/zed/lake/find/command.go
+++ b/cmd/zed/lake/find/command.go
@@ -70,7 +70,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.skipMissing, "Q", false, "skip errors caused by missing index files ")
 	f.StringVar(&c.indexFile, "x", "", "name of microindex for custom index searches")
 	f.StringVar(&c.pathField, "l", lake.DefaultAddPathField, "zng field name for path name of log file")

--- a/cmd/zed/lake/import/command.go
+++ b/cmd/zed/lake/import/command.go
@@ -27,7 +27,7 @@ from an existing file, S3 location, or stdin.
 
 The input data is sorted and partitioned by time into approximately equal
 sized ZNG files, called "chunks". The path of each chunk is a subdirectory in
-the specified root location (-R or ZAR_ROOT), where the subdirectory name is
+the specified root location (-R or ZED_LAKE_ROOT), where the subdirectory name is
 derived from the timestamp of the first zng record in that chunk.
 `,
 	New: New,
@@ -53,7 +53,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
 	f.BoolVar(&c.asc, "asc", false, "store archive data in ascending order")
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.StringVar(&c.dataPath, "data", "", "location for storing data files (defaults to root)")
 	c.thresh = lake.DefaultLogSizeThreshold
 	f.Var(&c.thresh, "s", "target size of chunk files, as '10MB' or '4GiB', etc.")

--- a/cmd/zed/lake/index/create.go
+++ b/cmd/zed/lake/index/create.go
@@ -58,7 +58,7 @@ type CreateCommand struct {
 
 func NewCreate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &CreateCommand{Command: parent.(*Command).Command}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.ensure, "ensure", false, "ensures that index rules are applied to all chunks")
 	f.StringVar(&c.keys, "k", "key", "one or more comma-separated key fields")
 	f.IntVar(&c.framesize, "f", 32*1024, "minimum frame size used in microindex file")
@@ -80,7 +80,7 @@ func (c *CreateCommand) Run(args []string) error {
 		return errors.New("unless -ensure is specified, one or more indexing patterns must be specified")
 	}
 	if c.root == "" {
-		return errors.New("a directory must be specified with -R or ZAR_ROOT")
+		return errors.New("a directory must be specified with -R or ZED_LAKE_ROOT")
 	}
 	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
 		return err

--- a/cmd/zed/lake/index/drop.go
+++ b/cmd/zed/lake/index/drop.go
@@ -39,7 +39,7 @@ type DropCommand struct {
 
 func NewDrop(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &DropCommand{Command: parent.(*Command).Command}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.noapply, "noapply", false, "remove index definition only")
 	f.BoolVar(&c.quiet, "q", false, "do not display progress updates will deleting indices")
 

--- a/cmd/zed/lake/index/ls.go
+++ b/cmd/zed/lake/index/ls.go
@@ -34,7 +34,7 @@ type LsCommand struct {
 
 func NewLs(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &LsCommand{Command: parent.(*Command).Command}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.stats, "stats", false, "print stats for each index definition")
 	c.output.SetFormatFlags(f)
 	c.output.Format = "table"
@@ -63,7 +63,7 @@ func (c *LsCommand) Run(args []string) error {
 		return err
 	}
 	if c.root == "" {
-		return errors.New("a directory must be specified with -R or ZAR_ROOT")
+		return errors.New("a directory must be specified with -R or ZED_LAKE_ROOT")
 	}
 
 	lk, err := lake.OpenLake(c.root, nil)

--- a/cmd/zed/lake/ls/command.go
+++ b/cmd/zed/lake/ls/command.go
@@ -45,7 +45,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.lflag, "l", false, "long form")
 	f.BoolVar(&c.relativePaths, "relative", false, "display paths relative to root")
 	f.BoolVar(&c.indexDesc, "desc", false, "display index description in lieu of index file name")

--- a/cmd/zed/lake/map/command.go
+++ b/cmd/zed/lake/map/command.go
@@ -55,7 +55,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
 	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root directory of zar archive to walk")
 	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
 	c.outputFlags.SetFlags(f)
 	c.procFlags.SetFlags(f)

--- a/cmd/zed/lake/query/command.go
+++ b/cmd/zed/lake/query/command.go
@@ -51,7 +51,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
 	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root directory of zar archive to walk")
 	f.BoolVar(&c.stats, "s", false, "print search stats to stderr on successful completion")
 	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
 	c.outputFlags.SetFlags(f)

--- a/cmd/zed/lake/rm/command.go
+++ b/cmd/zed/lake/rm/command.go
@@ -41,7 +41,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.relativePaths, "relative", false, "display paths relative to root")
 	f.BoolVar(&c.showRanges, "ranges", false, "display time ranges instead of paths")
 	return c, nil
@@ -57,7 +57,7 @@ func (c *Command) Run(args []string) error {
 		return errors.New("zar rm: no file specified")
 	}
 	if c.root == "" {
-		return errors.New("zar rm: no archive root specified with -R or ZAR_ROOT")
+		return errors.New("zar rm: no archive root specified with -R or ZED_LAKE_ROOT")
 	}
 
 	lk, err := lake.OpenLake(c.root, nil)

--- a/cmd/zed/lake/rmdirs/command.go
+++ b/cmd/zed/lake/rmdirs/command.go
@@ -34,7 +34,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	return c, nil
 }
 

--- a/cmd/zed/lake/stat/command.go
+++ b/cmd/zed/lake/stat/command.go
@@ -38,7 +38,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZED_LAKE_ROOT"), "root location of zar archive to walk")
 	f.StringVar(&c.format, "f", "table", "format for output data [zng,ndjson,table,text,zeek,zjson,tzng] (default \"table\")")
 	return c, nil
 }

--- a/docs/lake/README.md
+++ b/docs/lake/README.md
@@ -58,8 +58,8 @@ just doing a quick test we'll use local temp space.  We'll make it easier to
 run all the commands by setting an environment variable pointing to the root of
 the logs tree.
 ```
-export ZAR_ROOT=/tmp/logs
-mkdir $ZAR_ROOT
+export ZED_LAKE_ROOT=/tmp/logs
+mkdir $ZED_LAKE_ROOT
 ```
 
 Now, let's ingest the data using `zed lake import`.  We are working on more
@@ -216,7 +216,7 @@ zed lake ls -l
 You will see all the indexes left behind. They are just zng files.
 If you want to see one, just look at it with zq, e.g.
 ```
-find $ZAR_ROOT -name idx-* | head -n 1 | xargs zq -z -
+find $ZED_LAKE_ROOT -name idx-* | head -n 1 | xargs zq -z -
 ```
 Now if you run "zed lake find", it will efficiently look through all the index files
 instead of the raw lake data and run much faster...
@@ -312,7 +312,7 @@ zed lake ls custom.zng
 ```
 To see what's in it:
 ```
-find $ZAR_ROOT -name idx-$(zed lake index ls -f zng | zq -f text 'desc="zql-custom.zng" | cut id' -).zng | head -n 1 | xargs zq -f table 'head 10' -
+find $ZED_LAKE_ROOT -name idx-$(zed lake index ls -f zng | zq -f text 'desc="zql-custom.zng" | cut id' -).zng | head -n 1 | xargs zq -f table 'head 10' -
 ```
 You can see the IPs, counts, and _path strings.
 
@@ -320,7 +320,7 @@ At the bottom you'll also find a record describing the index layout. To
 see it:
 
 ```
-find $ZAR_ROOT -name idx-$(zed lake index ls -f zng | zq -f text 'desc="zql-custom.zng" | cut id' -).zng | head -n 1 | xargs zq -f table 'tail 1' -
+find $ZED_LAKE_ROOT -name idx-$(zed lake index ls -f zng | zq -f text 'desc="zql-custom.zng" | cut id' -).zng | head -n 1 | xargs zq -f table 'tail 1' -
 ```
 
 ## `zed lake find` with custom index
@@ -445,7 +445,7 @@ zed lake map -q -o words.zng "uri != null | cut uri | put count=1"
 ```
 again you can look at one of the files...
 ```
-find $ZAR_ROOT -name words.zng ! -size 0 | head -n 1 | xargs zq -z -
+find $ZED_LAKE_ROOT -name words.zng ! -size 0 | head -n 1 | xargs zq -z -
 ```
 Now we reduce by aggregating the uri and summing the counts:
 ```
@@ -580,5 +580,5 @@ zq -f text "count()" pipes2.zng
 To clean out all the files you've created in the lake directories and
 start over, just run
 ```
-zed lake rmdirs $ZAR_ROOT
+zed lake rmdirs $ZED_LAKE_ROOT
 ```


### PR DESCRIPTION
Now that `zar` has become `zed lake`, `ZAR_ROOT` should change. `ZED_LAKE_ROOT` is an obvious choice.