### PR TITLE
handle Zed bytes values in marshal/unmarshal

### DIFF
--- a/zng/resolver/marshal_test.go
+++ b/zng/resolver/marshal_test.go
@@ -309,7 +309,7 @@ func TestMarshalArray(t *testing.T) {
 	require.NotNil(t, rec)
 
 	exp := `
-#0:record[A1:array[int8],A2:array[string],A3:array[array[uint8]]]
+#0:record[A1:array[int8],A2:array[string],A3:array[bytes]]
 0:[[1;2;][foo;bar;]-;]
 `
 	assert.Equal(t, trim(exp), rectzng(t, rec))

--- a/zng/type.go
+++ b/zng/type.go
@@ -242,6 +242,8 @@ func LookupPrimitiveById(id int) Type {
 		return TypeUint64
 	case IdFloat64:
 		return TypeFloat64
+	case IdBytes:
+		return TypeBytes
 	case IdString:
 		return TypeString
 	case IdBstring:

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -762,7 +762,9 @@ func (u *UnmarshalZNGContext) decodeArray(zv zng.Value, arrVal reflect.Value) er
 		if arrVal.Kind() == reflect.Array {
 			return u.decodeArrayBytes(zv, arrVal)
 		}
-		return u.decodeSliceBytes(zv, arrVal)
+		// arrVal is a slice here.
+		arrVal.SetBytes(zv.Bytes)
+		return nil
 	}
 	arrType, ok := zng.AliasOf(zv.Type).(*zng.TypeArray)
 	if !ok {
@@ -802,18 +804,11 @@ func (u *UnmarshalZNGContext) decodeArray(zv zng.Value, arrVal reflect.Value) er
 	return nil
 }
 
-func (u *UnmarshalZNGContext) decodeSliceBytes(zv zng.Value, sliceVal reflect.Value) error {
-	sliceVal.Set(reflect.ValueOf([]uint8(zv.Bytes)))
-	return nil
-}
-
 func (u *UnmarshalZNGContext) decodeArrayBytes(zv zng.Value, arrayVal reflect.Value) error {
-	n := len(zv.Bytes)
-	if n != arrayVal.Len() {
+	if len(zv.Bytes) != arrayVal.Len() {
 		return errors.New("ZNG bytes value length differs from Go array")
 	}
-	for k := 0; k < n; k++ {
-		b := uint8(zv.Bytes[k])
+	for k, b := range zv.Bytes {
 		arrayVal.Index(k).Set(reflect.ValueOf(b))
 	}
 	return nil

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -449,6 +449,9 @@ func (m *MarshalZNGContext) encodeArray(arrayVal reflect.Value) (zng.Type, error
 func (m *MarshalZNGContext) lookupType(typ reflect.Type) (zng.Type, error) {
 	switch typ.Kind() {
 	case reflect.Array, reflect.Slice:
+		if typ.Elem().Kind() == reflect.Uint8 {
+			return zng.TypeBytes, nil
+		}
 		typ, err := m.lookupType(typ.Elem())
 		if err != nil {
 			return nil, err

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -327,6 +327,10 @@ func (m *MarshalZNGContext) encodeAny(v reflect.Value) (zng.Type, error) {
 		if v.IsNil() {
 			return m.encodeNil(v.Type())
 		}
+		if isIP(v.Type()) {
+			m.Builder.AppendPrimitive(zng.EncodeIP(v.Bytes()))
+			return zng.TypeIP, nil
+		}
 		if v.Type().Elem().Kind() == reflect.Uint8 {
 			return m.encodeSliceBytes(v)
 		}
@@ -418,15 +422,7 @@ func (m *MarshalZNGContext) encodeArrayBytes(arrayVal reflect.Value) (zng.Type, 
 	return zng.TypeBytes, nil
 }
 
-func isIP(typ reflect.Type) bool {
-	return typ.Name() == "IP" && typ.PkgPath() == "net"
-}
-
 func (m *MarshalZNGContext) encodeArray(arrayVal reflect.Value) (zng.Type, error) {
-	if isIP(arrayVal.Type()) {
-		m.Builder.AppendPrimitive(zng.EncodeIP(arrayVal.Bytes()))
-		return zng.TypeIP, nil
-	}
 	len := arrayVal.Len()
 	m.Builder.BeginContainer()
 	var innerType zng.Type
@@ -704,6 +700,10 @@ func (u *UnmarshalZNGContext) decodeAny(zv zng.Value, v reflect.Value) error {
 	default:
 		return fmt.Errorf("unsupported type: %v", v.Kind())
 	}
+}
+
+func isIP(typ reflect.Type) bool {
+	return typ.Name() == "IP" && typ.PkgPath() == "net"
 }
 
 func (u *UnmarshalZNGContext) decodeIP(zv zng.Value, v reflect.Value) error {

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -4,6 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/zsonio"
+	"github.com/brimdata/zed/zng"
 	"github.com/brimdata/zed/zson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,4 +87,69 @@ func TestMarshal(t *testing.T) {
 	z, err = m.Marshal(Roll(true))
 	require.NoError(t, err)
 	assert.Equal(t, `true (=Roll)`, z)
+}
+
+type BytesRecord struct {
+	B []byte
+}
+
+type BytesArrayRecord struct {
+	A [3]byte
+}
+
+type ID [4]byte
+
+type IDRecord struct {
+	A ID
+	B ID
+}
+
+func recToZSON(t *testing.T, rec *zng.Record) string {
+	var b strings.Builder
+	w := zsonio.NewWriter(zio.NopCloser(&b), zsonio.WriterOpts{})
+	err := w.Write(rec)
+	require.NoError(t, err)
+	return b.String()
+}
+
+func TestBytes(t *testing.T) {
+	b := BytesRecord{B: []byte{1, 2, 3}}
+	m := zson.NewZNGMarshaler()
+	rec, err := m.MarshalRecord(b)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	exp := `
+{B:0x010203}
+`
+	assert.Equal(t, trim(exp), recToZSON(t, rec))
+
+	a := BytesArrayRecord{A: [3]byte{4, 5, 6}}
+	rec, err = m.MarshalRecord(a)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	exp = `
+{A:0x040506}
+`
+	assert.Equal(t, trim(exp), recToZSON(t, rec))
+
+	id := IDRecord{A: ID{0, 1, 2, 3}, B: ID{4, 5, 6, 7}}
+	m = zson.NewZNGMarshaler()
+	m.Decorate(zson.StyleSimple)
+	rec, err = m.MarshalRecord(id)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	exp = `
+{A:0x00010203 (=ID),B:0x04050607 (ID)} (=IDRecord)
+	`
+	assert.Equal(t, trim(exp), recToZSON(t, rec))
+
+	var id2 IDRecord
+	u := zson.NewZNGUnmarshaler()
+	u.Bind(IDRecord{}, ID{})
+	err = zson.UnmarshalZNGRecord(rec, &id2)
+	require.NoError(t, err)
+	assert.Equal(t, id, id2)
 }

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -177,7 +177,7 @@ func TestBytes(t *testing.T) {
 	require.NotNil(t, rec)
 
 	exp = `
-	{S:null (bytes)}
+{S:null (0=([bytes]))}
 	`
 	assert.Equal(t, trim(exp), recToZSON(t, rec))
 

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -104,6 +104,12 @@ type IDRecord struct {
 	B ID
 }
 
+type IDSlice []byte
+
+type SliceRecord struct {
+	S []IDSlice
+}
+
 func recToZSON(t *testing.T, rec *zng.Record) string {
 	var b strings.Builder
 	w := zsonio.NewWriter(zio.NopCloser(&b), zsonio.WriterOpts{})
@@ -152,4 +158,27 @@ func TestBytes(t *testing.T) {
 	err = zson.UnmarshalZNGRecord(rec, &id2)
 	require.NoError(t, err)
 	assert.Equal(t, id, id2)
+
+	b2 := BytesRecord{B: nil}
+	m = zson.NewZNGMarshaler()
+	rec, err = m.MarshalRecord(b2)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	exp = `
+{B:null (bytes)}
+`
+	assert.Equal(t, trim(exp), recToZSON(t, rec))
+
+	s := SliceRecord{S: nil}
+	m = zson.NewZNGMarshaler()
+	rec, err = m.MarshalRecord(s)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	exp = `
+	{S:null (bytes)}
+	`
+	assert.Equal(t, trim(exp), recToZSON(t, rec))
+
 }


### PR DESCRIPTION
This commit changes the marshaling code to output a Zed bytes type
for Go byte slices and byte arrays and to detect when a bytes type
is being unmarshaled into a byte slice or array and unmarshal
accordingly.

We also fixed a bug where UnmarshalRecord failed when the out record
had a type name instead of a zng.TypeRecord.

Closes #2475 