### PR TITLE
improve parse error formatting

### DIFF
--- a/cli/lakecli/lakecli.go
+++ b/cli/lakecli/lakecli.go
@@ -39,7 +39,7 @@ type Root interface {
 	DeleteIndices(context.Context, []ksuid.KSUID) ([]index.Index, error)
 	LookupIndices(context.Context, []ksuid.KSUID) ([]index.Index, error)
 	ScanIndex(context.Context, zio.Writer, []ksuid.KSUID) error
-	Query(context.Context, driver.Driver, string) (zbuf.ScannerStats, error)
+	Query(ctx context.Context, d driver.Driver, src string, filenames ...string) (zbuf.ScannerStats, error)
 }
 
 type Pool interface {

--- a/cli/lakecli/local.go
+++ b/cli/lakecli/local.go
@@ -141,10 +141,10 @@ func (r *LocalRoot) ScanIndex(ctx context.Context, w zio.Writer, ids []ksuid.KSU
 	return r.Root.ScanIndex(ctx, w, ids)
 }
 
-func (r *LocalRoot) Query(ctx context.Context, d driver.Driver, zedSrc string) (zbuf.ScannerStats, error) {
-	query, err := compiler.ParseProc(zedSrc)
+func (r *LocalRoot) Query(ctx context.Context, d driver.Driver, src string, filenames ...string) (zbuf.ScannerStats, error) {
+	query, err := compiler.ParseProc(src, filenames...)
 	if err != nil {
-		return zbuf.ScannerStats{}, fmt.Errorf("parse error: %w", err)
+		return zbuf.ScannerStats{}, err
 	}
 	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
 		return zbuf.ScannerStats{}, err

--- a/cli/lakecli/remote.go
+++ b/cli/lakecli/remote.go
@@ -185,8 +185,8 @@ func (r *RemoteRoot) ScanIndex(ctx context.Context, w zio.Writer, ids []ksuid.KS
 	return errors.New("unsupported")
 }
 
-func (r *RemoteRoot) Query(ctx context.Context, d driver.Driver, query string) (zbuf.ScannerStats, error) {
-	res, err := r.conn.Query(ctx, query)
+func (r *RemoteRoot) Query(ctx context.Context, d driver.Driver, src string, filenames ...string) (zbuf.ScannerStats, error) {
+	res, err := r.conn.Query(ctx, src, filenames...)
 	if err != nil {
 		return zbuf.ScannerStats{}, err
 	}

--- a/cmd/zed/query/command.go
+++ b/cmd/zed/query/command.go
@@ -191,20 +191,17 @@ func isJoin(p ast.Proc) bool {
 }
 
 func ParseSourcesAndInputs(paths, includes Includes) ([]string, ast.Proc, error) {
-	srcs, err := includes.Read()
-	if err != nil {
-		return nil, nil, err
-	}
+	var src string
 	if len(paths) != 0 && !cli.FileExists(paths[0]) && !isURLWithKnownScheme(paths[0], "http", "https", "s3") {
 		if len(paths) == 1 {
 			// We don't interpret the first arg as a query if there
 			// are no additional args.
 			return nil, nil, fmt.Errorf("no such file: %s", paths[0])
 		}
-		srcs = append(srcs, paths[0])
+		src = paths[0]
 		paths = paths[1:]
 	}
-	query, err := parseZed(srcs)
+	query, err := compiler.ParseProc(src, includes...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -222,34 +219,6 @@ func isURLWithKnownScheme(path string, schemes ...string) bool {
 		}
 	}
 	return false
-}
-
-func CombineSources(args, includes Includes) (string, error) {
-	srcs, err := includes.Read()
-	if err != nil {
-		return "", err
-	}
-	zedSrc := strings.Join(append(srcs, args...), "\n")
-	if zedSrc == "" {
-		zedSrc = "*"
-	}
-	return zedSrc, nil
-}
-
-func ParseSources(args, includes Includes) (ast.Proc, error) {
-	zedSrc, err := CombineSources(args, includes)
-	if err != nil {
-		return nil, err
-	}
-	return compiler.ParseProc(zedSrc)
-}
-
-func parseZed(srcs []string) (ast.Proc, error) {
-	zedSrc := strings.Join(srcs, "\n")
-	if zedSrc == "" {
-		zedSrc = "*"
-	}
-	return compiler.ParseProc(zedSrc)
 }
 
 func PrintStats(stats zbuf.ScannerStats) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -140,8 +140,8 @@ func (r *Runtime) Parallelize(n int) error {
 
 // ParseProc() is an entry point for use from external go code,
 // mostly just a wrapper around Parse() that casts the return value.
-func ParseProc(z string) (ast.Proc, error) {
-	parsed, err := parser.ParseZed(z)
+func ParseProc(src string, filenames ...string) (ast.Proc, error) {
+	parsed, err := parser.ParseZed(filenames, src)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/parser/api.go
+++ b/compiler/parser/api.go
@@ -1,0 +1,146 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ParseZed calls ConcatSource followed by Parse.  If Parse fails, it calls
+// ImproveError.
+func ParseZed(filenames []string, src string) (interface{}, error) {
+	src, srcInfo, err := ConcatSource(filenames, src)
+	if err != nil {
+		return nil, err
+	}
+	p, err := Parse("", []byte(src))
+	if err != nil {
+		return nil, ImproveError(err, src, srcInfo)
+	}
+	return p, nil
+}
+
+// ParseZedByRule calls Parse with rule as entrypoint.  If Parse fails, it calls
+// ImproveError.
+func ParseZedByRule(rule, src string) (interface{}, error) {
+	p, err := Parse("", []byte(src), Entrypoint(rule))
+	if err != nil {
+		return nil, ImproveError(err, src, nil)
+	}
+	return p, nil
+}
+
+// SourceInfo holds source file offsets.
+type SourceInfo struct {
+	filename string
+	start    int
+	end      int
+}
+
+// ConcatSource concatenates the source files in filenames followed by src,
+// returning the result and a corresponding slice of SourceInfos.
+func ConcatSource(filenames []string, src string) (string, []SourceInfo, error) {
+	var b strings.Builder
+	var sis []SourceInfo
+	for _, f := range filenames {
+		bb, err := os.ReadFile(f)
+		if err != nil {
+			return "", nil, err
+		}
+		start := b.Len()
+		b.Write(bb)
+		sis = append(sis, SourceInfo{f, start, b.Len()})
+		b.WriteByte('\n')
+	}
+	start := b.Len()
+	b.WriteString(src)
+	sis = append(sis, SourceInfo{"", start, b.Len()})
+	if b.Len() == 0 {
+		return "*", nil, nil
+	}
+	return b.String(), sis, nil
+}
+
+// ImproveError tries to improve an error from Parse.  err is the error.  src is
+// the source code for which Parse return err.  If src came from ConcatSource,
+// sis is the corresponding slice of SourceInfo; otherwise, sis is nil.
+func ImproveError(err error, src string, sis []SourceInfo) error {
+	el, ok := err.(errList)
+	if !ok || len(el) != 1 {
+		return err
+	}
+	pe, ok := el[0].(*parserError)
+	if !ok {
+		return err
+	}
+	return NewError(src, sis, pe.pos.offset)
+}
+
+// Error is a parse error with nice formatting.  It includes the source code
+// line containing the error.
+type Error struct {
+	Offset int // offset into original source code
+
+	filename string // omitted from formatting if ""
+	lineNum  int    // zero-based; omitted from formatting if negative
+
+	line   string // contains no newlines
+	column int    // zero-based
+}
+
+// NewError returns an Error.  src is the source code containing the error.  If
+// src came from ConcatSource, sis is the corresponding slice of SourceInfo;
+// otherwise, src is nil.  offset is the offset of the error within src.
+func NewError(src string, sis []SourceInfo, offset int) error {
+	var filename string
+	for _, si := range sis {
+		if offset < si.end {
+			filename = si.filename
+			offset -= si.start
+			src = src[si.start:si.end]
+			break
+		}
+	}
+	lineNum := -1
+	if filename != "" || strings.Count(src, "\n") > 0 {
+		lineNum = strings.Count(src[:offset], "\n")
+	}
+	column := offset
+	if i := strings.LastIndexByte(src[:offset], '\n'); i != -1 {
+		column -= i + 1
+		src = src[i+1:]
+	}
+	if i := strings.IndexByte(src, '\n'); i != -1 {
+		src = src[:i]
+	}
+	return &Error{
+		Offset:   offset,
+		filename: filename,
+		lineNum:  lineNum,
+		line:     src,
+		column:   column,
+	}
+}
+
+func (e *Error) Error() string {
+	var b strings.Builder
+	b.WriteString("error parsing Zed ")
+	if e.filename != "" {
+		fmt.Fprintf(&b, "in %s ", e.filename)
+	}
+	b.WriteString("at ")
+	if e.lineNum >= 0 {
+		fmt.Fprintf(&b, "line %d, ", e.lineNum+1)
+	}
+	fmt.Fprintf(&b, "column %d:\n%s\n", e.column+1, e.line)
+	for k := 0; k < e.column; k++ {
+		if k >= e.column-4 && k != e.column-1 {
+			b.WriteByte('=')
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	b.WriteByte('^')
+	b.WriteString(" ===")
+	return b.String()
+}

--- a/compiler/parser/support.go
+++ b/compiler/parser/support.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -114,59 +113,4 @@ func makeUnicodeChar(chars interface{}) string {
 	}
 
 	return string(r)
-}
-
-func ImproveError(src string, e error) error {
-	el, ok := e.(errList)
-	if !ok || len(el) != 1 {
-		return e
-	}
-	pe, ok := el[0].(*parserError)
-	if !ok {
-		return e
-	}
-	lineNo, colNo := pe.pos.line-1, pe.pos.col
-	lines := strings.Split(src, "\n")
-	if lineNo >= len(lines) {
-		return e
-	}
-	var b strings.Builder
-	if len(lines) == 1 {
-		b.WriteString(fmt.Sprintf("error parsing Zed at column %d:\n", colNo))
-	} else {
-		b.WriteString(fmt.Sprintf("error parsing Zed at line %d, col %d:\n", lineNo+1, colNo))
-	}
-	b.WriteString(strings.Join(lines[:lineNo+1], "\n"))
-	b.WriteByte('\n')
-	colNo--
-	for k := 0; k < colNo; k++ {
-		if k >= colNo-4 && k != colNo-1 {
-			b.WriteByte('=')
-		} else {
-			b.WriteByte(' ')
-		}
-	}
-	b.WriteByte('^')
-	b.WriteString(" ===")
-	if lineNo+1 < len(lines) {
-		b.WriteByte('\n')
-		b.WriteString(strings.Join(lines[lineNo+1:], "\n"))
-	}
-	return errors.New(strings.TrimRight(b.String(), "\n"))
-}
-
-func ParseZed(src string) (interface{}, error) {
-	p, err := Parse("", []byte(src))
-	if err != nil {
-		return nil, ImproveError(src, err)
-	}
-	return p, nil
-}
-
-func ParseZedByRule(rule, src string) (interface{}, error) {
-	p, err := Parse("", []byte(src), Entrypoint(rule))
-	if err != nil {
-		return nil, ImproveError(src, err)
-	}
-	return p, nil
 }

--- a/compiler/ztests/badshaper.yaml
+++ b/compiler/ztests/badshaper.yaml
@@ -12,7 +12,6 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      zq: error parsing Zed at line 1, col 34:
+      zq: error parsing Zed in badshaper.zed at line 1, column 34:
       type foo={_path:string,testfield:"null"}
                                    === ^ ===
-      put . = shape(foo)

--- a/lake/ztests/query-parse-error.yaml
+++ b/lake/ztests/query-parse-error.yaml
@@ -1,0 +1,67 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  echo =1= >&2
+  ! zed lake query -z "$(cat bad-single-line.zed)"
+  echo =2= >&2
+  ! zed lake query -z "$(cat bad-multiple-lines.zed)"
+  echo =3= >&2
+  ! zed lake query -z -I good.zed "$(cat bad-single-line.zed)"
+  echo =4= >&2
+  ! zed lake query -z -I good.zed "$(cat bad-multiple-lines.zed)"
+  echo =5= >&2
+  ! zed lake query -z -I bad-single-line.zed
+  echo =6= >&2
+  ! zed lake query -z -I bad-multiple-lines.zed
+  echo =7= >&2
+  ! zed lake query -z -I good.zed -I bad-single-line.zed
+  echo =8= >&2
+  ! zed lake query -z -I good.zed -I bad-multiple-lines.zed
+
+inputs:
+  - name: bad-single-line.zed
+    data: |
+      from test \ count()
+  - name: bad-multiple-lines.zed
+    data: |
+      from
+      test \ count()
+  - name: good.zed
+    data: |
+      type mystring=string
+
+outputs:
+  - name: stderr
+    data: |
+      =1=
+      error parsing Zed at column 11:
+      from test \ count()
+            === ^ ===
+      =2=
+      error parsing Zed at line 2, column 6:
+      test \ count()
+       === ^ ===
+      =3=
+      error parsing Zed at column 11:
+      from test \ count()
+            === ^ ===
+      =4=
+      error parsing Zed at line 2, column 6:
+      test \ count()
+       === ^ ===
+      =5=
+      error parsing Zed in bad-single-line.zed at line 1, column 11:
+      from test \ count()
+            === ^ ===
+      =6=
+      error parsing Zed in bad-multiple-lines.zed at line 2, column 6:
+      test \ count()
+       === ^ ===
+      =7=
+      error parsing Zed in bad-single-line.zed at line 1, column 11:
+      from test \ count()
+            === ^ ===
+      =8=
+      error parsing Zed in bad-multiple-lines.zed at line 2, column 6:
+      test \ count()
+       === ^ ===

--- a/service/request.go
+++ b/service/request.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/brimdata/zed/api"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
@@ -184,6 +185,11 @@ func (w *ResponseWriter) Marshal(body interface{}) bool {
 func errorResponse(e error) (status int, ae *api.Error) {
 	status = http.StatusInternalServerError
 	ae = &api.Error{Type: "Error"}
+
+	var pe *parser.Error
+	if errors.As(e, &pe) {
+		ae.Info = map[string]int{"parse_error_offset": pe.Offset}
+	}
 
 	var ze *zqe.Error
 	if !errors.As(e, &ze) {

--- a/service/ztests/query-parse-error.yaml
+++ b/service/ztests/query-parse-error.yaml
@@ -1,0 +1,67 @@
+script: |
+  source service.sh
+  echo =1= >&2
+  ! zed api query -z "$(cat bad-single-line.zed)"
+  echo =2= >&2
+  ! zed api query -z "$(cat bad-multiple-lines.zed)"
+  echo =3= >&2
+  ! zed api query -z -I good.zed "$(cat bad-single-line.zed)"
+  echo =4= >&2
+  ! zed api query -z -I good.zed "$(cat bad-multiple-lines.zed)"
+  echo =5= >&2
+  ! zed api query -z -I bad-single-line.zed
+  echo =6= >&2
+  ! zed api query -z -I bad-multiple-lines.zed
+  echo =7= >&2
+  ! zed api query -z -I good.zed -I bad-single-line.zed
+  echo =8= >&2
+  ! zed api query -z -I good.zed -I bad-multiple-lines.zed
+
+inputs:
+  - name: bad-single-line.zed
+    data: |
+      from test \ count()
+  - name: bad-multiple-lines.zed
+    data: |
+      from
+      test \ count()
+  - name: good.zed
+    data: |
+      type mystring=string
+  - name: service.sh
+
+outputs:
+  - name: stderr
+    data: |
+      =1=
+      error parsing Zed at column 11:
+      from test \ count()
+            === ^ ===
+      =2=
+      error parsing Zed at line 2, column 6:
+      test \ count()
+       === ^ ===
+      =3=
+      error parsing Zed at column 11:
+      from test \ count()
+            === ^ ===
+      =4=
+      error parsing Zed at line 2, column 6:
+      test \ count()
+       === ^ ===
+      =5=
+      error parsing Zed in bad-single-line.zed at line 1, column 11:
+      from test \ count()
+            === ^ ===
+      =6=
+      error parsing Zed in bad-multiple-lines.zed at line 2, column 6:
+      test \ count()
+       === ^ ===
+      =7=
+      error parsing Zed in bad-single-line.zed at line 1, column 11:
+      from test \ count()
+            === ^ ===
+      =8=
+      error parsing Zed in bad-multiple-lines.zed at line 2, column 6:
+      test \ count()
+       === ^ ===


### PR DESCRIPTION
When a parse error occurs, Zed tools print the full source code with no
source file information.  This is inhospitable when programs are long,
composed from files and the command line, or composed from multiple
files.  Improve this by printing only the source code line containing
the error along with a file name if appropriate.

Closes #2391.