### PR TITLE
split optimizer out of semantic analysis

### DIFF
--- a/compiler/ast/dag/operator.go
+++ b/compiler/ast/dag/operator.go
@@ -16,6 +16,8 @@ type Op interface {
 	opNode()
 }
 
+var PassOp = &Pass{Kind: "Pass"}
+
 // Ops
 
 type (
@@ -45,13 +47,14 @@ type (
 		RightKey Expr         `json:"right_key"`
 		Args     []Assignment `json:"args"`
 	}
+	Merge struct {
+		Kind    string       `json:"kind" unpack:""`
+		Key     field.Static `json:"key"`
+		Reverse bool         `json:"reverse"`
+	}
 	Parallel struct {
 		Kind string `json:"kind" unpack:""`
 		Ops  []Op   `json:"ops"`
-		// XXX move mergeby to a downstream proc.  the optimizatoin
-		// can bookkeep this info outside of the dag.
-		MergeBy      field.Static `json:"merge_by,omitempty"`
-		MergeReverse bool         `json:"merge_reverse,omitempty"`
 	}
 	Pass struct {
 		Kind string `json:"kind" unpack:""`
@@ -94,10 +97,6 @@ type (
 	Switch struct {
 		Kind  string `json:"kind" unpack:""`
 		Cases []Case `json:"cases"`
-		// XXX move mergeby to a downstream proc.  the optimizatoin
-		// can bookkeep this info outside of the dag.
-		MergeBy      field.Static `json:"merge_by,omitempty"`
-		MergeReverse bool         `json:"merge_reverse,omitempty"`
 	}
 	Tail struct {
 		Kind  string `json:"kind" unpack:""`
@@ -162,6 +161,7 @@ func (*TypeProc) opNode()     {}
 func (*Shape) opNode()        {}
 func (*FieldCutter) opNode()  {}
 func (*TypeSplitter) opNode() {}
+func (*Merge) opNode()        {}
 
 func FanIn(op Op) int {
 	switch op := op.(type) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/brimdata/zed/compiler/ast"
 	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/compiler/kernel"
+	"github.com/brimdata/zed/compiler/optimizer"
 	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/compiler/semantic"
 	"github.com/brimdata/zed/expr"
@@ -16,10 +17,11 @@ import (
 var _ zbuf.Filter = (*Runtime)(nil)
 
 type Runtime struct {
-	zctx    *zson.Context
-	scope   *kernel.Scope
-	sem     *semantic.AST
-	outputs []proc.Interface
+	zctx      *zson.Context
+	scope     *kernel.Scope
+	optimizer *optimizer.Optimizer
+	consts    []dag.Op
+	outputs   []proc.Interface
 }
 
 func New(zctx *zson.Context, parserAST ast.Proc) (*Runtime, error) {
@@ -35,23 +37,25 @@ func NewWithZ(zctx *zson.Context, z string) (*Runtime, error) {
 }
 
 func NewWithSortedInput(zctx *zson.Context, parserAST ast.Proc, sortKey field.Static, sortRev bool) (*Runtime, error) {
-	sem := semantic.New(parserAST)
-	if err := sem.Analyze(); err != nil {
+	op, consts, err := semantic.Analyze(parserAST)
+	if err != nil {
 		return nil, err
 	}
+	opt := optimizer.New(op)
 	if sortKey != nil {
-		sem.SetInputOrder(sortKey, sortRev)
+		opt.SetInputOrder(sortKey, sortRev)
 	}
 	scope := kernel.NewScope()
 	// enter the global scope
 	scope.Enter()
-	if err := kernel.LoadConsts(zctx, scope, sem.Consts()); err != nil {
+	if err := kernel.LoadConsts(zctx, scope, consts); err != nil {
 		return nil, err
 	}
 	return &Runtime{
-		zctx:  zctx,
-		scope: scope,
-		sem:   sem,
+		zctx:      zctx,
+		scope:     scope,
+		optimizer: opt,
+		consts:    consts,
 	}, nil
 }
 
@@ -61,14 +65,14 @@ func (r *Runtime) Outputs() []proc.Interface {
 
 func (r *Runtime) Entry() dag.Op {
 	//XXX need to prepend consts depending on context
-	return r.sem.Entry()
+	return r.optimizer.Entry()
 }
 
 func (r *Runtime) AsFilter() (expr.Filter, error) {
 	if r == nil {
 		return nil, nil
 	}
-	f := r.sem.Filter()
+	f := r.optimizer.Filter()
 	if f == nil {
 		return nil, nil
 	}
@@ -79,7 +83,7 @@ func (r *Runtime) AsBufferFilter() (*expr.BufferFilter, error) {
 	if r == nil {
 		return nil, nil
 	}
-	f := r.sem.Filter()
+	f := r.optimizer.Filter()
 	if f == nil {
 		return nil, nil
 	}
@@ -93,7 +97,7 @@ func (r *Runtime) AsOp() dag.Op {
 	if r == nil {
 		return nil
 	}
-	f := r.sem.Filter()
+	f := r.optimizer.Filter()
 	if f == nil {
 		return nil
 	}
@@ -101,14 +105,12 @@ func (r *Runtime) AsOp() dag.Op {
 		Kind: "Filter",
 		Expr: f,
 	}
-	consts := r.sem.Consts()
+	consts := r.consts
 	if len(consts) == 0 {
 		return filterOp
 	}
-	var ops []dag.Op
-	for _, op := range consts {
-		ops = append(ops, op)
-	}
+	ops := make([]dag.Op, 0, len(consts)+1)
+	ops = append(ops, consts...)
 	ops = append(ops, filterOp)
 	return &dag.Sequential{
 		Kind: "Sequential",
@@ -118,15 +120,15 @@ func (r *Runtime) AsOp() dag.Op {
 
 // This must be called before the zbuf.Filter interface will work.
 func (r *Runtime) Optimize() error {
-	return r.sem.Optimize()
+	return r.optimizer.Optimize()
 }
 
 func (r *Runtime) IsParallelizable() bool {
-	return r.sem.IsParallelizable()
+	return r.optimizer.IsParallelizable()
 }
 
 func (r *Runtime) Parallelize(n int) bool {
-	return r.sem.Parallelize(n)
+	return r.optimizer.Parallelize(n)
 }
 
 // ParseProc() is an entry point for use from external go code,
@@ -159,7 +161,7 @@ func MustParseProc(query string) ast.Proc {
 
 func (r *Runtime) Compile(custom kernel.Hook, pctx *proc.Context, inputs []proc.Interface) error {
 	var err error
-	r.outputs, err = kernel.Compile(custom, r.sem.Entry(), pctx, r.scope, inputs)
+	r.outputs, err = kernel.Compile(custom, r.optimizer.Entry(), pctx, r.scope, inputs)
 	return err
 }
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -46,11 +46,6 @@ func TestCompileParents(t *testing.T) {
 		_, err := compiler.CompileZ("split (=>filter * =>filter * =>filter *) | filter *", pctx, sources)
 		require.Error(t, err)
 	})
-
-	t.Run("too many parents", func(t *testing.T) {
-		_, err := compiler.CompileZ("* | split(=>filter * =>filter *) | filter *", pctx, sources)
-		require.Error(t, err)
-	})
 }
 
 // TestCompileMergeDone exercises the bug reported in issue #1635.

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -1,0 +1,65 @@
+package optimizer
+
+import (
+	"github.com/brimdata/zed/compiler/ast/dag"
+	"github.com/brimdata/zed/field"
+)
+
+type Optimizer struct {
+	unopt   dag.Op
+	entry   dag.Op
+	filter  dag.Expr
+	sortKey field.Static
+	sortRev bool
+}
+
+func New(op dag.Op) *Optimizer {
+	return &Optimizer{
+		unopt: op,
+		entry: op,
+	}
+}
+
+func (o *Optimizer) Entry() dag.Op {
+	return o.entry
+}
+
+func (o *Optimizer) Filter() dag.Expr {
+	return o.filter
+}
+
+func (o *Optimizer) Optimize() error {
+	// Currently, we only lift the filter into the buffer scanner
+	// and push it out to distributed workers.  This could also be
+	// used by ZST to read only the columns but we need a bit more
+	// data structure here.  Also, this is where we would push
+
+	// analytics and search|cut into the column reader.
+	o.filter, o.entry = liftFilter(o.entry)
+	return nil
+}
+
+func (o *Optimizer) SetInputOrder(sortKey field.Static, sortRev bool) {
+	o.sortKey = sortKey
+	o.sortRev = sortRev
+	SetGroupByProcInputSortDir(o.entry, sortKey, zbufDirInt(sortRev))
+}
+
+// IsParallelizable reports whether Parallelize can parallelize p when called
+// with the same arguments.
+func (o *Optimizer) IsParallelizable() bool {
+	_, ok := parallelize(copyOp(o.unopt), 0, o.sortKey, o.sortRev)
+	return ok
+}
+
+// Parallelize takes a sequential proc AST and tries to
+// parallelize it by splitting as much as possible of the sequence
+// into n parallel branches. The boolean return argument indicates
+// whether the flowgraph could be parallelized.
+func (o *Optimizer) Parallelize(n int) bool {
+	op, ok := parallelize(copyOp(o.unopt), n, o.sortKey, o.sortRev)
+	if ok {
+		o.entry = op
+	}
+	return ok
+}

--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -1,4 +1,4 @@
-package semantic
+package optimizer
 
 import (
 	"encoding/json"

--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -8,8 +8,6 @@ import (
 	"github.com/brimdata/zed/field"
 )
 
-var passProc = &dag.Pass{Kind: "Pass"}
-
 //XXX
 func zbufDirInt(reversed bool) int {
 	if reversed {
@@ -46,7 +44,7 @@ func countConsts(ops []dag.Op) int {
 // returns nil and the unmodified flowgraph.
 func liftFilter(p dag.Op) (dag.Expr, dag.Op) {
 	if fp, ok := p.(*dag.Filter); ok {
-		return fp.Expr, passProc
+		return fp.Expr, dag.PassOp
 	}
 	seq, ok := p.(*dag.Sequential)
 	if ok && len(seq.Ops) > 0 {
@@ -55,7 +53,7 @@ func liftFilter(p dag.Op) (dag.Expr, dag.Op) {
 			panic("internal error: consts should have been removed from AST")
 		}
 		if fp, ok := seq.Ops[0].(*dag.Filter); ok {
-			rest := dag.Op(passProc)
+			rest := dag.Op(dag.PassOp)
 			if len(seq.Ops) > 1 {
 				rest = &dag.Sequential{
 					Kind: "Sequential",
@@ -196,27 +194,30 @@ func buildSplitFlowgraph(branch, tail []dag.Op, mergeField field.Static, reverse
 			Ops:  tail,
 		}, false
 	}
-	if len(tail) == 0 && mergeField != nil {
-		// Insert a pass tail in order to force a merge of the
-		// parallel branches when compiling. (Trailing parallel branches are wired to
-		// a mux output).
-		tail = []dag.Op{passProc}
-	}
-	pp := &dag.Parallel{
-		Kind:         "Parallel",
-		Ops:          []dag.Op{},
-		MergeBy:      mergeField,
-		MergeReverse: reverse,
-	}
+	branches := make([]dag.Op, 0, N)
 	for i := 0; i < N; i++ {
-		pp.Ops = append(pp.Ops, &dag.Sequential{
+		branches = append(branches, &dag.Sequential{
 			Kind: "Sequential",
 			Ops:  copyOps(branch),
 		})
 	}
+	sequence := []dag.Op{
+		&dag.Parallel{
+			Kind: "Parallel",
+			Ops:  branches,
+		},
+	}
+	if mergeField != nil {
+		sequence = append(sequence,
+			&dag.Merge{
+				Kind:    "Merge",
+				Key:     mergeField,
+				Reverse: reverse,
+			})
+	}
 	return &dag.Sequential{
 		Kind: "Sequential",
-		Ops:  append([]dag.Op{pp}, tail...),
+		Ops:  append(sequence, tail...),
 	}, true
 }
 

--- a/compiler/semantic/ast.go
+++ b/compiler/semantic/ast.go
@@ -3,86 +3,19 @@ package semantic
 import (
 	"github.com/brimdata/zed/compiler/ast"
 	"github.com/brimdata/zed/compiler/ast/dag"
-	"github.com/brimdata/zed/field"
 )
 
-type AST struct {
-	ast     ast.Proc
-	dag     dag.Op
-	unopt   dag.Op
-	consts  []dag.Op
-	filter  dag.Expr
-	sortKey field.Static
-	sortRev bool
-}
-
-func New(entry ast.Proc) *AST {
-	if entry == nil {
-		entry = &ast.Pass{"Pass"}
-	}
-	return &AST{ast: entry}
-}
-
-func (a *AST) Entry() dag.Op {
-	return a.dag
-}
-
-func (a *AST) Consts() []dag.Op {
-	return a.consts
-}
-
-func (a *AST) Filter() dag.Expr {
-	return a.filter
-}
-
 // Analyze analysis the AST and prepares it for runtime compilation.
-func (a *AST) Analyze() error {
-	var err error
+func Analyze(p ast.Proc) (dag.Op, []dag.Op, error) {
 	scope := NewScope()
 	scope.Enter()
-	a.consts, err = semConsts(nil, scope, a.ast)
+	consts, err := semConsts(nil, scope, p)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	a.dag, err = semProc(scope, a.ast)
+	entry, err := semProc(scope, p)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	a.unopt = a.dag
-	return nil
-}
-
-func (a *AST) Optimize() error {
-	// Currently, we only lift the filter into the buffer scanner
-	// and push it out to distributed workers.  This could also be
-	// used by ZST to read only the columns but we need a bit more
-	// data structure here.  Also, this is where we would push
-	// analytics and search|cut into the column reader.
-	a.filter, a.dag = liftFilter(a.dag)
-	return nil
-}
-
-func (a *AST) SetInputOrder(sortKey field.Static, sortRev bool) {
-	a.sortKey = sortKey
-	a.sortRev = sortRev
-	SetGroupByProcInputSortDir(a.dag, sortKey, zbufDirInt(sortRev))
-}
-
-// IsParallelizable reports whether Parallelize can parallelize p when called
-// with the same arguments.
-func (a *AST) IsParallelizable() bool {
-	_, ok := parallelize(copyOp(a.unopt), 0, a.sortKey, a.sortRev)
-	return ok
-}
-
-// Parallelize takes a sequential proc AST and tries to
-// parallelize it by splitting as much as possible of the sequence
-// into n parallel branches. The boolean return argument indicates
-// whether the flowgraph could be parallelized.
-func (a *AST) Parallelize(n int) bool {
-	p, ok := parallelize(copyOp(a.unopt), n, a.sortKey, a.sortRev)
-	if ok {
-		a.dag = p
-	}
-	return ok
+	return entry, consts, nil
 }

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -94,10 +94,8 @@ func semProc(scope *Scope, p ast.Proc) (dag.Op, error) {
 			ops = append(ops, converted)
 		}
 		return &dag.Parallel{
-			Kind:         "Parallel",
-			MergeBy:      p.MergeBy,
-			MergeReverse: p.MergeReverse,
-			Ops:          ops,
+			Kind: "Parallel",
+			Ops:  ops,
 		}, nil
 	case *ast.Sequential:
 		var ops []dag.Op

--- a/compiler/ztests/par-cut-put-rename.yaml
+++ b/compiler/ztests/par-cut-put-rename.yaml
@@ -14,5 +14,5 @@ outputs:
           | cut ts=ts,y=y,z=z
           | put x=y
           | rename y=z
-      ) merge-by ts
-      | pass
+      )
+      | merge ts

--- a/compiler/ztests/par-cut-uniq.yaml
+++ b/compiler/ztests/par-cut-uniq.yaml
@@ -10,5 +10,6 @@ outputs:
         =>
           filter *
           | cut ts=ts,foo=x
-      ) merge-by ts
+      )
+      | merge ts
       | uniq

--- a/compiler/ztests/par-drop-uniq.yaml
+++ b/compiler/ztests/par-drop-uniq.yaml
@@ -10,5 +10,6 @@ outputs:
         =>
           filter *
           | drop x
-      ) merge-by ts
+      )
+      | merge ts
       | uniq

--- a/compiler/ztests/par-every-count.yaml
+++ b/compiler/ztests/par-every-count.yaml
@@ -12,6 +12,7 @@ outputs:
           filter *
           | summarize every 1h partials-out sort-dir 1
               count=count() by ts=trunc(ts, 1h),y=y
-      ) merge-by ts
+      )
+      | merge ts
       | summarize every 1h partials-in sort-dir 1
           count=count() by ts=trunc(ts, 1h),y=y

--- a/compiler/ztests/par-put-rename-uniq.yaml
+++ b/compiler/ztests/par-put-rename-uniq.yaml
@@ -12,5 +12,6 @@ outputs:
           filter *
           | put x=foo
           | rename foo=boo
-      ) merge-by ts
+      )
+      | merge ts
       | uniq

--- a/compiler/ztests/par-put-tail.yaml
+++ b/compiler/ztests/par-put-tail.yaml
@@ -12,5 +12,6 @@ outputs:
           filter *
           | put a=1
           | tail 1
-      ) merge-by ts
+      )
+      | merge ts
       | tail 1

--- a/compiler/ztests/par-put-ts-rename.yaml
+++ b/compiler/ztests/par-put-ts-rename.yaml
@@ -8,6 +8,7 @@ outputs:
           filter *
         =>
           filter *
-      ) merge-by ts
+      )
+      | merge ts
       | put ts=foo
       | rename foo=boo

--- a/compiler/ztests/par-sort-x-uniq.yaml
+++ b/compiler/ztests/par-sort-x-uniq.yaml
@@ -10,5 +10,6 @@ outputs:
         =>
           filter *
           | sort x
-      ) merge-by x
+      )
+      | merge x
       | uniq

--- a/compiler/ztests/par-uniq.yaml
+++ b/compiler/ztests/par-uniq.yaml
@@ -8,5 +8,6 @@ outputs:
           filter *
         =>
           filter *
-      ) merge-by ts
+      )
+      | merge ts
       | uniq

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -187,12 +187,12 @@ func (c *canonDAG) op(p dag.Op) {
 		c.ret()
 		c.flush()
 		c.write(")")
-		if p.MergeBy != nil {
-			c.write(" merge-by ")
-			c.fieldpath(p.MergeBy)
-		}
-		if p.MergeReverse {
-			c.write(" rev")
+	case *dag.Merge:
+		c.next()
+		c.write("merge ")
+		c.fieldpath(p.Key)
+		if p.Reverse {
+			c.write(" (reverse)")
 		}
 	case *dag.Const:
 		c.write("const %s=", p.Name)


### PR DESCRIPTION
Now that the AST and DAG representations are distinct, this
commit splits out the optimizer into its own package, cleanly
delineating its indepedence of the AST from the optimizer, as 
it operates only on the DAG.  This sets us up to rewire the
merge logic in the optimizer so that a "from" Op can be added
more easily and dropped into the optimization framework
(e.g., it needs to be able to parallelize multiple sources on
different pools).