### PR TITLE
zapi query: Surface errors within query

### DIFF
--- a/service/ztests/query-bad-commit.yaml
+++ b/service/ztests/query-bad-commit.yaml
@@ -1,0 +1,13 @@
+script: |
+  source service.sh
+  zapi create -p test
+  zapi query "from test at doesnotexist"
+
+inputs:
+  - name: service.sh
+    source: service.sh
+
+outputs:
+  - name: stderr
+    data: |
+      doesnotexist: invalid commit ID


### PR DESCRIPTION
Was ignoring the ctrl message *api.QueryError. Don't do that.

Closes #2804