### PR TITLE
lake: rework deterministic-merge.yaml ztest

### DIFF
--- a/lake/ztests/deterministic-merge.yaml
+++ b/lake/ztests/deterministic-merge.yaml
@@ -1,8 +1,10 @@
 script: |
-  zed lake import -R logs -s 32B -
-  zed lake query -z -R logs "*" > 1.zson
-  zed lake query -z -R logs "*" > 2.zson
-  diff 1.zson 2.zson && echo success
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -p logs -q -S 32B
+  zed lake load -p logs -q -
+  zed lake query -p logs -z "*" > 1.zson
+  zed lake query -p logs -z "*" > 2.zson
 
 inputs:
   - name: stdin
@@ -22,6 +24,20 @@ inputs:
       {ts:1970-01-01T00:00:01Z,s:"crosshaul-capersome",v:109}
 
 outputs:
-  - name: stdout
-    data: |
-      success
+  - name: 1.zson
+    data: &1_zson |
+      {ts:1970-01-01T00:00:01Z,s:"protohydrogen-plesiomorphism",v:320}
+      {ts:1970-01-01T00:00:01Z,s:"lacklusterness-Magyarization",v:91}
+      {ts:1970-01-01T00:00:01Z,s:"gatelike-nucleolocentrosome",v:336}
+      {ts:1970-01-01T00:00:01Z,s:"Potamogalidae-precommissure",v:51}
+      {ts:1970-01-01T00:00:01Z,s:"proceeding-noncausality",v:449}
+      {ts:1970-01-01T00:00:01Z,s:"unethicalness-vallis",v:148}
+      {ts:1970-01-01T00:00:01Z,s:"unendeared-Petasites",v:331}
+      {ts:1970-01-01T00:00:01Z,s:"investitor-dortiship",v:287}
+      {ts:1970-01-01T00:00:01Z,s:"crosshaul-capersome",v:109}
+      {ts:1970-01-01T00:00:01Z,s:"subarea-preoffense",v:373}
+      {ts:1970-01-01T00:00:01Z,s:"Galchic-unwheeled",v:51}
+      {ts:1970-01-01T00:00:01Z,s:"psalis-Guarnieri",v:456}
+      {ts:1970-01-01T00:00:01Z,s:"harefoot-raucous",v:137}
+  - name: 2.zson
+    data: *1_zson


### PR DESCRIPTION
All zed lake commands in this test fail, but the test passes because
diff ultimately compares two empty files.  Rework the test to make it
more robust.