### PR TITLE
add squash

### DIFF
--- a/cmd/zed/lake/squash/command.go
+++ b/cmd/zed/lake/squash/command.go
@@ -17,16 +17,16 @@ var Squash = &charm.Spec{
 	Short: "combine commits in a pool's staging area",
 	Long: `
 The squash command takes multiple pending commits in a pool
-and combines them into a single pending commit printing to stdout
+and combines them into a single pending commit, printing to stdout
 the new tag of the squashed commits.  The combined commit can be
 subsequently committed with "zed lake commit".
 
-The order of the tags are significant as the pending commits are
-assembled into a snapshot summarizes reflecting the indicated order
+The order of the tags is significant as the pending commits are
+assembled into a snapshot reflecting the indicated order
 of any underlying add/delete operations.  If a delete operation
 encounters a tag that is not present in the implied commit,
 the squash will fail.  This integrity check is performed with
-respect to the head of the data pool's commit journal at the time it is run.
+respect to the head of the pool's commit journal at the time it is run.
 
 Currently, the previous commit messages are lost and a new message can be
 applied here with -message.  This will be addressed in issue #2561.

--- a/cmd/zed/lake/squash/command.go
+++ b/cmd/zed/lake/squash/command.go
@@ -1,0 +1,77 @@
+package squash
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	zedlake "github.com/brimdata/zed/cmd/zed/lake"
+	"github.com/brimdata/zed/pkg/charm"
+	"github.com/brimdata/zed/pkg/signalctx"
+)
+
+var Squash = &charm.Spec{
+	Name:  "squash",
+	Usage: "squash [options] tag [tag ...]",
+	Short: "combine commits in a pool's staging area",
+	Long: `
+The squash command takes multiple pending commits in a pool
+and combines them into a single pending commit printing to stdout
+the new tag of the squashed commits.  The combined commit can be
+subsequently committed with "zed lake commit".
+
+The order of the tags are significant as the pending commits are
+assembled into a snapshot summarizes reflecting the indicated order
+of any underlying add/delete operations.  If a delete operation
+encounters a tag that is not present in the implied commit,
+the squash will fail.  This integrity check is performed with
+respect to the head of the data pool's commit journal at the time it is run.
+
+Currently, the previous commit messages are lost and a new message can be
+applied here with -message.  This will be addressed in issue #2561.
+`,
+	New: New,
+}
+
+func init() {
+	zedlake.Cmd.Add(Squash)
+}
+
+type Command struct {
+	*zedlake.Command
+	lakeFlags zedlake.Flags
+	zedlake.CommitFlags
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*zedlake.Command)}
+	c.lakeFlags.SetFlags(f)
+	c.CommitFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	ctx, cancel := signalctx.New(os.Interrupt)
+	defer cancel()
+	pool, err := c.lakeFlags.OpenPool(ctx)
+	if err != nil {
+		return err
+	}
+	ids, err := zedlake.ParseIDs(args)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return errors.New("no commit tags specified")
+	}
+	commit, err := pool.Squash(ctx, ids, c.Date.Ts(), c.User, c.Message)
+	if err != nil {
+		return err
+	}
+	if !c.lakeFlags.Quiet {
+		fmt.Printf("squashed commit in staging: %s\n", commit)
+	}
+	return nil
+}

--- a/cmd/zed/lake/status/command.go
+++ b/cmd/zed/lake/status/command.go
@@ -86,7 +86,7 @@ func (c *Command) Run(args []string) error {
 	if c.drop {
 		return errors.New("TBD: issue #2541")
 	}
-	txns := make([]commit.Transaction, 0, len(ids))
+	txns := make([]*commit.Transaction, 0, len(ids))
 	for _, id := range ids {
 		txn, err := pool.LoadFromStaging(ctx, id)
 		if err != nil {
@@ -114,7 +114,7 @@ func (c *Command) Run(args []string) error {
 	return err
 }
 
-func printCommits(txns []commit.Transaction) {
+func printCommits(txns []*commit.Transaction) {
 	for _, txn := range txns {
 		fmt.Printf("commit %s\n", txn.ID)
 		for _, action := range txn.Actions {
@@ -124,7 +124,7 @@ func printCommits(txns []commit.Transaction) {
 	}
 }
 
-func marshalCommits(txns []commit.Transaction, w zbuf.Writer) error {
+func marshalCommits(txns []*commit.Transaction, w zbuf.Writer) error {
 	m := zson.NewZNGMarshaler()
 	for _, txn := range txns {
 		rec, err := m.MarshalRecord(txn)

--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/brimdata/zed/cmd/zed/lake/ls"
 	_ "github.com/brimdata/zed/cmd/zed/lake/merge"
 	_ "github.com/brimdata/zed/cmd/zed/lake/query"
+	_ "github.com/brimdata/zed/cmd/zed/lake/squash"
 	_ "github.com/brimdata/zed/cmd/zed/lake/stat"
 	_ "github.com/brimdata/zed/cmd/zed/lake/status"
 	_ "github.com/brimdata/zed/cmd/zed/lake/vacate"

--- a/lake/commit/patch.go
+++ b/lake/commit/patch.go
@@ -1,0 +1,59 @@
+package commit
+
+import (
+	"github.com/brimdata/zed/lake/segment"
+	"github.com/brimdata/zed/pkg/nano"
+	"github.com/segmentio/ksuid"
+)
+
+// A Patch represents a difference between a base snapshot and the patched
+// snapshot.  Patch implements View so either a patch or a base snapshot
+// can be traversed in the same manner.  Furthermore, patches can be easily
+// chained to implement a sequence of patches to a base snapshot.
+type Patch struct {
+	base *Snapshot
+	diff *Snapshot
+}
+
+func NewPatch(base *Snapshot) *Patch {
+	return &Patch{
+		base: base,
+		diff: NewSnapshot(),
+	}
+}
+
+func (p *Patch) Lookup(id ksuid.KSUID) (*segment.Reference, error) {
+	if s, err := p.diff.Lookup(id); err == nil {
+		return s, nil
+	}
+	return p.base.Lookup(id)
+}
+
+func (p *Patch) Select(span nano.Span) Segments {
+	segments := p.base.Select(span)
+	segments.Append(p.diff.Select(span))
+	return segments
+}
+
+func (p *Patch) AddSegment(seg *segment.Reference) error {
+	if p.base.Exists(seg.ID) {
+		return ErrExists
+	}
+	return p.diff.AddSegment(seg)
+}
+
+func (p *Patch) DeleteSegment(id ksuid.KSUID) error {
+	if p.diff.Exists(id) {
+		return p.diff.DeleteSegment(id)
+	}
+	return p.base.DeleteSegment(id)
+}
+
+func (p *Patch) NewTransaction() *Transaction {
+	segments := p.diff.segments
+	txn := newTransaction(ksuid.New(), len(segments))
+	for _, s := range segments {
+		txn.appendAdd(s)
+	}
+	return txn
+}

--- a/lake/commit/snapshot.go
+++ b/lake/commit/snapshot.go
@@ -101,7 +101,7 @@ func PlayAction(w Writeable, action actions.Interface) error {
 	return nil
 }
 
-// Play "plays" a recorded transaction into a whiteable snapshot.
+// Play "plays" a recorded transaction into a writeable snapshot.
 func Play(w Writeable, txn *Transaction) error {
 	for _, a := range txn.Actions {
 		if err := PlayAction(w, a); err != nil {

--- a/lake/commit/snapshot.go
+++ b/lake/commit/snapshot.go
@@ -1,48 +1,112 @@
 package commit
 
 import (
+	"errors"
+
+	"github.com/brimdata/zed/lake/commit/actions"
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/lake/segment"
 	"github.com/brimdata/zed/pkg/nano"
-	"github.com/brimdata/zed/zbuf"
 	"github.com/segmentio/ksuid"
 )
 
+var (
+	ErrExists   = errors.New("segment exists")
+	ErrNotFound = errors.New("segment not found")
+)
+
+type View interface {
+	Lookup(id ksuid.KSUID) (*segment.Reference, error)
+	Select(span nano.Span) Segments
+}
+
+type Writeable interface {
+	View
+	AddSegment(seg *segment.Reference) error
+	DeleteSegment(id ksuid.KSUID) error
+}
+
 // A snapshot summarizes the pool state at a given point in the journal.
-// XXX TBD: sort log by span and stack snapshot as a base layer
-// followed by change sets for each base-layer generation.  This is what
-// we will store in the journal sub-pool when this gets implemented.
-// See issue #XXX.
-// Also, snapshots should have index updates so each segment in the
-// snapshot could include which indexes are attached to it.
 type Snapshot struct {
 	at       journal.ID
-	order    zbuf.Order
-	segments []segment.Reference
+	segments map[ksuid.KSUID]*segment.Reference
 }
 
-func newSnapshot(at journal.ID, order zbuf.Order) *Snapshot {
-	return &Snapshot{at: at, order: order}
+func NewSnapshot() *Snapshot {
+	return &Snapshot{
+		segments: make(map[ksuid.KSUID]*segment.Reference),
+	}
 }
 
-func (s *Snapshot) Segments() []segment.Reference {
-	return s.segments
+func newSnapshotAt(at journal.ID) *Snapshot {
+	s := NewSnapshot()
+	s.at = at
+	return s
 }
 
-func (s *Snapshot) AddSegment(seg segment.Reference) {
-	s.segments = append(s.segments, seg)
+func (s *Snapshot) AddSegment(seg *segment.Reference) error {
+	id := seg.ID
+	if _, ok := s.segments[id]; ok {
+		return ErrExists
+	}
+	s.segments[id] = seg
+	return nil
 }
 
-func (s *Snapshot) DeleteSegment(id ksuid.KSUID) {
-	panic("TBD")
+func (s *Snapshot) DeleteSegment(id ksuid.KSUID) error {
+	if _, ok := s.segments[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.segments, id)
+	return nil
 }
 
-func (s *Snapshot) Select(span nano.Span) []*segment.Reference {
-	var segments []*segment.Reference
-	for k, seg := range s.segments {
+func (s *Snapshot) Exists(id ksuid.KSUID) bool {
+	_, ok := s.segments[id]
+	return ok
+}
+
+func (s *Snapshot) Lookup(id ksuid.KSUID) (*segment.Reference, error) {
+	seg, ok := s.segments[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return seg, nil
+}
+
+func (s *Snapshot) Select(span nano.Span) Segments {
+	var segments Segments
+	for _, seg := range s.segments {
 		if span.Overlaps(seg.Span()) {
-			segments = append(segments, &s.segments[k])
+			segments = append(segments, seg)
 		}
 	}
 	return segments
+}
+
+type Segments []*segment.Reference
+
+func (s *Segments) Append(segments Segments) {
+	*s = append(*s, segments...)
+}
+
+func PlayAction(w Writeable, action actions.Interface) error {
+	//XXX other cases like actions.AddIndex etc coming soon...
+	switch action := action.(type) {
+	case *actions.Add:
+		w.AddSegment(&action.Segment)
+	case *actions.Delete:
+		w.DeleteSegment(action.ID)
+	}
+	return nil
+}
+
+// Play "plays" a recorded transaction into a whiteable snapshot.
+func Play(w Writeable, txn *Transaction) error {
+	for _, a := range txn.Actions {
+		if err := PlayAction(w, a); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/lake/scanner.go
+++ b/lake/scanner.go
@@ -15,9 +15,9 @@ type Scanner struct {
 }
 
 func (s *Scanner) Scan(ctx context.Context, snap *commit.Snapshot, ch chan segment.Reference) error {
-	for _, seg := range snap.Segments() {
+	for _, seg := range snap.Select(nano.MaxSpan) {
 		select {
-		case ch <- seg:
+		case ch <- *seg:
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/lake/ztests/squash.yaml
+++ b/lake/ztests/squash.yaml
@@ -1,0 +1,23 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -q -p POOL
+  a=$(zed lake add -p POOL a.zson | head -1 | awk '{print $2}')
+  b=$(zed lake add -p POOL b.zson | head -1 | awk '{print $2}')
+  id=$(zed lake squash -p POOL $a $b | head -1 | awk '{print $NF}')
+  zed lake commit -q -p POOL $id
+  zed lake query -p POOL -z "sort ."
+
+inputs:
+  - name: a.zson
+    data: |
+      {a:1}
+  - name: b.zson
+    data: |
+      {b:1}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1}
+      {b:1}


### PR DESCRIPTION
This commit adds "zed lake squash" and also cleans up the snapshot
abstraction so delete works and patches to snapshots can be easily
chained together.

Closes #2543 

