### PR TITLE
zio/zngio: convert TZNG input to ZNG in two ztests

### DIFF
--- a/zio/zngio/ztests/union-array.yaml
+++ b/zio/zngio/ztests/union-array.yaml
@@ -1,8 +1,7 @@
 zed: '*'
 
 input: !!binary |
-        IzA6cmVjb3JkW2E6YXJyYXlbdW5pb25baW50NjQsc3RyaW5nXV1dCjA6W1sxOm
-        FzZGZhc2RmOy07MDoxMDA7XV0KMDpbLTtdCg==
+  +QIHEPcX9gEBYRgZEiMXBAISYXNkZmFzZGYABwIEyBkBAP8=
 
 output: |
   {a:["asdfasdf" (0=((int64,string))),null (0),100 (0)] (=1)} (=2)

--- a/zio/zngio/ztests/union-nested.yaml
+++ b/zio/zngio/ztests/union-nested.yaml
@@ -1,9 +1,8 @@
 zed: '*'
 
 input: !!binary |
-  IzA6cmVjb3JkW2E6dW5pb25bc3RyaW5nLGFycmF5W2ludDY0XSxhcnJheVtzdHJpbmddLH
-  VuaW9uW3N0cmluZyxpbnQ2NF1dXQowOlswOiJoZWxsbyI7XQowOlsxOlsxOzI7XV0KMDpb
-  MjpbImEiOyJiIjtdXQowOlszOjE6MTIzO10K
+  9wf3EPkCEAf5BBAXGBn2AQFhGhsKEwIQImhlbGxvIhsIDwQCCQQCBAQbDBcEBBEIImEiCC
+  JiIhsIDwQGCQQCBPb/
 
 output: |
   {a:"\"hello\"" (0=((string,1=([int64]),2=([string]),3=((string,int64)))))} (=4)


### PR DESCRIPTION
Despite the Base64 encoding, the input for these two tests is TZNG.  
Convert it to ZNG by sending it through "base64 -D | zq - | base64 -b 70".