### PR TITLE
add line number to TestMarkdownExample subtest names

### DIFF
--- a/tests/zq_example.go
+++ b/tests/zq_example.go
@@ -281,17 +281,10 @@ func TestcasesFromFile(filename string) ([]ZQExampleTest, error) {
 	if err != nil {
 		return nil, err
 	}
-	for i, example := range examples {
-		// Convert strings like
-		// /home/user/zql/docs/processors/README.md to
-		// /zql/docs/processors/README.md . RepoAbsPath() does not
-		// include a trailing filepath.Separator in its return.
-		testname := strings.TrimPrefix(absfilename, repopath)
-		// Now convert strings like /zql/docs/processors/README.md to
-		// zql/docs/processors/README.md1 go test will call such a test
-		// something like
-		// TestMarkdownExamples/zql/docs/processors/README.md1
-		testname = strings.TrimPrefix(testname, string(filepath.Separator)) + strconv.Itoa(i+1)
+	repopath += string(filepath.Separator)
+	for _, example := range examples {
+		linenum := bytes.Count(source[:example.command.Info.Segment.Start], []byte("\n")) + 2
+		testname := strings.TrimPrefix(absfilename, repopath) + ":" + strconv.Itoa(linenum)
 
 		command, err := QualifyCommand(BlockString(example.command, source))
 		if err != nil {


### PR DESCRIPTION
TestMarkdownExample subtests with a single Markdown file have names  
ending in sequential numbers, making the test source hard to find when a  
test fail. Change the sequential numbers to line numbers so that, for  
example, the test whose command appears on line 317 of  
docs/language/operators/README.md is named  
TestMarkdownExample/docs/language/operators/README.md:317.

Closes #2264