### PR TITLE
add "-at" option to "zed lake query"

### DIFF
--- a/cmd/zed/lake/command.go
+++ b/cmd/zed/lake/command.go
@@ -63,26 +63,34 @@ func ParseOrder(s string) (zbuf.Order, error) {
 func ParseIDs(args []string) ([]ksuid.KSUID, error) {
 	ids := make([]ksuid.KSUID, 0, len(args))
 	for _, s := range args {
-		// Check if this is a cut-and-paste from ZNG, which encodes
-		// the 20-byte KSUID as a 40 character hex string with 0x prefix.
-		var id ksuid.KSUID
-		if len(s) == 42 && s[0:2] == "0x" {
-			b, err := hex.DecodeString(s[2:])
-			if err != nil {
-				return nil, fmt.Errorf("illegal hex tag: %s", s)
-			}
-			id, err = ksuid.FromBytes(b)
-			if err != nil {
-				return nil, fmt.Errorf("illegal hex tag: %s", s)
-			}
-		} else {
-			var err error
-			id, err = ksuid.Parse(s)
-			if err != nil {
-				return nil, fmt.Errorf("%s: invalid commit ID", s)
-			}
+		id, err := ParseID(s)
+		if err != nil {
+			return nil, err
 		}
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+func ParseID(s string) (ksuid.KSUID, error) {
+	// Check if this is a cut-and-paste from ZNG, which encodes
+	// the 20-byte KSUID as a 40 character hex string with 0x prefix.
+	var id ksuid.KSUID
+	if len(s) == 42 && s[0:2] == "0x" {
+		b, err := hex.DecodeString(s[2:])
+		if err != nil {
+			return ksuid.Nil, fmt.Errorf("illegal hex tag: %s", s)
+		}
+		id, err = ksuid.FromBytes(b)
+		if err != nil {
+			return ksuid.Nil, fmt.Errorf("illegal hex tag: %s", s)
+		}
+	} else {
+		var err error
+		id, err = ksuid.Parse(s)
+		if err != nil {
+			return ksuid.Nil, fmt.Errorf("%s: invalid commit ID", s)
+		}
+	}
+	return id, nil
 }

--- a/cmd/zed/lake/query/command.go
+++ b/cmd/zed/lake/query/command.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"text/tabwriter"
 
 	"github.com/brimdata/zed/cli/outputflags"
@@ -13,6 +14,7 @@ import (
 	"github.com/brimdata/zed/cmd/zed/query"
 	"github.com/brimdata/zed/driver"
 	"github.com/brimdata/zed/lake"
+	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/rlimit"
 	"github.com/brimdata/zed/pkg/signalctx"
@@ -37,6 +39,7 @@ type Command struct {
 	*zedlake.Command
 	stats       bool
 	stopErr     bool
+	at          string
 	includes    query.Includes
 	lakeFlags   zedlake.Flags
 	outputFlags outputflags.Flags
@@ -46,6 +49,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedlake.Command)}
+	f.StringVar(&c.at, "at", "", "commit or journal ID at which to read pool")
 	f.BoolVar(&c.stats, "s", false, "print search stats to stderr on successful completion")
 	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
 	f.Var(&c.includes, "I", "source file containing Zed query text (may be used multiple times)")
@@ -74,7 +78,30 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	msrc := lake.NewMultiSource(pool)
+	var id journal.ID
+	if c.at != "" {
+		num, err := strconv.Atoi(c.at)
+		if err == nil {
+			ok, err := pool.IsJournalID(ctx, journal.ID(num))
+			if err != nil {
+				return err
+			}
+			if ok {
+				id = journal.ID(num)
+			}
+		}
+		if id == 0 {
+			commitID, err := zedlake.ParseID(c.at)
+			if err != nil {
+				return fmt.Errorf("zed lake query: -at argument is not a valid journal number or a commit tag: %s", c.at)
+			}
+			id, err = pool.Log().JournalIDOfCommit(ctx, 0, commitID)
+			if err != nil {
+				return fmt.Errorf("zed lake query: -at argument is not a valid journal number or a commit tag: %s", c.at)
+			}
+		}
+	}
+	msrc := lake.NewMultiSourceAt(pool, id)
 	writer, err := c.outputFlags.Open(ctx)
 	if err != nil {
 		return err

--- a/cmd/zed/lake/query/command.go
+++ b/cmd/zed/lake/query/command.go
@@ -80,8 +80,7 @@ func (c *Command) Run(args []string) error {
 	}
 	var id journal.ID
 	if c.at != "" {
-		num, err := strconv.Atoi(c.at)
-		if err == nil {
+		if num, err := strconv.Atoi(c.at); err == nil {
 			ok, err := pool.IsJournalID(ctx, journal.ID(num))
 			if err != nil {
 				return err

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -292,6 +292,14 @@ func (p *Pool) NewSegmentReader(ctx context.Context, snap *commit.Snapshot, span
 	return reader
 }
 
+func (p *Pool) IsJournalID(ctx context.Context, id journal.ID) (bool, error) {
+	head, tail, err := p.log.Boundaries(ctx)
+	if err != nil {
+		return false, err
+	}
+	return id >= tail && id <= head, nil
+}
+
 func DataPath(poolPath iosrc.URI) iosrc.URI {
 	return poolPath.AppendPath(DataTag)
 }

--- a/lake/ztests/time-travel.yaml
+++ b/lake/ztests/time-travel.yaml
@@ -1,0 +1,41 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -q -p POOL
+  a=$(zed lake load -p POOL a.zson | head -1 | awk '{print $3}')
+  b=$(zed lake load -p POOL b.zson | head -1 | awk '{print $3}')
+  zed lake query -p POOL -z "sort ."
+  echo === AT a
+  zed lake query -p POOL -at $a -z "sort ."
+  echo === AT b
+  zed lake query -p POOL -at $b -z "sort ."
+  id=$(zed lake delete -p POOL $a | head -1 | awk '{print $2}')
+  zed lake commit -p POOL -q $id
+  echo === with A deleted
+  zed lake query -p POOL -z "sort ."
+  echo === at B before A deleted
+  zed lake query -p POOL -at $b -z "sort ."
+
+inputs:
+  - name: a.zson
+    data: |
+      {a:1}
+  - name: b.zson
+    data: |
+      {b:1}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1}
+      {b:1}
+      === AT a
+      {a:1}
+      === AT b
+      {a:1}
+      {b:1}
+      === with A deleted
+      {b:1}
+      === at B before A deleted
+      {a:1}
+      {b:1}

--- a/ppl/zqd/storage/archivestore/archivestore.go
+++ b/ppl/zqd/storage/archivestore/archivestore.go
@@ -71,7 +71,7 @@ func (s *Storage) NativeOrder() zbuf.Order {
 }
 
 func (s *Storage) MultiSource() driver.MultiSource {
-	return lake.NewMultiSource(s.pool)
+	return lake.NewMultiSourceAt(s.pool, 0)
 }
 
 func (s *Storage) StaticSource(src driver.Source) driver.MultiSource {


### PR DESCRIPTION
This commit enables time travel by allowing a "zed lake query"
to run at any point in the commit journal.

Closes #2565 