### PR TITLE
Update page users see when connecting from a browser

### DIFF
--- a/service/core.go
+++ b/service/core.go
@@ -24,7 +24,7 @@ const indexPage = `
   <title>ZQD daemon</title>
   <body style="padding:10px">
     <h2>zed lake serve</h2>
-    <p>A <a href="https://github.com/brimdata/zed/tree/main/cmd/zed/lake/serve">zed lake serve</a> process is listening on this host/port.</p>
+    <p>A <a href="https://github.com/brimdata/zed/tree/main/cmd/zed/lake/serve">zed lake service</a> is listening on this host/port.</p>
     <p>If you're a <a href="https://www.brimsecurity.com/">Brim</a> user, connect to this host/port from the <a href="https://github.com/brimdata/brim">Brim application</a> in the graphical desktop interface in your operating system (not a web browser).</p>
     <p>If your goal is to perform command line operations against this Zed lake, use the <a href="https://github.com/brimdata/zed/tree/main/cmd/zapi">zapi</a> client.</p>
   </body>

--- a/service/core.go
+++ b/service/core.go
@@ -23,10 +23,10 @@ const indexPage = `
 <html>
   <title>ZQD daemon</title>
   <body style="padding:10px">
-    <h2>ZQD</h2>
-    <p>A <a href="https://github.com/brimdata/zed/tree/main/cmd/zed/lake/serve">zqd</a> daemon is listening on this host/port.</p>
+    <h2>zed lake serve</h2>
+    <p>A <a href="https://github.com/brimdata/zed/tree/main/cmd/zed/lake/serve">zed lake serve</a> process is listening on this host/port.</p>
     <p>If you're a <a href="https://www.brimsecurity.com/">Brim</a> user, connect to this host/port from the <a href="https://github.com/brimdata/brim">Brim application</a> in the graphical desktop interface in your operating system (not a web browser).</p>
-    <p>If your goal is to perform command line operations against this zqd, use the <a href="https://github.com/brimdata/zed/tree/main/cmd/zapi">zapi</a> client.</p>
+    <p>If your goal is to perform command line operations against this Zed lake, use the <a href="https://github.com/brimdata/zed/tree/main/cmd/zapi">zapi</a> client.</p>
   </body>
 </html>`
 


### PR DESCRIPTION
While updating the Troubleshooting article in the Brim wiki, I noticed that this page still mentions `zqd` and therefore should be updated.

Just to refresh folks on why this page exists, we once had Support issues back in the day because users on Linux didn't realize Brim was a desktop app and therefore they installed via `yum` or `apt` from the shell and then didn't know how to launch it. They poked around and saw the listening `zqd` process and figured they should connect to it from a browser.

The new page:

---

![](https://user-images.githubusercontent.com/5934157/118295608-ebd7a280-b490-11eb-96c9-31e66bcce469.png)