### PR TITLE
fix parallelizer bug with summarize key expressions

### DIFF
--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -83,6 +83,13 @@ func (o *Optimizer) parallelizeTrunk(seq *dag.Sequential, trunk *dag.Trunk, repl
 		egress := copyOp(ingress).(*dag.Summarize)
 		egress.PartialsOut = true
 		ingress.PartialsIn = true
+		// The upstream aggregators will compute any key expressions
+		// so the ingress aggregator should simply reference the key
+		// by its name.  This loop updates the ingress to do so.
+		keys := ingress.Keys
+		for k := range keys {
+			keys[k].RHS = keys[k].LHS
+		}
 		extend(trunk, egress)
 		seq.Ops[1] = ingress
 		//

--- a/compiler/ztests/par-every-count.yaml
+++ b/compiler/ztests/par-every-count.yaml
@@ -13,4 +13,4 @@ outputs:
       )
       | merge ts:asc
       | summarize every 1h partials-in sort-dir 1
-          count:=count() by ts:=trunc(ts, 1h),y:=y
+          count:=count() by ts:=ts,y:=y

--- a/compiler/ztests/par-groupby-func.yaml
+++ b/compiler/ztests/par-groupby-func.yaml
@@ -1,0 +1,15 @@
+script: zc -P 2 -C "from 'pool-s' | union(s) by n:=len(s)"
+
+outputs:
+  - name: stdout
+    data: |
+      from (
+        G2eDzBUfU6IEmUSGCa5kHyXMhoO =>
+          summarize partials-out
+              union:=union(s) by n:=len(s);
+        G2eDzBUfU6IEmUSGCa5kHyXMhoO =>
+          summarize partials-out
+              union:=union(s) by n:=len(s);
+      )
+      | summarize partials-in
+          union:=union(s) by n:=n

--- a/lake/ztests/group-by-func.yaml
+++ b/lake/ztests/group-by-func.yaml
@@ -1,0 +1,22 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -q -p data -orderby s:asc
+  head -2 in.zson | zed lake load -q -p data -
+  tail -3 in.zson | zed lake load -q -p data -
+  zed lake query -z 'from data | union(s) by len(s) | sort this'
+
+inputs:
+  - name: in.zson
+    data: |
+      {s:"a"}
+      {s:"ab"}
+      {s:"bc"}
+      {s:"d"}
+      {s:"e"}
+
+outputs:
+  - name: stdout
+    data: |
+      {len:1,union:|["a","d","e"]|}
+      {len:2,union:|["ab","bc"]|}


### PR DESCRIPTION
This commit fixes a bug in the flowgraph parallelizer where
the partials-in aggregator uses the wrong key expressions,
i.e., it uses the group-by key expressions "as is" rather than
referencing the key value already computed upstream.

This bug dates back to the original implementation of the
optimizer.

Closes #2728