### PR TITLE
zed query: support HTTP, HTTPS URLs as input files

### DIFF
--- a/cli/adaptor.go
+++ b/cli/adaptor.go
@@ -61,6 +61,6 @@ func (f *FileAdaptor) Open(ctx context.Context, zctx *zson.Context, path string,
 	}{sn, file}, nil
 }
 
-func (*FileAdaptor) Get(_ context.Context, _ *zson.Context, url string, pushdown zbuf.Filter) (zbuf.PullerCloser, error) {
-	return nil, errors.New("http source not yet implemented")
+func (f *FileAdaptor) Get(ctx context.Context, zctx *zson.Context, url string, pushdown zbuf.Filter) (zbuf.PullerCloser, error) {
+	return f.Open(ctx, zctx, url, pushdown)
 }

--- a/cmd/zq/ztests/http-multiple.yaml
+++ b/cmd/zq/ztests/http-multiple.yaml
@@ -1,0 +1,18 @@
+script: |
+  . http.bash
+  zq -z "sort ts" $http_base_url/log1.zson $http_base_url/log2.zson
+
+inputs:
+  - name: http.bash
+  - name: log1.zson
+    data: |
+      {ts:2018-03-24T17:15:21.255387Z,uid:"C8Tful1TvM3Zf5x8fl" (bstring)} (=0)
+  - name: log2.zson
+    data: |
+      {ts:2018-03-24T17:15:21.411148Z,uid:"CXWfTK3LRdiuQxBbM6" (bstring)} (=0)
+
+outputs:
+  - name: stdout
+    data: |
+      {ts:2018-03-24T17:15:21.255387Z,uid:"C8Tful1TvM3Zf5x8fl" (bstring)} (=0)
+      {ts:2018-03-24T17:15:21.411148Z,uid:"CXWfTK3LRdiuQxBbM6"} (0)

--- a/cmd/zq/ztests/http-notexist.yaml
+++ b/cmd/zq/ztests/http-notexist.yaml
@@ -1,0 +1,11 @@
+script: |
+  . http.bash
+  zq -z $http_base_url/does/not/exist
+
+inputs:
+  - name: http.bash
+
+outputs:
+  - name: stderr
+    regexp: |
+      http://127.0.0.1:\d+/does/not/exist: item does not exist

--- a/cmd/zq/ztests/http-simple.yaml
+++ b/cmd/zq/ztests/http-simple.yaml
@@ -1,0 +1,13 @@
+script: |
+  . http.bash
+  zq -z 'count()' $http_base_url/babble.zson
+
+inputs:
+  - name: http.bash
+  - name: babble.zson
+    source: ../../../testdata/babble.zson
+
+outputs:
+  - name: stdout
+    data: |
+      {count:1000 (uint64)} (=0)

--- a/cmd/zq/ztests/http.bash
+++ b/cmd/zq/ztests/http.bash
@@ -1,0 +1,18 @@
+http_port=$((RANDOM + 1024))
+http_base_url=http://127.0.0.1:$http_port
+
+python3 -m http.server -b 127.0.0.1 $http_port &> http.log &
+trap "kill -9 $!" EXIT
+
+i=0
+while :; do
+    python3 -c "from urllib.request import *; urlopen('$http_base_url')" &&
+        break
+    sleep 0.5
+    if ((i++ >= 10)); then
+        echo "timed out waiting for HTTP server"
+        echo "http.log:"
+        cat http.log
+        exit 1
+    fi
+done


### PR DESCRIPTION
This makes the following command work.

    zq -z https://github.com/brimdata/zed/raw/main/testdata/babble.zson

Closes #734.