### PR TITLE
fix zson parser bug with type values

### DIFF
--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -534,7 +534,7 @@ func (a Analyzer) convertTypeValue(zctx *Context, tv *zed.TypeValue, cast zng.Ty
 		return nil, err
 	}
 	if cast == nil {
-		cast = typ
+		cast = zng.TypeType
 	}
 	return &TypeValue{
 		Type:  cast,

--- a/zson/ztests/type-value-empty-record.yaml
+++ b/zson/ztests/type-value-empty-record.yaml
@@ -1,0 +1,6 @@
+zed: "*"
+
+input: &input |
+  {typ:({})}
+
+output: *input

--- a/zson/ztests/type-value.yaml
+++ b/zson/ztests/type-value.yaml
@@ -1,0 +1,6 @@
+zed: "*"
+
+input: &input |
+  {typ:(int64)}
+
+output: *input


### PR DESCRIPTION
This commit fixes a bug in the zson parser where the parser was
using the type value for the type instead of type "type".

Closes #2518