### PR TITLE
Double quotes on pip3 target to benefit Windows

### DIFF
--- a/python/zqd/README.md
+++ b/python/zqd/README.md
@@ -7,7 +7,7 @@ The `zqd` Python package provides a client for the REST API served by
 
 Install the latest version like this:
 ```sh
-pip install 'git+https://github.com/brimdata/zed#subdirectory=python/zqd'
+pip install "git+https://github.com/brimdata/zed#subdirectory=python/zqd"
 ```
 
 Install the version compatible with a local `zqd` like this:


### PR DESCRIPTION
File under "ya learn something new every day"...

 A community user emailed Brim Support and reported they were not able to follow our guidance to install the Python module.

```
C:\> pip3 install 'git+https://github.com/brimsec/zq#subdirectory=python/zqd'                                          
ERROR: Invalid requirement: "'git+https://github.com/brimsec/zq#subdirectory=python/zqd'"                                                                       
Hint: = is not a valid operator. Did you mean == ?
```

A little web research reveals that double quotes are needed on Windows. Those work fine on Linux also of course, so I'm switching over in this PR.

```
C:\> pip3 install "git+https://github.com/brimsec/zq#subdirectory=python/zqd"                                          
Collecting git+https://github.com/brimsec/zq#subdirectory=python/zqd            
...
Successfully installed certifi-2020.12.5 chardet-4.0.0 durationpy-0.5 idna-2.10 
python-dateutil-2.8.1 requests-2.25.1 six-1.16.0 urllib3-1.26.4 zqd-0.0.0       
```