### PR TITLE
report reasonable error when no zed lake root

### DIFF
--- a/cmd/zed/lake/flags.go
+++ b/cmd/zed/lake/flags.go
@@ -49,7 +49,7 @@ func (f *Flags) Open(ctx context.Context, engine storage.Engine) (*lake.Root, er
 		return nil, err
 	}
 	if root.Path == "" {
-		return nil, errors.New("no lake path specied: use -R or ZED_LAKE_ROOT environment")
+		return nil, errors.New("no lake path specied: use -R or set ZED_LAKE_ROOT")
 	}
 	return lake.Open(ctx, engine, root)
 }

--- a/cmd/zed/lake/flags.go
+++ b/cmd/zed/lake/flags.go
@@ -48,6 +48,9 @@ func (f *Flags) Open(ctx context.Context, engine storage.Engine) (*lake.Root, er
 	if err != nil {
 		return nil, err
 	}
+	if root.Path == "" {
+		return nil, errors.New("no lake path specied: use -R or ZED_LAKE_ROOT environment")
+	}
 	return lake.Open(ctx, engine, root)
 }
 

--- a/cmd/zed/lake/serve/command.go
+++ b/cmd/zed/lake/serve/command.go
@@ -75,7 +75,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer cleanup()
-	lakeRoot, err := c.lake.RootPath()
+	c.conf.Root, err = c.lake.RootPath()
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,6 @@ func (c *Command) Run(args []string) error {
 			return err
 		}
 	}
-	c.conf.Root = lakeRoot
 	core, err := service.NewCore(ctx, c.conf)
 	if err != nil {
 		return err

--- a/cmd/zed/lake/serve/command.go
+++ b/cmd/zed/lake/serve/command.go
@@ -75,6 +75,10 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer cleanup()
+	lakeRoot, err := c.lake.RootPath()
+	if err != nil {
+		return err
+	}
 	if err := c.initLogger(); err != nil {
 		return err
 	}
@@ -90,7 +94,7 @@ func (c *Command) Run(args []string) error {
 			return err
 		}
 	}
-	c.conf.Root = c.lake.Root
+	c.conf.Root = lakeRoot
 	core, err := service.NewCore(ctx, c.conf)
 	if err != nil {
 		return err

--- a/cmd/zed/ztests/no-lake-root.yaml
+++ b/cmd/zed/ztests/no-lake-root.yaml
@@ -1,0 +1,7 @@
+script: |
+  zed lake ls
+
+outputs:
+  - name: stderr
+    data: |
+      no lake path specied: use -R or ZED_LAKE_ROOT environment

--- a/cmd/zed/ztests/no-lake-root.yaml
+++ b/cmd/zed/ztests/no-lake-root.yaml
@@ -4,4 +4,4 @@ script: |
 outputs:
   - name: stderr
     data: |
-      no lake path specied: use -R or ZED_LAKE_ROOT environment
+      no lake path specied: use -R or set ZED_LAKE_ROOT

--- a/service/core.go
+++ b/service/core.go
@@ -33,7 +33,7 @@ const indexPage = `
 type Config struct {
 	Auth    AuthConfig
 	Logger  *zap.Logger
-	Root    string
+	Root    *storage.URI
 	Version string
 }
 
@@ -67,10 +67,7 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 			return nil, err
 		}
 	}
-	path, err := storage.ParseURI(conf.Root)
-	if err != nil {
-		return nil, err
-	}
+	path := conf.Root
 	var engine storage.Engine
 	switch storage.Scheme(path.Scheme) {
 	case storage.FileScheme:

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -579,12 +579,13 @@ func newCore(t *testing.T) (*service.Core, *client.Connection) {
 
 func newCoreAtDir(t *testing.T, dir string) (*service.Core, *client.Connection) {
 	t.Cleanup(func() { os.RemoveAll(dir) })
-	return newCoreWithConfig(t, service.Config{Root: dir})
+	u := storage.MustParseURI(dir)
+	return newCoreWithConfig(t, service.Config{Root: u})
 }
 
 func newCoreWithConfig(t *testing.T, conf service.Config) (*service.Core, *client.Connection) {
-	if conf.Root == "" {
-		conf.Root = t.TempDir()
+	if conf.Root == nil {
+		conf.Root = storage.MustParseURI(t.TempDir())
 	}
 	if conf.Logger == nil {
 		conf.Logger = zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))


### PR DESCRIPTION
This commit provides a better error when no lake root is specified.
While we were at it, we switch serivce.Config to use a storage.URI
instead of string to specify the root path.

Closes #2671