### PR TITLE
pool.ScanStaging: scan all

### DIFF
--- a/cli/lakecli/local.go
+++ b/cli/lakecli/local.go
@@ -222,17 +222,6 @@ func (p *LocalPool) Squash(ctx context.Context, ids []ksuid.KSUID) (ksuid.KSUID,
 }
 
 func (p *LocalPool) ScanStaging(ctx context.Context, w zio.Writer, ids []ksuid.KSUID) error {
-	if len(ids) == 0 {
-		// Show all of staging.
-		var err error
-		ids, err = p.pool.ListStagedCommits(ctx)
-		if err != nil {
-			return err
-		}
-		if len(ids) == 0 {
-			return errors.New("staging area empty")
-		}
-	}
 	return p.pool.ScanStaging(ctx, w, ids)
 }
 

--- a/cmd/zed/lake/status/command.go
+++ b/cmd/zed/lake/status/command.go
@@ -1,12 +1,16 @@
 package status
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"os"
 
 	"github.com/brimdata/zed/cli/lakecli"
 	"github.com/brimdata/zed/cli/outputflags"
 	zedapi "github.com/brimdata/zed/cmd/zed/api"
 	zedlake "github.com/brimdata/zed/cmd/zed/lake"
+	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
 )
@@ -59,5 +63,10 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer w.Close()
-	return pool.ScanStaging(ctx, w, ids)
+	err = pool.ScanStaging(ctx, w, ids)
+	if errors.Is(err, lake.ErrStagingEmpty) {
+		fmt.Fprintln(os.Stderr, "staging area is empty")
+		err = nil
+	}
+	return err
 }

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -244,8 +244,9 @@ func (p *Pool) StoreInStaging(ctx context.Context, txn *commit.Transaction) erro
 
 // ScanStaging writes the staging commits in ids to w.
 // If ids is empty, all staging commits are written.
-func (p *Pool) ScanStaging(ctx context.Context, w zio.Writer, ids []ksuid.KSUID) (err error) {
+func (p *Pool) ScanStaging(ctx context.Context, w zio.Writer, ids []ksuid.KSUID) error {
 	if len(ids) == 0 {
+		var err error
 		ids, err = p.ListStagedCommits(ctx)
 		if err != nil {
 			return err
@@ -260,8 +261,7 @@ func (p *Pool) ScanStaging(ctx context.Context, w zio.Writer, ids []ksuid.KSUID)
 	go func() {
 		defer close(ch)
 		for _, id := range ids {
-			var txn *commit.Transaction
-			txn, err = p.LoadFromStaging(ctx, id)
+			txn, err := p.LoadFromStaging(ctx, id)
 			if err != nil {
 				return
 			}
@@ -290,7 +290,7 @@ func (p *Pool) ScanStaging(ctx context.Context, w zio.Writer, ids []ksuid.KSUID)
 			return err
 		}
 	}
-	return err
+	return nil
 }
 
 func (p *Pool) Scan(ctx context.Context, snap *commit.Snapshot, ch chan segment.Reference) error {

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -242,9 +242,8 @@ func (p *Pool) StoreInStaging(ctx context.Context, txn *commit.Transaction) erro
 	return storage.Put(ctx, p.engine, p.StagingObject(txn.ID), bytes.NewReader(b))
 }
 
-// ScanStaging writes the provided commits in staging to the provided
-// zio.Writer.  If not commit tags are passed, all commits in staging are
-// written.
+// ScanStaging writes the staging commits in ids to w.
+// If ids is empty, all staging commits are written.
 func (p *Pool) ScanStaging(ctx context.Context, w zio.Writer, ids []ksuid.KSUID) (err error) {
 	if len(ids) == 0 {
 		ids, err = p.ListStagedCommits(ctx)

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -390,20 +390,13 @@ func handleScanStaging(c *Core, w *ResponseWriter, r *Request) {
 			return
 		}
 	}
-	if len(ids) == 0 {
-		ids, err = pool.ListStagedCommits(r.Context())
-		if err != nil {
-			w.Error(err)
-			return
-		}
-		if len(ids) == 0 {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-	}
 	zw := w.ZioWriter()
 	defer zw.Close()
 	if err := pool.ScanStaging(r.Context(), zw, ids); err != nil {
+		if errors.Is(err, lake.ErrStagingEmpty) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		w.Error(err)
 		return
 	}


### PR DESCRIPTION
If no ids are provided for pool.ScanStaging, scan all objects in
staging.