### PR TITLE
extend len() to handle records

### DIFF
--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -133,7 +133,9 @@ func (l *lenFn) Call(args []zng.Value) (zng.Value, error) {
 	if zv.Bytes == nil {
 		return zng.Value{zng.TypeInt64, nil}, nil
 	}
-	switch zng.AliasOf(args[0].Type).(type) {
+	switch typ := zng.AliasOf(args[0].Type).(type) {
+	case *zng.TypeRecord:
+		return zng.Value{zng.TypeInt64, l.Int(int64(len(typ.Columns)))}, nil
 	case *zng.TypeArray, *zng.TypeSet:
 		len, err := zv.ContainerLength()
 		if err != nil {

--- a/expr/function/ztests/length-record.yaml
+++ b/expr/function/ztests/length-record.yaml
@@ -1,0 +1,13 @@
+zed: cut n=len(.)
+
+input: |
+  {}
+  {x:1}
+  {x:1,s:"hello"}
+  {x:{a:1,b:2}}
+
+output: |
+  {n:0}
+  {n:1}
+  {n:2}
+  {n:1}


### PR DESCRIPTION
This commit extends the len() function to return the number of
fields in a record when applied to a record value.  Previously,
len() raised an error when applied to record values.

Closes #2374
