### PR TITLE
fix resolver.Mapper lock bug and further simplify

### DIFF
--- a/zio/mapper.go
+++ b/zio/mapper.go
@@ -27,7 +27,7 @@ func (m *Mapper) Read() (*zng.Record, error) {
 		return nil, nil
 	}
 	id := zng.TypeID(rec.Type)
-	sharedType := m.mapper.Map(id)
+	sharedType := m.mapper.Lookup(id)
 	if sharedType == nil {
 		sharedType, err = m.mapper.Enter(id, rec.Type)
 		if err != nil {

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -211,7 +211,7 @@ func readValue(r reader, code byte, m *resolver.Mapper, validate bool, rec *zng.
 		}
 		return nil, zng.ErrBadFormat
 	}
-	typ := m.Map(id)
+	typ := m.Lookup(id)
 	if typ == nil {
 		return nil, zng.ErrTypeIDInvalid
 	}

--- a/zng/flattener/flattener.go
+++ b/zng/flattener/flattener.go
@@ -70,7 +70,7 @@ func recode(dst zcode.Bytes, typ *zng.TypeRecord, in zcode.Bytes) (zcode.Bytes, 
 
 func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 	id := r.Type.ID()
-	flatType := f.mapper.Map(id)
+	flatType := f.mapper.Lookup(id)
 	if flatType == nil {
 		cols := FlattenColumns(r.Columns())
 		var err error

--- a/zng/resolver/mapper.go
+++ b/zng/resolver/mapper.go
@@ -18,7 +18,7 @@ func NewMapper(out *zson.Context) *Mapper {
 }
 
 // Lookup tranlates Zed types by type ID from one context to another.
-// The first context is implied by the argument to Map() and the output
+// The first context is implied by the argument to Lookup() and the output
 // type context is explicitly determined by the argument to NewMapper().
 // If a binding has not yet been entered, nil is returned and Enter()
 // should be called to create the binding.  There is a race here when two

--- a/zng/resolver/mapper.go
+++ b/zng/resolver/mapper.go
@@ -48,7 +48,6 @@ func (m *Mapper) Enter(id int, ext zng.Type) (zng.Type, error) {
 
 func (m *Mapper) EnterType(td int, typ zng.Type) {
 	m.mu.Lock()
-	defer m.mu.Lock()
 	if td >= cap(m.types) {
 		new := make([]zng.Type, td+1, td*2)
 		copy(new, m.types)
@@ -57,4 +56,5 @@ func (m *Mapper) EnterType(td int, typ zng.Type) {
 		m.types = m.types[:td+1]
 	}
 	m.types[td] = typ
+	m.mu.Unlock()
 }

--- a/zng/resolver/mapper.go
+++ b/zng/resolver/mapper.go
@@ -17,17 +17,23 @@ func NewMapper(out *zson.Context) *Mapper {
 	return &Mapper{outputCtx: out}
 }
 
-// Map maps an input side descriptor ID to an output side descriptor.
-// The outputs are stored in a Slice, which will create a new decriptor if
-// the type mapping is unknown to it.  The output side is assumed to be shared
-// while the input side owned by one thread of control.
-func (m *Mapper) Map(td int) zng.Type {
+// Lookup tranlates Zed types by type ID from one context to another.
+// The first context is implied by the argument to Map() and the output
+// type context is explicitly determined by the argument to NewMapper().
+// If a binding has not yet been entered, nil is returned and Enter()
+// should be called to create the binding.  There is a race here when two
+// threads attempt to update the same ID, but it is safe because the
+// outputContext will return the same the pointer so the second update
+// does not change anything.
+func (m *Mapper) Lookup(td int) zng.Type {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.Lookup(td)
+	if td < len(m.types) {
+		return m.types[td]
+	}
+	return nil
 }
 
-//XXX Enter should allocate the td as it creates the new type in the output context
 func (m *Mapper) Enter(id int, ext zng.Type) (zng.Type, error) {
 	typ, err := m.outputCtx.TranslateType(ext)
 	if err != nil {
@@ -40,19 +46,9 @@ func (m *Mapper) Enter(id int, ext zng.Type) (zng.Type, error) {
 	return nil, nil
 }
 
-func (m *Mapper) Translate(foreign zng.Type) (zng.Type, error) {
-	id := foreign.ID()
-	m.mu.RLock()
-	local := m.Map(id)
-	m.mu.RUnlock()
-	if local != nil {
-		return local, nil
-	}
-	return m.Enter(id, foreign)
-}
-
 func (m *Mapper) EnterType(td int, typ zng.Type) {
 	m.mu.Lock()
+	defer m.mu.Lock()
 	if td >= cap(m.types) {
 		new := make([]zng.Type, td+1, td*2)
 		copy(new, m.types)
@@ -61,14 +57,4 @@ func (m *Mapper) EnterType(td int, typ zng.Type) {
 		m.types = m.types[:td+1]
 	}
 	m.types[td] = typ
-	m.mu.Unlock()
-}
-
-func (m *Mapper) Lookup(td int) zng.Type {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	if td < len(m.types) {
-		return m.types[td]
-	}
-	return nil
 }


### PR DESCRIPTION
This commit fixes a locking bug introduced recently.
While we were here we deleted unused code and changed
Mapper.Map() to Mapper.Lookup() for consistency with
zson.Context.Lookup().