### PR TITLE
Join doc

### DIFF
--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -336,8 +336,8 @@ and preferences of some potential eaters of fruit.
 
 #### Example #1 - Inner join
 
-We'll start by outputting only the fruits for which we have one or more
-matching people that like it. The name of the matching person is copied
+We'll start by outputting only the fruits liked by at least one person.
+The name of the matching person is copied
 into a field of a different name in the joined results.
 
 Because we're performing an inner join (the default), the inclusion of the
@@ -378,7 +378,7 @@ fruits will be shown in the results even if no one likes them (e.g., `avocado`).
 
 As another variation, we'll also copy over the age of the matching person. By
 referencing only the field name rather than using `:=` for assignment, the
-original field name `age` from the opposite input is maintained in the results.
+original field name `age` is maintained in the results.
 
 The Zed script `left-join.zed`:
 
@@ -408,7 +408,7 @@ zq -z -I left-join.zed
 
 #### Example #3 - Right join
 
-Next we'll reverse the order of our join. Notice that this causes the `note`
+Next we'll change the join type from `left` to `right`. Notice that this causes the `note`
 field from the right-hand input to appear in the joined results.
 
 The Zed script `right-join.zed`:
@@ -456,15 +456,16 @@ The Zed script `inner-join-pools.zed`:
 
 ```mdtest-input inner-join-pools.zed
 from (
-  fruit => sort flavor;
-  people => sort likes;
+  fruit => pass;
+  people => pass;
 ) | inner join on flavor=likes eater:=name
 ```
 
 Populating the Pools, then executing the Zed script:
 
 ```mdtest-command
-export ZED_LAKE_ROOT=`mktemp -d`
+mkdir lake
+export ZED_LAKE_ROOT=lake
 zed lake init -q
 zed lake create -q -p fruit -orderby flavor:asc
 zed lake create -q -p people -orderby likes:asc

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -309,8 +309,8 @@ conn  2018-03-24T17:15:20.607695Z CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.
 | **Description**           | Return records derived from two inputs when particular values match between them.<br><br>The inputs must be sorted in the same order by their respective join keys. If an input source is already known to be sorted appropriately (either in an input file/object/stream, or if the data is pulled from a [Zed Lake](../../lake/design.md) in that's ordered by this key) an explicit [`sort`](https://github.com/brimdata/zed/tree/main/docs/language/operators#sort) is not required. ||
 | **Syntax**                | `[inner\|left\|right] join on <left-key>=<right-key> [field-list]`          |
 | **Required<br>arguments** | `<left-key>`<br>A field in the left-hand input whose contents will be checked for equality against the `<right-key>`<br><br>`<right-key>`<br>A field in the right-hand input whose contents will be checked for equality against the `<left-key>` |
-| **Optional<br>arguments** | `[inner\|left\|right]`<br>The type of join that should be performed.<br>• `inner` - Return records that have matching values in both inputs (default)<br>• `left` - Return all records from the left-hand input, and matched records from the right-hand input<br>• `right` - Return all records from the right-hand input, and matched records from the left-hand input<br><br>`[field-list]`<br>One or more comma-separated field names or assignments. The values in the field(s) specified will be copied from the _opposite_ input (right-hand side for a `left` or `inner` join, left-hand side for a `right` join) into the joined results. If no field list is provided, no fields from the opposite input will appear in the joined results (see [zed/2815](https://github.com/brimdata/zed/issues/2815) regarding expected enhancements in this area). |
-| **Limitations**           | • The order of the left/right key names in the equality test must follow the left/right order of the input sources that precede the `join` ([zed/2228](https://github.com/brimdata/zed/issues/2228))<br>• The Zed data types of the respective key fields must match precisely ([zed/2779](https://github.com/brimdata/zed/issues/2779))<br>• Only a simple equality test (not an arbitrary expression) is currently possible ([zed/2766](https://github.com/brimdata/zed/issues/2766))<br>• All fields included in the `[field-list]` must be present in a record of the opposite input for any of them to appear in the joined result ([zed/2833](https://github.com/brimdata/zed/issues/2833)) |
+| **Optional<br>arguments** | `[inner\|left\|right]`<br>The type of join that should be performed.<br>• `inner` - Return only records that have matching key values in both inputs (default)<br>• `left` - Return all records from the left-hand input, and matched records from the right-hand input<br>• `right` - Return all records from the right-hand input, and matched records from the left-hand input<br><br>`[field-list]`<br>One or more comma-separated field names or assignments. The values in the field(s) specified will be copied from the _opposite_ input (right-hand side for a `left` or `inner` join, left-hand side for a `right` join) into the joined results. If no field list is provided, no fields from the opposite input will appear in the joined results (see [zed/2815](https://github.com/brimdata/zed/issues/2815) regarding expected enhancements in this area). |
+| **Limitations**           | • The order of the left/right key names in the equality test must follow the left/right order of the input sources that precede the `join` ([zed/2228](https://github.com/brimdata/zed/issues/2228))<br>• The Zed data types of the respective key fields must match precisely ([zed/2779](https://github.com/brimdata/zed/issues/2779))<br>• Only a simple equality test (not an arbitrary expression) is currently possible ([zed/2766](https://github.com/brimdata/zed/issues/2766))<br>• All fields included in the `[field-list]` must be present in the record of the opposite input for any of them to appear in the joined result ([zed/2833](https://github.com/brimdata/zed/issues/2833)) |
 
 The first input data source for our examples is `fruit.ndjson`, which describes
 the characteristics of some fresh produce.
@@ -324,28 +324,30 @@ the characteristics of some fresh produce.
 {"name":"figs","color":"brown","flavor":"plain"}
 ```
 
-The other input data source is `people.ndjson`, which describes the traits and
-preferences of some potential fruit-eaters.
+The other input data source is `people.ndjson`, which describes the traits
+and preferences of some potential fruit-eaters.
 
 ```mdtest-input people.ndjson
 {"name":"morgan","age":61,"likes":"tart"}
 {"name":"quinn","age":14,"likes":"sweet","note":"many kids enjoy sweets"}
 {"name":"jessie","age":30,"likes":"plain"}
 {"name":"chris","age":47,"likes":"tart"}
-
 ```
 
 #### Example #1 - Inner join
 
-We'll start by outputting only the fruit for which we have one or more matching
-person that likes it. The name of the matching person is copied into a field
-of a different name in the joined results. Because we're performing an inner
-join (the default), the inclusion of the explicit `inner` is not strictly
-necessary, but may be included to help make the Zed self-documenting.
+We'll start by outputting only the fruits for which we have one or more
+matching person that likes it. The name of the matching person is copied
+into a field of a different name in the joined results.
 
-Notice how each input is specified separately within the parenthese-wrapped
+Because we're performing an inner join (the default), the inclusion of the
+explicit `inner` is not strictly necessary, but may be included to help make
+the Zed self-documenting.
+
+Notice how each input is specified separately within the parentheses-wrapped
 `from()` block before the `join` appears in our Zed pipeline.
 
+The Zed script `inner-join.zed`:
 ```mdtest-input inner-join.zed
 from (
   file fruit.ndjson => sort flavor;
@@ -371,15 +373,12 @@ zq -z -I inner-join.zed
 
 #### Example #2 - Left join
 
-Performing a left join that targets the same key fields, now all of our fruits
-will be shown even if no one likes them (note the inclusion of "avocado").
+By performing a left join that targets the same key fields, now all of our
+fruits will be shown even if no one likes them (e.g., `avocado`).
 
-Here we'll also copy over the age of the matching person. By indicating only
-the field name rather than a `:=` assignment, the original field name `age
-from the opposite input is maintained.
-
-The results include the `note` field frrom the left-hand input, since this was
-a left join.
+Here we'll also copy over the age of the matching person. By referencing only
+the field name rather than using `:=` for assignment, the original field name
+`age` from the opposite input is maintained.
 
 The Zed script `left-join.zed`:
 
@@ -409,8 +408,8 @@ zq -z -I left-join.zed
 
 #### Example #3 - Right join
 
-Next we'll reverse the order of our join. The results include the `note` field
-from the right-hand input, since this was a right join.
+Next we'll reverse the order of our join, which causes the `note` field from
+the right-hand input to appear in the joined results.
 
 The Zed script `right-join.zed`:
 
@@ -439,19 +438,19 @@ zq -z -I right-join.zed
 
 #### Example #4 - Inputs from Pools
 
-As our prior examples all used `zq` at the shell, we used `file` in our `from()`
-block to pull our respective inputs from named file sources. However, if the
-inputs are stored in Pools in a Zed lake, the Pool names would be specified in
-the `from()` block.
+As our prior examples all used `zq`, we used `file` in our `from()` block to
+pull our respective inputs from named file sources. However, if the inputs are
+stored in Pools in a Zed lake, the Pool names would be specified in the
+`from()` block.
 
 Here we'll load our data inputs to Pools in a temporary Zed Lake, then execute
 our inner join using `zed lake query`. If the Zed Lake had been fronted by a
-`zed lake serve` process, the equivalent operations would be performed via
-`zapi`.
+`zed lake serve` process, the equivalent operations would be performed over the
+network via `zapi`.
 
-Notice that becasue we happened to use `-orderby` to sort our Pools by the same
+Notice that because we happened to use `-orderby` to sort our Pools by the same
 keys that we reference in our `join`, we did not need to use any explicit
-sort`.
+`sort`.
 
 The Zed script `inner-join-pools.zed`:
 
@@ -488,9 +487,8 @@ zed lake query -z -I inner-join-pools.zed
 
 In addition to named files and Pools as we've used in the prior exampls, Zed is
 also intended to work on streams of data. Here we'll combine our file sources
-into a stream that we'll pipe into `zq` via stdin. To separate and sort the
-respective inputs, we use `has()` to uniquely identify the left and right
-sides.
+into a stream that we'll pipe into `zq` via stdin. To separate the respective
+inputs before sorting, we use `has()` to identify the left and right sides.
 
 The Zed script `inner-join-streamed.zed`:
 

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -494,9 +494,9 @@ records in the stream that will be treated as the left and right sides.
 The Zed script `inner-join-streamed.zed`:
 
 ```mdtest-input inner-join-streamed.zed
-* | split (
-  => has(color) | sort flavor
-  => has(age) | sort likes
+switch (
+  case has(color) => sort flavor
+  case has(age) => sort likes
 ) | inner join on flavor=likes eater:=name
 ```
 

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -464,7 +464,7 @@ from (
 Populating the Pools, then executing the Zed script:
 
 ```mdtest-command
-ZED_LAKE_ROOT=`mktemp -d`
+export ZED_LAKE_ROOT=`mktemp -d`
 zed lake init -q
 zed lake create -q -p fruit -orderby flavor:asc
 zed lake create -q -p people -orderby likes:asc

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -306,13 +306,13 @@ conn  2018-03-24T17:15:20.607695Z CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.
 
 |                           |                                               |
 | ------------------------- | --------------------------------------------- |
-| **Description**           | Return records derived from two inputs when particular values match between them.<br><br>The inputs must be sorted in the same order by their respective join keys. If an input source is already known to be sorted appropriately (either in an input file/object/stream, or if the data is pulled from a [Zed Lake](../../lake/design.md) in that's ordered by this key) an explicit [`sort`](https://github.com/brimdata/zed/tree/main/docs/language/operators#sort) is not required. ||
+| **Description**           | Return records derived from two inputs when particular values match between them.<br><br>The inputs must be sorted in the same order by their respective join keys. If an input source is already known to be sorted appropriately (either in an input file/object/stream, or if the data is pulled from a [Zed Lake](../../lake/design.md) in that's ordered by this key) an explicit upstream [`sort`](https://github.com/brimdata/zed/tree/main/docs/language/operators#sort) is not required. ||
 | **Syntax**                | `[inner\|left\|right] join on <left-key>=<right-key> [field-list]`          |
 | **Required<br>arguments** | `<left-key>`<br>A field in the left-hand input whose contents will be checked for equality against the `<right-key>`<br><br>`<right-key>`<br>A field in the right-hand input whose contents will be checked for equality against the `<left-key>` |
 | **Optional<br>arguments** | `[inner\|left\|right]`<br>The type of join that should be performed.<br>• `inner` - Return only records that have matching key values in both inputs (default)<br>• `left` - Return all records from the left-hand input, and matched records from the right-hand input<br>• `right` - Return all records from the right-hand input, and matched records from the left-hand input<br><br>`[field-list]`<br>One or more comma-separated field names or assignments. The values in the field(s) specified will be copied from the _opposite_ input (right-hand side for a `left` or `inner` join, left-hand side for a `right` join) into the joined results. If no field list is provided, no fields from the opposite input will appear in the joined results (see [zed/2815](https://github.com/brimdata/zed/issues/2815) regarding expected enhancements in this area). |
 | **Limitations**           | • The order of the left/right key names in the equality test must follow the left/right order of the input sources that precede the `join` ([zed/2228](https://github.com/brimdata/zed/issues/2228))<br>• The Zed data types of the respective key fields must match precisely ([zed/2779](https://github.com/brimdata/zed/issues/2779))<br>• Only a simple equality test (not an arbitrary expression) is currently possible ([zed/2766](https://github.com/brimdata/zed/issues/2766))<br>• All fields included in the `[field-list]` must be present in the record of the opposite input for any of them to appear in the joined result ([zed/2833](https://github.com/brimdata/zed/issues/2833)) |
 
-The first input data source for our examples is `fruit.ndjson`, which describes
+The first input data source for our usage examples is `fruit.ndjson`, which describes
 the characteristics of some fresh produce.
 
 ```mdtest-input fruit.ndjson
@@ -325,7 +325,7 @@ the characteristics of some fresh produce.
 ```
 
 The other input data source is `people.ndjson`, which describes the traits
-and preferences of some potential fruit-eaters.
+and preferences of some potential eaters of fruit.
 
 ```mdtest-input people.ndjson
 {"name":"morgan","age":61,"likes":"tart"}
@@ -374,11 +374,11 @@ zq -z -I inner-join.zed
 #### Example #2 - Left join
 
 By performing a left join that targets the same key fields, now all of our
-fruits will be shown even if no one likes them (e.g., `avocado`).
+fruits will be shown in the results even if no one likes them (e.g., `avocado`).
 
-Here we'll also copy over the age of the matching person. By referencing only
-the field name rather than using `:=` for assignment, the original field name
-`age` from the opposite input is maintained.
+As another variatino, we'll also copy over the age of the matching person. By
+referencing only the field name rather than using `:=` for assignment, the
+original field name `age` from the opposite input is maintained in the results.
 
 The Zed script `left-join.zed`:
 
@@ -408,8 +408,8 @@ zq -z -I left-join.zed
 
 #### Example #3 - Right join
 
-Next we'll reverse the order of our join, which causes the `note` field from
-the right-hand input to appear in the joined results.
+Next we'll reverse the order of our join. Notice that this casues the `note`
+field from the right-hand input to appear in the joined results.
 
 The Zed script `right-join.zed`:
 
@@ -440,17 +440,17 @@ zq -z -I right-join.zed
 
 As our prior examples all used `zq`, we used `file` in our `from()` block to
 pull our respective inputs from named file sources. However, if the inputs are
-stored in Pools in a Zed lake, the Pool names would be specified in the
+stored in Pools in a Zed lake, the Pool names would instead be specified in the
 `from()` block.
 
-Here we'll load our data inputs to Pools in a temporary Zed Lake, then execute
+Here we'll load our input data to Pools in a temporary Zed Lake, then execute
 our inner join using `zed lake query`. If the Zed Lake had been fronted by a
 `zed lake serve` process, the equivalent operations would be performed over the
-network via `zapi`.
+network via `zed api`.
 
 Notice that because we happened to use `-orderby` to sort our Pools by the same
 keys that we reference in our `join`, we did not need to use any explicit
-`sort`.
+upstream `sort`.
 
 The Zed script `inner-join-pools.zed`:
 
@@ -485,10 +485,11 @@ zed lake query -z -I inner-join-pools.zed
 
 #### Example #5 - Streamed input
 
-In addition to named files and Pools as we've used in the prior example, Zed is
-also intended to work on streams of data. Here we'll combine our file sources
-into a stream that we'll pipe into `zq` via stdin. To separate the respective
-inputs before sorting, we use `has()` to identify the left and right sides.
+In addition to the named files and Pools like we've used in the prior examples,
+Zed is also intended to work on streams of data. Here we'll combine our file
+sources into a stream that we'll pipe into `zq` via stdin. Because join requires
+two separate inputs, here we'll use the `has()` function to identify the
+records in the stream that will be treated as the left and right sides.
 
 The Zed script `inner-join-streamed.zed`:
 

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -337,8 +337,8 @@ and preferences of some potential eaters of fruit.
 #### Example #1 - Inner join
 
 We'll start by outputting only the fruits liked by at least one person.
-The name of the matching person is copied
-into a field of a different name in the joined results.
+The name of the matching person is copied into a field of a different name in
+the joined results.
 
 Because we're performing an inner join (the default), the inclusion of the
 explicit `inner` is not strictly necessary, but may be included to help make
@@ -408,8 +408,8 @@ zq -z -I left-join.zed
 
 #### Example #3 - Right join
 
-Next we'll change the join type from `left` to `right`. Notice that this causes the `note`
-field from the right-hand input to appear in the joined results.
+Next we'll change the join type from `left` to `right`. Notice that this causes
+the `note` field from the right-hand input to appear in the joined results.
 
 The Zed script `right-join.zed`:
 

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -337,7 +337,7 @@ and preferences of some potential fruit-eaters.
 #### Example #1 - Inner join
 
 We'll start by outputting only the fruits for which we have one or more
-matching person that likes it. The name of the matching person is copied
+matching people that like it. The name of the matching person is copied
 into a field of a different name in the joined results.
 
 Because we're performing an inner join (the default), the inclusion of the
@@ -485,7 +485,7 @@ zed lake query -z -I inner-join-pools.zed
 
 #### Example #5 - Streamed input
 
-In addition to named files and Pools as we've used in the prior exampls, Zed is
+In addition to named files and Pools as we've used in the prior example, Zed is
 also intended to work on streams of data. Here we'll combine our file sources
 into a stream that we'll pipe into `zq` via stdin. To separate the respective
 inputs before sorting, we use `has()` to identify the left and right sides.


### PR DESCRIPTION
Here's the long overdue doc for `join` as simple CLI-executable variations that use small sample data thanks to #2627. I'll add some PR comments where I'm unsure if we're showing things in the best possible way and/or if there's a possible enhancement to file.

In addition to the examples I've shown here, there's one more I was hoping to include but I'm not able to come up with the correct syntax. I'm not sure if I'm just getting the syntax wrong or if it's not possible at all. My goal is to effectively show a "multi-way join" by using hierarchy in the dataflow to join two inputs first, then join a third input with the output of the first join. Following on from the last of the examples shown, let's say we had this additional data source that had the RGB values of the colors we use for all our fruit.

```
$ cat colors.ndjson 
{"color":"red","hex":"#FF0000","rgb":{"r":255,"g":0,"b":0}}
{"color":"yellow","hex":"#FFFF00","rgb":{"r":255,"g":255,"b":0}}
{"color":"green","hex":"#008000","rgb":{"r":0,"g":128,"b":0}}
{"color":"brown","hex":"#A52A2A","rgb":{"r":165,"g":42,"b":42}}
```

As separate operations, I can first join this with my `fruit.ndjson` records:

```
$ cat color-join.zed 
from (
  file fruit.ndjson => sort color;
  file colors.ndjson => sort color;
) | inner join on color=color hex,rgb

$ zq -z -I color-join.zed | tee rgbfruit.zson
{name:"dates",color:"brown",flavor:"sweet",note:"in season",hex:"#A52A2A",rgb:{r:165,g:42,b:42}}
{name:"figs",color:"brown",flavor:"plain",hex:"#A52A2A",rgb:{r:165,g:42,b:42}}
{name:"avocado",color:"green",flavor:"savory",hex:"#008000",rgb:{r:0,g:128,b:0}}
{name:"apple",color:"red",flavor:"tart",hex:"#FF0000",rgb:{r:255,g:0,b:0}}
{name:"strawberry",color:"red",flavor:"sweet",hex:"#FF0000",rgb:{r:255,g:0,b:0}}
{name:"banana",color:"yellow",flavor:"sweet",hex:"#FFFF00",rgb:{r:255,g:255,b:0}}
```

...then join _that_ output with my `people.ndjson`:

```
$ cat inner-join-rgb.zed 
from (
  file rgbfruit.zson => sort flavor;
  file people.ndjson => sort likes;
) | inner join on flavor=likes eater:=name

$ zq -z -I inner-join-rgb.zed 
{name:"figs",color:"brown",flavor:"plain",hex:"#A52A2A",rgb:{r:165,g:42,b:42},eater:"jessie"}
{name:"dates",color:"brown",flavor:"sweet",note:"in season",hex:"#A52A2A",rgb:{r:165,g:42,b:42},eater:"quinn"}
{name:"strawberry",color:"red",flavor:"sweet",hex:"#FF0000",rgb:{r:255,g:0,b:0},eater:"quinn"}
{name:"banana",color:"yellow",flavor:"sweet",hex:"#FFFF00",rgb:{r:255,g:255,b:0},eater:"quinn"}
{name:"apple",color:"red",flavor:"tart",hex:"#FF0000",rgb:{r:255,g:0,b:0},eater:"morgan"}
{name:"apple",color:"red",flavor:"tart",hex:"#FF0000",rgb:{r:255,g:0,b:0},eater:"chris"}
```

However, my attempt to come up with the correct syntax to do this all in one Zed script all become parse errors, such as:

```
$ cat multi-way-join.zed 
from
( 
  (
    file fruit.ndjson => sort color;
    file colors.ndjson => sort color;
  ) | inner join on color=color hex,rgb | sort flavor;
  (
   file people.ndjson => sort likes;
  )
) | inner join on flavor=likes eater:=name

$ zq -z -I multi-way-join.zed
zq: parse error: error parsing Z at line 4, col 23:
from
( 
  (
    file fruit.ndjson => sort color;
                  === ^ ===
    file colors.ndjson => sort color;
  ) | inner join on color=color hex,rgb | sort flavor;
  (
   file people.ndjson => sort likes;
  )
) | inner join on flavor=likes eater:=name
```

Could someone who better understands the parser help me confirm if I'm barking up the wrong tree here? Thanks!