### PR TITLE
Events endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -147,3 +147,12 @@ type IndexPostRequest struct {
 	Patterns []string `json:"patterns"`
 	Zed      string   `json:"zed,omitempty"`
 }
+
+type EventPoolCommit struct {
+	CommitID string `json:"commit_id"`
+	PoolID   string `json:"pool_id"`
+}
+
+type EventPool struct {
+	PoolID string `json:"pool_id"`
+}

--- a/docs/lake/service-api.md
+++ b/docs/lake/service-api.md
@@ -42,6 +42,9 @@ The supported mime types are as follows:
   - [List Segments](#list-segments)
   - [List Log](#list-log)
 
+### Events subscription:
+  - [Events](#events)
+
 <!-- XXX: Index revamp -->
 <!-- - [Create Index](#create-index) -->
 <!-- - [List Indices](#list-indices) -->
@@ -630,6 +633,33 @@ A list of [actions](#actions).
     }
   }
 ]
+```
+
+### Events
+
+Subscribe to an events feed.
+
+```
+GET /events
+```
+
+#### Response
+
+An event-stream in the format of [Server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html).
+
+```
+event: pool-new
+data: {"pool_id": "1sMDXpVwqxm36Rc2vfrmgizc3jz"}
+
+event: pool-update
+data: {"pool_id": "1sMDXpVwqxm36Rc2vfrmgizc3jz"}
+
+event: pool-commit
+data: {"pool_id": "1sMDXpVwqxm36Rc2vfrmgizc3jz", "commit_id": "1tisISpHoWI7MAZdFBiMERXeA2X"}
+
+event: pool-delete
+data: {"pool_id": "1sMDXpVwqxm36Rc2vfrmgizc3jz"}
+
 ```
 
 ## Object Reference

--- a/service/core.go
+++ b/service/core.go
@@ -41,16 +41,16 @@ type Config struct {
 }
 
 type Core struct {
-	auth      *Auth0Authenticator
-	conf      Config
-	engine    storage.Engine
-	logger    *zap.Logger
-	registry  *prometheus.Registry
-	root      *lake.Root
-	routerAPI *mux.Router
-	routerAux *mux.Router
-	taskCount int64
-	subscriptions map[chan []byte]struct{}
+	auth            *Auth0Authenticator
+	conf            Config
+	engine          storage.Engine
+	logger          *zap.Logger
+	registry        *prometheus.Registry
+	root            *lake.Root
+	routerAPI       *mux.Router
+	routerAux       *mux.Router
+	taskCount       int64
+	subscriptions   map[chan []byte]struct{}
 	subscriptionsMu sync.RWMutex
 }
 
@@ -117,14 +117,14 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	routerAPI.Use(panicCatchMiddleware(conf.Logger))
 
 	c := &Core{
-		auth:      authenticator,
-		conf:      conf,
-		engine:    engine,
-		logger:    conf.Logger.Named("core"),
-		root:      root,
-		registry:  registry,
-		routerAPI: routerAPI,
-		routerAux: routerAux,
+		auth:          authenticator,
+		conf:          conf,
+		engine:        engine,
+		logger:        conf.Logger.Named("core"),
+		root:          root,
+		registry:      registry,
+		routerAPI:     routerAPI,
+		routerAux:     routerAux,
 		subscriptions: make(map[chan []byte]struct{}),
 	}
 

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -624,7 +624,10 @@ func handleSubscribe(c *Core, w *ResponseWriter, r *Request) {
 				f.Flush()
 			}
 		case <-r.Context().Done():
+			c.subscriptionsMu.Lock()
 			delete(c.subscriptions, subscription)
+			c.subscriptionsMu.Unlock()
+
 			return
 		}
 	}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -274,11 +274,12 @@ func handleCommit(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 	}
 
-	b, err := json.Marshal(struct{
+	b, err := json.Marshal(struct {
 		CommitID string `json:"commit_id"`
-		PoolID string `json:"pool_id"`}{
+		PoolID   string `json:"pool_id"`
+	}{
 		CommitID: commitID.String(),
-		PoolID: pool.ID.String(),
+		PoolID:   pool.ID.String(),
 	})
 	if err != nil {
 		w.Error(err)


### PR DESCRIPTION
Adds an `/events` endpoint which will provide clients/subscribers with event updates via the [Server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html) mechanism. For now, the implementation provide the following events: `pool-new`, `pool-update`, `pool-delete`, and `pool-commit`. Upon receiving these events the app can then decide how/when it wants to take more action (i.e. fetch new data).

Signed-off-by: Mason Fish <mason@looky.cloud>