### PR TITLE
csv.Reader enable TrimLeadingSpace

### DIFF
--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -31,6 +31,7 @@ type Reader struct {
 func NewReader(r io.Reader, zctx *zson.Context) *Reader {
 	reader := csv.NewReader(r)
 	reader.ReuseRecord = true
+	reader.TrimLeadingSpace = true
 	return &Reader{
 		reader:    reader,
 		marshaler: zson.NewZNGMarshalerWithContext(zctx),

--- a/zio/csvio/ztests/issue-2332.yaml
+++ b/zio/csvio/ztests/issue-2332.yaml
@@ -1,0 +1,14 @@
+script: zq -i csv -z '*' -
+
+inputs:
+  - name: stdin
+    data: |
+      "Letter", "Frequency", "Percentage"
+        "A",  24373121,  8.1
+        "B",   4762938,  1.6
+
+outputs:
+  - name: stdout
+    data: |
+      {Letter:"A",Frequency:24373121.,Percentage:8.1}
+      {Letter:"B",Frequency:4762938.,Percentage:1.6}


### PR DESCRIPTION
This fixes an issue where the Reader would return an error on columns
placed in quotes.

Closes #2332