### PR TITLE
simplify Zed enums

### DIFF
--- a/compiler/ast/zed/type.go
+++ b/compiler/ast/zed/type.go
@@ -29,11 +29,9 @@ type (
 		Kind  string `json:"kind" unpack:""`
 		Types []Type `json:"types"`
 	}
-	// Enum has just the elements and relies on the semantic checker
-	// to determine a type from the decorator either within or from above.
 	TypeEnum struct {
-		Kind     string  `json:"kind" unpack:""`
-		Elements []Field `json:"elements"`
+		Kind    string   `json:"kind" unpack:""`
+		Symbols []string `json:"symbols"`
 	}
 	TypeMap struct {
 		Kind    string `json:"kind" unpack:""`

--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -237,19 +237,16 @@ The `<ntypes>` and the type IDs are all encoded as `uvarint`.
 
 #### 2.1.1.5 Enum Typedef
 
-An enum type is encoded as the type code of the enum values as a `uvarint`
-followed by a count of the number of elements in the enum, and in turn,
-followed by the names and values of each element.
+An enum type is encoded as a `uvarint` representing the number of symbols
+in the enumeration followed by the names of each symbol.
 ```
---------------------------------------------------------
-|0xfa|<type-id>|<nelem>|<name1><val-1><name2><val-2>...|
---------------------------------------------------------
+--------------------------------
+|0xfa|<nelem>|<name1><name2>...|
+--------------------------------
 ```
-`<type-id>` and `<nelem>` are encoded as `uvarint`.
+`<nelem>` is encoded as `uvarint`.
 The names have the same UTF-8 format as record field names and are encoded
-as tag-encoded primitive strings.  Each value is encoded as
-a tag-encoded value in accordance with the type indicated
-by `<type-id>`.
+as counted strings following the same convention as record fields.
 
 #### 2.1.1.6 Map Typedef
 
@@ -496,8 +493,8 @@ the type of the value in reference to the union's list of defined types,
 and the second element is the value encoded according to that type.
 
 An enumeration value is represented as the `uvarint` encoding of the
-positional index determining the value in reference to the enum's
-list of defined elements.
+positional index of that value's symbol in reference to the enum's
+list of defined symbols.
 
 A map value is encoded as a container as a sequence of alternating tag-encoded
 key and value encoded as keys and values of the underlying key and value types.

--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -246,7 +246,7 @@ in the enumeration followed by the names of each symbol.
 ```
 `<nelem>` is encoded as `uvarint`.
 The names have the same UTF-8 format as record field names and are encoded
-as counted strings following the same convention as record fields.
+as counted strings following the same convention as record field names.
 
 #### 2.1.1.6 Map Typedef
 

--- a/docs/formats/zson.md
+++ b/docs/formats/zson.md
@@ -191,8 +191,7 @@ and include
 * _array_ - an ordered sequence of zero or more values called elements,
 * _set_ - a set of zero or more unique values called elements,
 * _union_ - a type representing values whose type is any of a specified collection of two or more types,
-* _enum_ - a type representing values taken from a specified collection of one or more uniformly
-typed values, which can be either primitive or complex, and
+* _enum_ - a type representing a finite set of symbols typically representing categories, and
 * _map_ - a collection of zero or more key/value pairs where the keys are of a
 uniform type called the key type and the values are of a uniform type called
 the value type.
@@ -268,7 +267,7 @@ If a ZSON input includes data that is not valid UTF-8, the input is invalid.
 
 ZSON identifiers are used in several contexts, as names of:
 * unquoted fields,
-* unquoted enum elements, and
+* unquoted enum symbols, and
 * external type definitions.
 
 Identifiers are case-sensitive and can contain Unicode letters, `$`, `_`,
@@ -322,7 +321,7 @@ _self describing_ in the sense that its type name can be entirely derived
 from its value, e.g., a record type can be derived from a record value
 because all of the field names and type names are present in the value, but
 an enum type cannot be derived from an enum value because not all the enumerated
-names are present in the value.  In the the latter case, the long form
+symbols are present in the value.  In the the latter case, the long form
 `(<type-name>=(<type>))` must be used.
 
 It is an error for an external type to be defined to a different type
@@ -545,21 +544,19 @@ needed to resolve the ambiguity, e.g.,
 
 #### 3.4.5 Enum Value
 
-An enum type represents a named set of values where enum values are
-referenced by name.  The simple form of an
-enum is a list of names, where the values are of type `int64` but
-enums may be defined as set of values of an arbitrary type.
+An enum type represents a symbol from a finite set of symbols
+referenced by name.
 
 An enum value has the form
 ```
 <name>
 ```
 where the name is either an identifier or a quoted string and it uniquely
-names one of the enum elements.
+corresponds to one of the enum symbols.
 
-Such a value must appear in a context where the enum type is known, i.e.,
+Such a enum value must appear in a context where the enum type is known, i.e.,
 with an explicit enum type decorator or within a complex type where the
-contained enum type is defined by the complex type.
+contained enum type is defined by the complex type's decorator.
 
 When an enum name is `true`, `false`, or `null`, it must be quoted.
 
@@ -651,16 +648,12 @@ where there are at least two types in the list.
 
 #### 3.5.5 Enum Type
 
-An _enum type_ has two forms.  The simple form is:
+An _enum type_ has the form:
 ```
 < <identifier>, <identifier>, ... >
 ```
-and the complex form is:
-```
-< <identifier>:<value>, <identifier>=<value>, ... >
-```
-In the same form, the underlying enum value is equal to its positional
-index in the list of identifiers as an uint64 type.
+The positional index of the each enum symbol is significant, e.g., two enum types
+with the same set of symbols but in different order are distinct.
 
 #### 3.5.6 Map Type
 

--- a/docs/formats/zson.md
+++ b/docs/formats/zson.md
@@ -554,7 +554,7 @@ An enum value has the form
 where the name is either an identifier or a quoted string and it uniquely
 corresponds to one of the enum symbols.
 
-Such a enum value must appear in a context where the enum type is known, i.e.,
+Such an enum value must appear in a context where the enum type is known, i.e.,
 with an explicit enum type decorator or within a complex type where the
 contained enum type is defined by the complex type's decorator.
 

--- a/expr/cast.go
+++ b/expr/cast.go
@@ -167,11 +167,11 @@ func castToStringy(typ zng.Type) func(zng.Value) (zng.Value, error) {
 		}
 		if enum, ok := zv.Type.(*zng.TypeEnum); ok {
 			selector, _ := zng.DecodeUint(zv.Bytes)
-			element, err := enum.Element(int(selector))
+			symbol, err := enum.Symbol(int(selector))
 			if err != nil {
 				return zng.NewError(err), nil
 			}
-			return zng.Value{typ, zng.EncodeString(element.Name)}, nil
+			return zng.Value{typ, zng.EncodeString(symbol)}, nil
 		}
 		if zng.IsStringy(id) {
 			// If it's already stringy, then the z encoding can stay

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -303,17 +303,9 @@ func newNumeric(lhs, rhs Evaluator) numeric {
 }
 
 func enumify(v zng.Value) (zng.Value, error) {
-	// automatically convert an enum to its value when coercing
-	if typ, ok := v.Type.(*zng.TypeEnum); ok {
-		selector, err := zng.DecodeUint(v.Bytes)
-		if err != nil {
-			return zng.Value{}, err
-		}
-		elem, err := typ.Element(int(selector))
-		if err != nil {
-			return zng.Value{}, err
-		}
-		return zng.Value{typ.Type, elem.Value}, nil
+	// automatically convert an enum to its index value when coercing
+	if _, ok := v.Type.(*zng.TypeEnum); ok {
+		return zng.Value{zng.TypeUint64, v.Bytes}, nil
 	}
 	return v, nil
 }

--- a/zio/tzngio/string.go
+++ b/zio/tzngio/string.go
@@ -28,14 +28,11 @@ func ColumnString(prefix string, columns []zng.Column, suffix string) string {
 }
 
 func StringTypeEnum(t *zng.TypeEnum) string {
-	typ := t.Type
 	var out []string
-	for _, e := range t.Elements {
-		name := FormatName(e.Name)
-		val := StringOf(zng.Value{typ, e.Value}, OutFormatZNG, false)
-		out = append(out, fmt.Sprintf("%s:[%s]", name, val))
+	for _, s := range t.Symbols {
+		out = append(out, FormatName(s))
 	}
-	return fmt.Sprintf("enum[%s,%s]", typ, strings.Join(out, ","))
+	return fmt.Sprintf("enum[%s]", strings.Join(out, ","))
 }
 
 func FormatName(name string) string {

--- a/zio/zjsonio/stream.go
+++ b/zio/zjsonio/stream.go
@@ -106,8 +106,6 @@ func (s *Stream) hasTypeType(typ zng.Type) bool {
 				break
 			}
 		}
-	case *zng.TypeEnum:
-		b = s.hasTypeType(t.Type)
 	case *zng.TypeOfType:
 		b = true
 	default:

--- a/zio/zngio/encoder.go
+++ b/zio/zngio/encoder.go
@@ -133,23 +133,13 @@ func (e *Encoder) encodeTypeArray(dst []byte, ext *zng.TypeArray) ([]byte, zng.T
 }
 
 func (e *Encoder) encodeTypeEnum(dst []byte, ext *zng.TypeEnum) ([]byte, zng.Type, error) {
-	var elemType zng.Type
-	var err error
-	dst, elemType, err = e.Encode(dst, ext.Type)
-	if err != nil {
-		return nil, nil, err
-	}
-	elems := ext.Elements
-	typ := e.zctx.LookupTypeEnum(elemType, elems)
+	symbols := ext.Symbols
+	typ := e.zctx.LookupTypeEnum(symbols)
 	dst = append(dst, zng.TypeDefEnum)
-	dst = zcode.AppendUvarint(dst, uint64(zng.TypeID(typ)))
-	dst = zcode.AppendUvarint(dst, uint64(len(elems)))
-	container := zng.IsContainerType(typ)
-	for _, elem := range elems {
-		name := []byte(elem.Name)
-		dst = zcode.AppendUvarint(dst, uint64(len(name)))
-		dst = append(dst, name...)
-		dst = zcode.AppendAs(dst, container, elem.Value)
+	dst = zcode.AppendUvarint(dst, uint64(len(symbols)))
+	for _, s := range symbols {
+		dst = zcode.AppendUvarint(dst, uint64(len(s)))
+		dst = append(dst, s...)
 	}
 	return dst, typ, nil
 }

--- a/zio/zsonio/ztests/enum.yaml
+++ b/zio/zsonio/ztests/enum.yaml
@@ -3,13 +3,13 @@ zed: "*"
 output-flags: -f zson -pretty=4
 
 input: |
-  {flip:HEADS (0=(<HEADS:0 (uint8),TAILS:1>))} (=1)
+  {flip:HEADS (0=(<HEADS,TAILS>))} (=1)
   {flip:TAILS} (1)
   {flip:HEADS} (1)
 
 output: |
   {
-      flip: HEADS (0=(<HEADS:0 (uint8),TAILS:1>))
+      flip: HEADS (0=(<HEADS,TAILS>))
   } (=1)
   {
       flip: TAILS

--- a/zng/recordval.go
+++ b/zng/recordval.go
@@ -174,7 +174,7 @@ func checkEnum(typ *TypeEnum, body zcode.Bytes) error {
 	if err != nil {
 		return err
 	}
-	if int(selector) >= len(typ.Elements) {
+	if int(selector) >= len(typ.Symbols) {
 		return errors.New("enum selector out of range")
 	}
 	return nil

--- a/zng/type.go
+++ b/zng/type.go
@@ -368,19 +368,6 @@ func trimInnerTypes(typ string, raw string) string {
 	return innerTypes
 }
 
-//XXX where is this used?
-// ReferencedID returns the underlying type from the given referential type.
-// e.g., aliases and enums both refer to other underlying types and the
-// Value's Bytes field is encoded according to the underlying type.
-// XXX we initially had this as a method on Type but it was removed in favor
-// of TypeAlias.ID() returning the underlying type where code that cared
-// has to check if the type is an alias and use TypeAlias.AliasID().  Now that
-// we have enums we need to implement a similar workaround.  It seems like we
-// should add back the Type method that we took out.
-func ReferencedID(typ Type) int {
-	return typ.ID()
-}
-
 func TypeID(typ Type) int {
 	if alias, ok := typ.(*TypeAlias); ok {
 		return alias.id

--- a/zng/type.go
+++ b/zng/type.go
@@ -350,8 +350,6 @@ func AliasTypes(typ Type) []*TypeAlias {
 		for _, typ := range typ.Types {
 			aliases = append(aliases, AliasTypes(typ)...)
 		}
-	case *TypeEnum:
-		aliases = AliasTypes(typ.Type)
 	case *TypeMap:
 		keyAliases := AliasTypes(typ.KeyType)
 		valAliases := AliasTypes(typ.KeyType)
@@ -370,6 +368,7 @@ func trimInnerTypes(typ string, raw string) string {
 	return innerTypes
 }
 
+//XXX where is this used?
 // ReferencedID returns the underlying type from the given referential type.
 // e.g., aliases and enums both refer to other underlying types and the
 // Value's Bytes field is encoded according to the underlying type.
@@ -379,9 +378,6 @@ func trimInnerTypes(typ string, raw string) string {
 // we have enums we need to implement a similar workaround.  It seems like we
 // should add back the Type method that we took out.
 func ReferencedID(typ Type) int {
-	if typ, ok := typ.(*TypeEnum); ok {
-		return typ.Type.ID()
-	}
 	return typ.ID()
 }
 

--- a/zng/ztests/enum-err.yaml
+++ b/zng/ztests/enum-err.yaml
@@ -4,9 +4,9 @@ script: |
 inputs:
   - name: stdin
     data: |
-      {e:bang (0=(<foo:1 (int32),bar:2,baz:4>))} (=1)
+      {e:bang (0=(<foo,bar,baz>))} (=1)
 
 outputs:
   - name: stderr
     regexp: |
-      zson: identifier "bang" not a member of enum type "<foo:1,bar:2,baz:4>"
+      zson: identifier "bang" not a member of enum type "<foo,bar,baz>"

--- a/zng/ztests/enum.yaml
+++ b/zng/ztests/enum.yaml
@@ -1,11 +1,11 @@
 zed: "put s:=string(e), v:=e+1"
 
 input: |
-  {e:foo (0=(<foo:1 (int32),bar:2,baz:4>))} (=1)
+  {e:foo (0=(<foo,bar,baz>))} (=1)
   {e:bar} (1)
   {e:baz} (1)
 
 output: |
-  {e:foo (0=(<foo:1 (int32),bar:2,baz:4>)),s:"foo",v:2} (=1)
-  {e:bar,s:"bar",v:3} (1)
-  {e:baz,s:"baz",v:5} (1)
+  {e:foo (0=(<foo,bar,baz>)),s:"foo",v:1} (=1)
+  {e:bar,s:"bar",v:2} (1)
+  {e:baz,s:"baz",v:3} (1)

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -3,6 +3,7 @@ package zson
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -234,7 +235,13 @@ func buildUnion(b *zcode.Builder, union *Union) error {
 }
 
 func buildEnum(b *zcode.Builder, enum *Enum) error {
-	b.AppendPrimitive(zng.EncodeUint(uint64(enum.Selector)))
+	typ, ok := enum.Type.(*zng.TypeEnum)
+	if !ok {
+		// This shouldn't happen.
+		return errors.New("enum value is not of type enum")
+	}
+	selector := typ.Lookup(enum.Name)
+	b.AppendPrimitive(zng.EncodeUint(uint64(selector)))
 	return nil
 }
 

--- a/zson/context.go
+++ b/zson/context.go
@@ -164,14 +164,14 @@ func (c *Context) LookupTypeUnion(types []zng.Type) *zng.TypeUnion {
 	return typ
 }
 
-func (c *Context) LookupTypeEnum(elemType zng.Type, elements []zng.Element) *zng.TypeEnum {
-	key := FormatType(&zng.TypeEnum{Type: elemType, Elements: elements})
+func (c *Context) LookupTypeEnum(symbols []string) *zng.TypeEnum {
+	key := FormatType(&zng.TypeEnum{Symbols: symbols})
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if typ, ok := c.toType[key]; ok {
 		return typ.(*zng.TypeEnum)
 	}
-	typ := zng.NewTypeEnum(c.nextIDWithLock(), elemType, elements)
+	typ := zng.NewTypeEnum(c.nextIDWithLock(), symbols)
 	c.enterWithLock(typ)
 	return typ
 }

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -401,17 +401,11 @@ func (f *Formatter) formatTypeUnion(typ *zng.TypeUnion) {
 
 func (f *Formatter) formatTypeEnum(typ *zng.TypeEnum) error {
 	f.build("<")
-	inner := typ.Type
-	for k, elem := range typ.Elements {
+	for k, s := range typ.Symbols {
 		if k > 0 {
 			f.build(",")
 		}
-		f.buildf("%s:", zng.QuotedName(elem.Name))
-		known := k != 0
-		const parentImplied = true
-		if err := f.formatValue(0, inner, elem.Value, known, parentImplied, true); err != nil {
-			return err
-		}
+		f.buildf("%s", zng.QuotedName(s))
 	}
 	f.build(">")
 	return nil
@@ -534,11 +528,11 @@ func formatType(b *strings.Builder, typedefs typemap, typ zng.Type) {
 		b.WriteByte(')')
 	case *zng.TypeEnum:
 		b.WriteByte('<')
-		for k, elem := range t.Elements {
+		for k, s := range t.Symbols {
 			if k > 0 {
 				b.WriteByte(',')
 			}
-			b.WriteString(zng.QuotedName(elem.Name))
+			b.WriteString(zng.QuotedName(s))
 		}
 		b.WriteByte('>')
 	default:

--- a/zson/parser-types.go
+++ b/zson/parser-types.go
@@ -299,7 +299,7 @@ func (p *Parser) matchTypeEnum() (*zed.TypeEnum, error) {
 	if ok, err := l.match('<'); !ok || err != nil {
 		return nil, err
 	}
-	fields, err := p.matchEnumFields()
+	fields, err := p.matchEnumSymbols()
 	if err != nil {
 		return nil, err
 	}
@@ -311,24 +311,24 @@ func (p *Parser) matchTypeEnum() (*zed.TypeEnum, error) {
 		return nil, p.error("mismatched brackets while parsing enum type")
 	}
 	return &zed.TypeEnum{
-		Kind:     "TypeEnum",
-		Elements: fields,
+		Kind:    "TypeEnum",
+		Symbols: fields,
 	}, nil
 }
 
-func (p *Parser) matchEnumFields() ([]zed.Field, error) {
+func (p *Parser) matchEnumSymbols() ([]string, error) {
 	l := p.lexer
-	var fields []zed.Field
+	var symbols []string
 	for {
-		field, err := p.matchEnumField()
+		name, ok, err := p.matchSymbol()
 		if err != nil {
 			return nil, err
 		}
-		if field == nil {
-			break
+		if !ok {
+			return nil, nil
 		}
-		fields = append(fields, *field)
-		ok, err := l.match(',')
+		symbols = append(symbols, name)
+		ok, err = l.match(',')
 		if err != nil {
 			return nil, err
 		}
@@ -336,32 +336,5 @@ func (p *Parser) matchEnumFields() ([]zed.Field, error) {
 			break
 		}
 	}
-	return fields, nil
-}
-
-func (p *Parser) matchEnumField() (*zed.Field, error) {
-	l := p.lexer
-	name, ok, err := p.matchSymbol()
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return nil, nil
-	}
-	ok, err = l.match(':')
-	if err != nil {
-		return nil, err
-	}
-	var val zed.Value
-	if ok {
-		v, err := p.ParseValue()
-		if err != nil {
-			return nil, err
-		}
-		val = v
-	}
-	return &zed.Field{
-		Name:  name,
-		Value: val,
-	}, nil
+	return symbols, nil
 }


### PR DESCRIPTION
This commit simplifies Zed enums by removing the values from the
list of symbols.  The benefit of this was always dubious and avoiding
the crossing the type/value boundary (by encoding values in types)
simplifies things quite a bit.

Closes #2508