### PR TITLE
cmd/zed: add test for -version flag

### DIFF
--- a/cmd/zed/ztests/version.yaml
+++ b/cmd/zed/ztests/version.yaml
@@ -1,0 +1,7 @@
+script: |
+  zed -version
+
+outputs:
+  - name: stdout
+    regexp: |
+      Version: v[0-9]+\..*


### PR DESCRIPTION
Inspired by #2462, which seems to have been fixed elsewhere.