### PR TITLE
zson: add check for match tight

### DIFF
--- a/zson/lexer.go
+++ b/zson/lexer.go
@@ -106,8 +106,8 @@ func (l *Lexer) match(b byte) (bool, error) {
 }
 
 func (l *Lexer) matchTight(b byte) (bool, error) {
-	if len(l.cursor) == 0 {
-		return false, io.EOF
+	if err := l.check(1); err != nil {
+		return false, err
 	}
 	if b == l.cursor[0] {
 		if err := l.skip(1); err != nil {


### PR DESCRIPTION
If the cursor was empty but underlying stream not empty, match tight
would erroneously return EOF. Add check before match to ensure this does
not happen.

Closes #2783