### PR TITLE
rework TestMarkdownExamples to use bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-run: build bin/minio
 	@ZTEST_PATH="$(CURDIR)/dist:$(CURDIR)/bin" go test . -run $(TEST)
 
 test-heavy: build $(SAMPLEDATA)
-	@go test -tags=heavy ./tests
+	@PATH="$(CURDIR)/dist:$(PATH)" go test -tags=heavy ./tests
 
 .PHONY: test-services
 test-services: build

--- a/docs/language/aggregate-functions/README.md
+++ b/docs/language/aggregate-functions/README.md
@@ -37,7 +37,7 @@ Multiple aggregate functions may be invoked at the same time.
 To simultaneously calculate the minimum, maximum, and average of connection
 duration:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'min(duration),max(duration),avg(duration)' conn.log.gz
 ```
 
@@ -55,7 +55,7 @@ instead use `:=` to specify an explicit name for the generated field.
 
 #### Example:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'quickest:=min(duration),longest:=max(duration),typical:=avg(duration)' conn.log.gz
 ```
 
@@ -82,7 +82,7 @@ function will operate.
 To check whether we've seen higher DNS round-trip times when servers return
 longer lists of `answers`:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'answers != null | every 5m short_rtt:=avg(rtt) where len(answers)<=2, short_count:=count() where len(answers)<=2, long_rtt:=avg(rtt) where len(answers)>2, long_count:=count() where len(answers)>2 | sort ts' dns.log.gz
 ```
 
@@ -114,7 +114,7 @@ TS                   SHORT_RTT            SHORT_COUNT LONG_RTT             LONG_
 Let's say you've been studying `weird` records and noticed that lots of
 connections have made one or more bad HTTP requests.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count() by name | sort -r count' weird.log.gz
 ```
 
@@ -131,7 +131,7 @@ above_hole_data_without_any_acks            107
 To count the number of connections for which this was the _only_ category of
 `weird` record observed:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'only_bads:=and(name=="bad_HTTP_request") by uid | count() where only_bads==true' weird.log.gz
 ```
 
@@ -156,7 +156,7 @@ COUNT
 
 To see the `name` of a Zeek `weird` record in our sample data:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'any(name)' weird.log.gz
 ```
 
@@ -186,7 +186,7 @@ TCP_ack_underflow_or_misorder
 To calculate the average number of bytes originated by all connections as
 captured in Zeek `conn` records:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'avg(orig_bytes)' conn.log.gz
 ```
 
@@ -212,7 +212,7 @@ AVG
 To assemble the sequence of HTTP methods invoked in each interaction with the
 Bing search engine:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'host=="www.bing.com" | methods:=collect(method) by uid | sort uid' http.log.gz
 ```
 
@@ -241,7 +241,7 @@ CI0SCN14gWpY087KA3 GET,POST,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET
 
 To count the number of records in the entire sample data set:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count()' *.log.gz
 ```
 
@@ -257,7 +257,7 @@ Let's say we wanted to know how many records contain a field called `mime_type`.
 The following example shows us that count and that the field is present in
 our Zeek `ftp` and `files` records.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count(mime_type) by _path | filter count > 0 | sort -r count' *.log.gz
 ```
 
@@ -283,7 +283,7 @@ ftp   93
 
 To see an approximate count of unique `uid` values in our sample data set:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'countdistinct(uid)' *
 ```
 
@@ -295,7 +295,7 @@ COUNTDISTINCT
 
 To see the precise value, which may take longer to execute:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count() by uid | count()' *
 ```
 
@@ -324,7 +324,7 @@ to perform this test, the Zed using `countdistinct()` executed almost 3x faster.
 To see the maximum number of bytes originated by any connection in our sample
 data:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'max(orig_bytes)' conn.log.gz
 ```
 
@@ -350,7 +350,7 @@ MAX
 To see the quickest round trip time of all DNS queries observed in our sample
 data:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'min(rtt)' dns.log.gz
 ```
 
@@ -376,7 +376,7 @@ MIN
 Let's say you've noticed there's lots of HTTP traffic happening on ports higher
 than the standard port `80`.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count() by id.resp_p | sort -r count' http.log.gz
 ```
 
@@ -393,7 +393,7 @@ ID.RESP_P COUNT
 The following query confirms this high-port traffic is present, but that none
 of those ports are higher than what TCP allows.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'some_highports:=or(id.resp_p>80),impossible_ports:=or(id.resp_p>65535)' http.log.gz
 ```
 
@@ -419,7 +419,7 @@ T              F
 To calculate the total number of bytes across all file payloads logged in our
 sample data:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'sum(total_bytes)' files.log.gz
 ```
 
@@ -446,7 +446,7 @@ SUM
 To observe which HTTP methods were invoked in each interaction with the Bing
 search engine:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'host=="www.bing.com" | methods:=union(method) by uid | sort uid' http.log.gz
 ```
 

--- a/docs/language/data-types/README.md
+++ b/docs/language/data-types/README.md
@@ -30,7 +30,7 @@ However, if we cast it to an `ip` type, now the CIDR match is successful. The
 `bad cast` warning on stderr tells us that some of the values for `ref_id`
 could _not_ be successfully cast to `ip`.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'put ref_id:=ip(ref_id)| filter ref_id in 83.162.0.0/16 | count()' ntp.log.gz
 ```
 

--- a/docs/language/expressions/README.md
+++ b/docs/language/expressions/README.md
@@ -3,7 +3,7 @@
 Comprehensive documentation for Zed expressions is still a work in progress. In
 the meantime, here's an example expression with simple math to get started:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'duration > 100 | put total_bytes:=orig_bytes+resp_bytes | cut orig_bytes,resp_bytes,total_bytes' conn.log.gz
 ```
 

--- a/docs/language/grouping/README.md
+++ b/docs/language/grouping/README.md
@@ -42,7 +42,7 @@ specification of each unit.
 To see the total number of bytes originated across all connections during each
 minute:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'every 1m sum(orig_bytes) | sort -r ts' conn.log.gz
 ```
 
@@ -61,7 +61,7 @@ TS                   SUM
 To see which 30-second intervals contained the most records, expressing the
 duration as a half-minute:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'every 0.5m count() | sort -r count' *.log.gz
 ```
 
@@ -79,7 +79,7 @@ TS                   COUNT
 To see the highest-numbered responding network port during each 90-second
 interval, expressing the duration as a mix of minutes and seconds:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'every 1m30s max(id.resp_p) | sort -r ts' conn.log.gz
 ```
 
@@ -105,7 +105,7 @@ The simplest example summarizes the unique values of the named field(s), which
 requires no aggregate function. To see which protocols were observed in our
 Zeek `conn` records:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'by proto | sort' conn.log.gz
 ```
 
@@ -121,7 +121,7 @@ If you work a lot at the UNIX/Linux shell, you might have sought to accomplish
 the same via a familiar, verbose idiom. This works in Zed, but the `by`
 shorthand is preferable.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'cut proto | sort | uniq' conn.log.gz
 ```
 
@@ -139,7 +139,7 @@ By specifying multiple comma-separated field names, one batch is formed for each
 unique combination of values found in those fields. To see which responding
 IP+port combinations generated the most traffic:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'sum(resp_bytes) by id.resp_h,id.resp_p  | sort -r sum' conn.log.gz
 ```
 
@@ -166,7 +166,7 @@ responding DNS servers generated the longest answers, we can group by
 both `id.resp_h` and an expression that evaluates the length of `answers`
 arrays.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'len(answers) > 0 | count() by id.resp_h,num_answers:=len(answers) | sort -r num_answers,count' dns.log.gz
 ```
 
@@ -188,7 +188,7 @@ the grouping to have effect.
 Let's say we've performed separate aggregations for fields present in different
 Zeek records. First we count the unique `host` values in `http` records.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count() by host | sort -r | head 3' http.log.gz
 ```
 
@@ -202,7 +202,7 @@ HOST       COUNT
 
 Next we count the unique `query` values in `dns` records.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count() by query | sort -r | head 3' dns.log.gz
 ```
 
@@ -226,7 +226,7 @@ and the `host` field not being present in any of the `dns` records. This can
 be observed by looking at the [ZSON](../../formats/zson.md)
 representation of the type definitions for each record type.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f zson 'count() by _path,typeof(.) | sort _path' http.log.gz dns.log.gz
 ```
 
@@ -250,7 +250,7 @@ records under a single schema. This has the effect of populating missing
 fields with null values. Now that the named fields are present in
 all records, the `by` grouping has the desired effect.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'fuse | count() by host,query | sort -r | head 3' http.log.gz dns.log.gz
 ```
 
@@ -273,7 +273,7 @@ should be used downstream of the aggregate function(s) in the Zed pipeline.
 If we were counting records into 5-minute batches and wanted to see these
 results ordered by incrementing timestamp of each batch:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'every 5m count() | sort ts' *.log.gz
 ```
 
@@ -289,7 +289,7 @@ TS                   COUNT
 
 If we'd wanted to see them ordered from lowest to highest record count:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'every 5m count() | sort count' *.log.gz
 ```
 

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -43,7 +43,7 @@ The following available operators are documented in detail below:
 
 To return only the `ts` and `uid` columns of `conn` records:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'cut ts,uid' conn.log.gz
 ```
 
@@ -64,7 +64,7 @@ the Zeek `smb_mapping` logs in our sample data contain the field named
 `share_type`, the following query returns records for many other log types that
 contain the `_path` and/or `ts` that we included in our field list.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'cut _path,ts,share_type' *
 ```
 
@@ -85,7 +85,7 @@ Contrast this with a [similar example](#example-2-3) that shows how
 If no records are found that contain any of the named fields, `cut` returns a
 warning.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'cut nothere,alsoabsent' weird.log.gz
 ```
 
@@ -99,7 +99,7 @@ cut: no record found with columns nothere,alsoabsent
 To return only the `ts` and `uid` columns of `conn` records, with `ts` renamed
 to `time`:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'cut time:=ts,uid' conn.log.gz
 ```
 
@@ -127,7 +127,7 @@ TIME                        UID
 To return all fields _other than_ the `_path` field and `id` record of `weird`
 records:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'drop _path,id' weird.log.gz
 ```
 
@@ -160,7 +160,7 @@ TS                          UID                NAME                             
 
 To further trim the data returned in our [`cut`](#cut) example:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'cut ts,uid | filter uid=="CXWfTK3LRdiuQxBbM6"' conn.log.gz
 ```
 
@@ -174,7 +174,7 @@ TS                          UID
 
 An alternative syntax for our [`and` example](../search-syntax/README.md#and):
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'filter www.*cdn*.com _path=="ssl"' *.log.gz
 ```
 
@@ -201,7 +201,7 @@ ssl   2018-03-24T17:24:00.189735Z CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85
 
 Let's say you'd started with table-formatted output of both `stats` and `weird` records:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'ts < 1521911721' stats.log.gz weird.log.gz
 ```
 
@@ -239,7 +239,7 @@ is assembled in a first pass through the data stream, which enables the
 presentation of the results under a single, wider header row with no further
 interruptions between the subsequent data rows.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f csv 'ts < 1521911721 | fuse' stats.log.gz weird.log.gz
 ```
 
@@ -271,7 +271,7 @@ Other output formats invoked via `zq -f` that benefit greatly from the use of
 
 To see the first `dns` record:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'head' dns.log.gz
 ```
 
@@ -285,7 +285,7 @@ dns   2018-03-24T17:15:20.865716Z C2zK5f13SbCtKcyiW5 10.47.1.100 41772     10.0.
 
 To see the first five `conn` records with activity on port `80`:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'id.resp_p==80 | head 5' conn.log.gz
 ```
 
@@ -313,7 +313,7 @@ conn  2018-03-24T17:15:20.607695Z CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.
 
 To return only the `ts` and `uid` columns of `conn` records:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'pick ts,uid' conn.log.gz
 ```
 
@@ -334,7 +334,7 @@ data contains the field named `share_type`, the following query returns columns
 for only that record type. The many other Zeek record types that also include
 `_path` and/or `ts` fields are not returned.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'pick _path,ts,share_type' *
 ```
 
@@ -355,7 +355,7 @@ Contrast this with a [similar example](#example-2) that shows how
 If no records are found that contain any of the named fields, `pick` returns a
 warning.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'pick nothere,alsoabsent' weird.log.gz
 ```
 
@@ -369,7 +369,7 @@ pick: no record found with columns nothere,alsoabsent
 To return only the `ts` and `uid` columns of `conn` records, with `ts` renamed
 to `time`:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'pick time:=ts,uid' conn.log.gz
 ```
 
@@ -398,7 +398,7 @@ TIME                        UID
 
 Compute a `total_bytes` field in `conn` records:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -q -f table 'put total_bytes := orig_bytes + resp_bytes | sort -r total_bytes | cut id, orig_bytes, resp_bytes, total_bytes' conn.log.gz
 ```
 
@@ -429,7 +429,7 @@ ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P ORIG_BYTES RESP_BYTES TOTAL_BY
 
 Rename `ts` to `time`, rename one of the inner fields of `id`, and rename the `id` record itself to `conntuple`:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
  zq -f table 'rename time:=ts, id.src:=id.orig_h, conntuple:=id' conn.log.gz
 ```
 
@@ -458,7 +458,7 @@ conn  2018-03-24T17:15:22.690601Z CuKFds250kxFgkhh8f 10.47.25.80    50813       
 
 To sort `x509` records by `certificate.subject`:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'sort certificate.subject' x509.log.gz
 ```
 
@@ -483,7 +483,7 @@ Now we'll sort `x509` records first by `certificate.subject`, then by the `id`.
 Compared to the previous example, note how this changes the order of some
 records that had the same `certificate.subject` value.
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'sort certificate.subject,id' x509.log.gz
 ```
 
@@ -511,7 +511,7 @@ a `sort` in reverse order. Note that even though we didn't list a field name as
 an explicit argument, the `sort` operator did what we wanted because it found a
 field of the `uint64` [data type](../data-types/README.md).
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count() by id.orig_h | sort -r' conn.log.gz
 ```
 
@@ -531,7 +531,7 @@ In this example we count the number of times each distinct username appears in
 `http` records, but deliberately put the unset username at the front of the
 list:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'count() by username | sort -nulls first username' http.log.gz
 ```
 
@@ -562,7 +562,7 @@ wwonka       1
 
 To see the last `dns` record:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'tail' dns.log.gz
 ```
 
@@ -576,7 +576,7 @@ dns   2018-03-24T17:36:30.151237Z C0ybvu4HG3yWv6H5cb 172.31.255.5 60878     10.0
 
 To see the last five `conn` records with activity on port `80`:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'id.resp_p==80 | tail 5' conn.log.gz
 ```
 
@@ -605,7 +605,7 @@ conn  2018-03-24T17:36:28.752765Z COICgc1FXHKteyFy67 10.0.0.227     61314     10
 
 To see a count of the top issuers of X.509 certificates:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'cut certificate.issuer | sort | uniq -c | sort -r' x509.log.gz
 ```
 

--- a/docs/language/search-syntax/README.md
+++ b/docs/language/search-syntax/README.md
@@ -28,7 +28,7 @@ we'll sometimes make use of the `-z` option to output the text-based
 [ZSON](../../formats/zson.md) format, which is readable at the command line.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -z '*' conn.log.gz
 ```
 
@@ -61,7 +61,7 @@ zq -z '* | cut server_tree_name' ntlm.log.gz
 
 #### Example:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -z 'cut server_tree_name' ntlm.log.gz
 ```
 
@@ -97,7 +97,7 @@ appears within `string`-type fields (such as the field `certificate.subject` in
 > matching field values.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table '10.150.0.85' *.log.gz
 ```
 
@@ -138,7 +138,7 @@ search. If typed bare as our Zed query, we'd experience two problems:
 However, wrapping in quotes gives the desired result.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table '"O=Internet Widgits"' *.log.gz
 ```
 
@@ -169,7 +169,7 @@ hostnames that include the letters `cdn` in the middle of them, such as
 `www.cdn.amazon.com` or `www.herokucdn.com`.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'www.*cdn*.com' *.log.gz
 ```
 
@@ -198,7 +198,7 @@ matches records that contain the substring `CN=*` as is often found in the
 start of certificate subjects.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table '"CN=*"' *.log.gz
 ```
 
@@ -242,7 +242,7 @@ But if you're only interested in records having to do with "ad" or "tag"
 services, the following regexp search can accomplish this.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table '/www.google(ad|tag)services.com/' *.log.gz
 ```
 
@@ -273,7 +273,7 @@ will only match records containing the field called `uid` where it is set to
 the precise string value `ChhAfsfyuz4n2hFMe`.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'uid=="ChhAfsfyuz4n2hFMe"' *.log.gz
 ```
 
@@ -293,7 +293,7 @@ we match records in which the values in the fields for originating and
 responding ports are the same.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'id.orig_p==id.resp_p' conn.log.gz
 ```
 
@@ -317,7 +317,7 @@ in two ways.
    our sample data are of `string` type, since it logs an HTTP header that is
    often a hostname or an IP address.
 
-   ```zq-command
+   ```zq-command zed-sample-data/zeek-default
    zq -z 'count() by host | sort count,host' http.log.gz
    ```
 
@@ -358,7 +358,7 @@ following example produces no output.
 
 #### Example:
 
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'certificate.subject=="Widgits"' *.log.gz
 ```
 
@@ -370,7 +370,7 @@ To achieve this with a field/value match, we enter `matches` before specifying
 a [glob wildcard](#glob-wildcards).
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'certificate.subject matches *Widgits*' *.log.gz
 ```
 
@@ -388,7 +388,7 @@ x509  2018-03-24T17:15:47.493786Z FdBWBA3eODh6nHFt82 3                   C5F8CDF
 [Regular expressions](#regular-expressions) can also be used with `matches`.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'uri matches /scripts\/waE8_BuNCEKM.(pl|sh)/' http.log.gz
 ```
 
@@ -414,7 +414,7 @@ multiple responses that may have been returned for a query. To determine which
 responses included hostname `e5803.b.akamaiedge.net`, we'll use `in`.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table '"e5803.b.akamaiedge.net" in answers' dns.log.gz
 ```
 
@@ -438,7 +438,7 @@ However, the `query` field does exist in our `dns` records, so the following
 example does return matches.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'query in answers' dns.log.gz
 ```
 
@@ -455,7 +455,7 @@ Determining whether the value of a Zeek `ip`-type field is contained within a
 subnet also uses `in`.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'id.resp_h in 208.78.0.0/16' conn.log.gz
 ```
 
@@ -477,7 +477,7 @@ In addition to testing for equality via `==` and finding patterns via
 For example, the following search finds connections that have transferred many bytes.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'orig_bytes > 1000000' *.log.gz
 ```
 
@@ -496,7 +496,7 @@ such as this search that finds DNS requests that were issued for hostnames at
 the high end of the alphabet.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'query > "zippy"' *.log.gz
 ```
 
@@ -553,7 +553,7 @@ couple `ssl` records. You could quickly isolate just the SSL records by
 leveraging this implicit `and`.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'www.*cdn*.com _path=="ssl"' *.log.gz
 ```
 
@@ -576,7 +576,7 @@ For example, we can revisit two of our previous example searches that each only
 returned a few records, searching now with `or` to see them all at once.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'orig_bytes > 1000000 or query > "zippy"' *.log.gz
 ```
 
@@ -607,7 +607,7 @@ some of the less-common Zeek record types by inverting the logic of a
 [regexp match](#regular-expressions).
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'not _path matches /conn|dns|files|ssl|x509|http|weird/' *.log.gz
 ```
 
@@ -640,7 +640,7 @@ all `smb_mapping` records in which the `share_type` field is set to a value
 other than `DISK`.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'not share_type=="DISK" _path=="smb_mapping"' *.log.gz
 ```
 
@@ -662,7 +662,7 @@ _other than_ `smb_mapping` records that have the value of their `share_type`
 field set to `DISK`.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table 'not (share_type=="DISK" _path=="smb_mapping")' *.log.gz
 ```
 
@@ -683,7 +683,7 @@ conn  2018-03-24T17:15:23.205187Z CBrzd94qfowOqJwCHa 10.47.25.80    50813     10
 Parentheses can also be nested.
 
 #### Example:
-```zq-command
+```zq-command zed-sample-data/zeek-default
 zq -f table '((not share_type=="DISK") and (service=="IPC")) _path=="smb_mapping"' *.log.gz
 ```
 

--- a/tests/zq_example.go
+++ b/tests/zq_example.go
@@ -1,76 +1,39 @@
+// Package tests finds example shell commands in Markdown files and runs them,
+// checking for expected output.
+//
+// Example commands and outputs are specified in fenced code blocks whose info
+// string (https://spec.commonmark.org/0.29/#info-string) has zq-command or
+// zq-output as the first word.  These blocks must be paired.
+//
+//    ```zq-command [path]
+//    echo hello
+//    ```
+//    ```zq-output
+//    hello
+//    ```
+//
+// The content of each zq-command block is fed to "bash -e -o pipefail" on
+// standard input.  The shell's working directory is the repository root unless
+// the block's info string contains a second word, which then specifies the
+// working directory as a path relative to the repository root.  The shell's
+// combined standard output and standard error must exactly match the content of
+// the following zq-output block except as described below.
+//
+// If head:N appears as the second word in a zq-output block's info string,
+// where N is a non-negative interger, then only the first N lines of shell
+// output are examined, and any "...\n" suffix of the block content is ignored.
+//
+//    ```zq-command
+//    echo hello
+//    echo goodbye
+//    ```
+//    ```zq-output head:1
+//    hello
+//    ...
+//    ```
+//
+// If head is malformed or N is invalid, the word is ignored.
 package tests
-
-/*
-Find valid ZQ examples in markdown, run them against
-https://github.com/brimdata/zed-sample-data/zeek-default, and compare results in
-docs with results produced.
-
-Use markers in markdown fenced code blocks to denote either a zq command or
-output from zq. Use is like:
-
-```zq-command
-zq "* | count()
-```
-```zq-output
-1234
-```
-
-This is in compliance with https://spec.commonmark.org/0.29/#example-113
-
-Doc authors MUST pair off each command and output in their own fenced code blocks.
-
-A zq-command code block MUST be one line after the leading line, which includes
-the info string. A zq-command MUST start with "zq". A zq-command MUST quote the
-full zql with single quotes. The zql MAY contain double quotes, but it MUST NOT
-contain single quotes.
-
-Examples:
-
-zql '* | count()' *.log.gz  # ok
-zql  * | count()  *.log.gz  # not ok
-zql "* | count()" *.log.gz  # not ok
-
-zql 'field="value"   | count()' *.log.gz  # ok
-zql 'field=\'value\' | count()' *.log.gz  # not ok
-zql 'field='value'   | count()' *.log.gz  # not ok
-zql "field=\"value\" | count()" *.log.gz  # not ok
-
-A zq-command MUST reference one or more files or globs, expanded at
-zed-sample-data/zeek-default.
-
-Examples:
-
-zql '* | count()' *.log.gz                # ok
-zql '* | count()' conn.log.gz             # ok
-zql '* | count()' conn.log.gz http.log.gz # ok
-zql '* | count()' c*.log.gz d*.log.gz     # ok
-zql '* | count()'                         # not ok
-
-A zq-command MAY contain a sh-compliant comment string (denoted by '#') on the
-line. Everything including and after the first # is stripped away.
-
-A zq-output fenced code block MAY be multiple lines. zq-output MUST be verbatim
-from the actual zq output.
-
-zq-output MAY contain an optional marker to support record truncation. The
-marker is denoted by "head:N" where N MUST be a non-negative integer
-representing the number of lines to show. The marker MAY contain an ellipsis
-via three dots "..." at the end to imply to readers the continuation of records
-not shown.
-
-Example:
-
-```zq-output head:4
-_PATH COUNT
-conn  3
-dhcp  2
-dns   1
-...
-```
-
-If head is malformed or N is invalid, fall back to verification against all
-records.
-*/
 
 import (
 	"bufio"
@@ -106,14 +69,17 @@ type ZQExampleInfo struct {
 // from a ZQExampleInfo.
 type ZQExampleTest struct {
 	Name            string
-	Command         []string
+	Command         string
+	Dir             string
 	Expected        string
 	OutputLineCount int
 }
 
 // Run runs a zq command and returns its output.
 func (t *ZQExampleTest) Run() (string, error) {
-	c := exec.Command(t.Command[0], t.Command[1:]...)
+	c := exec.Command("bash", "-e", "-o", "pipefail")
+	c.Dir = t.Dir
+	c.Stdin = strings.NewReader(t.Command)
 	var b bytes.Buffer
 	c.Stdout = &b
 	c.Stderr = &b
@@ -213,49 +179,6 @@ func BlockString(fcb *ast.FencedCodeBlock, source []byte) string {
 	return b.String()
 }
 
-// QualifyCommand translates a zq-command example to a runnable command,
-// including abspath to zq binary and globs turned into absolute file paths.
-func QualifyCommand(command string) ([]string, error) {
-	command = strings.TrimSpace(command)
-	command = strings.Split(command, "#")[0]
-
-	pieces := strings.Split(command, "'")
-	if len(pieces) != 3 {
-		return nil, fmt.Errorf("could not split zq command 3 tokens: %s", command)
-	}
-
-	command_and_flags := strings.Split(strings.TrimSpace(pieces[0]), " ")
-	if command_and_flags[0] != "zq" {
-		return nil, fmt.Errorf("command does not start with zq: %s", command)
-	}
-	// Nice, but this makes unit testing more complicated.
-	zq, err := ZQAbsPath()
-	if err != nil {
-		return nil, err
-	}
-	command_and_flags[0] = zq
-
-	zql := strings.TrimSpace(pieces[1])
-
-	var fileargs []string
-	sampledata, err := ZedSampleDataAbsPath()
-	if err != nil {
-		return nil, err
-	}
-	for _, relglobarg := range strings.Split(strings.TrimSpace(pieces[2]), " ") {
-		files, err := filepath.Glob(filepath.Join(sampledata, "zeek-default", relglobarg))
-		if err != nil {
-			return nil, err
-		}
-		fileargs = append(fileargs, files...)
-	}
-
-	finalized := command_and_flags
-	finalized = append(finalized, zql)
-	finalized = append(finalized, fileargs...)
-	return finalized, nil
-}
-
 // TestcasesFromFile returns ZQ example test cases from ZQ example pairs found
 // in a file.
 func TestcasesFromFile(filename string) ([]ZQExampleTest, error) {
@@ -281,18 +204,19 @@ func TestcasesFromFile(filename string) ([]ZQExampleTest, error) {
 		return nil, err
 	}
 	repopath += string(filepath.Separator)
-	for _, example := range examples {
-		linenum := bytes.Count(source[:example.command.Info.Segment.Start], []byte("\n")) + 2
-		testname := strings.TrimPrefix(absfilename, repopath) + ":" + strconv.Itoa(linenum)
-
-		command, err := QualifyCommand(BlockString(example.command, source))
-		if err != nil {
-			return tests, err
+	for _, e := range examples {
+		linenum := bytes.Count(source[:e.command.Info.Segment.Start], []byte("\n")) + 2
+		var commandDir string
+		if infoWords := strings.Fields(string(e.command.Info.Segment.Value(source))); len(infoWords) > 0 {
+			commandDir = infoWords[1]
 		}
-
-		output := strings.TrimSuffix(BlockString(example.output, source), "...\n")
-
-		tests = append(tests, ZQExampleTest{testname, command, output, example.outputLineCount})
+		tests = append(tests, ZQExampleTest{
+			Name:            strings.TrimPrefix(absfilename, repopath) + ":" + strconv.Itoa(linenum),
+			Command:         BlockString(e.command, source),
+			Dir:             filepath.Join(repopath, commandDir),
+			Expected:        strings.TrimSuffix(BlockString(e.output, source), "...\n"),
+			OutputLineCount: e.outputLineCount,
+		})
 	}
 	return tests, nil
 }

--- a/tests/zq_example.go
+++ b/tests/zq_example.go
@@ -207,7 +207,7 @@ func TestcasesFromFile(filename string) ([]ZQExampleTest, error) {
 	for _, e := range examples {
 		linenum := bytes.Count(source[:e.command.Info.Segment.Start], []byte("\n")) + 2
 		var commandDir string
-		if infoWords := strings.Fields(string(e.command.Info.Segment.Value(source))); len(infoWords) > 0 {
+		if infoWords := strings.Fields(string(e.command.Info.Segment.Value(source))); len(infoWords) > 1 {
 			commandDir = infoWords[1]
 		}
 		tests = append(tests, ZQExampleTest{


### PR DESCRIPTION
TestMarkdownExaamples can only run zq, and only against files in
zed-sample-data/zeek-default/. Rework it so zq-command blocks can
contain arbitrary commands executed by "bash -e -o pipefail" with a
working directory that defaults to the repository root but can be
specified with a word after zq-command in a block's info string.

We should remove zq from the names of lots of things touched here,
but that can happen later.