### PR TITLE
fix whitespace bug in ztest regexps

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -257,7 +257,7 @@ func (f *File) load(dir string) ([]byte, *regexp.Regexp, error) {
 		return b, nil, err
 	}
 	if f.Re != "" {
-		re, err := regexp.Compile(f.Re)
+		re, err := regexp.Compile(strings.TrimSpace(f.Re))
 		return nil, re, err
 	}
 	if f.Symlink != "" {
@@ -316,7 +316,7 @@ func (z *ZTest) check() error {
 	}
 	if z.ErrorRE != "" {
 		var err error
-		z.errRegex, err = regexp.Compile(z.ErrorRE)
+		z.errRegex, err = regexp.Compile(strings.TrimSpace(z.ErrorRE))
 		return err
 	}
 	return nil
@@ -481,7 +481,7 @@ func checkPatterns(patterns map[string]*regexp.Regexp, dir *Dir, stdout, stderr 
 			}
 		}
 		if !re.Match(body) {
-			return fmt.Errorf("%s: regex %s does not match %s'", name, re, body)
+			return fmt.Errorf("%s: regex %s does not match %s", name, re, body)
 		}
 	}
 	return nil


### PR DESCRIPTION
Many times I have written a regexp ztest rule only to be mystified
for why it didn't work.  The mystery lies in a yaml newline that
is embedded in the regexp requiring a silent match of a newline
immediately at the end of any regexp.  This commit adds a
string.TrimSpace to ztest whitespace to fix this.  This means
that you can't rely on whitespace at the start or end of a regexp
and must explicitly put any such whitespace in parens.  None of the
existing tests work this way.

We also removed an extraneous single quote from the regexp error
message.