### PR TITLE
add zson.FormatType()

### DIFF
--- a/cmd/zsontypes/zsontypes.go
+++ b/cmd/zsontypes/zsontypes.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/zed/zio/tzngio"
 	"github.com/brimdata/zed/zng"
 	"github.com/brimdata/zed/zng/resolver"
+	"github.com/brimdata/zed/zson"
 )
 
 var ZsonTypes = &charm.Spec{
@@ -73,7 +74,7 @@ func (c *Command) printTypes(fname string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s: %s\n", key, typ.ZSON())
+		fmt.Printf("%s: %s\n", key, zson.FormatType(typ))
 	}
 	return nil
 }

--- a/docs/language/grouping/README.md
+++ b/docs/language/grouping/README.md
@@ -233,12 +233,12 @@ zq -f zson 'count() by _path,typeof(.) | sort _path' http.log.gz dns.log.gz
 ```zq-output
 {
     _path: "dns",
-    typeof: ({_path:string,ts:time,uid:bstring,id:{orig_h:ip,orig_p:port=(uint16),resp_h:ip,resp_p:port=(uint16)},proto:zenum=(string),trans_id:uint64,rtt:duration,query:bstring,qclass:uint64,qclass_name:bstring,qtype:uint64,qtype_name:bstring,rcode:uint64,rcode_name:bstring,AA:bool,TC:bool,RD:bool,RA:bool,Z:uint64,answers:[bstring],TTLs:[duration],rejected:bool}),
+    typeof: ({_path:string,ts:time,uid:bstring,id:{orig_h:ip,orig_p:port=(uint16),resp_h:ip,resp_p:port},proto:zenum=(string),trans_id:uint64,rtt:duration,query:bstring,qclass:uint64,qclass_name:bstring,qtype:uint64,qtype_name:bstring,rcode:uint64,rcode_name:bstring,AA:bool,TC:bool,RD:bool,RA:bool,Z:uint64,answers:[bstring],TTLs:[duration],rejected:bool}),
     count: 53615 (uint64)
 } (=0)
 {
     _path: "http",
-    typeof: ({_path:string,ts:time,uid:bstring,id:{orig_h:ip,orig_p:port=(uint16),resp_h:ip,resp_p:port=(uint16)},trans_depth:uint64,method:bstring,host:bstring,uri:bstring,referrer:bstring,version:bstring,user_agent:bstring,origin:bstring,request_body_len:uint64,response_body_len:uint64,status_code:uint64,status_msg:bstring,info_code:uint64,info_msg:bstring,tags:|[zenum=(string)]|,username:bstring,password:bstring,proxied:|[bstring]|,orig_fuids:[bstring],orig_filenames:[bstring],orig_mime_types:[bstring],resp_fuids:[bstring],resp_filenames:[bstring],resp_mime_types:[bstring]}),
+    typeof: ({_path:string,ts:time,uid:bstring,id:{orig_h:ip,orig_p:port=(uint16),resp_h:ip,resp_p:port},trans_depth:uint64,method:bstring,host:bstring,uri:bstring,referrer:bstring,version:bstring,user_agent:bstring,origin:bstring,request_body_len:uint64,response_body_len:uint64,status_code:uint64,status_msg:bstring,info_code:uint64,info_msg:bstring,tags:|[zenum=(string)]|,username:bstring,password:bstring,proxied:|[bstring]|,orig_fuids:[bstring],orig_filenames:[bstring],orig_mime_types:[bstring],resp_fuids:[bstring],resp_filenames:[bstring],resp_mime_types:[bstring]}),
     count: 144034
 } (0)
 ```

--- a/expr/agg/fuse.go
+++ b/expr/agg/fuse.go
@@ -3,7 +3,6 @@ package agg
 import (
 	"fmt"
 
-	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zng"
 	"github.com/brimdata/zed/zng/resolver"
 )
@@ -54,7 +53,7 @@ func (f *fuse) Result(zctx *resolver.Context) (zng.Value, error) {
 	for typ := range f.shapes {
 		schema.Mixin(typ)
 	}
-	return zng.Value{zng.TypeType, zcode.Bytes(schema.Type.ZSON())}, nil
+	return zctx.Context.LookupTypeValue(schema.Type), nil
 }
 
 func (f *fuse) ConsumeAsPartial(p zng.Value) error {

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -249,6 +249,6 @@ func (b *Builder) buildEnum(enum *Enum) error {
 }
 
 func (b *Builder) buildTypeValue(tv *TypeValue) error {
-	b.AppendPrimitive(zcode.Bytes(tv.Value.ZSON()))
+	b.AppendPrimitive(zcode.Bytes(FormatType(tv.Value)))
 	return nil
 }

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -353,42 +353,42 @@ func (f *Formatter) formatTypeBody(typ zng.Type) error {
 }
 
 func (f *Formatter) formatTypeRecord(typ *zng.TypeRecord) {
-	var sep string
 	f.build("{")
-	for _, col := range typ.Columns {
-		f.build(sep)
+	for k, col := range typ.Columns {
+		if k > 0 {
+			f.build(",")
+		}
 		f.build(zng.QuotedName(col.Name))
 		f.build(":")
 		f.formatType(col.Type)
-		sep = ","
 	}
 	f.build("}")
 }
 
 func (f *Formatter) formatTypeUnion(typ *zng.TypeUnion) {
-	var sep string
 	f.build("(")
-	for _, typ := range typ.Types {
-		f.build(sep)
+	for k, typ := range typ.Types {
+		if k > 0 {
+			f.build(",")
+		}
 		f.formatType(typ)
-		sep = ","
 	}
 	f.build(")")
 }
 
 func (f *Formatter) formatTypeEnum(typ *zng.TypeEnum) error {
-	var sep string
 	f.build("<")
 	inner := typ.Type
 	for k, elem := range typ.Elements {
-		f.build(sep)
+		if k > 0 {
+			f.build(",")
+		}
 		f.buildf("%s:", zng.QuotedName(elem.Name))
 		known := k != 0
 		const parentImplied = true
 		if err := f.formatValue(0, inner, elem.Value, known, parentImplied, true); err != nil {
 			return err
 		}
-		sep = ","
 	}
 	f.build(">")
 	return nil
@@ -448,13 +448,13 @@ func formatType(b *strings.Builder, typedefs typemap, typ zng.Type) {
 		}
 	case *zng.TypeRecord:
 		b.WriteByte('{')
-		var sep string
-		for _, col := range t.Columns {
-			b.WriteString(sep)
+		for k, col := range t.Columns {
+			if k > 0 {
+				b.WriteByte(',')
+			}
 			b.WriteString(zng.QuotedName(col.Name))
 			b.WriteString(":")
 			formatType(b, typedefs, col.Type)
-			sep = ","
 		}
 		b.WriteByte('}')
 	case *zng.TypeArray:
@@ -473,20 +473,20 @@ func formatType(b *strings.Builder, typedefs typemap, typ zng.Type) {
 		b.WriteString("}|")
 	case *zng.TypeUnion:
 		b.WriteByte('(')
-		var sep string
-		for _, typ := range t.Types {
-			b.WriteString(sep)
+		for k, typ := range t.Types {
+			if k > 0 {
+				b.WriteByte(',')
+			}
 			formatType(b, typedefs, typ)
-			sep = ","
 		}
 		b.WriteByte(')')
 	case *zng.TypeEnum:
 		b.WriteByte('<')
-		var sep string
-		for _, elem := range t.Elements {
-			b.WriteString(sep)
+		for k, elem := range t.Elements {
+			if k > 0 {
+				b.WriteByte(',')
+			}
 			b.WriteString(zng.QuotedName(elem.Name))
-			sep = ","
 		}
 		b.WriteByte('>')
 	default:

--- a/zson/ztests/typeof.yaml
+++ b/zson/ztests/typeof.yaml
@@ -30,4 +30,4 @@ outputs:
       {typeof:({metric:string,ts:time,value:float64})}
       {typeof:(access_list=({info:string,nets:[net]}))}
       {typeof:({metric:string,ts:time,value:{x:int64,y:int64}})}
-      {typeof:(conn=({info:string,src:socket=({addr:ip,port:uint16}),dst:socket=({addr:ip,port:uint16})}))}
+      {typeof:(conn=({info:string,src:socket=({addr:ip,port:uint16}),dst:socket}))}


### PR DESCRIPTION
This commits add the FormatType() function that formats up a
zng.Type in its canonical form.  The ZSON() method on zng.Type
didn't quite work right because it would output multiple
embedded typedefs when only the first is needed.  We may want
to get rid of the ZSON() method at some point as is commented
in issue #2473.