### PR TITLE
disable cut warnings for parallel lake queries

### DIFF
--- a/compiler/ast/dag/operator.go
+++ b/compiler/ast/dag/operator.go
@@ -24,8 +24,9 @@ var PassOp = &Pass{Kind: "Pass"}
 
 type (
 	Cut struct {
-		Kind string       `json:"kind" unpack:""`
-		Args []Assignment `json:"args"`
+		Kind  string       `json:"kind" unpack:""`
+		Args  []Assignment `json:"args"`
+		Quiet bool         `json:"quiet"`
 	}
 	Drop struct {
 		Kind string `json:"kind" unpack:""`

--- a/compiler/kernel/proc.go
+++ b/compiler/kernel/proc.go
@@ -105,6 +105,9 @@ func (b *Builder) compileLeaf(op dag.Op, parent proc.Interface) (proc.Interface,
 			return nil, err
 		}
 		cutter.AllowPartialCuts()
+		if v.Quiet {
+			cutter.Quiet()
+		}
 		return proc.FromFunction(b.pctx, parent, cutter), nil
 	case *dag.Pick:
 		assignments, err := compileAssignments(v.Args, b.pctx.Zctx, b.scope)

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -215,11 +215,23 @@ func (o *Optimizer) Parallelize(n int) error {
 	from := seq.Ops[0].(*dag.From)
 	trunks := poolTrunks(from)
 	if len(trunks) == 1 {
+		quietCuts(trunks[0])
 		if err := o.parallelizeTrunk(seq, trunks[0], replicas); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func quietCuts(trunk *dag.Trunk) {
+	if trunk.Seq == nil {
+		return
+	}
+	for _, op := range trunk.Seq.Ops {
+		if cut, ok := op.(*dag.Cut); ok {
+			cut.Quiet = true
+		}
+	}
 }
 
 func poolTrunks(from *dag.From) []*dag.Trunk {

--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -25,6 +25,7 @@ type Cutter struct {
 	droppers     []*Dropper
 	dropperCache []*Dropper
 	dirty        bool
+	quiet        bool
 }
 
 // NewCutter returns a Cutter for fieldnames. If complement is true,
@@ -63,6 +64,10 @@ func (c *Cutter) AllowPartialCuts() {
 	n := len(c.fieldRefs)
 	c.droppers = make([]*Dropper, n)
 	c.dropperCache = make([]*Dropper, n)
+}
+
+func (c *Cutter) Quiet() {
+	c.quiet = true
 }
 
 func (c *Cutter) FoundCut() bool {
@@ -168,7 +173,7 @@ func fieldList(fields []Evaluator) string {
 func (_ *Cutter) String() string { return "cut" }
 
 func (c *Cutter) Warning() string {
-	if c.FoundCut() {
+	if c.quiet || c.FoundCut() {
 		return ""
 	}
 	return fmt.Sprintf("no record found with columns %s", fieldList(c.fieldExprs))

--- a/lake/ztests/quiet-cut.yaml
+++ b/lake/ztests/quiet-cut.yaml
@@ -1,0 +1,17 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -p logs -q
+  zed lake load -q -p logs in.zson
+  zed lake query "from logs | cut notafield"
+
+inputs:
+  - name: in.zson
+    data: |
+      {x:1}
+      {x:2}
+      {x:3}
+
+outputs:
+  - name: stderr
+    data: ""


### PR DESCRIPTION
When a query having a cut is parallelized, the warnings can occur
even though a field is found on one of the parallelized branches.
In fact, every branch that does not find the cut fields, issues a
warning.  This commit disables cut warning for queries that are
parallelized to avoid this problem.  A better approach is to warn
at compile-time based on the presence of fields gleened from type
information that will be stored with each segment.  This approach
will be implemented in a future PR.

Closes #2759 