### PR TITLE
fix type-value consistency bug

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -10,7 +10,6 @@ import (
 	"github.com/brimdata/zed/expr/agg"
 	"github.com/brimdata/zed/expr/function"
 	"github.com/brimdata/zed/field"
-	"github.com/brimdata/zed/zng"
 	"github.com/brimdata/zed/zson"
 )
 
@@ -469,7 +468,7 @@ func compileTypeValue(zctx *zson.Context, scope *Scope, t *zed.TypeValue) (expr.
 	if err != nil {
 		return nil, err
 	}
-	return expr.NewLiteral(zng.NewTypeType(typ)), nil
+	return expr.NewLiteral(zson.NewTypeType(typ)), nil
 }
 
 func compileRegexpMatch(zctx *zson.Context, scope *Scope, match *dag.RegexpMatch) (expr.Evaluator, error) {

--- a/compiler/kernel/proc.go
+++ b/compiler/kernel/proc.go
@@ -548,7 +548,7 @@ func (b *Builder) LoadConsts(ops []dag.Op) error {
 			if err != nil {
 				return err
 			}
-			zv := zng.NewTypeType(alias)
+			zv := zson.NewTypeType(alias)
 			scope.Bind(name, &zv)
 
 		default:

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -767,7 +767,7 @@ func (t *TypeFunc) Eval(rec *zng.Record) (zng.Value, error) {
 		if typ == nil {
 			return zng.Missing, nil
 		}
-		t.zv = zng.NewTypeType(typ)
+		t.zv = zson.NewTypeType(typ)
 	}
 	return t.zv, nil
 }

--- a/expr/ztests/typedef-match.yaml
+++ b/expr/ztests/typedef-match.yaml
@@ -1,0 +1,7 @@
+zed: typeof(this)=type(bar)
+
+input: &input |
+  {x:{a:1} (=foo),y:{a:2} (foo)} (=bar)
+  {x:{a:3},y:{a:4}} (bar)
+
+output: *input

--- a/zng/typetype.go
+++ b/zng/typetype.go
@@ -8,10 +8,6 @@ import (
 
 type TypeOfType struct{}
 
-func NewTypeType(t Type) Value {
-	return Value{TypeType, zcode.Bytes(t.ZSON())}
-}
-
 func (t *TypeOfType) ID() int {
 	return IDType
 }

--- a/zson/zson.go
+++ b/zson/zson.go
@@ -88,3 +88,7 @@ func ParseValue(zctx *Context, zson string) (zng.Value, error) {
 func TranslateType(zctx *Context, astType zed.Type) (zng.Type, error) {
 	return NewAnalyzer().convertType(zctx, astType)
 }
+
+func NewTypeType(t zng.Type) zng.Value {
+	return zng.Value{zng.TypeType, zcode.Bytes(FormatType(t))}
+}


### PR DESCRIPTION
This commit fixes a bug where type values were created both with the
ZSON() method on zng.Type as well as zson.FormatType().  The latter
is correct as the ZSON() method does not create canonical form and
import cycles prevent an easy fix.  The workaround for now is to
move NewTypeType() into package zson and have it call zson.FormatType()
instead of zng.Type.ZSON().