### PR TITLE
colorize zson

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -23,6 +23,7 @@ type Flags struct {
 	forceBinary   bool
 	zsonShortcut  bool
 	zsonPretty    bool
+	color         bool
 }
 
 func (f *Flags) Options() zio.WriterOpts {
@@ -34,6 +35,7 @@ func (f *Flags) setFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&f.UTF8, "U", false, "display zeek strings as UTF-8")
 	fs.BoolVar(&f.Text.ShowTypes, "T", false, "display field types in text output")
 	fs.BoolVar(&f.Text.ShowFields, "F", false, "display field names in text output")
+	fs.BoolVar(&f.color, "color", true, "enable/disable color formatting for -Z and lake text output")
 	fs.IntVar(&f.Zng.StreamRecordsMax, "b", 0, "limit for number of records in each ZNG stream (0 for no limit)")
 	fs.IntVar(&f.Zng.LZ4BlockSize, "znglz4blocksize", zngio.DefaultLZ4BlockSize,
 		"LZ4 block size in bytes for ZNG compression (nonpositive to disable)")
@@ -111,7 +113,7 @@ func (f *Flags) Open(ctx context.Context) (zbuf.WriteCloser, error) {
 		}
 		return d, nil
 	}
-	if f.outputFile == "" && terminal.IsTerminalFile(os.Stdout) {
+	if f.outputFile == "" && f.color && terminal.IsTerminalFile(os.Stdout) {
 		color.Enabled = true
 	}
 	w, err := emitter.NewFile(ctx, f.outputFile, f.WriterOpts)

--- a/pkg/terminal/color/color.go
+++ b/pkg/terminal/color/color.go
@@ -40,10 +40,12 @@ func (code Code) Colorize(s string) string {
 func Gray(level int) Code {
 	if level < 0 {
 		level = 0
-	} else if level > 23 {
-		level = 23
+	} else if level > 255 {
+		level = 24
+	} else {
+		level = (level * 24) / 255
 	}
-	return Code(255 - level)
+	return Code(255 - 24 + level)
 }
 
 func Palette() string {

--- a/pkg/terminal/color/stack.go
+++ b/pkg/terminal/color/stack.go
@@ -55,7 +55,7 @@ func (s *Stack) ColorEnd(b *strings.Builder) {
 	}
 }
 
-func (s *Stack) ColorStartBytes(b *bytes.Buffer, code Code) {
+func (s *Stack) StartInBytes(b *bytes.Buffer, code Code) {
 	if !Enabled {
 		return
 	}
@@ -63,7 +63,25 @@ func (s *Stack) ColorStartBytes(b *bytes.Buffer, code Code) {
 	b.WriteString(code.String())
 }
 
-func (s *Stack) ColorEndBytes(b *bytes.Buffer) {
+func (s *Stack) EndInBytes(b *bytes.Buffer) {
+	if !Enabled {
+		return
+	}
+	op := s.Pop()
+	if op != "" {
+		b.WriteString(op)
+	}
+}
+
+func (s *Stack) StartInString(b *strings.Builder, code Code) {
+	if !Enabled {
+		return
+	}
+	s.Push(code)
+	b.WriteString(code.String())
+}
+
+func (s *Stack) EndInString(b *strings.Builder) {
 	if !Enabled {
 		return
 	}

--- a/pkg/terminal/color/stack.go
+++ b/pkg/terminal/color/stack.go
@@ -1,8 +1,7 @@
 package color
 
 import (
-	"bytes"
-	"strings"
+	"io"
 )
 
 type Stack []Code
@@ -37,56 +36,22 @@ func (s Stack) Top() Code {
 	return s[len(s)-1]
 }
 
-func (s *Stack) ColorStart(b *strings.Builder, code Code) {
+func (s *Stack) Start(w io.Writer, code Code) error {
 	if !Enabled {
-		return
+		return nil
 	}
 	s.Push(code)
-	b.WriteString(code.String())
+	_, err := io.WriteString(w, code.String())
+	return err
 }
 
-func (s *Stack) ColorEnd(b *strings.Builder) {
+func (s *Stack) End(w io.Writer) error {
 	if !Enabled {
-		return
+		return nil
 	}
-	op := s.Pop()
-	if op != "" {
-		b.WriteString(op)
+	var err error
+	if op := s.Pop(); op != "" {
+		_, err = io.WriteString(w, op)
 	}
-}
-
-func (s *Stack) StartInBytes(b *bytes.Buffer, code Code) {
-	if !Enabled {
-		return
-	}
-	s.Push(code)
-	b.WriteString(code.String())
-}
-
-func (s *Stack) EndInBytes(b *bytes.Buffer) {
-	if !Enabled {
-		return
-	}
-	op := s.Pop()
-	if op != "" {
-		b.WriteString(op)
-	}
-}
-
-func (s *Stack) StartInString(b *strings.Builder, code Code) {
-	if !Enabled {
-		return
-	}
-	s.Push(code)
-	b.WriteString(code.String())
-}
-
-func (s *Stack) EndInString(b *strings.Builder) {
-	if !Enabled {
-		return
-	}
-	op := s.Pop()
-	if op != "" {
-		b.WriteString(op)
-	}
+	return err
 }

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -148,20 +148,20 @@ func (t table) append(a actions.Interface) {
 
 func (t table) formatStaged(b *bytes.Buffer, commit *actions.StagedCommit, colors *color.Stack) {
 	id := commit.CommitID()
-	colors.StartInBytes(b, color.GrayYellow)
+	colors.Start(b, color.GrayYellow)
 	b.WriteString("staged ")
 	b.WriteString(id.String())
-	colors.EndInBytes(b)
+	colors.End(b)
 	b.WriteString("\n\n")
 	t.formatActions(b, id)
 }
 
 func (t table) formatCommit(b *bytes.Buffer, commit *actions.CommitMessage, width int, colors *color.Stack) {
 	id := commit.CommitID()
-	colors.StartInBytes(b, color.GrayYellow)
+	colors.Start(b, color.GrayYellow)
 	b.WriteString("commit ")
 	b.WriteString(id.String())
-	colors.EndInBytes(b)
+	colors.End(b)
 	b.WriteString("\nAuthor: ")
 	b.WriteString(commit.Author)
 	b.WriteString("\nDate:   ")

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -148,20 +148,20 @@ func (t table) append(a actions.Interface) {
 
 func (t table) formatStaged(b *bytes.Buffer, commit *actions.StagedCommit, colors *color.Stack) {
 	id := commit.CommitID()
-	colors.ColorStartBytes(b, color.GrayYellow)
+	colors.StartInBytes(b, color.GrayYellow)
 	b.WriteString("staged ")
 	b.WriteString(id.String())
-	colors.ColorEndBytes(b)
+	colors.EndInBytes(b)
 	b.WriteString("\n\n")
 	t.formatActions(b, id)
 }
 
 func (t table) formatCommit(b *bytes.Buffer, commit *actions.CommitMessage, width int, colors *color.Stack) {
 	id := commit.CommitID()
-	colors.ColorStartBytes(b, color.GrayYellow)
+	colors.StartInBytes(b, color.GrayYellow)
 	b.WriteString("commit ")
 	b.WriteString(id.String())
-	colors.ColorEndBytes(b)
+	colors.EndInBytes(b)
 	b.WriteString("\nAuthor: ")
 	b.WriteString(commit.Author)
 	b.WriteString("\nDate:   ")

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -428,13 +428,13 @@ func (f *Formatter) startColorPrimitive(typ zng.Type) {
 
 func (f *Formatter) startColor(code color.Code) {
 	if f.tab > 0 {
-		f.colors.StartInString(&f.builder, code)
+		f.colors.Start(&f.builder, code)
 	}
 }
 
 func (f *Formatter) endColor() {
 	if f.tab > 0 {
-		f.colors.EndInString(&f.builder)
+		f.colors.End(&f.builder)
 	}
 }
 

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/brimdata/zed/pkg/terminal/color"
 	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zng"
 )
@@ -21,6 +22,7 @@ type Formatter struct {
 	builder     strings.Builder
 	stack       []strings.Builder
 	implied     map[zng.Type]bool
+	colors      color.Stack
 }
 
 func NewFormatter(pretty int) *Formatter {
@@ -93,7 +95,9 @@ func (f *Formatter) formatValue(indent int, typ zng.Type, bytes zcode.Bytes, par
 	var null bool
 	switch t := typ.(type) {
 	default:
+		f.startColorPrimitive(typ)
 		f.build(typ.ZSONOf(bytes))
+		f.endColor()
 	case *zng.TypeAlias:
 		err = f.formatValue(indent, t.Type, bytes, known, parentImplied, false)
 	case *zng.TypeRecord:
@@ -109,7 +113,9 @@ func (f *Formatter) formatValue(indent int, typ zng.Type, bytes zcode.Bytes, par
 	case *zng.TypeEnum:
 		f.build(t.ZSONOf(bytes))
 	case *zng.TypeOfType:
+		f.startColorPrimitive(zng.TypeType)
 		f.buildf("(%s)", string(bytes))
+		f.endColor()
 	}
 	if err == nil && decorate {
 		f.decorate(typ, parentKnown, null)
@@ -127,6 +133,8 @@ func (f *Formatter) decorate(typ zng.Type, known, null bool) {
 	if known || (!null && f.isImplied(typ)) {
 		return
 	}
+	f.startColor(color.Gray(200))
+	defer f.endColor()
 	if name, ok := f.typedefs[typ]; ok {
 		f.buildf(" (%s)", name)
 		return
@@ -165,7 +173,9 @@ func (f *Formatter) formatRecord(indent int, typ *zng.TypeRecord, bytes zcode.By
 			return err
 		}
 		f.build(sep)
+		f.startColor(color.Blue)
 		f.indent(indent, zng.QuotedName(field.Name))
+		f.endColor()
 		f.build(":")
 		if f.tab > 0 {
 			f.build(" ")
@@ -397,6 +407,35 @@ func (f *Formatter) formatTypeEnum(typ *zng.TypeEnum) error {
 	}
 	f.build(">")
 	return nil
+}
+
+var colors = map[zng.Type]color.Code{
+	zng.TypeString:  color.Green,
+	zng.TypeBstring: color.Green,
+	zng.TypeError:   color.Red,
+	zng.TypeType:    color.Orange,
+}
+
+func (f *Formatter) startColorPrimitive(typ zng.Type) {
+	if f.tab > 0 {
+		c, ok := colors[zng.AliasOf(typ)]
+		if !ok {
+			c = color.Reset
+		}
+		f.startColor(c)
+	}
+}
+
+func (f *Formatter) startColor(code color.Code) {
+	if f.tab > 0 {
+		f.colors.StartInString(&f.builder, code)
+	}
+}
+
+func (f *Formatter) endColor() {
+	if f.tab > 0 {
+		f.colors.EndInString(&f.builder)
+	}
 }
 
 func (f *Formatter) isImplied(typ zng.Type) bool {


### PR DESCRIPTION
This commit add colorization of zson -Z text.  This is a simple start
that we can improve upon over time.  We should probably unify the
colors with the app (though the terminal color codes are limited and
aren't generic RGB values).  Type decorators are toned down in a
light gray to make them less obstrusive.  We also added -color to
outputflags so color can be disabled with -color=false and the
upcoming defaults settings

Closes #2578 
