### PR TITLE
add "zed lake delete"

### DIFF
--- a/cmd/zed/lake/delete/command.go
+++ b/cmd/zed/lake/delete/command.go
@@ -78,6 +78,9 @@ func (c *Command) Run(args []string) error {
 		return errors.New("no data or commit tags specified")
 	}
 	ids, err := pool.LookupTags(ctx, tags)
+	if err != nil {
+		return err
+	}
 	commitID, err := pool.Delete(ctx, ids)
 	if err != nil {
 		return err

--- a/cmd/zed/lake/status/command.go
+++ b/cmd/zed/lake/status/command.go
@@ -24,10 +24,6 @@ var Status = &charm.Spec{
 "zed lake status" shows a data pool's pending commits from its staging area.
 If a staged commit tag (e.g., as output by "zed lake add") is given,
 then details for that pending commit are displayed.
-
-If -drop is specified, then one or more commits are required and the commit
-is deleted from staging along with the underlying data that was written
-into the lake.
 `,
 	New: New,
 }
@@ -38,14 +34,12 @@ func init() {
 
 type Command struct {
 	*zedlake.Command
-	drop        bool
 	lakeFlags   zedlake.Flags
 	outputFlags outputflags.Flags
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
-	f.BoolVar(&c.drop, "drop", false, "delete specified commits from staging")
 	c.lakeFlags.SetFlags(f)
 	c.outputFlags.SetFlags(f)
 	return c, nil
@@ -71,9 +65,6 @@ func (c *Command) Run(args []string) error {
 			return err
 		}
 	} else {
-		if c.drop {
-			return errors.New("no commits specified for deletion")
-		}
 		ids, err = pool.GetStagedCommits(ctx)
 		if err != nil {
 			return err
@@ -82,9 +73,6 @@ func (c *Command) Run(args []string) error {
 			fmt.Println("no commits in staging")
 			return nil
 		}
-	}
-	if c.drop {
-		return errors.New("TBD: issue #2541")
 	}
 	txns := make([]*commit.Transaction, 0, len(ids))
 	for _, id := range ids {

--- a/lake/commit/actions/actions.go
+++ b/lake/commit/actions/actions.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Interface interface {
+	CommitID() ksuid.KSUID
 	fmt.Stringer
 }
 
@@ -23,6 +24,10 @@ type Add struct {
 	Segment segment.Reference `zng:"segment"`
 }
 
+func (a *Add) CommitID() ksuid.KSUID {
+	return a.Commit
+}
+
 func (a *Add) String() string {
 	return fmt.Sprintf("ADD %s", a.Segment)
 }
@@ -34,12 +39,21 @@ type CommitMessage struct {
 	Message string      `zng:"message"`
 }
 
+func (c *CommitMessage) CommitID() ksuid.KSUID {
+	return c.ID
+}
+
 func (c *CommitMessage) String() string {
 	return fmt.Sprintf("COMMIT %s %s %s %s", c.ID, c.Date, c.Author, c.Message)
 }
 
 type Delete struct {
-	ID ksuid.KSUID `zng:"id"`
+	Commit ksuid.KSUID `zng:"commit"`
+	ID     ksuid.KSUID `zng:"id"`
+}
+
+func (d *Delete) CommitID() ksuid.KSUID {
+	return d.Commit
 }
 
 func (d *Delete) String() string {

--- a/lake/commit/log.go
+++ b/lake/commit/log.go
@@ -143,7 +143,7 @@ func (l *Log) SnapshotOfCommit(ctx context.Context, at journal.ID, commit ksuid.
 			return nil, false, err
 		}
 		if action == nil {
-			break
+			return snapshot, ok, nil
 		}
 		if action.CommitID() == commit {
 			ok = true
@@ -154,5 +154,4 @@ func (l *Log) SnapshotOfCommit(ctx context.Context, at journal.ID, commit ksuid.
 			PlayAction(snapshot, action)
 		}
 	}
-	return snapshot, ok, nil
 }

--- a/lake/commit/snapshot.go
+++ b/lake/commit/snapshot.go
@@ -84,6 +84,14 @@ func (s *Snapshot) Select(span nano.Span) Segments {
 	return segments
 }
 
+func (s *Snapshot) SelectAll() Segments {
+	var segments Segments
+	for _, seg := range s.segments {
+		segments = append(segments, seg)
+	}
+	return segments
+}
+
 type Segments []*segment.Reference
 
 func (s *Segments) Append(segments Segments) {

--- a/lake/commit/transaction.go
+++ b/lake/commit/transaction.go
@@ -40,6 +40,14 @@ func NewAddsTxn(id ksuid.KSUID, segments []segment.Reference) *Transaction {
 	return txn
 }
 
+func NewDeletesTxn(id ksuid.KSUID, ids []ksuid.KSUID) *Transaction {
+	txn := newTransaction(id, len(ids))
+	for _, id := range ids {
+		txn.appendDelete(id)
+	}
+	return txn
+}
+
 func (t *Transaction) Append(action actions.Interface) {
 	t.Actions = append(t.Actions, action)
 }
@@ -61,6 +69,10 @@ func (t *Transaction) appendAdds(segments []segment.Reference) {
 
 func (t *Transaction) appendAdd(s *segment.Reference) {
 	t.Append(&actions.Add{Commit: t.ID, Segment: *s})
+}
+
+func (t *Transaction) appendDelete(id ksuid.KSUID) {
+	t.Append(&actions.Delete{Commit: t.ID, ID: id})
 }
 
 func (t Transaction) Serialize() ([]byte, error) {

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -113,7 +113,7 @@ func (p *Pool) Add(ctx context.Context, zctx *zson.Context, r zbuf.Reader) (ksui
 
 func (p *Pool) Delete(ctx context.Context, ids []ksuid.KSUID) (ksuid.KSUID, error) {
 	id := ksuid.New()
-	// IDs aren't vetted here and will fail at commit time if prolematic.
+	// IDs aren't vetted here and will fail at commit time if problematic.
 	txn := commit.NewDeletesTxn(id, ids)
 	if err := p.StoreInStaging(ctx, txn); err != nil {
 		return ksuid.Nil, err

--- a/lake/segment/reference.go
+++ b/lake/segment/reference.go
@@ -116,11 +116,19 @@ func (r Reference) Span() nano.Span {
 }
 
 func (r Reference) RowObjectName() string {
-	return fmt.Sprintf("%s.zng", r.ID)
+	return RowObjectName(r.ID)
+}
+
+func RowObjectName(id ksuid.KSUID) string {
+	return fmt.Sprintf("%s.zng", id)
 }
 
 func (r Reference) RowObjectPath(path iosrc.URI) iosrc.URI {
-	return path.AppendPath(r.RowObjectName())
+	return RowObjectPath(path, r.ID)
+}
+
+func RowObjectPath(path iosrc.URI, id ksuid.KSUID) iosrc.URI {
+	return path.AppendPath(RowObjectName(id))
 }
 
 func (r Reference) SeekObjectName() string {

--- a/lake/ztests/delete.yaml
+++ b/lake/ztests/delete.yaml
@@ -1,0 +1,33 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -q -p POOL
+  a=$(zed lake load -p POOL a.zson | head -1 | awk '{print $3}')
+  b=$(zed lake load -p POOL b.zson | head -1 | awk '{print $3}')
+  zed lake query -p POOL -z "sort ."
+  id=$(zed lake delete -p POOL $a | head -1 | awk '{print $2}')
+  zed lake commit -p POOL -q $id
+  echo ===
+  zed lake query -p POOL -z "sort ."
+  id=$(zed lake delete -p POOL $b | head -1 | awk '{print $2}')
+  zed lake commit -p POOL -q $id
+  echo ===
+  zed lake query -p POOL -z "sort ."
+
+
+inputs:
+  - name: a.zson
+    data: |
+      {a:1}
+  - name: b.zson
+    data: |
+      {b:1}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1}
+      {b:1}
+      ===
+      {b:1}
+      ===


### PR DESCRIPTION
This commit adds the "zed lake delete" command along with new support
in the commit layer for handling delete actions and querying the
commit journal by commit ID.

Closes #2544 