### PR TITLE
add typeunder()

### DIFF
--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -86,6 +86,8 @@ func New(zctx *zson.Context, name string, narg int) (Interface, bool, error) {
 		f = &trunc{}
 	case "typeof":
 		f = &typeOf{zctx}
+	case "typeunder":
+		f = &typeUnder{zctx}
 	case "nameof":
 		f = &nameOf{}
 	case "fields":
@@ -161,6 +163,15 @@ type typeOf struct {
 
 func (t *typeOf) Call(args []zng.Value) (zng.Value, error) {
 	typ := args[0].Type
+	return t.zctx.LookupTypeValue(typ), nil
+}
+
+type typeUnder struct {
+	zctx *zson.Context
+}
+
+func (t *typeUnder) Call(args []zng.Value) (zng.Value, error) {
+	typ := zng.AliasOf(args[0].Type)
 	return t.zctx.LookupTypeValue(typ), nil
 }
 

--- a/expr/function/ztests/typeunder.yaml
+++ b/expr/function/ztests/typeunder.yaml
@@ -1,0 +1,11 @@
+zed: cut typeunder(this), typeof(this)
+
+input: |
+  {}
+  {x:1}
+  {x:1} (=foo)
+
+output: |
+  {typeunder:({}),typeof:({})}
+  {typeunder:({x:int64}),typeof:({x:int64})}
+  {typeunder:({x:int64}),typeof:(foo=({x:int64}))}


### PR DESCRIPTION
This commit adds a function to get at the concrete type underlying
a named type.  This has come up many times but apparently there is
no current issue for it.