### PR TITLE
fix dataflow through cut operators

### DIFF
--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -166,7 +166,7 @@ func analyzeCuts(assignments []dag.Assignment, layout order.Layout) order.Layout
 		lhsKey := fieldKey(lhs)
 		if rhs == nil {
 			// If the RHS depends on a well-defined set of fields
-			// (non of which are unambiguous like this.foo[this.bar]),
+			// (none of which are unambiguous like this.foo[this.bar]),
 			// and if all of such dependencies do not have an order
 			// to preserve, then we can continue along by clearing
 			// the LHS from the scoreboard knowing that is being set
@@ -214,7 +214,7 @@ func analyzeCuts(assignments []dag.Assignment, layout order.Layout) order.Layout
 func fieldKey(f field.Path) string {
 	var b []byte
 	for _, s := range f {
-		b = append(b, []byte(s)...)
+		b = append(b, s...)
 		b = append(b, 0)
 	}
 	return string(b)

--- a/compiler/ztests/par-layout-dataflow.yaml
+++ b/compiler/ztests/par-layout-dataflow.yaml
@@ -1,0 +1,24 @@
+script: |
+  zc -C -P 2 "from 'pool-ts:asc' | cut x:=ts,ts:=1"
+  echo ===
+  zc -C -P 2 "from 'pool-ts:desc' | cut x:=ts,ts:=1"
+
+
+outputs:
+  - name: stdout
+    data: |
+      from (
+        G2eDzBUfU6IEmUSGCa5kHyXMhoO =>
+          cut x:=ts,ts:=1;
+        G2eDzBUfU6IEmUSGCa5kHyXMhoO =>
+          cut x:=ts,ts:=1;
+      )
+      | merge x:asc
+      ===
+      from (
+        G2eDzBUfU6IEmUSGCa5kHyXMhoO =>
+          cut x:=ts,ts:=1;
+        G2eDzBUfU6IEmUSGCa5kHyXMhoO =>
+          cut x:=ts,ts:=1;
+      )
+      | merge x:desc

--- a/compiler/ztests/par-put-ts-rename-count.yaml
+++ b/compiler/ztests/par-put-ts-rename-count.yaml
@@ -1,3 +1,5 @@
+skip: we no longer parallelize now when we clobber the sort key.  issue 2756
+
 script: zed compile -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo | count()"
 
 outputs:

--- a/compiler/ztests/par-put-ts-rename-sort.yaml
+++ b/compiler/ztests/par-put-ts-rename-sort.yaml
@@ -1,3 +1,5 @@
+skip: we no longer parallelize now when we clobber the sort key.  issue 2756
+
 script: zed compile -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo | sort"
 
 outputs:

--- a/compiler/ztests/par-put-ts-rename.yaml
+++ b/compiler/ztests/par-put-ts-rename.yaml
@@ -1,3 +1,5 @@
+skip: we no longer parallelize now when we clobber the sort key.  issue 2756
+
 script: zed compile -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo"
 
 outputs:


### PR DESCRIPTION
This commit fixes a problem where a query would be incorrectly
parallelized by merging on the wrong key because sufficient
dataflow info was not properly tracked.  While we fixed this
we broke another optimization that doesn't seem important to
maintain (and anyway was based on flawed logic).  These tests
are marked "skip".  When we implement proper dataflow analysis
as part of issue #2756, we can turn the tests back on.

Closes #2663 