### PR TITLE
use atomic writefile when commiting to journal

### DIFF
--- a/lake/commit/log.go
+++ b/lake/commit/log.go
@@ -68,6 +68,10 @@ func (l *Log) Commit(ctx context.Context, commit *Transaction) error {
 	if err != nil {
 		return err
 	}
+	//XXX It's a bug to do this loop here as the committer above should
+	// recompute its commit and check for a write-conflict.  Right now,
+	// we are just demo-ing concurrent loads so it's not a problem,
+	// but it will eventually become one.  This is all addressed in #2546.
 	for attempts := 0; attempts < MaxRetries; attempts++ {
 		err := l.journal.Commit(ctx, b)
 		if err != nil {

--- a/lake/commit/log.go
+++ b/lake/commit/log.go
@@ -26,10 +26,10 @@ type Log struct {
 
 const (
 	journalHandle = "J"
-	MaxRetries    = 10
+	maxRetries    = 10
 )
 
-var ErrRetriesExceeded = fmt.Errorf("commit journal unavailable after %d attempts", MaxRetries)
+var ErrRetriesExceeded = fmt.Errorf("commit journal unavailable after %d attempts", maxRetries)
 
 func newLog(path iosrc.URI, order zbuf.Order) *Log {
 	return &Log{
@@ -72,7 +72,7 @@ func (l *Log) Commit(ctx context.Context, commit *Transaction) error {
 	// recompute its commit and check for a write-conflict.  Right now,
 	// we are just demo-ing concurrent loads so it's not a problem,
 	// but it will eventually become one.  This is all addressed in #2546.
-	for attempts := 0; attempts < MaxRetries; attempts++ {
+	for attempts := 0; attempts < maxRetries; attempts++ {
 		err := l.journal.Commit(ctx, b)
 		if err != nil {
 			if os.IsExist(err) {

--- a/lake/commit/log.go
+++ b/lake/commit/log.go
@@ -3,7 +3,10 @@ package commit
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"os"
+	"time"
 
 	"github.com/brimdata/zed/lake/commit/actions"
 	"github.com/brimdata/zed/lake/journal"
@@ -21,7 +24,12 @@ type Log struct {
 	snapshots map[journal.ID]*Snapshot
 }
 
-const journalHandle = "J"
+const (
+	journalHandle = "J"
+	MaxRetries    = 10
+)
+
+var ErrRetriesExceeded = fmt.Errorf("commit journal unavailable after %d attempts", MaxRetries)
 
 func newLog(path iosrc.URI, order zbuf.Order) *Log {
 	return &Log{
@@ -60,7 +68,18 @@ func (l *Log) Commit(ctx context.Context, commit *Transaction) error {
 	if err != nil {
 		return err
 	}
-	return l.journal.Commit(ctx, b)
+	for attempts := 0; attempts < MaxRetries; attempts++ {
+		err := l.journal.Commit(ctx, b)
+		if err != nil {
+			if os.IsExist(err) {
+				time.Sleep(time.Millisecond)
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+	return ErrRetriesExceeded
 }
 
 func (l *Log) Open(ctx context.Context, head, tail journal.ID) (io.Reader, error) {

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -73,7 +73,7 @@ func (q *Queue) Commit(ctx context.Context, b []byte) error {
 		return err
 	}
 	uri := q.uri(head + 1)
-	if err := iosrc.WriteFile(ctx, uri, b); err != nil {
+	if err := iosrc.WriteFileIfNotExists(ctx, uri, b); err != nil {
 		return err
 	}
 	if head == 0 {

--- a/pkg/iosrc/file.go
+++ b/pkg/iosrc/file.go
@@ -38,6 +38,18 @@ func (s *FileSource) WriteFile(_ context.Context, d []byte, uri URI) error {
 	return wrapfileError(uri, err)
 }
 
+func (s *FileSource) WriteFileIfNotExists(_ context.Context, b []byte, uri URI) error {
+	f, err := os.OpenFile(uri.Filepath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0600)
+	if err == nil {
+		return wrapfileError(uri, err)
+	}
+	_, err = f.Write(b)
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	return wrapfileError(uri, err)
+}
+
 func (s *FileSource) MkdirAll(uri URI, perm os.FileMode) error {
 	return wrapfileError(uri, os.MkdirAll(uri.Filepath(), perm))
 }

--- a/pkg/iosrc/file.go
+++ b/pkg/iosrc/file.go
@@ -38,12 +38,12 @@ func (s *FileSource) WriteFile(_ context.Context, d []byte, uri URI) error {
 	return wrapfileError(uri, err)
 }
 
-func (s *FileSource) WriteFileIfNotExists(_ context.Context, b []byte, uri URI) error {
+func (s *FileSource) WriteFileIfNotExists(_ context.Context, d []byte, uri URI) error {
 	f, err := os.OpenFile(uri.Filepath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, s.Perm)
 	if err != nil {
 		return wrapfileError(uri, err)
 	}
-	_, err = f.Write(b)
+	_, err = f.Write(d)
 	if closeErr := f.Close(); err == nil {
 		err = closeErr
 	}

--- a/pkg/iosrc/file.go
+++ b/pkg/iosrc/file.go
@@ -40,7 +40,7 @@ func (s *FileSource) WriteFile(_ context.Context, d []byte, uri URI) error {
 
 func (s *FileSource) WriteFileIfNotExists(_ context.Context, b []byte, uri URI) error {
 	f, err := os.OpenFile(uri.Filepath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0600)
-	if err == nil {
+	if err != nil {
 		return wrapfileError(uri, err)
 	}
 	_, err = f.Write(b)

--- a/pkg/iosrc/file.go
+++ b/pkg/iosrc/file.go
@@ -39,7 +39,7 @@ func (s *FileSource) WriteFile(_ context.Context, d []byte, uri URI) error {
 }
 
 func (s *FileSource) WriteFileIfNotExists(_ context.Context, b []byte, uri URI) error {
-	f, err := os.OpenFile(uri.Filepath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0600)
+	f, err := os.OpenFile(uri.Filepath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, s.Perm)
 	if err != nil {
 		return wrapfileError(uri, err)
 	}

--- a/pkg/iosrc/iosrc.go
+++ b/pkg/iosrc/iosrc.go
@@ -29,6 +29,7 @@ type Source interface {
 	NewWriter(context.Context, URI) (io.WriteCloser, error)
 	ReadFile(context.Context, URI) ([]byte, error)
 	WriteFile(context.Context, []byte, URI) error
+	WriteFileIfNotExists(context.Context, []byte, URI) error
 	Remove(context.Context, URI) error
 	RemoveAll(context.Context, URI) error
 	// Exists returns true if the specified uri exists and an error is there
@@ -73,6 +74,10 @@ func ReadFile(ctx context.Context, uri URI) ([]byte, error) {
 
 func WriteFile(ctx context.Context, uri URI, d []byte) error {
 	return DefaultMuxSource.WriteFile(ctx, uri, d)
+}
+
+func WriteFileIfNotExists(ctx context.Context, uri URI, d []byte) error {
+	return DefaultMuxSource.WriteFileIfNotExists(ctx, uri, d)
 }
 
 func Exists(ctx context.Context, uri URI) (bool, error) {

--- a/pkg/iosrc/mock/mock_source.go
+++ b/pkg/iosrc/mock/mock_source.go
@@ -6,11 +6,10 @@ package mock
 
 import (
 	context "context"
-	io "io"
-	reflect "reflect"
-
 	iosrc "github.com/brimdata/zed/pkg/iosrc"
 	gomock "github.com/golang/mock/gomock"
+	io "io"
+	reflect "reflect"
 )
 
 // MockSource is a mock of Source interface
@@ -162,7 +161,13 @@ func (m *MockSource) WriteFile(arg0 context.Context, arg1 []byte, arg2 iosrc.URI
 	return ret0
 }
 
-// WriteFile mocks base method
+// WriteFile indicates an expected call of WriteFile
+func (mr *MockSourceMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockSource)(nil).WriteFile), arg0, arg1, arg2)
+}
+
+// WriteFileIfNotExists mocks base method
 func (m *MockSource) WriteFileIfNotExists(arg0 context.Context, arg1 []byte, arg2 iosrc.URI) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFileIfNotExists", arg0, arg1, arg2)
@@ -170,8 +175,8 @@ func (m *MockSource) WriteFileIfNotExists(arg0 context.Context, arg1 []byte, arg
 	return ret0
 }
 
-// WriteFile indicates an expected call of WriteFile
-func (mr *MockSourceMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
+// WriteFileIfNotExists indicates an expected call of WriteFileIfNotExists
+func (mr *MockSourceMockRecorder) WriteFileIfNotExists(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockSource)(nil).WriteFile), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFileIfNotExists", reflect.TypeOf((*MockSource)(nil).WriteFileIfNotExists), arg0, arg1, arg2)
 }

--- a/pkg/iosrc/mock/mock_source.go
+++ b/pkg/iosrc/mock/mock_source.go
@@ -6,10 +6,11 @@ package mock
 
 import (
 	context "context"
-	iosrc "github.com/brimdata/zed/pkg/iosrc"
-	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
+
+	iosrc "github.com/brimdata/zed/pkg/iosrc"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockSource is a mock of Source interface
@@ -157,6 +158,14 @@ func (mr *MockSourceMockRecorder) Stat(arg0, arg1 interface{}) *gomock.Call {
 func (m *MockSource) WriteFile(arg0 context.Context, arg1 []byte, arg2 iosrc.URI) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteFile mocks base method
+func (m *MockSource) WriteFileIfNotExists(arg0 context.Context, arg1 []byte, arg2 iosrc.URI) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteFileIfNotExists", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/pkg/iosrc/mux.go
+++ b/pkg/iosrc/mux.go
@@ -70,6 +70,14 @@ func (m *MuxSource) WriteFile(ctx context.Context, uri URI, d []byte) error {
 	return source.WriteFile(ctx, d, uri)
 }
 
+func (m *MuxSource) WriteFileIfNotExists(ctx context.Context, uri URI, d []byte) error {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return err
+	}
+	return source.WriteFileIfNotExists(ctx, d, uri)
+}
+
 func (m *MuxSource) Exists(ctx context.Context, uri URI) (bool, error) {
 	source, err := m.GetSource(uri)
 	if err != nil {

--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -52,7 +52,7 @@ func (s *s3Source) WriteFile(ctx context.Context, d []byte, u URI) error {
 }
 
 func (s *s3Source) WriteFileIfNotExists(ctx context.Context, d []byte, u URI) error {
-	return errors.New("s3Source.WriteFileIfNotExists not yet implemented.  Issue #XXX")
+	return errors.New("s3Source.WriteFileIfNotExists not yet implemented.  Issue #2615")
 }
 
 func (s *s3Source) Remove(ctx context.Context, u URI) error {

--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -51,6 +51,10 @@ func (s *s3Source) WriteFile(ctx context.Context, d []byte, u URI) error {
 	return err
 }
 
+func (s *s3Source) WriteFileIfNotExists(ctx context.Context, d []byte, u URI) error {
+	return errors.New("s3Source.WriteFileIfNotExists not yet implemented.  Issue #XXX")
+}
+
 func (s *s3Source) Remove(ctx context.Context, u URI) error {
 	return wrapErr(s3io.Remove(ctx, u.String(), s.Client))
 }

--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -52,7 +52,7 @@ func (s *s3Source) WriteFile(ctx context.Context, d []byte, u URI) error {
 }
 
 func (s *s3Source) WriteFileIfNotExists(ctx context.Context, d []byte, u URI) error {
-	return errors.New("s3Source.WriteFileIfNotExists not yet implemented.  Issue #2615")
+	return s.WriteFile(ctx, d, u)
 }
 
 func (s *s3Source) Remove(ctx context.Context, u URI) error {

--- a/pkg/iosrc/stdio.go
+++ b/pkg/iosrc/stdio.go
@@ -30,6 +30,10 @@ func (s *StdioSource) WriteFile(_ context.Context, _ []byte, _ URI) error {
 	return errStdioNotSupport
 }
 
+func (s *StdioSource) WriteFileIfNotExists(_ context.Context, _ []byte, _ URI) error {
+	return errStdioNotSupport
+}
+
 func (s *StdioSource) Remove(_ context.Context, uri URI) error {
 	return errStdioNotSupport
 }


### PR DESCRIPTION
This commit adds support to the file system iosrc path for
writing the journal files atomically.  We wanted to wait until
issue #2615 was done, but Phil ran into this problem when
running his demo workload (via concurrent processes running
"zed lake load"), hence this stopgap for now.

Fixes #2614 
