### PR TITLE
fix read/write race in journal.Queue

### DIFF
--- a/lake/journal/journal_test.go
+++ b/lake/journal/journal_test.go
@@ -1,0 +1,48 @@
+package journal
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func newQueue(ctx context.Context, t *testing.T) *Queue {
+	path := storage.MustParseURI(t.TempDir())
+	engine := storage.NewLocalEngine()
+	q, err := Create(ctx, engine, path)
+	require.NoError(t, err)
+	return q
+}
+
+func TestJournalConcurrent(t *testing.T) {
+	ctx := context.Background()
+	q := newQueue(ctx, t)
+	const N = 50
+	ch := make(chan error)
+	for i := 0; i < N; i++ {
+		go func(which int) {
+			for {
+				err := q.Commit(ctx, []byte("hello, world"))
+				if os.IsExist(err) {
+					continue
+				}
+				if err == nil {
+					ch <- err
+					return
+				}
+				head, _ := q.ReadHead(ctx)
+				tail, _ := q.ReadTail(ctx)
+				err = fmt.Errorf("%d: head %d, tail %d: %s", which, head, tail, err)
+				ch <- err
+				return
+			}
+		}(i)
+	}
+	for i := 0; i < N; i++ {
+		require.NoError(t, <-ch)
+	}
+}

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -142,7 +142,7 @@ func readID(ctx context.Context, engine storage.Engine, path *storage.URI) (ID, 
 		}
 		retry++
 		if retry > MaxReadRetry {
-			return Nil, errors.New("can read but not parse contents of journal HEAD")
+			return Nil, fmt.Errorf("can read but not parse contents of journal HEAD: %s", string(b))
 		}
 		time.Sleep(timeout)
 		timeout *= 2

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/brimdata/zed/pkg/byteconv"
 	"github.com/brimdata/zed/pkg/storage"
@@ -23,6 +24,8 @@ var (
 type ID uint64
 
 const Nil ID = 0
+
+const MaxReadRetry = 10
 
 type Queue struct {
 	engine   storage.Engine
@@ -127,15 +130,21 @@ func writeID(ctx context.Context, engine storage.Engine, u *storage.URI, id ID) 
 }
 
 func readID(ctx context.Context, engine storage.Engine, path *storage.URI) (ID, error) {
-	b, err := storage.Get(ctx, engine, path)
-	if err != nil {
-		return Nil, err
+	var retry int
+	for {
+		b, err := storage.Get(ctx, engine, path)
+		if err != nil {
+			return Nil, err
+		}
+		if id, err := byteconv.ParseUint64(b); err == nil {
+			return ID(id), nil
+		}
+		retry++
+		if retry > MaxReadRetry {
+			return Nil, errors.New("can read but not parse contents of journal HEAD")
+		}
+		time.Sleep(time.Millisecond)
 	}
-	id, err := byteconv.ParseUint64(b)
-	if err != nil {
-		return Nil, err
-	}
-	return ID(id), nil
 }
 
 func Create(ctx context.Context, engine storage.Engine, path *storage.URI) (*Queue, error) {

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -143,7 +143,7 @@ func readID(ctx context.Context, engine storage.Engine, path *storage.URI) (ID, 
 		}
 		retry++
 		if retry > MaxReadRetry || timeout > 5*time.Second {
-			return Nil, fmt.Errorf("can read but not parse contents of journal HEAD: %s", string(b))
+			return Nil, fmt.Errorf("can read but not parse contents of journal HEAD: %s", b)
 		}
 		select {
 		case <-time.After(timeout):

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -145,7 +145,11 @@ func readID(ctx context.Context, engine storage.Engine, path *storage.URI) (ID, 
 		if retry > MaxReadRetry || timeout > 5*time.Second {
 			return Nil, fmt.Errorf("can read but not parse contents of journal HEAD: %s", string(b))
 		}
-		time.Sleep(timeout)
+		select {
+		case <-time.After(timeout):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 		t := 2 * int(timeout)
 		timeout = time.Duration(t + rand.Intn(t))
 	}

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -131,6 +131,7 @@ func writeID(ctx context.Context, engine storage.Engine, u *storage.URI, id ID) 
 
 func readID(ctx context.Context, engine storage.Engine, path *storage.URI) (ID, error) {
 	var retry int
+	timeout := time.Millisecond
 	for {
 		b, err := storage.Get(ctx, engine, path)
 		if err != nil {
@@ -143,7 +144,11 @@ func readID(ctx context.Context, engine storage.Engine, path *storage.URI) (ID, 
 		if retry > MaxReadRetry {
 			return Nil, errors.New("can read but not parse contents of journal HEAD")
 		}
-		time.Sleep(time.Millisecond)
+		time.Sleep(timeout)
+		timeout *= 2
+		if timeout > time.Second {
+			timeout = time.Second
+		}
 	}
 }
 

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -148,7 +148,7 @@ func readID(ctx context.Context, engine storage.Engine, path *storage.URI) (ID, 
 		select {
 		case <-time.After(timeout):
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return Nil, ctx.Err()
 		}
 		t := 2 * int(timeout)
 		timeout = time.Duration(t + rand.Intn(t))

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -141,14 +142,12 @@ func readID(ctx context.Context, engine storage.Engine, path *storage.URI) (ID, 
 			return ID(id), nil
 		}
 		retry++
-		if retry > MaxReadRetry {
+		if retry > MaxReadRetry || timeout > 5*time.Second {
 			return Nil, fmt.Errorf("can read but not parse contents of journal HEAD: %s", string(b))
 		}
 		time.Sleep(timeout)
-		timeout *= 2
-		if timeout > time.Second {
-			timeout = time.Second
-		}
+		t := 2 * int(timeout)
+		timeout = time.Duration(t + rand.Intn(t))
 	}
 }
 


### PR DESCRIPTION
When reading HEAD, the journal can read the contents while
a writer has opened and truncated the contents but before the
writer has written the updated HEAD.  This happens only on
file systems, not cloud objects, as cloud writes are atomic.

The fix is to simply retry the read when the read is successful
but the content cannot be parsed.  This fix is preferred over
a more complicated locking model as the HEAD read is just advisory
and not required for correctness of the log abstraction.

Closes #2699