### PR TITLE
Change wrccdc link

### DIFF
--- a/zeek/README.md
+++ b/zeek/README.md
@@ -229,7 +229,7 @@ Next we'll walk through an example where we handle each of these exceptions.
 ## Sample data
 
 First we'll regenerate our Zeek JSON logs from the same subset of
-[wrccdc 2018 pcaps](https://https://wrccdc.org/) described in
+[wrccdc 2018 pcaps](https://wrccdc.org/) described in
 the [zed-sample-data README](https://github.com/brimdata/zed-sample-data/blob/main/README.md),
 but with a customized Zeek v3.1.2 that has the following additional packages
 installed:

--- a/zeek/README.md
+++ b/zeek/README.md
@@ -229,7 +229,7 @@ Next we'll walk through an example where we handle each of these exceptions.
 ## Sample data
 
 First we'll regenerate our Zeek JSON logs from the same subset of
-[wrccdc 2018 pcaps](https://archive.wrccdc.org/pcaps/2018/) described in
+[wrccdc 2018 pcaps](https://https://wrccdc.org/) described in
 the [zed-sample-data README](https://github.com/brimdata/zed-sample-data/blob/main/README.md),
 but with a customized Zeek v3.1.2 that has the following additional packages
 installed:


### PR DESCRIPTION
The site for the pcap archive at [https://archive.wrccdc.org](https://archive.wrccdc.org) has been unreachable for several days, which sets off failures in the nightly markdown link checker. I've emailed two different wrccdc email addresses to ask if the outage is temporary but neither has responded, so I feel like I should just change to a "live" link for now.

(I know this particular doc is due for a wider overhaul regardless [#2594]. Just doing one thing at a time.)