### PR TITLE
don't try to ZNG marshal unexported fields in structs

### DIFF
--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -401,6 +401,12 @@ func (m *MarshalZNGContext) encodeRecord(sval reflect.Value) (zng.Type, error) {
 	var columns []zng.Column
 	stype := sval.Type()
 	for i := 0; i < stype.NumField(); i++ {
+		if !sval.Field(i).CanInterface() {
+			// If we can't access this field, silently ignore it
+			// like the json marshaler does.  This occurs when
+			// struct fields are not exported.
+			continue
+		}
 		field := stype.Field(i)
 		name := fieldName(field)
 		typ, err := m.encodeValue(sval.Field(i))

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -223,3 +223,15 @@ func TestBug2575(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, trim(exp), actual)
 }
+
+type Foo struct {
+	A int
+	a int
+}
+
+func TestUnexported(t *testing.T) {
+	f := &Foo{1, 2}
+	m := zson.NewZNGMarshaler()
+	_, err := m.Marshal(f)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The go reflect package panics when code tries to access
an unexported struct field.  This commit changes the logic
in the ZNG marshal to skip such fields just like Go's
encoding/json package does.

Closes #2582