### PR TITLE
fix bug that stopped help from being printed with no CLI args

### DIFF
--- a/cmd/zed/ztests/blank-help.yaml
+++ b/cmd/zed/ztests/blank-help.yaml
@@ -1,0 +1,7 @@
+script: |
+  zed
+
+outputs:
+  - name: stderr
+    regexp: |
+      run zed commands

--- a/pkg/charm/charm.go
+++ b/pkg/charm/charm.go
@@ -59,16 +59,16 @@ func (s *Spec) Exec(parent Command, args []string) error {
 
 func (s *Spec) ExecRoot(args []string) error {
 	path, rest, showHidden, err := parse(s, args, nil)
-	if err != nil {
-		if err == NeedHelp {
-			path, err := parseHelp(s, args)
-			if err != nil {
-				return err
-			}
-			displayHelp(path, showHidden)
-			return nil
-		}
-		return err
+	if err == nil {
+		err = path.run(rest)
 	}
-	return path.run(rest)
+	if err == NeedHelp {
+		path, err := parseHelp(s, args)
+		if err != nil {
+			return err
+		}
+		displayHelp(path, showHidden)
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
This commit fixes a bug introduced when I blindly integrated feedback
in PR #2596 :)  The logic here is restored to handle the case where
either the parse or the run result indicates that help should be displayed.

Fixes #2607 
