### PR TITLE
zio/csvio: pass zctx to ZNG marshaler in NewReader

### DIFF
--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -11,7 +11,6 @@ import (
 )
 
 type Reader struct {
-	zctx      *zson.Context
 	reader    *csv.Reader
 	marshaler *zson.MarshalZNGContext
 	strings   bool
@@ -33,9 +32,8 @@ func NewReader(r io.Reader, zctx *zson.Context) *Reader {
 	reader := csv.NewReader(r)
 	reader.ReuseRecord = true
 	return &Reader{
-		zctx:      zctx,
 		reader:    reader,
-		marshaler: zson.NewZNGMarshaler(),
+		marshaler: zson.NewZNGMarshalerWithContext(zctx),
 		//strings:   opts.StringsOnly,
 	}
 }

--- a/zio/csvio/reader_test.go
+++ b/zio/csvio/reader_test.go
@@ -1,0 +1,18 @@
+package csvio
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brimdata/zed/zson"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReaderUsesContextParameter(t *testing.T) {
+	zctx := zson.NewContext()
+	rec, err := NewReader(strings.NewReader("f\n1\n"), zctx).Read()
+	require.NoError(t, err)
+	typ, err := zctx.LookupType(rec.Type.ID())
+	require.NoError(t, err)
+	require.Exactly(t, rec.Type, typ)
+}


### PR DESCRIPTION
Fixes #2670.