### PR TITLE
add driver search-end message for single-path query

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -160,6 +160,11 @@ func run(pctx *proc.Context, d Driver, runtime *compiler.Runtime, statsTicker <-
 						err = warnErr
 					}
 				}
+				if len(runtime.Outputs()) == 1 {
+					if endErr := d.ChannelEnd(0); err == nil {
+						err = endErr
+					}
+				}
 				return err
 			}
 			batch, cid := extractLabel(p)


### PR DESCRIPTION
The CI tests with the app expect a SearchEnd message
even if there is only one query.  This commit adds
back support for this message.