### PR TITLE
ztest: change skip field to string from boolean

### DIFF
--- a/expr/agg/ztests/fuse-container.yaml
+++ b/expr/agg/ztests/fuse-container.yaml
@@ -1,5 +1,4 @@
-# Enable after fixing https://github.com/brimdata/zed/issues/2145.
-skip: true
+skip: Enable after fixing https://github.com/brimdata/zed/issues/2145.
 
 zed: all=fuse(.),r=fuse(r)
 

--- a/expr/agg/ztests/fuse-dup.yaml
+++ b/expr/agg/ztests/fuse-dup.yaml
@@ -1,5 +1,4 @@
-# Enable after fixing https://github.com/brimdata/zed/issues/2145.
-skip: true
+skip: Enable after fixing https://github.com/brimdata/zed/issues/2145.
 
 zed: fuse(.)
 

--- a/ppl/zqd/ztests/archivestore/postpcap-suricata.yaml
+++ b/ppl/zqd/ztests/archivestore/postpcap-suricata.yaml
@@ -1,4 +1,4 @@
-skip: true
+skip: Flaky.
 
 script: |
   source services.sh

--- a/ppl/zqd/ztests/pcap/postpcap-suricata.yaml
+++ b/ppl/zqd/ztests/pcap/postpcap-suricata.yaml
@@ -1,4 +1,4 @@
-skip: true
+skip: Flaky.
 
 script: |
   source services.sh

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -107,6 +107,9 @@
 // is not a script test, Run runs ztests in the current process and skips
 // the script tests.  Otherwise, Run runs each ztest in a separate process
 // using the zq executable in the directories specified by ZTEST_PATH.
+//
+// Tests of either style can be skipped by setting the skip field to a non-empty
+// string.  A message containing the string will be written to the test log.
 package ztest
 
 import (
@@ -285,8 +288,11 @@ func (f *File) load(dir string) ([]byte, *regexp.Regexp, error) {
 
 // ZTest defines a ztest.
 type ZTest struct {
+	Skip string `yaml:"skip,omitempty"`
+	Tag  string `yaml:"tag,omitempty"`
+
+	// For Zed-style tests.
 	Zed         string `yaml:"zed,omitempty"`
-	Skip        bool   `yaml:"skip,omitempty"`
 	Input       string `yaml:"input,omitempty"`
 	Output      string `yaml:"output,omitempty"`
 	OutputHex   string `yaml:"outputHex,omitempty"`
@@ -294,11 +300,11 @@ type ZTest struct {
 	ErrorRE     string `yaml:"errorRE"`
 	errRegex    *regexp.Regexp
 	Warnings    string `yaml:"warnings,omitempty"`
-	// shell mode params
+
+	// For script-style tests.
 	Script  string   `yaml:"script,omitempty"`
 	Inputs  []File   `yaml:"inputs,omitempty"`
 	Outputs []File   `yaml:"outputs,omitempty"`
-	Tag     string   `yaml:"tag,omitempty"`
 	Env     []string `yaml:"env,omitempty"`
 }
 
@@ -390,8 +396,8 @@ func (z *ZTest) ShouldSkip(path string) string {
 		return "script test on Windows"
 	case z.Script != "" && path == "":
 		return "script test on in-process run"
-	case z.Skip:
-		return "skip is true"
+	case z.Skip != "":
+		return z.Skip
 	case z.Tag != "" && z.Tag != os.Getenv("ZTEST_TAG"):
 		return fmt.Sprintf("tag %q does not match ZTEST_TAG=%q", z.Tag, os.Getenv("ZTEST_TAG"))
 	}

--- a/ztest/ztest_test.go
+++ b/ztest/ztest_test.go
@@ -13,6 +13,6 @@ func TestShouldSkip(t *testing.T) {
 	} else {
 		assert.Equal(t, "script test on in-process run", (&ZTest{Script: "x"}).ShouldSkip(""))
 	}
-	assert.Equal(t, "skip is true", (&ZTest{Skip: true}).ShouldSkip(""))
+	assert.Equal(t, "reason", (&ZTest{Skip: "reason"}).ShouldSkip(""))
 	assert.Equal(t, `tag "x" does not match ZTEST_TAG=""`, (&ZTest{Tag: "x"}).ShouldSkip(""))
 }


### PR DESCRIPTION
Skip a ztest if its skip field is a non-empty string. Also, write a  
message containing the string to the test log.