### PR TITLE
Fix link to RFC 8259

### DIFF
--- a/docs/formats/zson.md
+++ b/docs/formats/zson.md
@@ -424,7 +424,7 @@ value in a record, as an element in an array, etc).
 #### 3.3.1 String Escape Rules
 
 Double-quoted `string` syntax is the same as that of JSON as described
-[RFC 8529](https://tools.ietf.org/html/rfc8529), specifically:
+[RFC 8259](https://tools.ietf.org/html/rfc8259#section-7), specifically:
 
 * The sequence `\uhhhh` where each `h` is a hexadecimal digit represents
   the Unicode code point corresponding to the given


### PR DESCRIPTION
I happened to try clicking the link in the ZSON spec and found it went to the wrong place. While I was fixing it I figured we might as well link directly to the anchor for the relevant section.

(Fun fact: @nwt actually "suggested" the correct link to the RFC in PR review comment [https://github.com/brimdata/zed/pull/1715#discussion_r533838382](https://github.com/brimdata/zed/pull/1715#discussion_r533838382) but then two characters were swapped in the commit that actually got merged, presumably because the edit was made outside of GitHub and then pushed. This illustrates the value of using the "accept suggestion" workflow so you can blame the person who made the suggestion if there's an error rather than making the mistake yourself. :trollface:)