### PR TITLE
Fix FileStorage size on windows

### DIFF
--- a/pkg/storage/file.go
+++ b/pkg/storage/file.go
@@ -133,7 +133,7 @@ type fileSizer struct {
 var _ Sizer = (*fileSizer)(nil)
 
 func (f *fileSizer) Size() (int64, error) {
-	info, err := os.Stat(f.uri.Path)
+	info, err := os.Stat(f.uri.Filepath())
 	if err != nil {
 		return 0, wrapfileError(f.uri, err)
 	}


### PR DESCRIPTION
Method should use Filepath() not Path, which will have a "/" before the
drive (not a valid windows path).