### PR TITLE
fix bug in lakeio formatSegment()

### DIFF
--- a/cmd/zed/lake/ztests/log.yaml
+++ b/cmd/zed/lake/ztests/log.yaml
@@ -22,11 +22,11 @@ outputs:
       Date:   2021-05-28T15:13:42Z
 
           Add \w{27} \d+\w+ bytes 1 records
-             from null: \(\) to null: \(\)
-      
+             from null \(null\) \(null\) to null \(null\) \(null\)
+
       commit \w{27}
       Author: testuser
       Date:   2021-05-28T15:13:43Z
-      
+
           Add \w{27} \d+\w+ bytes 1 records
-             from null: \(\) to null: \(\)
+             from null \(null\) \(null\) to null \(null\) \(null\)

--- a/cmd/zed/lake/ztests/ls-segments.yaml
+++ b/cmd/zed/lake/ztests/ls-segments.yaml
@@ -18,6 +18,6 @@ outputs:
   - name: stdout
     regexp: |
       \w{27} \d+B bytes 1 records
-         from null: \(\) to null: \(\)
+         from null \(null\) \(null\) to null \(null\) \(null\)
       \w{27} \d+B bytes 1 records
-         from null: \(\) to null: \(\)
+         from null \(null\) \(null\) to null \(null\) \(null\)

--- a/lake/ztests/issue-2784.yaml
+++ b/lake/ztests/issue-2784.yaml
@@ -6,8 +6,7 @@ script: |
   b=$(zed lake add -p test b.zson | head -1 | awk '{print $1}')
   zed lake commit -q -p test -user testuser -date 2021-06-18T14:29:28Z $a $b
   zed lake status -p test
-  echo ===
-  zed lake log -p test
+  zed lake log -p test -f zng | zq -z "sort segment.meta.first | cut first:=segment.meta.first,last:=segment.meta.last" -
 
 inputs:
   - name: a.zson
@@ -22,12 +21,6 @@ outputs:
     data: |
       staging area is empty
   - name: stdout
-    regexp: |
-      commit \w{27}
-      Author: testuser
-      Date:   2021-06-18T14:29:28Z
-
-          Add \w{27} \d+B bytes 1 records
-             from int64: \(02\) to int64: \(02\)
-          Add \w{27} \d+B bytes 1 records
-             from int64: \(04\) to int64: \(04\)
+    data: |
+      {first:1,last:1}
+      {first:2,last:2}

--- a/service/ztests/issue-2784.yaml
+++ b/service/ztests/issue-2784.yaml
@@ -5,8 +5,7 @@ script: |
   b=$(zed api add -p test b.zson | head -1 | awk '{print $1}')
   zed api commit -q -p test -user testuser -date 2021-06-18T14:29:28Z $a $b
   zed api status -p test
-  echo ===
-  zed api log -p test
+  zed api log -p test -f zng | zq -z "sort segment.meta.first | cut first:=segment.meta.first,last:=segment.meta.last" -
 
 inputs:
   - name: service.sh
@@ -23,12 +22,6 @@ outputs:
     data: |
       staging area is empty
   - name: stdout
-    regexp: |
-      commit \w{27}
-      Author: testuser
-      Date:   2021-06-18T14:29:28Z
-
-          Add \w{27} \d+B bytes 1 records
-             from int64: \(02\) to int64: \(02\)
-          Add \w{27} \d+B bytes 1 records
-             from int64: \(04\) to int64: \(04\)
+    data: |
+      {first:1,last:1}
+      {first:2,last:2}

--- a/service/ztests/log.yaml
+++ b/service/ztests/log.yaml
@@ -23,11 +23,11 @@ outputs:
       Date:   2021-05-28T15:13:42Z
 
           Add \w{27} \d+\w+ bytes 1 records
-             from null: \(\) to null: \(\)
-      
+             from null \(null\) \(null\) to null \(null\) \(null\)
+
       commit \w{27}
       Author: testuser
       Date:   2021-05-28T15:13:43Z
-      
+
           Add \w{27} \d+\w+ bytes 1 records
-             from null: \(\) to null: \(\)
+             from null \(null\) \(null\) to null \(null\) \(null\)

--- a/service/ztests/ls-segments.yaml
+++ b/service/ztests/ls-segments.yaml
@@ -19,6 +19,6 @@ outputs:
   - name: stdout
     regexp: |
       \w{27} \d+B bytes 1 records
-         from null: \(\) to null: \(\)
+         from null \(null\) \(null\) to null \(null\) \(null\)
       \w{27} \d+B bytes 1 records
-         from null: \(\) to null: \(\)
+         from null \(null\) \(null\) to null \(null\) \(null\)

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -124,9 +124,9 @@ func formatSegment(b *bytes.Buffer, seg *segment.Reference, prefix string, inden
 	b.WriteString("\n  ")
 	tab(b, indent)
 	b.WriteString(" from ")
-	b.WriteString(seg.First.String())
+	b.WriteString(zson.String(seg.First))
 	b.WriteString(" to ")
-	b.WriteString(seg.Last.String())
+	b.WriteString(zson.String(seg.Last))
 	b.WriteByte('\n')
 }
 

--- a/zio/lakeio/ztests/keyrange.yaml
+++ b/zio/lakeio/ztests/keyrange.yaml
@@ -1,0 +1,17 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -q -p POOL -orderby a
+  zed lake load -q -p POOL in.zson
+  zed lake log -p POOL
+
+inputs:
+  - name: in.zson
+    data: |
+      {a:1}
+      {a:2}
+      {a:3}
+
+outputs:
+  - name: stdout
+    regexp: from 1 to 3


### PR DESCRIPTION
This commit fixes a simple bug in formatSegment() in lakeio to print the key range using zson.String() instead of zng.Value.String().  While we were here, we noticed system tests failing that relied upon the ADD order of objects in a commit log.  Since squash uses snapshot which uses a Go map to figure out all the ADDs for a given snapshot, order is not (and need not be) preserved.  We updated these tests to use zng output with some zq magic to handle the potential reordering.

The null weirdness will be fixed in #2818 

closes #2803
closes #2817 
