### PR TITLE
mdtest: change zq- keyword prefix to mdtest-

### DIFF
--- a/docs/language/aggregate-functions/README.md
+++ b/docs/language/aggregate-functions/README.md
@@ -37,12 +37,12 @@ Multiple aggregate functions may be invoked at the same time.
 To simultaneously calculate the minimum, maximum, and average of connection
 duration:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'min(duration),max(duration),avg(duration)' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 MIN      MAX         AVG
 0.000001 1269.512465 1.6373747834138621
 ```
@@ -55,12 +55,12 @@ instead use `:=` to specify an explicit name for the generated field.
 
 #### Example:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'quickest:=min(duration),longest:=max(duration),typical:=avg(duration)' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 QUICKEST LONGEST     TYPICAL
 0.000001 1269.512465 1.6373747834138621
 ```
@@ -82,12 +82,12 @@ function will operate.
 To check whether we've seen higher DNS round-trip times when servers return
 longer lists of `answers`:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'answers != null | every 5m short_rtt:=avg(rtt) where len(answers)<=2, short_count:=count() where len(answers)<=2, long_rtt:=avg(rtt) where len(answers)>2, long_count:=count() where len(answers)>2 | sort ts' dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 TS                   SHORT_RTT            SHORT_COUNT LONG_RTT             LONG_COUNT
 2018-03-24T17:15:00Z 0.004386461911629731 7628        0.01571223665048545  824
 2018-03-24T17:20:00Z 0.006360169034406226 9010        0.01992656544502617  764
@@ -114,12 +114,12 @@ TS                   SHORT_RTT            SHORT_COUNT LONG_RTT             LONG_
 Let's say you've been studying `weird` records and noticed that lots of
 connections have made one or more bad HTTP requests.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count() by name | sort -r count' weird.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 NAME                                        COUNT
 bad_HTTP_request                            11777
 line_terminated_with_single_CR              11734
@@ -131,12 +131,12 @@ above_hole_data_without_any_acks            107
 To count the number of connections for which this was the _only_ category of
 `weird` record observed:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'only_bads:=and(name=="bad_HTTP_request") by uid | count() where only_bads==true' weird.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 COUNT
 37
 ```
@@ -156,7 +156,7 @@ COUNT
 
 To see the `name` of a Zeek `weird` record in our sample data:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'any(name)' weird.log.gz
 ```
 
@@ -165,7 +165,7 @@ field in the stream, but in general you should not rely upon this.  In this
 case, the output is:
 
 #### Output:
-```zq-output
+```mdtest-output
 ANY
 TCP_ack_underflow_or_misorder
 ```
@@ -186,12 +186,12 @@ TCP_ack_underflow_or_misorder
 To calculate the average number of bytes originated by all connections as
 captured in Zeek `conn` records:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'avg(orig_bytes)' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 AVG
 176.9861548654682
 ```
@@ -212,12 +212,12 @@ AVG
 To assemble the sequence of HTTP methods invoked in each interaction with the
 Bing search engine:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'host=="www.bing.com" | methods:=collect(method) by uid | sort uid' http.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 UID                METHODS
 C1iilt2FG8PnyEl0bb GET,GET,POST,GET,GET,POST
 C31wi6XQB8h9igoa5  GET,GET,POST,POST,POST
@@ -241,12 +241,12 @@ CI0SCN14gWpY087KA3 GET,POST,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET
 
 To count the number of records in the entire sample data set:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count()' *.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 COUNT
 1462078
 ```
@@ -257,11 +257,11 @@ Let's say we wanted to know how many records contain a field called `mime_type`.
 The following example shows us that count and that the field is present in
 our Zeek `ftp` and `files` records.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count(mime_type) by _path | filter count > 0 | sort -r count' *.log.gz
 ```
 
-```zq-output
+```mdtest-output
 _PATH COUNT
 files 162986
 ftp   93
@@ -283,24 +283,24 @@ ftp   93
 
 To see an approximate count of unique `uid` values in our sample data set:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'countdistinct(uid)' *
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 COUNTDISTINCT
 1029651
 ```
 
 To see the precise value, which may take longer to execute:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count() by uid | count()' *
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 COUNT
 1021953
 ```
@@ -324,12 +324,12 @@ to perform this test, the Zed using `countdistinct()` executed almost 3x faster.
 To see the maximum number of bytes originated by any connection in our sample
 data:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'max(orig_bytes)' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 MAX
 4862366
 ```
@@ -350,12 +350,12 @@ MAX
 To see the quickest round trip time of all DNS queries observed in our sample
 data:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'min(rtt)' dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 MIN
 0.000012
 ```
@@ -376,12 +376,12 @@ MIN
 Let's say you've noticed there's lots of HTTP traffic happening on ports higher
 than the standard port `80`.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count() by id.resp_p | sort -r count' http.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 ID.RESP_P COUNT
 80        134496
 8080      5204
@@ -393,12 +393,12 @@ ID.RESP_P COUNT
 The following query confirms this high-port traffic is present, but that none
 of those ports are higher than what TCP allows.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'some_highports:=or(id.resp_p>80),impossible_ports:=or(id.resp_p>65535)' http.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 SOME_HIGHPORTS IMPOSSIBLE_PORTS
 T              F
 ```
@@ -419,12 +419,12 @@ T              F
 To calculate the total number of bytes across all file payloads logged in our
 sample data:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'sum(total_bytes)' files.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 SUM
 3092961270
 ```
@@ -446,12 +446,12 @@ SUM
 To observe which HTTP methods were invoked in each interaction with the Bing
 search engine:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'host=="www.bing.com" | methods:=union(method) by uid | sort uid' http.log.gz
 ```
 
 #### Output:
-```zq-output head:9
+```mdtest-output head:9
 UID                METHODS
 C1iilt2FG8PnyEl0bb GET,POST
 C31wi6XQB8h9igoa5  GET,POST

--- a/docs/language/data-types/README.md
+++ b/docs/language/data-types/README.md
@@ -30,12 +30,12 @@ However, if we cast it to an `ip` type, now the CIDR match is successful. The
 `bad cast` warning on stderr tells us that some of the values for `ref_id`
 could _not_ be successfully cast to `ip`.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'put ref_id:=ip(ref_id)| filter ref_id in 83.162.0.0/16 | count()' ntp.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 bad cast
 COUNT
 28

--- a/docs/language/expressions/README.md
+++ b/docs/language/expressions/README.md
@@ -3,12 +3,12 @@
 Comprehensive documentation for Zed expressions is still a work in progress. In
 the meantime, here's an example expression with simple math to get started:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'duration > 100 | put total_bytes:=orig_bytes+resp_bytes | cut orig_bytes,resp_bytes,total_bytes' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 ORIG_BYTES RESP_BYTES TOTAL_BYTES
 32         0          32
 32         0          32

--- a/docs/language/grouping/README.md
+++ b/docs/language/grouping/README.md
@@ -42,12 +42,12 @@ specification of each unit.
 To see the total number of bytes originated across all connections during each
 minute:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'every 1m sum(orig_bytes) | sort -r ts' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 TS                   SUM
 2018-03-24T17:36:00Z 1443272
 2018-03-24T17:35:00Z 3851308
@@ -61,12 +61,12 @@ TS                   SUM
 To see which 30-second intervals contained the most records, expressing the
 duration as a half-minute:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'every 0.5m count() | sort -r count' *.log.gz
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 TS                   COUNT
 2018-03-24T17:19:00Z 73512
 2018-03-24T17:16:30Z 59701
@@ -79,12 +79,12 @@ TS                   COUNT
 To see the highest-numbered responding network port during each 90-second
 interval, expressing the duration as a mix of minutes and seconds:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'every 1m30s max(id.resp_p) | sort -r ts' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 TS                   MAX
 2018-03-24T17:36:00Z 60008
 2018-03-24T17:34:30Z 60008
@@ -105,12 +105,12 @@ The simplest example summarizes the unique values of the named field(s), which
 requires no aggregate function. To see which protocols were observed in our
 Zeek `conn` records:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'by proto | sort' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 PROTO
 icmp
 tcp
@@ -121,12 +121,12 @@ If you work a lot at the UNIX/Linux shell, you might have sought to accomplish
 the same via a familiar, verbose idiom. This works in Zed, but the `by`
 shorthand is preferable.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'cut proto | sort | uniq' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 PROTO
 icmp
 tcp
@@ -139,12 +139,12 @@ By specifying multiple comma-separated field names, one batch is formed for each
 unique combination of values found in those fields. To see which responding
 IP+port combinations generated the most traffic:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'sum(resp_bytes) by id.resp_h,id.resp_p  | sort -r sum' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 ID.RESP_H       ID.RESP_P SUM
 52.216.132.61   443       1781778597
 10.47.3.200     80        1544111786
@@ -166,12 +166,12 @@ responding DNS servers generated the longest answers, we can group by
 both `id.resp_h` and an expression that evaluates the length of `answers`
 arrays.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'len(answers) > 0 | count() by id.resp_h,num_answers:=len(answers) | sort -r num_answers,count' dns.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 ID.RESP_H       NUM_ANSWERS COUNT
 10.0.0.100      16          4
 216.239.34.10   16          2
@@ -188,12 +188,12 @@ the grouping to have effect.
 Let's say we've performed separate aggregations for fields present in different
 Zeek records. First we count the unique `host` values in `http` records.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count() by host | sort -r | head 3' http.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 HOST       COUNT
 10.47.7.58 24693
 10.47.2.58 16499
@@ -202,12 +202,12 @@ HOST       COUNT
 
 Next we count the unique `query` values in `dns` records.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count() by query | sort -r | head 3' dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 QUERY                                                     COUNT
 ise.wrccdc.org                                            22160
 *\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 3834
@@ -226,12 +226,12 @@ and the `host` field not being present in any of the `dns` records. This can
 be observed by looking at the [ZSON](../../formats/zson.md)
 representation of the type definitions for each record type.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f zson 'count() by _path,typeof(.) | sort _path' http.log.gz dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 {
     _path: "dns",
     typeof: ({_path:string,ts:time,uid:bstring,id:{orig_h:ip,orig_p:port=(uint16),resp_h:ip,resp_p:port},proto:zenum=(string),trans_id:uint64,rtt:duration,query:bstring,qclass:uint64,qclass_name:bstring,qtype:uint64,qtype_name:bstring,rcode:uint64,rcode_name:bstring,AA:bool,TC:bool,RD:bool,RA:bool,Z:uint64,answers:[bstring],TTLs:[duration],rejected:bool}),
@@ -250,12 +250,12 @@ records under a single schema. This has the effect of populating missing
 fields with null values. Now that the named fields are present in
 all records, the `by` grouping has the desired effect.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'fuse | count() by host,query | sort -r | head 3' http.log.gz dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 HOST       QUERY          COUNT
 10.47.7.58 -              24693
 -          ise.wrccdc.org 22160
@@ -273,12 +273,12 @@ should be used downstream of the aggregate function(s) in the Zed pipeline.
 If we were counting records into 5-minute batches and wanted to see these
 results ordered by incrementing timestamp of each batch:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'every 5m count() | sort ts' *.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 TS                   COUNT
 2018-03-24T17:15:00Z 441229
 2018-03-24T17:20:00Z 337264
@@ -289,12 +289,12 @@ TS                   COUNT
 
 If we'd wanted to see them ordered from lowest to highest record count:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'every 5m count() | sort count' *.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 TS                   COUNT
 2018-03-24T17:35:00Z 98755
 2018-03-24T17:30:00Z 274284

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -43,12 +43,12 @@ The following available operators are documented in detail below:
 
 To return only the `ts` and `uid` columns of `conn` records:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'cut ts,uid' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 TS                          UID
 2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
@@ -64,12 +64,12 @@ the Zeek `smb_mapping` logs in our sample data contain the field named
 `share_type`, the following query returns records for many other log types that
 contain the `_path` and/or `ts` that we included in our field list.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'cut _path,ts,share_type' *
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 _PATH        TS
 capture_loss 2018-03-24T17:30:20.600852Z
 capture_loss 2018-03-24T17:36:30.158766Z
@@ -85,12 +85,12 @@ Contrast this with a [similar example](#example-2-3) that shows how
 If no records are found that contain any of the named fields, `cut` returns a
 warning.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'cut nothere,alsoabsent' weird.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 cut: no record found with columns nothere,alsoabsent
 ```
 
@@ -99,12 +99,12 @@ cut: no record found with columns nothere,alsoabsent
 To return only the `ts` and `uid` columns of `conn` records, with `ts` renamed
 to `time`:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'cut time:=ts,uid' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 TIME                        UID
 2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
@@ -127,12 +127,12 @@ TIME                        UID
 To return all fields _other than_ the `_path` field and `id` record of `weird`
 records:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'drop _path,id' weird.log.gz
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 TS                          UID                NAME                             ADDL             NOTICE PEER
 2018-03-24T17:15:20.600843Z C1zOivgBT6dBmknqk  TCP_ack_underflow_or_misorder    -                F      zeek
 2018-03-24T17:15:20.608108Z -                  truncated_header                 -                F      zeek
@@ -160,12 +160,12 @@ TS                          UID                NAME                             
 
 To further trim the data returned in our [`cut`](#cut) example:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'cut ts,uid | filter uid=="CXWfTK3LRdiuQxBbM6"' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 TS                          UID
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
 ```
@@ -174,12 +174,12 @@ TS                          UID
 
 An alternative syntax for our [`and` example](../search-syntax/README.md#and):
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'filter www.*cdn*.com _path=="ssl"' *.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H    ID.RESP_P VERSION CIPHER                                CURVE     SERVER_NAME       RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS                                                            CLIENT_CERT_CHAIN_FUIDS SUBJECT            ISSUER                                  CLIENT_SUBJECT CLIENT_ISSUER VALIDATION_STATUS
 ssl   2018-03-24T17:23:00.244457Z CUG0fiQAzL4rNWxai  10.47.2.100 36150     52.85.83.228 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FXKmyTbr7HlvyL1h8,FADhCTvkq1ILFnD3j,FoVjYR16c3UIuXj4xk,FmiRYe1P53KOolQeVi   (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
 ssl   2018-03-24T17:24:00.189735Z CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FuW2cZ3leE606wXSia,Fu5kzi1BUwnF0bSCsd,FyTViI32zPvCmNXgSi,FwV6ff3JGj4NZcVPE4 (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
@@ -201,12 +201,12 @@ ssl   2018-03-24T17:24:00.189735Z CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85
 
 Let's say you'd started with table-formatted output of both `stats` and `weird` records:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'ts < 1521911721' stats.log.gz weird.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          PEER MEM PKTS_PROC BYTES_RECV PKTS_DROPPED PKTS_LINK PKT_LAG EVENTS_PROC EVENTS_QUEUED ACTIVE_TCP_CONNS ACTIVE_UDP_CONNS ACTIVE_ICMP_CONNS TCP_CONNS UDP_CONNS ICMP_CONNS TIMERS ACTIVE_TIMERS FILES ACTIVE_FILES DNS_REQUESTS ACTIVE_DNS_REQUESTS REASSEM_TCP_SIZE REASSEM_FILE_SIZE REASSEM_FRAG_SIZE REASSEM_UNKNOWN_SIZE
 stats 2018-03-24T17:15:20.600725Z zeek 74  26        29375      -            -         -       404         11            1                0                0                 1         0         0          36     32            0     0            0            0                   1528             0                 0                 0
 _PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H      ID.RESP_P NAME                             ADDL NOTICE PEER
@@ -239,12 +239,12 @@ is assembled in a first pass through the data stream, which enables the
 presentation of the results under a single, wider header row with no further
 interruptions between the subsequent data rows.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f csv 'ts < 1521911721 | fuse' stats.log.gz weird.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _path,ts,peer,mem,pkts_proc,bytes_recv,pkts_dropped,pkts_link,pkt_lag,events_proc,events_queued,active_tcp_conns,active_udp_conns,active_icmp_conns,tcp_conns,udp_conns,icmp_conns,timers,active_timers,files,active_files,dns_requests,active_dns_requests,reassem_tcp_size,reassem_file_size,reassem_frag_size,reassem_unknown_size,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,name,addl,notice
 stats,2018-03-24T17:15:20.600725Z,zeek,74,26,29375,,,,404,11,1,0,0,1,0,0,36,32,0,0,0,0,1528,0,0,0,,,,,,,,
 weird,2018-03-24T17:15:20.600843Z,zeek,,,,,,,,,,,,,,,,,,,,,,,,,C1zOivgBT6dBmknqk,10.47.1.152,49562,23.217.103.245,80,TCP_ack_underflow_or_misorder,,F
@@ -271,12 +271,12 @@ Other output formats invoked via `zq -f` that benefit greatly from the use of
 
 To see the first `dns` record:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'head' dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT     QUERY          QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                        TTLS       REJECTED
 dns   2018-03-24T17:15:20.865716Z C2zK5f13SbCtKcyiW5 10.47.1.100 41772     10.0.0.100 53        udp   36329    0.00087 ise.wrccdc.org 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 ise.wrccdc.cpp.edu,134.71.3.16 2230,41830 F
 ```
@@ -285,12 +285,12 @@ dns   2018-03-24T17:15:20.865716Z C2zK5f13SbCtKcyiW5 10.47.1.100 41772     10.0.
 
 To see the first five `conn` records with activity on port `80`:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'id.resp_p==80 | head 5' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H   ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY   ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:15:20.602122Z C4RZ6d4r5mJHlSYFI6 10.164.94.120 33299     10.47.3.200 80        tcp   -       0.003077 0          235        RSTO       -          -          0            ^dtfAR    4         208           4         678           -
 conn  2018-03-24T17:15:20.606178Z CnKmhv4RfyAZ3fVc8b 10.164.94.120 36125     10.47.3.200 80        tcp   -       0.000002 0          0          RSTOS0     -          -          0            R         2         104           0         0             -
@@ -313,12 +313,12 @@ conn  2018-03-24T17:15:20.607695Z CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.
 
 To return only the `ts` and `uid` columns of `conn` records:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'pick ts,uid' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 TS                          UID
 2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
@@ -334,12 +334,12 @@ data contains the field named `share_type`, the following query returns columns
 for only that record type. The many other Zeek record types that also include
 `_path` and/or `ts` fields are not returned.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'pick _path,ts,share_type' *
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 _PATH       TS                          SHARE_TYPE
 smb_mapping 2018-03-24T17:15:21.382822Z DISK
 smb_mapping 2018-03-24T17:15:21.625534Z PIPE
@@ -355,12 +355,12 @@ Contrast this with a [similar example](#example-2) that shows how
 If no records are found that contain any of the named fields, `pick` returns a
 warning.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'pick nothere,alsoabsent' weird.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 pick: no record found with columns nothere,alsoabsent
 ```
 
@@ -369,12 +369,12 @@ pick: no record found with columns nothere,alsoabsent
 To return only the `ts` and `uid` columns of `conn` records, with `ts` renamed
 to `time`:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'pick time:=ts,uid' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 TIME                        UID
 2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
@@ -398,12 +398,12 @@ TIME                        UID
 
 Compute a `total_bytes` field in `conn` records:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -q -f table 'put total_bytes := orig_bytes + resp_bytes | sort -r total_bytes | cut id, orig_bytes, resp_bytes, total_bytes' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P ORIG_BYTES RESP_BYTES TOTAL_BYTES
 10.47.7.154   27300     52.216.132.61   443       859        1781771107 1781771966
 10.164.94.120 33691     10.47.3.200     80        355        1543916493 1543916848
@@ -429,12 +429,12 @@ ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P ORIG_BYTES RESP_BYTES TOTAL_BY
 
 Rename `ts` to `time`, rename one of the inner fields of `id`, and rename the `id` record itself to `conntuple`:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
  zq -f table 'rename time:=ts, id.src:=id.orig_h, conntuple:=id' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 _PATH TIME                        UID                CONNTUPLE.SRC  CONNTUPLE.ORIG_P CONNTUPLE.RESP_H CONNTUPLE.RESP_P PROTO SERVICE  DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY     ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl 10.164.94.120  39681            10.47.3.155      3389             tcp   -        0.004266 97         19         RSTR       -          -          0            ShADTdtr    10        730           6         342           -
 conn  2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6 10.47.25.80    50817            10.128.0.218     23189            tcp   -        0.000486 0          0          REJ        -          -          0            Sr          2         104           2         80            -
@@ -458,12 +458,12 @@ conn  2018-03-24T17:15:22.690601Z CuKFds250kxFgkhh8f 10.47.25.80    50813       
 
 To sort `x509` records by `certificate.subject`:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'sort certificate.subject' x509.log.gz
 ```
 
 #### Output:
-```zq-output head:10
+```mdtest-output head:10
 _PATH TS                          ID                 CERTIFICATE.VERSION CERTIFICATE.SERIAL                     CERTIFICATE.SUBJECT                                                                               CERTIFICATE.ISSUER                                                                                                                                       CERTIFICATE.NOT_VALID_BEFORE CERTIFICATE.NOT_VALID_AFTER CERTIFICATE.KEY_ALG CERTIFICATE.SIG_ALG     CERTIFICATE.KEY_TYPE CERTIFICATE.KEY_LENGTH CERTIFICATE.EXPONENT CERTIFICATE.CURVE SAN.DNS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      SAN.URI SAN.EMAIL SAN.IP BASIC_CONSTRAINTS.CA BASIC_CONSTRAINTS.PATH_LEN
 x509  2018-03-24T17:29:38.233315Z Fn2Gkp2Qd434JylJX9 3                   CB11D05B561B4BB1                       C=/C=US/ST=HI/O=Goldner and Sons/OU=1080p/CN=goldner.sons.net/emailAddress=1080p@goldner.sons.net C=/C=US/ST=HI/O=Goldner and Sons/OU=1080p/CN=goldner.sons.net/emailAddress=1080p@goldner.sons.net                                                        2016-05-09T10:09:02Z         2018-05-09T10:09:02Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            -       -         -      T                    -
 x509  2018-03-24T17:18:48.524223Z Fxq7P31K2FS3v7CBSh 3                   031489479BCD9C116EA7B6162E5E68E6       CN=*.adnxs.com,O=AppNexus\\, Inc.,L=New York,ST=New York,C=US                                     CN=DigiCert ECC Secure Server CA,O=DigiCert Inc,C=US                                                                                                     2018-01-25T08:00:00Z         2019-01-25T20:00:00Z        id-ecPublicKey      ecdsa-with-SHA256       ecdsa                256                    -                    prime256v1        *.adnxs.com,adnxs.com                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        -       -         -      F                    -
@@ -483,12 +483,12 @@ Now we'll sort `x509` records first by `certificate.subject`, then by the `id`.
 Compared to the previous example, note how this changes the order of some
 records that had the same `certificate.subject` value.
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'sort certificate.subject,id' x509.log.gz
 ```
 
 #### Output:
-```zq-output head:10
+```mdtest-output head:10
 _PATH TS                          ID                 CERTIFICATE.VERSION CERTIFICATE.SERIAL                     CERTIFICATE.SUBJECT                                                                               CERTIFICATE.ISSUER                                                                                                                                       CERTIFICATE.NOT_VALID_BEFORE CERTIFICATE.NOT_VALID_AFTER CERTIFICATE.KEY_ALG CERTIFICATE.SIG_ALG     CERTIFICATE.KEY_TYPE CERTIFICATE.KEY_LENGTH CERTIFICATE.EXPONENT CERTIFICATE.CURVE SAN.DNS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      SAN.URI SAN.EMAIL SAN.IP BASIC_CONSTRAINTS.CA BASIC_CONSTRAINTS.PATH_LEN
 x509  2018-03-24T17:29:38.233315Z Fn2Gkp2Qd434JylJX9 3                   CB11D05B561B4BB1                       C=/C=US/ST=HI/O=Goldner and Sons/OU=1080p/CN=goldner.sons.net/emailAddress=1080p@goldner.sons.net C=/C=US/ST=HI/O=Goldner and Sons/OU=1080p/CN=goldner.sons.net/emailAddress=1080p@goldner.sons.net                                                        2016-05-09T10:09:02Z         2018-05-09T10:09:02Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            -       -         -      T                    -
 x509  2018-03-24T17:18:48.524679Z F6WWPk3ajsHLrmNFdb 3                   031489479BCD9C116EA7B6162E5E68E6       CN=*.adnxs.com,O=AppNexus\\, Inc.,L=New York,ST=New York,C=US                                     CN=DigiCert ECC Secure Server CA,O=DigiCert Inc,C=US                                                                                                     2018-01-25T08:00:00Z         2019-01-25T20:00:00Z        id-ecPublicKey      ecdsa-with-SHA256       ecdsa                256                    -                    prime256v1        *.adnxs.com,adnxs.com                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        -       -         -      F                    -
@@ -511,12 +511,12 @@ a `sort` in reverse order. Note that even though we didn't list a field name as
 an explicit argument, the `sort` operator did what we wanted because it found a
 field of the `uint64` [data type](../data-types/README.md).
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count() by id.orig_h | sort -r' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 ID.ORIG_H                COUNT
 10.174.251.215           279014
 10.47.24.81              162237
@@ -531,12 +531,12 @@ In this example we count the number of times each distinct username appears in
 `http` records, but deliberately put the unset username at the front of the
 list:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'count() by username | sort -nulls first username' http.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 USERNAME     COUNT
 -            139175
 M32318       4854
@@ -562,12 +562,12 @@ wwonka       1
 
 To see the last `dns` record:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'tail' dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H ID.RESP_P PROTO TRANS_ID RTT QUERY           QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS TTLS REJECTED
 dns   2018-03-24T17:36:30.151237Z C0ybvu4HG3yWv6H5cb 172.31.255.5 60878     10.0.0.1  53        udp   36243    -   talk.google.com 1      C_INTERNET  1     A          -     -          F  F  T  F  0 -       -    F
 ```
@@ -576,12 +576,12 @@ dns   2018-03-24T17:36:30.151237Z C0ybvu4HG3yWv6H5cb 172.31.255.5 60878     10.0
 
 To see the last five `conn` records with activity on port `80`:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'id.resp_p==80 | tail 5' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H      ID.ORIG_P ID.RESP_H    ID.RESP_P PROTO SERVICE DURATION  ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY    ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:33:23.087149Z CqPl942ft1MCpuNQgk 10.218.221.240 63812     10.47.2.20   80        tcp   -       15.607782 0          0          S1         -          -          0            Sh         2         88            10        440           -
 conn  2018-03-24T17:36:25.557756Z CKCuBO2N2sY6m8qkv6 10.128.0.247   30549     10.47.22.65  80        tcp   http    0.006639  334        271        SF         -          -          0            ShADTftFa  10        1092          6         806           -
@@ -605,12 +605,12 @@ conn  2018-03-24T17:36:28.752765Z COICgc1FXHKteyFy67 10.0.0.227     61314     10
 
 To see a count of the top issuers of X.509 certificates:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'cut certificate.issuer | sort | uniq -c | sort -r' x509.log.gz
 ```
 
 #### Output:
-```zq-output head:3
+```mdtest-output head:3
 CERTIFICATE.ISSUER                                                                                                                                       _UNIQ
 O=VMware Installer                                                                                                                                       1761
 CN=Snozberry                                                                                                                                             1108

--- a/docs/language/search-syntax/README.md
+++ b/docs/language/search-syntax/README.md
@@ -28,12 +28,12 @@ we'll sometimes make use of the `-z` option to output the text-based
 [ZSON](../../formats/zson.md) format, which is readable at the command line.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -z '*' conn.log.gz
 ```
 
 #### Output:
-```zq-output head:4
+```mdtest-output head:4
 {_path:"conn",ts:2018-03-24T17:15:21.255387Z,uid:"C8Tful1TvM3Zf5x8fl" (bstring),id:{orig_h:10.164.94.120,orig_p:39681 (port=(uint16)),resp_h:10.47.3.155,resp_p:3389 (port)} (=0),proto:"tcp" (=zenum),service:null (bstring),duration:4.266ms,orig_bytes:97 (uint64),resp_bytes:19 (uint64),conn_state:"RSTR" (bstring),local_orig:null (bool),local_resp:null (bool),missed_bytes:0 (uint64),history:"ShADTdtr" (bstring),orig_pkts:10 (uint64),orig_ip_bytes:730 (uint64),resp_pkts:6 (uint64),resp_ip_bytes:342 (uint64),tunnel_parents:null (1=(|[bstring]|))} (=2)
 {_path:"conn",ts:2018-03-24T17:15:21.411148Z,uid:"CXWfTK3LRdiuQxBbM6",id:{orig_h:10.47.25.80,orig_p:50817,resp_h:10.128.0.218,resp_p:23189},proto:"tcp",service:null,duration:486us,orig_bytes:0,resp_bytes:0,conn_state:"REJ",local_orig:null,local_resp:null,missed_bytes:0,history:"Sr",orig_pkts:2,orig_ip_bytes:104,resp_pkts:2,resp_ip_bytes:80,tunnel_parents:null} (2)
 {_path:"conn",ts:2018-03-24T17:15:21.926018Z,uid:"CM59GGQhNEoKONb5i",id:{orig_h:10.47.25.80,orig_p:50817,resp_h:10.128.0.218,resp_p:23189},proto:"tcp",service:null,duration:538us,orig_bytes:0,resp_bytes:0,conn_state:"REJ",local_orig:null,local_resp:null,missed_bytes:0,history:"Sr",orig_pkts:2,orig_ip_bytes:104,resp_pkts:2,resp_ip_bytes:80,tunnel_parents:null} (2)
@@ -61,12 +61,12 @@ zq -z '* | cut server_tree_name' ntlm.log.gz
 
 #### Example:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -z 'cut server_tree_name' ntlm.log.gz
 ```
 
 #### Output:
-```zq-output head:3
+```mdtest-output head:3
 {server_tree_name:"factory.oompa.loompa" (bstring)} (=0)
 {server_tree_name:"factory.oompa.loompa"} (0)
 {server_tree_name:"jerry.land"} (0)
@@ -97,12 +97,12 @@ appears within `string`-type fields (such as the field `certificate.subject` in
 > matching field values.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table '10.150.0.85' *.log.gz
 ```
 
 #### Output:
-```zq-output head:10
+```mdtest-output head:10
 _PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H   ID.RESP_P PROTO SERVICE DURATION  ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY         ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:15:22.18798Z  CFis4J1xm9BOgtib34 10.47.8.10   56800     10.150.0.85 443       tcp   -       1.000534  31         77         SF         -          -          0            ^dtAfDTFr       8         382           10        554           -
 conn  2018-03-24T17:15:25.527535Z CnvVUp1zg3fnDKrlFk 10.47.27.186 58665     10.150.0.85 443       tcp   -       1.000958  31         77         SF         -          -          0            ^dtAfDFTr       8         478           10        626           -
@@ -138,12 +138,12 @@ search. If typed bare as our Zed query, we'd experience two problems:
 However, wrapping in quotes gives the desired result.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table '"O=Internet Widgits"' *.log.gz
 ```
 
 #### Output:
-```zq-output head:10
+```mdtest-output head:10
 _PATH  TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H   ID.RESP_P FUID               FILE_MIME_TYPE FILE_DESC PROTO NOTE                     MSG                                                              SUB                                                          SRC          DST         P   N PEER_DESCR ACTIONS            SUPPRESS_FOR REMOTE_LOCATION.COUNTRY_CODE REMOTE_LOCATION.REGION REMOTE_LOCATION.CITY REMOTE_LOCATION.LATITUDE REMOTE_LOCATION.LONGITUDE
 notice 2018-03-24T17:15:32.521729Z Ckwqsn2ZSiVGtyiFO5 10.47.24.186 55782     10.150.0.85 443       FZW30y2Nwc9i0qmdvg -              -         tcp   SSL::Invalid_Server_Cert SSL certificate validation failed with (self signed certificate) CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU 10.47.24.186 10.150.0.85 443 - -          Notice::ACTION_LOG 3600         -                            -                      -                    -                        -
 _PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H   ID.RESP_P VERSION CIPHER                                CURVE  SERVER_NAME RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS   CLIENT_CERT_CHAIN_FUIDS SUBJECT                                                      ISSUER                                                       CLIENT_SUBJECT CLIENT_ISSUER VALIDATION_STATUS
@@ -169,12 +169,12 @@ hostnames that include the letters `cdn` in the middle of them, such as
 `www.cdn.amazon.com` or `www.herokucdn.com`.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'www.*cdn*.com' *.log.gz
 ```
 
 #### Output:
-```zq-output head:10
+```mdtest-output head:10
 _PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY              QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                                                                                                                                                                                                                                                                                                      TTLS                                REJECTED
 dns   2018-03-24T17:16:24.038839Z ChS4MN2D9iPNzSwAw4 10.47.2.154 59353     10.0.0.100 53        udp   11089    0.000785 www.amazon.com     1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.cdn.amazon.com,d3ag4hukkh62yn.cloudfront.net,54.192.139.227                                                                                                                                                                                                                                                                              578,57,57                           F
 dns   2018-03-24T17:16:24.038843Z ChS4MN2D9iPNzSwAw4 10.47.2.154 59353     10.0.0.100 53        udp   11089    0.000784 www.amazon.com     1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.cdn.amazon.com,d3ag4hukkh62yn.cloudfront.net,54.192.139.227                                                                                                                                                                                                                                                                              578,57,57                           F
@@ -198,12 +198,12 @@ matches records that contain the substring `CN=*` as is often found in the
 start of certificate subjects.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table '"CN=*"' *.log.gz
 ```
 
 #### Output:
-```zq-output head:10
+```mdtest-output head:10
 _PATH  TS                          UID                ID.ORIG_H  ID.ORIG_P ID.RESP_H   ID.RESP_P FUID              FILE_MIME_TYPE FILE_DESC PROTO NOTE                     MSG                                                                             SUB                                                                                          SRC        DST         P   N PEER_DESCR ACTIONS            SUPPRESS_FOR REMOTE_LOCATION.COUNTRY_CODE REMOTE_LOCATION.REGION REMOTE_LOCATION.CITY REMOTE_LOCATION.LATITUDE REMOTE_LOCATION.LONGITUDE
 notice 2018-03-24T17:16:58.268179Z CVkrLo2Wjo4r51ZDZ7 10.47.8.10 56808     64.4.54.254 443       FYwv52OzGGIJPop3l -              -         tcp   SSL::Invalid_Server_Cert SSL certificate validation failed with (unable to get local issuer certificate) CN=*.vortex-win.data.microsoft.com,OU=Microsoft,O=Microsoft Corporation,L=Redmond,ST=WA,C=US 10.47.8.10 64.4.54.254 443 - -          Notice::ACTION_LOG 3600         -                            -                      -                    -                        -
 _PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H       ID.RESP_P VERSION CIPHER                                        CURVE     SERVER_NAME                                             RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS                                                            CLIENT_CERT_CHAIN_FUIDS                                  SUBJECT                                                                                                                                                  ISSUER                                                                                                                                   CLIENT_SUBJECT                                             CLIENT_ISSUER                                            VALIDATION_STATUS
@@ -242,12 +242,12 @@ But if you're only interested in records having to do with "ad" or "tag"
 services, the following regexp search can accomplish this.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table '/www.google(ad|tag)services.com/' *.log.gz
 ```
 
 #### Output:
-```zq-output head:10
+```mdtest-output head:10
 _PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                     QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                             TTLS      REJECTED
 dns   2018-03-24T17:15:46.07484Z  CYjLXM1Yp1ZuuVJQV1 10.47.6.154 12478     10.10.6.1  53        udp   49089    0.001342 www.googletagservices.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                             0         F
 dns   2018-03-24T17:15:46.074842Z CYjLXM1Yp1ZuuVJQV1 10.47.6.154 12478     10.10.6.1  53        udp   49089    0.001375 www.googletagservices.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                             0         F
@@ -273,13 +273,13 @@ will only match records containing the field called `uid` where it is set to
 the precise string value `ChhAfsfyuz4n2hFMe`.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'uid=="ChhAfsfyuz4n2hFMe"' *.log.gz
 ```
 
 #### Output:
 
-```zq-output
+```mdtest-output
 _PATH TS                          UID               ID.ORIG_H    ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:36:30.158539Z ChhAfsfyuz4n2hFMe 10.239.34.35 56602     10.47.6.51 873       tcp   -       0.000004 0          0          S0         -          -          0            S       2         88            0         0             -
  ```
@@ -293,13 +293,13 @@ we match records in which the values in the fields for originating and
 responding ports are the same.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'id.orig_p==id.resp_p' conn.log.gz
 ```
 
 #### Output:
 
-```zq-output head:4
+```mdtest-output head:4
 _PATH TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P PROTO SERVICE DURATION   ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:15:22.942327Z C6QN8gJLaOXw0GiA6  10.47.24.81   60004     10.128.0.238    60004     tcp   -       0.003538   0          0          SF         -          -          0            ShAafF  8         344           8         344           -
 conn  2018-03-24T17:15:38.523165Z CzFhMc47JPCOG4Z9E9 10.47.3.142   137       10.164.94.120   137       udp   dns     2.99937    300        0          S0         -          -          0            D       6         468           0         0             -
@@ -317,12 +317,12 @@ in two ways.
    our sample data are of `string` type, since it logs an HTTP header that is
    often a hostname or an IP address.
 
-   ```zq-command zed-sample-data/zeek-default
+   ```mdtest-command zed-sample-data/zeek-default
    zq -z 'count() by host | sort count,host' http.log.gz
    ```
 
    #### Output:
-   ```zq-output head:3
+   ```mdtest-output head:3
    {host:"0988253c66242502070643933dd49e88.clo.footprintdns.com" (bstring),count:1 (uint64)} (=0)
    {host:"10.47.21.1",count:1} (0)
    {host:"10.47.21.80/..",count:1} (0)
@@ -358,25 +358,25 @@ following example produces no output.
 
 #### Example:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'certificate.subject=="Widgits"' *.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 ```
 
 To achieve this with a field/value match, we enter `matches` before specifying
 a [glob wildcard](#glob-wildcards).
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'certificate.subject matches *Widgits*' *.log.gz
 ```
 
 #### Output:
 
-```zq-output head:5
+```mdtest-output head:5
 _PATH TS                          ID                 CERTIFICATE.VERSION CERTIFICATE.SERIAL CERTIFICATE.SUBJECT                                          CERTIFICATE.ISSUER                                           CERTIFICATE.NOT_VALID_BEFORE CERTIFICATE.NOT_VALID_AFTER CERTIFICATE.KEY_ALG CERTIFICATE.SIG_ALG     CERTIFICATE.KEY_TYPE CERTIFICATE.KEY_LENGTH CERTIFICATE.EXPONENT CERTIFICATE.CURVE SAN.DNS SAN.URI SAN.EMAIL SAN.IP BASIC_CONSTRAINTS.CA BASIC_CONSTRAINTS.PATH_LEN
 x509  2018-03-24T17:15:32.519299Z FZW30y2Nwc9i0qmdvg 3                   C5F8CDF3FFCBBF2D   CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU 2018-03-22T14:22:37Z         2045-08-06T14:20:00Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -       -       -         -      T                    -
 x509  2018-03-24T17:15:42.635094Z Fo9ltu1O8DGE0KAgC  3                   C5F8CDF3FFCBBF2D   CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU 2018-03-22T14:22:37Z         2045-08-06T14:20:00Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -       -       -         -      T                    -
@@ -388,12 +388,12 @@ x509  2018-03-24T17:15:47.493786Z FdBWBA3eODh6nHFt82 3                   C5F8CDF
 [Regular expressions](#regular-expressions) can also be used with `matches`.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'uri matches /scripts\/waE8_BuNCEKM.(pl|sh)/' http.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H   ID.RESP_P TRANS_DEPTH METHOD HOST        URI                         REFERRER VERSION USER_AGENT                                                      ORIGIN REQUEST_BODY_LEN RESPONSE_BODY_LEN STATUS_CODE STATUS_MSG INFO_CODE INFO_MSG TAGS    USERNAME PASSWORD PROXIED ORIG_FUIDS ORIG_FILENAMES ORIG_MIME_TYPES RESP_FUIDS         RESP_FILENAMES RESP_MIME_TYPES
 http  2018-03-24T17:17:41.67439Z  Cq3Knz2CEXSJB8ktj  10.164.94.120 40913     10.47.3.142 5800      1           GET    10.47.3.142 /scripts/waE8_BuNCEKM.sh    -        1.0     Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0) -      0                151               404         Not Found  -         -        (empty) -        -        -       -          -              -               F8Jbkj1K2qm2xUR1Bj -              text/html
 http  2018-03-24T17:17:42.427215Z C5yUcM3CEFl86YIfY7 10.164.94.120 34369     10.47.3.142 5800      1           GET    10.47.3.142 /scripts/waE8_BuNCEKM.pl    -        1.0     Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0) -      0                151               404         Not Found  -         -        (empty) -        -        -       -          -              -               F5M3Jc4B8xeR13JrP3 -              text/html
@@ -414,12 +414,12 @@ multiple responses that may have been returned for a query. To determine which
 responses included hostname `e5803.b.akamaiedge.net`, we'll use `in`.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table '"e5803.b.akamaiedge.net" in answers' dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                               TTLS         REJECTED
 dns   2018-03-24T17:20:25.827504Z CATruWimwi1KR0gec  10.47.3.10 63576     10.0.0.100 53        udp   16678    0.072468 www.techrepublic.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.techrepublic.com.edgekey.net,e5803.b.akamaiedge.net,23.55.209.124 180,17936,20 F
 dns   2018-03-24T17:20:25.827506Z CATruWimwi1KR0gec  10.47.3.10 63576     10.0.0.100 53        udp   16678    0.072468 www.techrepublic.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.techrepublic.com.edgekey.net,e5803.b.akamaiedge.net,23.55.209.124 180,17936,20 F
@@ -438,12 +438,12 @@ However, the `query` field does exist in our `dns` records, so the following
 example does return matches.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'query in answers' dns.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY      QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS    TTLS REJECTED
 dns   2018-03-24T17:24:06.142423Z CCd3Uu1nPHikbjizuc 10.47.7.10 53280     10.0.0.100 53        udp   25252    0.000868 10.47.7.30 1      C_INTERNET  1     A          0     NOERROR    T  F  T  T  0 10.47.7.30 0    F
 dns   2018-03-24T17:24:06.142426Z CCd3Uu1nPHikbjizuc 10.47.7.10 53280     10.0.0.100 53        udp   25252    0.000869 10.47.7.30 1      C_INTERNET  1     A          0     NOERROR    T  F  T  T  0 10.47.7.30 0    F
@@ -455,12 +455,12 @@ Determining whether the value of a Zeek `ip`-type field is contained within a
 subnet also uses `in`.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'id.resp_h in 208.78.0.0/16' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H     ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:32:44.212387Z CngWP41W7wzyQtMG4k 10.47.26.25 59095     208.78.71.136 53        udp   dns     0.003241 72         402        SF         -          -          0            Dd      2         128           2         458           -
 conn  2018-03-24T17:32:52.32455Z  CgZ2D84oSTX0Xw2fEl 10.47.26.25 59095     208.78.70.136 53        udp   dns     0.004167 144        804        SF         -          -          0            Dd      4         256           4         916           -
@@ -477,12 +477,12 @@ In addition to testing for equality via `==` and finding patterns via
 For example, the following search finds connections that have transferred many bytes.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'orig_bytes > 1000000' *.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H    ID.RESP_P PROTO SERVICE DURATION    ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY          ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:25:15.208232Z CVimRo24ubbKqFvNu7 172.30.255.1 11        10.128.0.207 0         icmp  -       100.721937  1647088    0          OTH        -          -          0            -                44136     2882896       0         0             -
 conn  2018-03-24T17:15:20.630818Z CO0MhB2NCc08xWaly8 10.47.1.154  49814     134.71.3.17  443       tcp   -       1269.512465 1618740    12880888   OTH        -          -          0            ^dtADTatTtTtTtT  110169    7594230       111445    29872050      -
@@ -496,12 +496,12 @@ such as this search that finds DNS requests that were issued for hostnames at
 the high end of the alphabet.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'query > "zippy"' *.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID               ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                                                    QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                                TTLS       REJECTED
 dns   2018-03-24T17:30:09.84174Z  Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001694 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0          F
 dns   2018-03-24T17:30:09.841742Z Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001697 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0          F
@@ -553,12 +553,12 @@ couple `ssl` records. You could quickly isolate just the SSL records by
 leveraging this implicit `and`.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'www.*cdn*.com _path=="ssl"' *.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 _PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H    ID.RESP_P VERSION CIPHER                                CURVE     SERVER_NAME       RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS                                                            CLIENT_CERT_CHAIN_FUIDS SUBJECT            ISSUER                                  CLIENT_SUBJECT CLIENT_ISSUER VALIDATION_STATUS
 ssl   2018-03-24T17:23:00.244457Z CUG0fiQAzL4rNWxai  10.47.2.100 36150     52.85.83.228 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FXKmyTbr7HlvyL1h8,FADhCTvkq1ILFnD3j,FoVjYR16c3UIuXj4xk,FmiRYe1P53KOolQeVi   (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
 ssl   2018-03-24T17:24:00.189735Z CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FuW2cZ3leE606wXSia,Fu5kzi1BUwnF0bSCsd,FyTViI32zPvCmNXgSi,FwV6ff3JGj4NZcVPE4 (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
@@ -576,13 +576,13 @@ For example, we can revisit two of our previous example searches that each only
 returned a few records, searching now with `or` to see them all at once.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'orig_bytes > 1000000 or query > "zippy"' *.log.gz
 ```
 
 #### Output:
 
-```zq-output head:10
+```mdtest-output head:10
 _PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H    ID.RESP_P PROTO SERVICE DURATION    ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY          ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:25:15.208232Z CVimRo24ubbKqFvNu7 172.30.255.1 11        10.128.0.207 0         icmp  -       100.721937  1647088    0          OTH        -          -          0            -                44136     2882896       0         0             -
 conn  2018-03-24T17:15:20.630818Z CO0MhB2NCc08xWaly8 10.47.1.154  49814     134.71.3.17  443       tcp   -       1269.512465 1618740    12880888   OTH        -          -          0            ^dtADTatTtTtTtT  110169    7594230       111445    29872050      -
@@ -607,13 +607,13 @@ some of the less-common Zeek record types by inverting the logic of a
 [regexp match](#regular-expressions).
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'not _path matches /conn|dns|files|ssl|x509|http|weird/' *.log.gz
 ```
 
 #### Output:
 
-```zq-output head:10
+```mdtest-output head:10
 _PATH        TS                          TS_DELTA   PEER GAPS ACKS    PERCENT_LOST
 capture_loss 2018-03-24T17:30:20.600852Z 900.000127 zeek 1400 1414346 0.098986
 capture_loss 2018-03-24T17:36:30.158766Z 369.557914 zeek 919  663314  0.138547
@@ -640,12 +640,12 @@ all `smb_mapping` records in which the `share_type` field is set to a value
 other than `DISK`.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'not share_type=="DISK" _path=="smb_mapping"' *.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 _PATH       TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H    ID.RESP_P PATH                     SERVICE NATIVE_FILE_SYSTEM SHARE_TYPE
 smb_mapping 2018-03-24T17:15:21.625534Z ChZRry3Z4kv3i25TJf 10.164.94.120 36315     10.47.8.208  445       \\\\SNOZBERRY\\IPC$      IPC     -                  PIPE
 smb_mapping 2018-03-24T17:15:22.021668Z C0jyse1JYc82Acu4xl 10.164.94.120 34691     10.47.8.208  445       \\\\SNOZBERRY\\IPC$      IPC     -                  PIPE
@@ -662,12 +662,12 @@ _other than_ `smb_mapping` records that have the value of their `share_type`
 field set to `DISK`.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table 'not (share_type=="DISK" _path=="smb_mapping")' *.log.gz
 ```
 
 #### Output:
-```zq-output head:9
+```mdtest-output head:9
 _PATH        TS                          TS_DELTA   PEER GAPS ACKS    PERCENT_LOST
 capture_loss 2018-03-24T17:30:20.600852Z 900.000127 zeek 1400 1414346 0.098986
 capture_loss 2018-03-24T17:36:30.158766Z 369.557914 zeek 919  663314  0.138547
@@ -683,12 +683,12 @@ conn  2018-03-24T17:15:23.205187Z CBrzd94qfowOqJwCHa 10.47.25.80    50813     10
 Parentheses can also be nested.
 
 #### Example:
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -f table '((not share_type=="DISK") and (service=="IPC")) _path=="smb_mapping"' *.log.gz
 ```
 
 #### Output:
-```zq-output head:5
+```mdtest-output head:5
 _PATH       TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H    ID.RESP_P PATH                     SERVICE NATIVE_FILE_SYSTEM SHARE_TYPE
 smb_mapping 2018-03-24T17:15:21.625534Z ChZRry3Z4kv3i25TJf 10.164.94.120 36315     10.47.8.208  445       \\\\SNOZBERRY\\IPC$      IPC     -                  PIPE
 smb_mapping 2018-03-24T17:15:22.021668Z C0jyse1JYc82Acu4xl 10.164.94.120 34691     10.47.8.208  445       \\\\SNOZBERRY\\IPC$      IPC     -                  PIPE

--- a/mdtest/zq_example.go
+++ b/mdtest/zq_example.go
@@ -2,32 +2,32 @@
 // checking for expected output.
 //
 // Example commands and outputs are specified in fenced code blocks whose info
-// string (https://spec.commonmark.org/0.29/#info-string) has zq-command or
-// zq-output as the first word.  These blocks must be paired.
+// string (https://spec.commonmark.org/0.29/#info-string) has mdtest-command or
+// mdtest-output as the first word.  These blocks must be paired.
 //
-//    ```zq-command [path]
+//    ```mdtest-command [path]
 //    echo hello
 //    ```
-//    ```zq-output
+//    ```mdtest-output
 //    hello
 //    ```
 //
-// The content of each zq-command block is fed to "bash -e -o pipefail" on
+// The content of each mdtest-command block is fed to "bash -e -o pipefail" on
 // standard input.  The shell's working directory is the repository root unless
 // the block's info string contains a second word, which then specifies the
 // working directory as a path relative to the repository root.  The shell's
 // combined standard output and standard error must exactly match the content of
-// the following zq-output block except as described below.
+// the following mdtest-output block except as described below.
 //
-// If head:N appears as the second word in a zq-output block's info string,
+// If head:N appears as the second word in a mdtest-output block's info string,
 // where N is a non-negative interger, then only the first N lines of shell
 // output are examined, and any "...\n" suffix of the block content is ignored.
 //
-//    ```zq-command
+//    ```mdtest-command
 //    echo hello
 //    echo goodbye
 //    ```
-//    ```zq-output head:1
+//    ```mdtest-output head:1
 //    hello
 //    ...
 //    ```
@@ -53,8 +53,8 @@ import (
 type ZQExampleBlockType string
 
 const (
-	ZQCommand    ZQExampleBlockType = "zq-command"
-	ZQOutput     ZQExampleBlockType = "zq-output"
+	ZQCommand    ZQExampleBlockType = "mdtest-command"
+	ZQOutput     ZQExampleBlockType = "mdtest-output"
 	ZQOutputHead string             = "head:"
 )
 
@@ -102,7 +102,7 @@ func (t *ZQExampleTest) Run() (string, error) {
 	return s, nil
 }
 
-// ZQOutputLineCount returns the number of lines against which zq-output should
+// ZQOutputLineCount returns the number of lines against which mdtest-output should
 // be verified.
 func ZQOutputLineCount(fcb *ast.FencedCodeBlock, source []byte) int {
 	count := fcb.Lines().Len()
@@ -120,7 +120,7 @@ func ZQOutputLineCount(fcb *ast.FencedCodeBlock, source []byte) int {
 	return customCount
 }
 
-// CollectExamples returns zq-command / zq-output pairs from a single
+// CollectExamples returns mdtest-command / zq-output pairs from a single
 // markdown source after parsing it as a goldmark AST.
 func CollectExamples(node ast.Node, source []byte) ([]ZQExampleInfo, error) {
 	var examples []ZQExampleInfo

--- a/mdtest/zq_example_test.go
+++ b/mdtest/zq_example_test.go
@@ -19,54 +19,54 @@ func TestCollectExamples(t *testing.T) {
 	t.Parallel()
 	tests := []markdownunittest{
 		{
-			name: "zq-command only",
+			name: "mdtest-command only",
 			markdown: `
-~~~zq-command only
+~~~mdtest-command only
 1234
 ~~~
 ~~~
 other code block
 ~~~
 `,
-			strerror: "zq-command without a following zq-output"},
+			strerror: "mdtest-command without a following mdtest-output"},
 		{
-			name: "zq-output only",
+			name: "mdtest-output only",
 			markdown: `
-~~~zq-output only
+~~~mdtest-output only
 1234
 ~~~
 ~~~
 other code block
 ~~~
 `,
-			strerror: "zq-output without a preceeding zq-command"},
+			strerror: "mdtest-output without a preceeding mdtest-command"},
 		{
 			name: "two commands",
 			markdown: `
-~~~zq-command 1
+~~~mdtest-command 1
 block 1
 ~~~
-~~~zq-command 2
+~~~mdtest-command 2
 block 2
 ~~~
-~~~zq-output 2
+~~~mdtest-output 2
 block 3
 ~~~
 `,
-			strerror: "subsequent zq-command after another zq-command"},
+			strerror: "subsequent mdtest-command after another mdtest-command"},
 		{
 			name: "two items",
 			markdown: `
-~~~zq-command 1
+~~~mdtest-command 1
 block 1
 ~~~
-~~~zq-output 1
+~~~mdtest-output 1
 block 2
 ~~~
-~~~zq-command 2
+~~~mdtest-command 2
 block 3
 ~~~
-~~~zq-output 2
+~~~mdtest-output 2
 block 4
 ~~~
 `,
@@ -74,10 +74,10 @@ block 4
 		{
 			name: "headed output",
 			markdown: `
-~~~zq-command
+~~~mdtest-command
 block 1
 ~~~
-~~~zq-output head:1
+~~~mdtest-output head:1
 block 2
 block 2 continued
 ~~~

--- a/zeek/Reading-Zeek-Log-Formats.md
+++ b/zeek/Reading-Zeek-Log-Formats.md
@@ -24,12 +24,12 @@ being read via `zq` and output as [ZSON](../docs/formats/zson.md).
 
 #### Example:
 
-```zq-command zed-sample-data/zeek-default
+```mdtest-command zed-sample-data/zeek-default
 zq -Z 'head 1' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 {
     _path: "conn",
     ts: 2018-03-24T17:15:21.255387Z,
@@ -85,12 +85,12 @@ which was generated using the JSON Streaming Logs package.
 
 #### Example:
 
-```zq-command zed-sample-data/zeek-ndjson
+```mdtest-command zed-sample-data/zeek-ndjson
 zq -Z 'head 1' conn.ndjson.gz
 ```
 
 #### Output:
-```zq-output
+```mdtest-output
 {
     _path: "conn",
     _write_ts: "2018-03-24T17:15:21.400275Z",


### PR DESCRIPTION
The zq-command and zq-output keywords used in the info strings of fenced
code blocks haven't really fit since the change to allow arbitrary shell
commands.  Now that the package is called mdtest, mdtest-command and
mdtest-output make more sense.

Depends on #2812.