### PR TITLE
expr: replace all fields with error when Shaper fails

### DIFF
--- a/expr/ztests/shape-string-time-err.yaml
+++ b/expr/ztests/shape-string-time-err.yaml
@@ -1,0 +1,9 @@
+zed: |
+  put . = shape({f1:time})
+
+input: |
+  {f1:"WellWhatDoYouThinkOfThis",f2:"NotMuch"}
+
+output: |
+  {error:"Could not find format for \"WellWhatDoYouThinkOfThis\"" (error)} (=0)
+


### PR DESCRIPTION
step.castPrimitive assumes that a primitive caster always returns a
zng.Value of the "to" type, but some casters can return a zng.TypeError.
When this happens, castPrimitive appends the error's bytes to its
builder anyway.  If the "to" type isn't stringy, the resulting record is
almost certain to be malformed.  Address this by replacing the entire
record with a record containing a single field named "error" whose value
is the caster error.

This is a short-term fix.  The long-term fix (#2710) is to adjust the target
record type so the field on which the error occurred can contain the
error.

Closes #2605.