### PR TITLE
move zio.ReaderOpts and WriterOpts to zio/anyio

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -9,19 +9,18 @@ import (
 	"github.com/brimdata/zed/cli/auto"
 	"github.com/brimdata/zed/pkg/iosrc"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zson"
 )
 
 type Flags struct {
-	zio.ReaderOpts
+	anyio.ReaderOpts
 	ReadMax  auto.Bytes
 	ReadSize auto.Bytes
 }
 
-func (f *Flags) Options() zio.ReaderOpts {
+func (f *Flags) Options() anyio.ReaderOpts {
 	return f.ReaderOpts
 }
 

--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -9,14 +9,14 @@ import (
 	"github.com/brimdata/zed/pkg/terminal"
 	"github.com/brimdata/zed/pkg/terminal/color"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/emitter"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zio/zstio"
 )
 
 type Flags struct {
-	zio.WriterOpts
+	anyio.WriterOpts
 	DefaultFormat string
 	dir           string
 	outputFile    string
@@ -25,7 +25,7 @@ type Flags struct {
 	zsonPretty    bool
 }
 
-func (f *Flags) Options() zio.WriterOpts {
+func (f *Flags) Options() anyio.WriterOpts {
 	return f.WriterOpts
 }
 

--- a/lake/lake_test.go
+++ b/lake/lake_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/pkg/iosrc"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zson"
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,7 @@ func createLake(t *testing.T, rootPath iosrc.URI, srcfile string) {
 
 func importTestFile(t *testing.T, pool *lake.Pool, srcfile string) {
 	zctx := zson.NewContext()
-	reader, err := anyio.OpenFile(zctx, srcfile, zio.ReaderOpts{})
+	reader, err := anyio.OpenFile(zctx, srcfile, anyio.ReaderOpts{})
 	require.NoError(t, err)
 	defer reader.Close()
 

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -9,7 +9,6 @@ import (
 	"github.com/brimdata/zed/compiler"
 	"github.com/brimdata/zed/driver"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/emitter"
 	"github.com/brimdata/zed/zson"
@@ -30,7 +29,7 @@ func Trim(s string) string {
 }
 
 func stringReader(input string, ifmt string, zctx *zson.Context) (zbuf.Reader, error) {
-	opts := zio.ReaderOpts{
+	opts := anyio.ReaderOpts{
 		Format: ifmt,
 	}
 	rc := ioutil.NopCloser(strings.NewReader(input))
@@ -43,7 +42,7 @@ func newEmitter(ofmt string) (*emitter.Bytes, error) {
 		ofmt = "tzng"
 	}
 	// XXX text format options not supported
-	return emitter.NewBytes(zio.WriterOpts{Format: ofmt})
+	return emitter.NewBytes(anyio.WriterOpts{Format: ofmt})
 }
 
 func (i *Internal) Run() (string, error) {

--- a/ppl/zqd/handlers.go
+++ b/ppl/zqd/handlers.go
@@ -19,7 +19,6 @@ import (
 	"github.com/brimdata/zed/ppl/zqd/search"
 	"github.com/brimdata/zed/ppl/zqd/storage/archivestore"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zqe"
@@ -657,7 +656,7 @@ func handleIntakePostData(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	zctx := zson.NewContext()
-	zr, err := anyio.NewReaderWithOpts(r.Body, zctx, zio.ReaderOpts{Zng: zngio.ReaderOpts{Validate: true}})
+	zr, err := anyio.NewReaderWithOpts(r.Body, zctx, anyio.ReaderOpts{Zng: zngio.ReaderOpts{Validate: true}})
 	if err != nil {
 		respondError(c, w, r, err)
 		return

--- a/ppl/zqd/ingest/archivepcap.go
+++ b/ppl/zqd/ingest/archivepcap.go
@@ -16,7 +16,7 @@ import (
 	"github.com/brimdata/zed/ppl/zqd/pcapstorage"
 	"github.com/brimdata/zed/ppl/zqd/storage/archivestore"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zson"
 	"golang.org/x/sync/errgroup"
 )
@@ -169,7 +169,7 @@ func (p *archivePcapOp) runAnalyzer(ctx context.Context, group *errgroup.Group, 
 	if err != nil {
 		return nil, nil, err
 	}
-	dr, err := newLogTailer(p.zctx, logdir, zio.ReaderOpts{})
+	dr, err := newLogTailer(p.zctx, logdir, anyio.ReaderOpts{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/ppl/zqd/ingest/log.go
+++ b/ppl/zqd/ingest/log.go
@@ -13,7 +13,6 @@ import (
 	"github.com/brimdata/zed/pkg/iosrc"
 	"github.com/brimdata/zed/ppl/zqd/storage"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zqe"
@@ -43,7 +42,7 @@ func NewLogOp(ctx context.Context, store storage.Storage, req api.LogPostRequest
 		warnings:  make([]string, 0, 5),
 		zctx:      zson.NewContext(),
 	}
-	opts := zio.ReaderOpts{Zng: zngio.ReaderOpts{Validate: true}}
+	opts := anyio.ReaderOpts{Zng: zngio.ReaderOpts{Validate: true}}
 	proc, err := ast.UnpackJSONAsProc(req.Shaper)
 	if err != nil {
 		return nil, err

--- a/ppl/zqd/ingest/logtailer.go
+++ b/ppl/zqd/ingest/logtailer.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/brimdata/zed/pkg/fs"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zng"
 	"github.com/brimdata/zed/zson"
@@ -21,7 +20,7 @@ type result struct {
 // written log data are transformed into *zng.Records and returned on a
 // first-come-first serve basis.
 type logTailer struct {
-	opts    zio.ReaderOpts
+	opts    anyio.ReaderOpts
 	readers map[string]*fs.TFile
 	watcher *fs.DirWatcher
 	zctx    *zson.Context
@@ -32,7 +31,7 @@ type logTailer struct {
 	wg      sync.WaitGroup
 }
 
-func newLogTailer(zctx *zson.Context, dir string, opts zio.ReaderOpts) (*logTailer, error) {
+func newLogTailer(zctx *zson.Context, dir string, opts anyio.ReaderOpts) (*logTailer, error) {
 	dir = filepath.Clean(dir)
 	watcher, err := fs.NewDirWatcher(dir)
 	if err != nil {

--- a/ppl/zqd/ingest/logtailer_test.go
+++ b/ppl/zqd/ingest/logtailer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimdata/zed/driver"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/zsonio"
 	"github.com/brimdata/zed/zson"
 	"github.com/stretchr/testify/suite"
@@ -59,7 +60,7 @@ func (s *logTailerTSuite) SetupTest() {
 	s.dir = dir
 	s.T().Cleanup(func() { os.RemoveAll(s.dir) })
 	s.zctx = zson.NewContext()
-	s.dr, err = newLogTailer(s.zctx, s.dir, zio.ReaderOpts{Format: "zson"})
+	s.dr, err = newLogTailer(s.zctx, s.dir, anyio.ReaderOpts{Format: "zson"})
 	s.Require().NoError(err)
 }
 

--- a/ppl/zqd/ingest/multipartlogreader.go
+++ b/ppl/zqd/ingest/multipartlogreader.go
@@ -11,7 +11,6 @@ import (
 	"github.com/brimdata/zed/compiler/ast"
 	"github.com/brimdata/zed/driver"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zng"
@@ -23,7 +22,7 @@ const maxShaperAstBytes = 1000 * 1000
 
 type MultipartLogReader struct {
 	mr        *multipart.Reader
-	opts      zio.ReaderOpts
+	opts      anyio.ReaderOpts
 	stopErr   bool
 	shaperAST ast.Proc
 	warnings  []string
@@ -35,7 +34,7 @@ type MultipartLogReader struct {
 func NewMultipartLogReader(mr *multipart.Reader, zctx *zson.Context) *MultipartLogReader {
 	return &MultipartLogReader{
 		mr:   mr,
-		opts: zio.ReaderOpts{Zng: zngio.ReaderOpts{Validate: true}},
+		opts: anyio.ReaderOpts{Zng: zngio.ReaderOpts{Validate: true}},
 		zctx: zctx,
 	}
 }

--- a/ppl/zqd/ingest/pcap.go
+++ b/ppl/zqd/ingest/pcap.go
@@ -320,7 +320,7 @@ func (p *legacyPcapOp) createSnapshot(ctx context.Context) error {
 func (p *legacyPcapOp) convertSuricataLog(ctx context.Context) error {
 	zctx := zson.NewContext()
 	path := filepath.Join(p.logdir, "eve.json")
-	zr, err := anyio.OpenFile(zctx, path, zio.ReaderOpts{})
+	zr, err := anyio.OpenFile(zctx, path, anyio.ReaderOpts{})
 	if err != nil {
 		return err
 	}

--- a/python/brim/src/zqext.go
+++ b/python/brim/src/zqext.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/brimdata/zed/compiler"
 	"github.com/brimdata/zed/driver"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/emitter"
 	"github.com/brimdata/zed/zson"
@@ -53,7 +52,7 @@ func doZqlFileEval(inquery, inpath, informat, outpath, outformat string) (err er
 	}
 
 	zctx := zson.NewContext()
-	rc, err := anyio.OpenFile(zctx, inpath, zio.ReaderOpts{
+	rc, err := anyio.OpenFile(zctx, inpath, anyio.ReaderOpts{
 		Format: informat,
 	})
 	if err != nil {
@@ -61,7 +60,7 @@ func doZqlFileEval(inquery, inpath, informat, outpath, outformat string) (err er
 	}
 	defer rc.Close()
 
-	w, err := emitter.NewFile(context.Background(), outpath, zio.WriterOpts{
+	w, err := emitter.NewFile(context.Background(), outpath, anyio.WriterOpts{
 		Format: outformat,
 	})
 	if err != nil {

--- a/zio/anyio/file.go
+++ b/zio/anyio/file.go
@@ -8,7 +8,6 @@ import (
 	"github.com/brimdata/zed/pkg/iosrc"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zng"
 	"github.com/brimdata/zed/zson"
 )
@@ -17,11 +16,11 @@ import (
 // which can be a local file path, a local directory path, or an S3
 // URL. If the path is neither of these or can't otherwise be opened,
 // an error is returned.
-func OpenFile(zctx *zson.Context, path string, opts zio.ReaderOpts) (*zbuf.File, error) {
+func OpenFile(zctx *zson.Context, path string, opts ReaderOpts) (*zbuf.File, error) {
 	return OpenFileWithContext(context.Background(), zctx, path, opts)
 }
 
-func OpenFileWithContext(ctx context.Context, zctx *zson.Context, path string, opts zio.ReaderOpts) (*zbuf.File, error) {
+func OpenFileWithContext(ctx context.Context, zctx *zson.Context, path string, opts ReaderOpts) (*zbuf.File, error) {
 	uri, err := iosrc.ParseURI(path)
 	if err != nil {
 		return nil, err
@@ -33,7 +32,7 @@ func OpenFileWithContext(ctx context.Context, zctx *zson.Context, path string, o
 	return OpenFromNamedReadCloser(zctx, f, path, opts)
 }
 
-func OpenFromNamedReadCloser(zctx *zson.Context, rc io.ReadCloser, path string, opts zio.ReaderOpts) (*zbuf.File, error) {
+func OpenFromNamedReadCloser(zctx *zson.Context, rc io.ReadCloser, path string, opts ReaderOpts) (*zbuf.File, error) {
 	var err error
 	r := io.Reader(rc)
 	if opts.Format != "parquet" && opts.Format != "zst" {
@@ -55,7 +54,7 @@ func OpenFromNamedReadCloser(zctx *zson.Context, rc io.ReadCloser, path string, 
 func OpenFiles(ctx context.Context, zctx *zson.Context, paths ...string) ([]zbuf.Reader, error) {
 	var readers []zbuf.Reader
 	for _, path := range paths {
-		reader, err := OpenFileWithContext(ctx, zctx, path, zio.ReaderOpts{})
+		reader, err := OpenFileWithContext(ctx, zctx, path, ReaderOpts{})
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +68,7 @@ type multiFileReader struct {
 	ctx    context.Context
 	zctx   *zson.Context
 	paths  []string
-	opts   zio.ReaderOpts
+	opts   ReaderOpts
 }
 
 var _ zbuf.ReadCloser = (*multiFileReader)(nil)
@@ -79,11 +78,11 @@ var _ zbuf.ScannerAble = (*multiFileReader)(nil)
 // of the provided input paths. They're read sequentially. Once all inputs have
 // reached end of stream, Read will return end of stream. If any of the readers
 // return a non-nil error, Read will return that error.
-func MultiFileReader(zctx *zson.Context, paths []string, opts zio.ReaderOpts) zbuf.ReadCloser {
+func MultiFileReader(zctx *zson.Context, paths []string, opts ReaderOpts) zbuf.ReadCloser {
 	return MultiFileReaderWithContext(context.Background(), zctx, paths, opts)
 }
 
-func MultiFileReaderWithContext(ctx context.Context, zctx *zson.Context, paths []string, opts zio.ReaderOpts) zbuf.ReadCloser {
+func MultiFileReaderWithContext(ctx context.Context, zctx *zson.Context, paths []string, opts ReaderOpts) zbuf.ReadCloser {
 	return &multiFileReader{
 		ctx:   ctx,
 		zctx:  zctx,

--- a/zio/anyio/file_test.go
+++ b/zio/anyio/file_test.go
@@ -55,7 +55,7 @@ func TestMultiFileScanner(t *testing.T) {
 	f2 := writeTemp(t, []byte(input[1]))
 	defer os.Remove(f2)
 
-	mfr := MultiFileReader(zson.NewContext(), []string{f1, f2}, zio.ReaderOpts{})
+	mfr := MultiFileReader(zson.NewContext(), []string{f1, f2}, ReaderOpts{})
 	sn, err := zbuf.NewScanner(context.Background(), mfr, nil, nano.MaxSpan)
 	require.NoError(t, err)
 	_, ok := sn.(*multiFileScanner)

--- a/zio/anyio/lookup.go
+++ b/zio/anyio/lookup.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/csvio"
 	"github.com/brimdata/zed/zio/jsonio"
 	"github.com/brimdata/zed/zio/lakeio"
@@ -33,7 +32,7 @@ func (*nullWriter) Close() error {
 	return nil
 }
 
-func LookupWriter(w io.WriteCloser, opts zio.WriterOpts) (zbuf.WriteCloser, error) {
+func LookupWriter(w io.WriteCloser, opts WriterOpts) (zbuf.WriteCloser, error) {
 	if opts.Format == "" {
 		opts.Format = "tzng"
 	}
@@ -71,7 +70,7 @@ func LookupWriter(w io.WriteCloser, opts zio.WriterOpts) (zbuf.WriteCloser, erro
 	}
 }
 
-func lookupReader(r io.Reader, zctx *zson.Context, opts zio.ReaderOpts) (zbuf.Reader, error) {
+func lookupReader(r io.Reader, zctx *zson.Context, opts ReaderOpts) (zbuf.Reader, error) {
 	switch opts.Format {
 	case "csv":
 		return csvio.NewReader(r, zctx), nil

--- a/zio/anyio/reader.go
+++ b/zio/anyio/reader.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/tzngio"
 	"github.com/brimdata/zed/zio/zeekio"
 	"github.com/brimdata/zed/zio/zjsonio"
@@ -15,7 +15,13 @@ import (
 	"github.com/brimdata/zed/zson"
 )
 
-func NewReaderWithOpts(r io.Reader, zctx *zson.Context, opts zio.ReaderOpts) (zbuf.Reader, error) {
+type ReaderOpts struct {
+	Format string
+	Zng    zngio.ReaderOpts
+	AwsCfg *aws.Config
+}
+
+func NewReaderWithOpts(r io.Reader, zctx *zson.Context, opts ReaderOpts) (zbuf.Reader, error) {
 	recorder := NewRecorder(r)
 	track := NewTrack(recorder)
 
@@ -70,7 +76,7 @@ func NewReaderWithOpts(r io.Reader, zctx *zson.Context, opts zio.ReaderOpts) (zb
 }
 
 func NewReader(r io.Reader, zctx *zson.Context) (zbuf.Reader, error) {
-	return NewReaderWithOpts(r, zctx, zio.ReaderOpts{})
+	return NewReaderWithOpts(r, zctx, ReaderOpts{})
 }
 
 func joinErrs(errs []error) error {

--- a/zio/anyio/writer.go
+++ b/zio/anyio/writer.go
@@ -1,0 +1,17 @@
+package anyio
+
+import (
+	"github.com/brimdata/zed/zio/textio"
+	"github.com/brimdata/zed/zio/zngio"
+	"github.com/brimdata/zed/zio/zsonio"
+	"github.com/brimdata/zed/zio/zstio"
+)
+
+type WriterOpts struct {
+	Format string
+	UTF8   bool
+	Text   textio.WriterOpts
+	Zng    zngio.WriterOpts
+	ZSON   zsonio.WriterOpts
+	Zst    zstio.WriterOpts
+}

--- a/zio/emitter/bytes.go
+++ b/zio/emitter/bytes.go
@@ -17,7 +17,7 @@ func (b *Bytes) Bytes() []byte {
 	return b.buf.Bytes()
 }
 
-func NewBytes(opts zio.WriterOpts) (*Bytes, error) {
+func NewBytes(opts anyio.WriterOpts) (*Bytes, error) {
 	b := &Bytes{}
 	w, err := anyio.LookupWriter(zio.NopCloser(&b.buf), opts)
 	if err != nil {

--- a/zio/emitter/dir.go
+++ b/zio/emitter/dir.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/zed/pkg/iosrc"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zng"
 )
 
@@ -28,13 +29,13 @@ type Dir struct {
 	prefix  string
 	ext     string
 	stderr  io.Writer // XXX use warnings channel
-	opts    zio.WriterOpts
+	opts    anyio.WriterOpts
 	writers map[zng.Type]zbuf.WriteCloser
 	paths   map[string]zbuf.WriteCloser
 	source  iosrc.Source
 }
 
-func NewDir(ctx context.Context, dir, prefix string, stderr io.Writer, opts zio.WriterOpts) (*Dir, error) {
+func NewDir(ctx context.Context, dir, prefix string, stderr io.Writer, opts anyio.WriterOpts) (*Dir, error) {
 	uri, err := iosrc.ParseURI(dir)
 	if err != nil {
 		return nil, err
@@ -46,7 +47,7 @@ func NewDir(ctx context.Context, dir, prefix string, stderr io.Writer, opts zio.
 	return NewDirWithSource(ctx, uri, prefix, stderr, opts, src)
 }
 
-func NewDirWithSource(ctx context.Context, dir iosrc.URI, prefix string, stderr io.Writer, opts zio.WriterOpts, source iosrc.Source) (*Dir, error) {
+func NewDirWithSource(ctx context.Context, dir iosrc.URI, prefix string, stderr io.Writer, opts anyio.WriterOpts, source iosrc.Source) (*Dir, error) {
 	if err := iosrc.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}

--- a/zio/emitter/dir_test.go
+++ b/zio/emitter/dir_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brimdata/zed/pkg/iosrc"
 	iosrcmock "github.com/brimdata/zed/pkg/iosrc/mock"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zson"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,7 @@ func TestDirS3Source(t *testing.T) {
 
 	r := zson.NewReader(strings.NewReader(input), zson.NewContext())
 	require.NoError(t, err)
-	w, err := NewDirWithSource(context.Background(), uri, "", os.Stderr, zio.WriterOpts{Format: "zson"}, src)
+	w, err := NewDirWithSource(context.Background(), uri, "", os.Stderr, anyio.WriterOpts{Format: "zson"}, src)
 	require.NoError(t, err)
 	require.NoError(t, zbuf.Copy(w, r))
 }

--- a/zio/emitter/file.go
+++ b/zio/emitter/file.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimdata/zed/zio/anyio"
 )
 
-func NewFile(ctx context.Context, path string, opts zio.WriterOpts) (zbuf.WriteCloser, error) {
+func NewFile(ctx context.Context, path string, opts anyio.WriterOpts) (zbuf.WriteCloser, error) {
 	if path == "" {
 		path = "stdout"
 	}
@@ -35,7 +35,7 @@ func IsTerminal(w io.Writer) bool {
 	return false
 }
 
-func NewFileWithSource(ctx context.Context, path iosrc.URI, opts zio.WriterOpts, source iosrc.Source) (zbuf.WriteCloser, error) {
+func NewFileWithSource(ctx context.Context, path iosrc.URI, opts anyio.WriterOpts, source iosrc.Source) (zbuf.WriteCloser, error) {
 	f, err := source.NewWriter(ctx, path)
 	if err != nil {
 		return nil, err

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -2,28 +2,7 @@ package zio
 
 import (
 	"io"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/brimdata/zed/zio/textio"
-	"github.com/brimdata/zed/zio/zngio"
-	"github.com/brimdata/zed/zio/zsonio"
-	"github.com/brimdata/zed/zio/zstio"
 )
-
-type ReaderOpts struct {
-	Format string
-	Zng    zngio.ReaderOpts
-	AwsCfg *aws.Config
-}
-
-type WriterOpts struct {
-	Format string
-	UTF8   bool
-	Text   textio.WriterOpts
-	Zng    zngio.WriterOpts
-	ZSON   zsonio.WriterOpts
-	Zst    zstio.WriterOpts
-}
 
 func Extension(format string) string {
 	switch format {


### PR DESCRIPTION
This will enable us to move some of the zbuf interfaces into zio without
creating import cycles.