### PR TITLE
Add perf check GitHub Actions Workflow

### DIFF
--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -1,0 +1,27 @@
+name: Perf check
+
+on:
+  push:
+    branches:
+      - rc-v*
+  schedule:
+    - cron: '5 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  perf-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run the perf testing script
+      run: make perf-compare
+    - name: Notify Brim HQ of failure
+      uses: tiloio/slack-webhook-action@v1.1.2
+      if: ${{ failure() }}
+      with:
+        slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_TEST }}
+        slack_json: |
+            {
+              "username": "github-actions",
+              "text": "Workflow \"${{ github.event.workflow_run.name }}\" failed on main.\n${{ github.event.workflow_run.html_url }}"
+            }  

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -22,8 +22,8 @@ jobs:
         curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_18.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security:zeek.gpg > /dev/null
         sudo apt update
         sudo apt -y install zeek
-    - name: Run the perf testing script
-      run: PATH="$(pwd)/dist:/opt/zeek/bin:$PATH" make perf-compare
+        echo /opt/zeek/bin >> $GITHUB_PATH
+    - run: PATH="$PWD/dist:$PATH" make perf-compare
     - name: Notify Brim HQ of failure
       uses: tiloio/slack-webhook-action@v1.1.2
       if: ${{ failure() }}

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         go-version: '1.16'
     - uses: actions/checkout@v2
-    - name: Install Zeek (so we have zeek-cut)
+    - name: Add zeek-cut
       run: |
         echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_18.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
         curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_18.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security:zeek.gpg > /dev/null

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -32,5 +32,5 @@ jobs:
         slack_json: |
             {
               "username": "github-actions",
-              "text": "Perf check failed: https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}"
+              "text": "${{ github.workflow }} failed: https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}"
             }  

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   perf-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v2
       with:

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -10,11 +10,20 @@ on:
 
 jobs:
   perf-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
     - uses: actions/checkout@v2
+    - name: Install Zeek (so we have zeek-cut)
+      run: |
+        echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_18.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
+        curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_18.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security:zeek.gpg > /dev/null
+        sudo apt update
+        sudo apt -y install zeek
     - name: Run the perf testing script
-      run: make perf-compare
+      run: PATH="$(pwd)/dist:/opt/zeek/bin:$PATH" make perf-compare
     - name: Notify Brim HQ of failure
       uses: tiloio/slack-webhook-action@v1.1.2
       if: ${{ failure() }}
@@ -23,5 +32,5 @@ jobs:
         slack_json: |
             {
               "username": "github-actions",
-              "text": "Workflow \"${{ github.event.workflow_run.name }}\" failed on main.\n${{ github.event.workflow_run.html_url }}"
+              "text": "Perf check failed: https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}"
             }  

--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -1,4 +1,4 @@
-name: Perf check
+name: Perf compare
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  perf-check:
+  perf-compare:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v2

--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         go-version: '1.16'
     - uses: actions/checkout@v2
-    - name: Add zeek-cut
+    - name: Add zeek-cut to PATH
       run: |
         echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_18.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
         curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_18.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security:zeek.gpg > /dev/null


### PR DESCRIPTION
#2783 (which was recently found by someone outside the core Brim team) could have been caught by `make perf-compare`, since that happens to run through all the read/write permutations of many supported input/output log formats. The full run through the perf permutations takes a long time even on a beefy system, and I expect on an Actions runner it's going to take a super long time. Therefore I'm proposing to make it a job that typically runs nightly, since I expect this to break rarely. For good measure I also threw in a triggered run when creating release candidates, since I figure it never hurts to be extra conservative then, in the unlikely event we broke something at the last minute.

If our goal was to actually track perf improvements/regressions, the fancy thing to do would be to run this on a beefy host/VM, log the results into a time-series database, and have logic that checks the results over time for statistically significant deltas and notifies us of them. I've done this in past lives, but I'm not trying to go that far here. For now I'm just leveraging the any-to-any nature of the script.

I ended up refining and testing this one through a fork so I could run it via  `workflow_dispatch` on `main`. To see it doing the right thing by failing on the #2783 failure, see the output of [https://github.com/philrz/zed/runs/2741274093?check_suite_focus=true.](https://github.com/philrz/zed/runs/2741274093?check_suite_focus=true.) If this PR is approved, I'll hold off on merging until the fix for #2783 comes through, I bring my fork current, and observe it running successfully to completion.