### PR TITLE
zed query: remove -P flag

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -531,14 +531,10 @@ func NewAggAssignment(kind string, lval field.Static, arg field.Static) Assignme
 }
 
 func FanIn(p Proc) int {
-	first := p
-	if seq, ok := first.(*Sequential); ok {
-		first = seq.Procs[0]
-	}
-	if p, ok := first.(*Parallel); ok {
-		return len(p.Procs)
-	}
-	if _, ok := first.(*Join); ok {
+	switch p := p.(type) {
+	case *Sequential:
+		return FanIn(p.Procs[0])
+	case *Join:
 		return 2
 	}
 	return 1

--- a/driver/ztests/parallel-err.yaml
+++ b/driver/ztests/parallel-err.yaml
@@ -1,10 +1,12 @@
 script: |
-  zq -P -z 'split ( => put k=a+10 => put k=b+20) | sort k' A.zson
+  zq -z 'join a=b' A.zson
 
 inputs:
   - name: A.zson
     data: |
       {a:1 (int32)} (=0)
+      {a:2} (0)
+      {a:3} (0)
 
 outputs:
   - name: stderr

--- a/driver/ztests/parallel-stdin.yaml
+++ b/driver/ztests/parallel-stdin.yaml
@@ -1,32 +1,21 @@
 script: |
-  zq -P -z 'split ( => put k=a+10 => put k=b+20) | sort k' - B.zson
+  zq -z 'join a=b b=b' - B.zson
 
 inputs:
   - name: stdin
     data: |
       {a:1 (int32)} (=0)
+      {a:2} (0)
       {a:3} (0)
-      {a:5} (0)
-      {a:3} (0)
-      {a:1} (0)
   - name: B.zson
     data: |
-      {b:2 (int32)} (=0)
-      {b:4} (0)
-      {b:6} (0)
-      {b:4} (0)
+      {b:1 (int32)} (=0)
       {b:2} (0)
+      {b:3} (0)
 
 outputs:
   - name: stdout
     data: |
-      {a:1 (int32),k:11} (=0)
-      {a:1,k:11} (0)
-      {a:3,k:13} (0)
-      {a:3,k:13} (0)
-      {a:5,k:15} (0)
-      {b:2 (int32),k:22} (=1)
-      {b:2,k:22} (1)
-      {b:4,k:24} (1)
-      {b:4,k:24} (1)
-      {b:6,k:26} (1)
+      {a:1 (int32),b:1 (int32)} (=0)
+      {a:2,b:2} (0)
+      {a:3,b:3} (0)

--- a/driver/ztests/parallel.yaml
+++ b/driver/ztests/parallel.yaml
@@ -1,32 +1,21 @@
 script: |
-  zq -P -z 'split ( => put k=a+10 => put k=b+20) | sort k' A.zson B.zson
+  zq -z 'join a=b b=b' A.zson B.zson
 
 inputs:
   - name: A.zson
     data: |
       {a:1 (int32)} (=0)
+      {a:2} (0)
       {a:3} (0)
-      {a:5} (0)
-      {a:3} (0)
-      {a:1} (0)
   - name: B.zson
     data: |
-      {b:2 (int32)} (=0)
-      {b:4} (0)
-      {b:6} (0)
-      {b:4} (0)
+      {b:1 (int32)} (=0)
       {b:2} (0)
+      {b:3} (0)
 
 outputs:
   - name: stdout
     data: |
-      {a:1 (int32),k:11} (=0)
-      {a:1,k:11} (0)
-      {a:3,k:13} (0)
-      {a:3,k:13} (0)
-      {a:5,k:15} (0)
-      {b:2 (int32),k:22} (=1)
-      {b:2,k:22} (1)
-      {b:4,k:24} (1)
-      {b:4,k:24} (1)
-      {b:6,k:26} (1)
+      {a:1 (int32),b:1 (int32)} (=0)
+      {a:2,b:2} (0)
+      {a:3,b:3} (0)

--- a/proc/join/ztests/empty-inner.yaml
+++ b/proc/join/ztests/empty-inner.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -P -z 'split ( => filter * => filter *) | left join a=b hit=sc | sort a' A.zson C.zson
+  zq -z 'left join a=b hit=sc | sort a' A.zson C.zson
 
 inputs:
   - name: A.zson

--- a/proc/join/ztests/expr.yaml
+++ b/proc/join/ztests/expr.yaml
@@ -1,11 +1,11 @@
 script: |
-  zq -z -P 'left join s b' A.zson B.zson
+  zq -z 'left join s b' A.zson B.zson
   echo ===
-  zq -z -P 'left join s=(to_lower(s)) b' A.zson B.zson
+  zq -z 'left join s=(to_lower(s)) b' A.zson B.zson
   echo ===
-  zq -z -P 'left join (to_lower(s))=(to_lower(s)) b' A.zson B.zson
+  zq -z 'left join (to_lower(s))=(to_lower(s)) b' A.zson B.zson
   echo ===
-  zq -z -P 'left join s' A.zson B.zson
+  zq -z 'left join s' A.zson B.zson
 
 inputs:
   - name: A.zson

--- a/proc/join/ztests/kinds.yaml
+++ b/proc/join/ztests/kinds.yaml
@@ -1,10 +1,10 @@
 script: |
   echo === LEFT ===
-  zq -P -z 'left join a=b hit=sb | sort a' A.zson B.zson
+  zq -z 'left join a=b hit=sb | sort a' A.zson B.zson
   echo === INNER ===
-  zq -P -z 'inner join a=b hit=sb | sort a' A.zson B.zson
+  zq -z 'inner join a=b hit=sb | sort a' A.zson B.zson
   echo === RIGHT ===
-  zq -P -z 'right join b=c hit=sb | sort c' B.zson C.zson
+  zq -z 'right join b=c hit=sb | sort c' B.zson C.zson
 
 inputs:
   - name: A.zson


### PR DESCRIPTION
Instead, when join is the first operation in a Zed program, require two  
input files, and use the first and second as the left and right join  
inputs, respectively. Otherwise, merge the inputs by timestamp as usual.