### PR TITLE
Use new mdtest-input in "Zed/Zeek Data Type Compatibility" doc

### DIFF
--- a/zeek/Data-Type-Compatibility.md
+++ b/zeek/Data-Type-Compatibility.md
@@ -70,13 +70,20 @@ applicable to handling certain types.
 
 ## Example
 
-The following example shows an input TSV log that includes each Zeek data type,
-how it's output as ZSON by `zq`, and then how it's written back out again as a Zeek
+The following example shows a TSV log that includes each Zeek data type, how
+it's output as ZSON by `zq`, and then how it's written back out again as a Zeek
 log. You may find it helpful to refer to this example when reading the
 [Type-Specific Details](#type-specific-details) sections.
 
+#### Viewing the TSV log:
+
 ```
-$ cat zeek_types.log
+cat zeek_types.log
+```
+
+#### Output:
+
+```mdtest-input zeek_types.log
 #separator \x09
 #set_separator	,
 #empty_field	(empty)
@@ -86,8 +93,15 @@ $ cat zeek_types.log
 T	123	456	123.4560	1592502151.123456	123.456	smile\xf0\x9f\x98\x81smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	things,in,a,set	order,is,important	Jeanne	122
 ```
 
+#### Reading the TSV log, outputting as ZSON, and saving a copy:
+
+```mdtest-command
+zq -Z zeek_types.log | tee zeek_types.zson
 ```
-$ zq -Z zeek_types.log | tee zeek_types.zson
+
+#### Output:
+
+```mdtest-output
 {
     my_bool: true,
     my_count: 123 (uint64),
@@ -119,8 +133,14 @@ $ zq -Z zeek_types.log | tee zeek_types.zson
 } (=3)
 ```
 
-``` 
-$ zq -f zeek zeek_types.zson
+#### Reading the saved ZSON output and outputting as Zeek TSV:
+
+```mdtest-command
+zq -f zeek zeek_types.zson
+```
+
+#### Output:
+```mdtest-output
 #separator \x09
 #set_separator	,
 #empty_field	(empty)
@@ -232,10 +252,17 @@ Zed that refer to the record at a higher level but affect all values lower
 down in the record hierarchy.
 
 Revisiting the data from our example, we can output all fields within
-`my_record` via this Zed operation:
+`my_record` via a Zed [`cut`](../docs/language/operators#cut) operation.
 
+#### Command:
+
+```mdtest-command
+zq -f zeek 'cut my_record' zeek_types.zson
 ```
-$ zq -f zeek 'cut my_record' zeek_types.zson
+
+#### Output:
+
+```mdtest-output
 #separator \x09
 #set_separator	,
 #empty_field	(empty)


### PR DESCRIPTION
Since the "Zed/Zeek Data Type Compatibility" relies on special ad hoc test data, the new `mdtest-input` support (#2627) is well-suited to ensuring we don't regress there.