### PR TITLE
pkg/storage: fix Seeker.Seek

### DIFF
--- a/pkg/storage/bytes.go
+++ b/pkg/storage/bytes.go
@@ -9,6 +9,7 @@ type bytesReader struct {
 }
 
 var _ Reader = (*bytesReader)(nil)
+var _ Sizer = (*bytesReader)(nil)
 
 func NewBytesReader(b []byte) *bytesReader {
 	return &bytesReader{bytes.NewReader(b)}
@@ -16,4 +17,8 @@ func NewBytesReader(b []byte) *bytesReader {
 
 func (*bytesReader) Close() error {
 	return nil
+}
+
+func (b *bytesReader) Size() (int64, error) {
+	return b.Reader.Size(), nil
 }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -97,12 +97,17 @@ func NewSeeker(r Reader) (*Seeker, error) {
 		return nil, err
 	}
 	return &Seeker{
-		Seeker: io.NewSectionReader(r, 0, size),
-		Reader: r,
+		ReadSeeker: io.NewSectionReader(r, 0, size),
+		Reader:     r,
 	}, nil
 }
 
 type Seeker struct {
-	io.Seeker
+	io.ReadSeeker
 	Reader
+}
+
+// Read resolves the ambiguous selector s.Read to s.ReadSeeker.Read.
+func (s *Seeker) Read(b []byte) (int, error) {
+	return s.ReadSeeker.Read(b)
 }

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeeker(t *testing.T) {
+	r := NewBytesReader([]byte{0, 1})
+	s, err := NewSeeker(r)
+	require.NoError(t, err)
+
+	// Test that ReadAt doesn't affect the offset.
+	b := make([]byte, 3)
+	n, err := s.ReadAt(b, 1)
+	assert.ErrorIs(t, err, io.EOF)
+	assert.Equal(t, 1, n)
+	assert.EqualValues(t, 1, b[0])
+	n64, err := s.Seek(0, io.SeekCurrent)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, n64)
+
+	// Test Read followed by Seek to the beginning.
+	for i := 0; i < 3; i++ {
+		n, err = s.Read(b)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, n)
+		assert.EqualValues(t, 0, b[0])
+		assert.EqualValues(t, 1, b[1])
+		n64, err = s.Seek(0, io.SeekStart)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 0, n64)
+	}
+}

--- a/zst/ztests/empty-file.yaml
+++ b/zst/ztests/empty-file.yaml
@@ -4,4 +4,4 @@ script: |
 outputs:
   - name: stderr
     regexp: |
-      .*: zst trailer not found
+      .*: EOF


### PR DESCRIPTION
Seeker.Seek and Seeker.Read denote methods on different embedded
interfaces, causing Seek to operate on a different offset than Read.
Fix that by embedding an io.ReadSeeker.

Fixes #2851.