### PR TITLE
zson: enable aliases for all primitive types

### DIFF
--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -227,21 +227,12 @@ func stringToEnum(val *ast.Primitive, cast zng.Type) Value {
 }
 
 func castType(typ, cast zng.Type) (zng.Type, error) {
-	if typ == cast || typ == zng.TypeNull {
+	typID, castID := typ.ID(), cast.ID()
+	if typID == castID || typID == zng.IdNull ||
+		zng.IsInteger(typID) && zng.IsInteger(castID) ||
+		zng.IsFloat(typID) && zng.IsFloat(castID) ||
+		zng.IsStringy(typID) && zng.IsStringy(castID) {
 		return cast, nil
-	}
-	if zng.IsStringy(typ.ID()) {
-		if zng.IsStringy(cast.ID()) {
-			return cast, nil
-		}
-	} else if zng.IsInteger(typ.ID()) {
-		if zng.IsInteger(cast.ID()) {
-			return cast, nil
-		}
-	} else if zng.IsFloat(typ.ID()) {
-		if zng.IsFloat(cast.ID()) {
-			return cast, nil
-		}
 	}
 	return nil, fmt.Errorf("type mismatch: %q cannot be used as %q", typ.ZSON(), cast.ZSON())
 }

--- a/zson/ztests/primitive-alias.yaml
+++ b/zson/ztests/primitive-alias.yaml
@@ -1,0 +1,51 @@
+zed: '*'
+
+# Add "typ:({}) (mytype=(type))," (between net and err to maintain type
+# ID order) when https://github.com/brimdata/zed/issues/2518 is fixed.
+input: |
+  {
+    u8:0 (myuint8=(uint8)),
+    u16:0 (myuint16=(uint16)),
+    u32:0 (myuint32=(uint32)),
+    u64:0 (myuint64=(uint64)),
+    i8:0 (myint8=(int8)),
+    i16:0 (myint16=(int16)),
+    i32:0 (myint32=(int32)),
+    i64:0 (myint64=(int64)),
+    dur:0m (myduration=(duration)),
+    tim:1970-01-01T00:00:00Z (mytime=(time)),
+    f64:0. (myfloat64=(float64)),
+    boo:false (mybool=(bool)),
+    byt:0x00 (mybytes=(bytes)),
+    str:"" (mystring=(string)),
+    bst:"" (mybstring=(bstring)),
+    ip:0.0.0.0 (myip=(ip)),
+    net:0.0.0.0/0 (mynet=(net)),
+    err:"" (myerror=(error)),
+    nul:null (mynull=(null))
+  }
+
+output-flags: -pretty=2
+
+output: |
+  {
+    u8: 0 (myuint8=(uint8)),
+    u16: 0 (myuint16=(uint16)),
+    u32: 0 (myuint32=(uint32)),
+    u64: 0 (myuint64=(uint64)),
+    i8: 0 (myint8=(int8)),
+    i16: 0 (myint16=(int16)),
+    i32: 0 (myint32=(int32)),
+    i64: 0 (=myint64),
+    dur: 0s (=myduration),
+    tim: 1970-01-01T00:00:00Z (=mytime),
+    f64: 0. (=myfloat64),
+    boo: false (=mybool),
+    byt: 0x00 (=mybytes),
+    str: "" (=mystring),
+    bst: "" (mybstring=(bstring)),
+    ip: 0.0.0.0 (=myip),
+    net: 0.0.0.0/0 (=mynet),
+    err: "" (myerror=(error)),
+    nul: null (mynull=(null))
+  } (=0)


### PR DESCRIPTION
ZSON allows aliases for the integer, float, and stringy primitive types.  
Extend that to all primitive types.

Note that the test omits a type value due to #2518.