### PR TITLE
compiler/parser: unify from, split, and switch syntax

### DIFF
--- a/cmd/zq/ztests/from-file-error.yaml
+++ b/cmd/zq/ztests/from-file-error.yaml
@@ -4,7 +4,7 @@ script: |
 inputs:
   - name: query.zed
     data: |
-      from ( file a.zson )
+      from ( file a.zson; )
 
 outputs:
   - name: stderr

--- a/cmd/zq/ztests/from-file.yaml
+++ b/cmd/zq/ztests/from-file.yaml
@@ -4,7 +4,7 @@ script: |
 inputs:
   - name: query.zed
     data: |
-      from ( file a.zson )
+      from ( file a.zson; )
   - name: a.zson
     data: &a_zson |
       {f:1}

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -318,174 +318,169 @@ function peg$parse(input, options) {
       peg$c15 = function(p) { return p },
       peg$c16 = "=>",
       peg$c17 = peg$literalExpectation("=>", false),
-      peg$c18 = function(first, rest) {
-            return [first, ... rest[0]]
-          },
-      peg$c19 = function(first) {
-            return [first]
+      peg$c18 = function(s) { return s },
+      peg$c19 = function(e, proc) {
+            return {"expr": e, "proc": proc}
           },
       peg$c20 = function(proc) {
             return {"expr": {"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}
           },
-      peg$c21 = function(e, proc) {
-            return {"expr": e, "proc": proc}
+      peg$c21 = "default",
+      peg$c22 = peg$literalExpectation("default", true),
+      peg$c23 = function(source, seq) {
+            return {"kind": "Trunk", "source": source, "seq": seq}
           },
-      peg$c22 = "default",
-      peg$c23 = peg$literalExpectation("default", true),
-      peg$c24 = function(source, seq) {
-            return {"kind": "Trunk", "source": source, "seq":seq }
-          },
-      peg$c25 = function(seq) { return seq },
-      peg$c26 = "",
-      peg$c27 = function() { return null},
-      peg$c28 = "split",
-      peg$c29 = peg$literalExpectation("split", false),
-      peg$c30 = "(",
-      peg$c31 = peg$literalExpectation("(", false),
-      peg$c32 = ")",
-      peg$c33 = peg$literalExpectation(")", false),
-      peg$c34 = function(procArray) {
+      peg$c24 = function(seq) { return seq },
+      peg$c25 = "",
+      peg$c26 = function() { return null},
+      peg$c27 = "split",
+      peg$c28 = peg$literalExpectation("split", false),
+      peg$c29 = "(",
+      peg$c30 = peg$literalExpectation("(", false),
+      peg$c31 = ")",
+      peg$c32 = peg$literalExpectation(")", false),
+      peg$c33 = function(procArray) {
             return {"kind": "Parallel", "procs": procArray}
           },
-      peg$c35 = "switch",
-      peg$c36 = peg$literalExpectation("switch", false),
-      peg$c37 = function(caseArray) {
+      peg$c34 = "switch",
+      peg$c35 = peg$literalExpectation("switch", false),
+      peg$c36 = function(caseArray) {
             return {"kind": "Switch", "cases": caseArray}
           },
-      peg$c38 = "from",
-      peg$c39 = peg$literalExpectation("from", false),
-      peg$c40 = function(trunks) {
+      peg$c37 = "from",
+      peg$c38 = peg$literalExpectation("from", false),
+      peg$c39 = function(trunks) {
             return {"kind": "From", "trunks": trunks}
           },
-      peg$c41 = function(f) { return f },
-      peg$c42 = function(a) { return a },
-      peg$c43 = function(expr) {
+      peg$c40 = function(f) { return f },
+      peg$c41 = function(a) { return a },
+      peg$c42 = function(expr) {
             return {"kind": "Filter", "expr": expr}
           },
-      peg$c44 = /^[);]/,
-      peg$c45 = peg$classExpectation([")", ";"], false, false),
-      peg$c46 = "|",
-      peg$c47 = peg$literalExpectation("|", false),
-      peg$c48 = "{",
-      peg$c49 = peg$literalExpectation("{", false),
-      peg$c50 = "[",
-      peg$c51 = peg$literalExpectation("[", false),
-      peg$c52 = ":",
-      peg$c53 = peg$literalExpectation(":", false),
-      peg$c54 = "matches",
-      peg$c55 = peg$literalExpectation("matches", false),
-      peg$c56 = "==",
-      peg$c57 = peg$literalExpectation("==", false),
-      peg$c58 = "!=",
-      peg$c59 = peg$literalExpectation("!=", false),
-      peg$c60 = "in",
-      peg$c61 = peg$literalExpectation("in", false),
-      peg$c62 = "<=",
-      peg$c63 = peg$literalExpectation("<=", false),
-      peg$c64 = "<",
-      peg$c65 = peg$literalExpectation("<", false),
-      peg$c66 = ">=",
-      peg$c67 = peg$literalExpectation(">=", false),
-      peg$c68 = ">",
-      peg$c69 = peg$literalExpectation(">", false),
-      peg$c70 = function() { return text() },
-      peg$c71 = "-with",
-      peg$c72 = peg$literalExpectation("-with", false),
-      peg$c73 = ",",
-      peg$c74 = peg$literalExpectation(",", false),
-      peg$c75 = function(first, rest) {
+      peg$c43 = /^[);]/,
+      peg$c44 = peg$classExpectation([")", ";"], false, false),
+      peg$c45 = "|",
+      peg$c46 = peg$literalExpectation("|", false),
+      peg$c47 = "{",
+      peg$c48 = peg$literalExpectation("{", false),
+      peg$c49 = "[",
+      peg$c50 = peg$literalExpectation("[", false),
+      peg$c51 = ":",
+      peg$c52 = peg$literalExpectation(":", false),
+      peg$c53 = "matches",
+      peg$c54 = peg$literalExpectation("matches", false),
+      peg$c55 = "==",
+      peg$c56 = peg$literalExpectation("==", false),
+      peg$c57 = "!=",
+      peg$c58 = peg$literalExpectation("!=", false),
+      peg$c59 = "in",
+      peg$c60 = peg$literalExpectation("in", false),
+      peg$c61 = "<=",
+      peg$c62 = peg$literalExpectation("<=", false),
+      peg$c63 = "<",
+      peg$c64 = peg$literalExpectation("<", false),
+      peg$c65 = ">=",
+      peg$c66 = peg$literalExpectation(">=", false),
+      peg$c67 = ">",
+      peg$c68 = peg$literalExpectation(">", false),
+      peg$c69 = function() { return text() },
+      peg$c70 = "-with",
+      peg$c71 = peg$literalExpectation("-with", false),
+      peg$c72 = ",",
+      peg$c73 = peg$literalExpectation(",", false),
+      peg$c74 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c76 = function(t) { return ["or", t] },
-      peg$c77 = function(first, expr) { return ["and", expr] },
-      peg$c78 = function(first, rest) {
+      peg$c75 = function(t) { return ["or", t] },
+      peg$c76 = function(first, expr) { return ["and", expr] },
+      peg$c77 = function(first, rest) {
             return makeBinaryExprChain(first,rest)
           },
-      peg$c79 = "!",
-      peg$c80 = peg$literalExpectation("!", false),
-      peg$c81 = function(e) {
+      peg$c78 = "!",
+      peg$c79 = peg$literalExpectation("!", false),
+      peg$c80 = function(e) {
             return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c82 = function(expr) { return expr },
-      peg$c83 = "*",
-      peg$c84 = peg$literalExpectation("*", false),
-      peg$c88 = function(search) { return search },
-      peg$c89 = function(v) {
+      peg$c81 = function(expr) { return expr },
+      peg$c82 = "*",
+      peg$c83 = peg$literalExpectation("*", false),
+      peg$c87 = function(search) { return search },
+      peg$c88 = function(v) {
             return {"kind": "Search", "text": text(), "value": v}
           },
-      peg$c90 = function() {
+      peg$c89 = function() {
             return {"kind": "Primitive", "type": "bool", "text": "true"}
           },
-      peg$c91 = function(v) {
+      peg$c90 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": v}
           },
-      peg$c92 = function(pattern) {
+      peg$c91 = function(pattern) {
             return {"kind": "RegexpSearch", "pattern": pattern}
           },
-      peg$c93 = peg$literalExpectation("matches", true),
-      peg$c94 = function(f, pattern) {
+      peg$c92 = peg$literalExpectation("matches", true),
+      peg$c93 = function(f, pattern) {
             return {"kind": "RegexpMatch", "pattern": pattern, "expr": f}
           },
-      peg$c95 = "type(",
-      peg$c96 = peg$literalExpectation("type(", false),
-      peg$c97 = function(every, keys, limit) {
+      peg$c94 = "type(",
+      peg$c95 = peg$literalExpectation("type(", false),
+      peg$c96 = function(every, keys, limit) {
             return {"kind": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
           },
-      peg$c98 = function(every, aggs, keys, limit) {
+      peg$c97 = function(every, aggs, keys, limit) {
             let p = {"kind": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
             }
             return p
           },
-      peg$c99 = "summarize",
-      peg$c100 = peg$literalExpectation("summarize", false),
-      peg$c101 = "every",
-      peg$c102 = peg$literalExpectation("every", true),
-      peg$c103 = function(dur) { return dur },
-      peg$c104 = function() { return null },
-      peg$c105 = function(columns) { return columns },
-      peg$c106 = "with",
-      peg$c107 = peg$literalExpectation("with", false),
-      peg$c108 = "-limit",
-      peg$c109 = peg$literalExpectation("-limit", false),
-      peg$c110 = function(limit) { return limit },
-      peg$c111 = function() { return 0 },
-      peg$c112 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c113 = function(first, expr) { return expr },
-      peg$c114 = function(first, rest) {
+      peg$c98 = "summarize",
+      peg$c99 = peg$literalExpectation("summarize", false),
+      peg$c100 = "every",
+      peg$c101 = peg$literalExpectation("every", true),
+      peg$c102 = function(dur) { return dur },
+      peg$c103 = function() { return null },
+      peg$c104 = function(columns) { return columns },
+      peg$c105 = "with",
+      peg$c106 = peg$literalExpectation("with", false),
+      peg$c107 = "-limit",
+      peg$c108 = peg$literalExpectation("-limit", false),
+      peg$c109 = function(limit) { return limit },
+      peg$c110 = function() { return 0 },
+      peg$c111 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c112 = function(first, expr) { return expr },
+      peg$c113 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c115 = ":=",
-      peg$c116 = peg$literalExpectation(":=", false),
-      peg$c117 = function(lval, agg) {
+      peg$c114 = ":=",
+      peg$c115 = peg$literalExpectation(":=", false),
+      peg$c116 = function(lval, agg) {
             return {"kind": "Assignment", "lhs": lval, "rhs": agg}
           },
-      peg$c118 = function(agg) {
+      peg$c117 = function(agg) {
             return {"kind": "Assignment", "lhs": null, "rhs": agg}
           },
-      peg$c119 = ".",
-      peg$c120 = peg$literalExpectation(".", false),
-      peg$c121 = function(op, expr, where) {
+      peg$c118 = ".",
+      peg$c119 = peg$literalExpectation(".", false),
+      peg$c120 = function(op, expr, where) {
             let r = {"kind": "Agg", "name": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c122 = "where",
-      peg$c123 = peg$literalExpectation("where", false),
-      peg$c124 = function(first, rest) {
+      peg$c121 = "where",
+      peg$c122 = peg$literalExpectation("where", false),
+      peg$c123 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c125 = "sort",
-      peg$c126 = peg$literalExpectation("sort", true),
-      peg$c127 = function(args, l) { return l },
-      peg$c128 = function(args, list) {
+      peg$c124 = "sort",
+      peg$c125 = peg$literalExpectation("sort", true),
+      peg$c126 = function(args, l) { return l },
+      peg$c127 = function(args, list) {
             let argm = args;
             let proc = {"kind": "Sort", "args": list, "order": "asc", "nullsfirst": false};
             if ( "r" in argm) {
@@ -498,24 +493,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c129 = function(args) { return makeArgMap(args) },
-      peg$c130 = "-r",
-      peg$c131 = peg$literalExpectation("-r", false),
-      peg$c132 = function() { return {"name": "r", "value": null} },
-      peg$c133 = "-nulls",
-      peg$c134 = peg$literalExpectation("-nulls", false),
-      peg$c135 = "first",
-      peg$c136 = peg$literalExpectation("first", false),
-      peg$c137 = "last",
-      peg$c138 = peg$literalExpectation("last", false),
-      peg$c139 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c140 = "top",
-      peg$c141 = peg$literalExpectation("top", true),
-      peg$c142 = function(n) { return n},
-      peg$c143 = "-flush",
-      peg$c144 = peg$literalExpectation("-flush", false),
-      peg$c145 = function(limit, flush, f) { return f },
-      peg$c146 = function(limit, flush, fields) {
+      peg$c128 = function(args) { return makeArgMap(args) },
+      peg$c129 = "-r",
+      peg$c130 = peg$literalExpectation("-r", false),
+      peg$c131 = function() { return {"name": "r", "value": null} },
+      peg$c132 = "-nulls",
+      peg$c133 = peg$literalExpectation("-nulls", false),
+      peg$c134 = "first",
+      peg$c135 = peg$literalExpectation("first", false),
+      peg$c136 = "last",
+      peg$c137 = peg$literalExpectation("last", false),
+      peg$c138 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c139 = "top",
+      peg$c140 = peg$literalExpectation("top", true),
+      peg$c141 = function(n) { return n},
+      peg$c142 = "-flush",
+      peg$c143 = peg$literalExpectation("-flush", false),
+      peg$c144 = function(limit, flush, f) { return f },
+      peg$c145 = function(limit, flush, fields) {
             let proc = {"kind": "Top", "limit": 0, "args": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
@@ -528,93 +523,93 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c147 = "cut",
-      peg$c148 = peg$literalExpectation("cut", true),
-      peg$c149 = function(args) {
+      peg$c146 = "cut",
+      peg$c147 = peg$literalExpectation("cut", true),
+      peg$c148 = function(args) {
             return {"kind": "Cut", "args": args}
           },
-      peg$c150 = "pick",
-      peg$c151 = peg$literalExpectation("pick", true),
-      peg$c152 = function(args) {
+      peg$c149 = "pick",
+      peg$c150 = peg$literalExpectation("pick", true),
+      peg$c151 = function(args) {
             return {"kind": "Pick", "args": args}
           },
-      peg$c153 = "drop",
-      peg$c154 = peg$literalExpectation("drop", true),
-      peg$c155 = function(args) {
+      peg$c152 = "drop",
+      peg$c153 = peg$literalExpectation("drop", true),
+      peg$c154 = function(args) {
             return {"kind": "Drop", "args": args}
           },
-      peg$c156 = "head",
-      peg$c157 = peg$literalExpectation("head", true),
-      peg$c158 = function(count) { return {"kind": "Head", "count": count} },
-      peg$c159 = function() { return {"kind": "Head", "count": 1} },
-      peg$c160 = "tail",
-      peg$c161 = peg$literalExpectation("tail", true),
-      peg$c162 = function(count) { return {"kind": "Tail", "count": count} },
-      peg$c163 = function() { return {"kind": "Tail", "count": 1} },
-      peg$c164 = "filter",
-      peg$c165 = peg$literalExpectation("filter", true),
-      peg$c166 = function(op) {
+      peg$c155 = "head",
+      peg$c156 = peg$literalExpectation("head", true),
+      peg$c157 = function(count) { return {"kind": "Head", "count": count} },
+      peg$c158 = function() { return {"kind": "Head", "count": 1} },
+      peg$c159 = "tail",
+      peg$c160 = peg$literalExpectation("tail", true),
+      peg$c161 = function(count) { return {"kind": "Tail", "count": count} },
+      peg$c162 = function() { return {"kind": "Tail", "count": 1} },
+      peg$c163 = "filter",
+      peg$c164 = peg$literalExpectation("filter", true),
+      peg$c165 = function(op) {
             return op
           },
-      peg$c167 = "uniq",
-      peg$c168 = peg$literalExpectation("uniq", true),
-      peg$c169 = "-c",
-      peg$c170 = peg$literalExpectation("-c", false),
-      peg$c171 = function() {
+      peg$c166 = "uniq",
+      peg$c167 = peg$literalExpectation("uniq", true),
+      peg$c168 = "-c",
+      peg$c169 = peg$literalExpectation("-c", false),
+      peg$c170 = function() {
             return {"kind": "Uniq", "cflag": true}
           },
-      peg$c172 = function() {
+      peg$c171 = function() {
             return {"kind": "Uniq", "cflag": false}
           },
-      peg$c173 = "put",
-      peg$c174 = peg$literalExpectation("put", true),
-      peg$c175 = function(args) {
+      peg$c172 = "put",
+      peg$c173 = peg$literalExpectation("put", true),
+      peg$c174 = function(args) {
             return {"kind": "Put", "args": args}
           },
-      peg$c176 = "rename",
-      peg$c177 = peg$literalExpectation("rename", true),
-      peg$c178 = function(first, cl) { return cl },
-      peg$c179 = function(first, rest) {
+      peg$c175 = "rename",
+      peg$c176 = peg$literalExpectation("rename", true),
+      peg$c177 = function(first, cl) { return cl },
+      peg$c178 = function(first, rest) {
             return {"kind": "Rename", "args": [first, ... rest]}
           },
-      peg$c180 = "fuse",
-      peg$c181 = peg$literalExpectation("fuse", true),
-      peg$c182 = function() {
+      peg$c179 = "fuse",
+      peg$c180 = peg$literalExpectation("fuse", true),
+      peg$c181 = function() {
             return {"kind": "Fuse"}
           },
-      peg$c183 = "shape",
-      peg$c184 = peg$literalExpectation("shape", true),
-      peg$c185 = function() {
+      peg$c182 = "shape",
+      peg$c183 = peg$literalExpectation("shape", true),
+      peg$c184 = function() {
             return {"kind": "Shape"}
           },
-      peg$c186 = "join",
-      peg$c187 = peg$literalExpectation("join", true),
-      peg$c188 = function(style, leftKey, rightKey, columns) {
+      peg$c185 = "join",
+      peg$c186 = peg$literalExpectation("join", true),
+      peg$c187 = function(style, leftKey, rightKey, columns) {
             let proc = {"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": null};
             if (columns) {
               proc["args"] = columns[1];
             }
             return proc
           },
-      peg$c189 = function(style, key, columns) {
+      peg$c188 = function(style, key, columns) {
             let proc = {"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": null};
             if (columns) {
               proc["args"] = columns[1];
             }
             return proc
           },
-      peg$c190 = "inner",
-      peg$c191 = peg$literalExpectation("inner", true),
-      peg$c192 = function() { return "inner" },
-      peg$c193 = "left",
-      peg$c194 = peg$literalExpectation("left", true),
-      peg$c195 = function() { return "left" },
-      peg$c196 = "right",
-      peg$c197 = peg$literalExpectation("right", true),
-      peg$c198 = function() { return "right" },
-      peg$c199 = "sample",
-      peg$c200 = peg$literalExpectation("sample", true),
-      peg$c201 = function(e) {
+      peg$c189 = "inner",
+      peg$c190 = peg$literalExpectation("inner", true),
+      peg$c191 = function() { return "inner" },
+      peg$c192 = "left",
+      peg$c193 = peg$literalExpectation("left", true),
+      peg$c194 = function() { return "left" },
+      peg$c195 = "right",
+      peg$c196 = peg$literalExpectation("right", true),
+      peg$c197 = function() { return "right" },
+      peg$c198 = "sample",
+      peg$c199 = peg$literalExpectation("sample", true),
+      peg$c200 = function(e) {
             return {"kind": "Sequential", "procs": [
               
             {"kind": "Summarize",
@@ -650,78 +645,77 @@ function peg$parse(input, options) {
             "rhs": {"kind": "ID", "name": "sample"}}]}]}
           
           },
-      peg$c202 = function(lval) { return lval},
-      peg$c203 = function() { return {"kind":"Root"} },
-      peg$c204 = function(source) {
+      peg$c201 = function(lval) { return lval},
+      peg$c202 = function() { return {"kind":"Root"} },
+      peg$c203 = function(source) {
             return {"kind":"From", "trunks": [{"kind": "Trunk","source": source}]}
           },
-      peg$c205 = "file",
-      peg$c206 = peg$literalExpectation("file", true),
-      peg$c207 = function(path, format, layout) {
+      peg$c204 = "file",
+      peg$c205 = peg$literalExpectation("file", true),
+      peg$c206 = function(path, format, layout) {
             return {"kind": "File", "path": path, "format": format, "layout": layout }
           },
-      peg$c208 = peg$literalExpectation("from", true),
-      peg$c209 = function(body) { return body },
-      peg$c210 = function(name, at, over, order) {
+      peg$c207 = peg$literalExpectation("from", true),
+      peg$c208 = function(body) { return body },
+      peg$c209 = function(name, at, over, order) {
             return {"kind": "Pool", "name": name, "at": at, "range": over, "scan_order": order}
           },
-      peg$c211 = "get",
-      peg$c212 = peg$literalExpectation("get", true),
-      peg$c213 = function(url, format, layout) {
+      peg$c210 = "get",
+      peg$c211 = peg$literalExpectation("get", true),
+      peg$c212 = function(url, format, layout) {
             return {"kind": "HTTP", "url": url, "format": format, "layout": layout }
           },
-      peg$c214 = "http:",
-      peg$c215 = peg$literalExpectation("http:", false),
-      peg$c216 = "https:",
-      peg$c217 = peg$literalExpectation("https:", false),
-      peg$c218 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
-      peg$c219 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
-      peg$c220 = "at",
-      peg$c221 = peg$literalExpectation("at", true),
-      peg$c222 = function(id) { return id },
-      peg$c223 = /^[0-9a-zA-Z]/,
-      peg$c224 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
-      peg$c225 = "over",
-      peg$c226 = peg$literalExpectation("over", true),
-      peg$c227 = "to",
-      peg$c228 = peg$literalExpectation("to", true),
-      peg$c229 = function(lower, upper) {
+      peg$c213 = "http:",
+      peg$c214 = peg$literalExpectation("http:", false),
+      peg$c215 = "https:",
+      peg$c216 = peg$literalExpectation("https:", false),
+      peg$c217 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
+      peg$c218 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
+      peg$c219 = "at",
+      peg$c220 = peg$literalExpectation("at", true),
+      peg$c221 = function(id) { return id },
+      peg$c222 = /^[0-9a-zA-Z]/,
+      peg$c223 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
+      peg$c224 = "over",
+      peg$c225 = peg$literalExpectation("over", true),
+      peg$c226 = "to",
+      peg$c227 = peg$literalExpectation("to", true),
+      peg$c228 = function(lower, upper) {
             return {"kind":"Range","lower": lower, "upper": upper}
           },
-      peg$c230 = function(val) { return val },
-      peg$c231 = function(name) { return name },
-      peg$c232 = function(s) { return s },
-      peg$c233 = "order",
-      peg$c234 = peg$literalExpectation("order", true),
-      peg$c235 = function(keys, order) {
+      peg$c229 = function(val) { return val },
+      peg$c230 = function(name) { return name },
+      peg$c231 = "order",
+      peg$c232 = peg$literalExpectation("order", true),
+      peg$c233 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c236 = "format",
-      peg$c237 = peg$literalExpectation("format", true),
-      peg$c238 = function() { return "" },
-      peg$c239 = ":asc",
-      peg$c240 = peg$literalExpectation(":asc", true),
-      peg$c241 = function() { return "asc" },
-      peg$c242 = ":desc",
-      peg$c243 = peg$literalExpectation(":desc", true),
-      peg$c244 = function() { return "desc" },
-      peg$c245 = "asc",
-      peg$c246 = peg$literalExpectation("asc", true),
-      peg$c247 = "desc",
-      peg$c248 = peg$literalExpectation("desc", true),
-      peg$c249 = "pass",
-      peg$c250 = peg$literalExpectation("pass", true),
-      peg$c251 = function() {
+      peg$c234 = "format",
+      peg$c235 = peg$literalExpectation("format", true),
+      peg$c236 = function() { return "" },
+      peg$c237 = ":asc",
+      peg$c238 = peg$literalExpectation(":asc", true),
+      peg$c239 = function() { return "asc" },
+      peg$c240 = ":desc",
+      peg$c241 = peg$literalExpectation(":desc", true),
+      peg$c242 = function() { return "desc" },
+      peg$c243 = "asc",
+      peg$c244 = peg$literalExpectation("asc", true),
+      peg$c245 = "desc",
+      peg$c246 = peg$literalExpectation("desc", true),
+      peg$c247 = "pass",
+      peg$c248 = peg$literalExpectation("pass", true),
+      peg$c249 = function() {
             return {"kind":"Pass"}
           },
-      peg$c252 = "explode",
-      peg$c253 = peg$literalExpectation("explode", true),
-      peg$c254 = function(args, typ, as) {
+      peg$c250 = "explode",
+      peg$c251 = peg$literalExpectation("explode", true),
+      peg$c252 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c255 = function(typ) { return typ},
-      peg$c256 = function(lhs) { return lhs },
-      peg$c258 = function(first, rest) {
+      peg$c253 = function(typ) { return typ},
+      peg$c254 = function(lhs) { return lhs },
+      peg$c256 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -730,53 +724,53 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c259 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c260 = "?",
-      peg$c261 = peg$literalExpectation("?", false),
-      peg$c262 = function(condition, thenClause, elseClause) {
+      peg$c257 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c258 = "?",
+      peg$c259 = peg$literalExpectation("?", false),
+      peg$c260 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c263 = function(first, op, expr) { return [op, expr] },
-      peg$c264 = function(first, rest) {
+      peg$c261 = function(first, op, expr) { return [op, expr] },
+      peg$c262 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c265 = function(first, comp, expr) { return [comp, expr] },
-      peg$c266 = function() { return "="},
-      peg$c267 = "+",
-      peg$c268 = peg$literalExpectation("+", false),
-      peg$c269 = "-",
-      peg$c270 = peg$literalExpectation("-", false),
-      peg$c271 = "/",
-      peg$c272 = peg$literalExpectation("/", false),
-      peg$c273 = function(e) {
+      peg$c263 = function(first, comp, expr) { return [comp, expr] },
+      peg$c264 = function() { return "="},
+      peg$c265 = "+",
+      peg$c266 = peg$literalExpectation("+", false),
+      peg$c267 = "-",
+      peg$c268 = peg$literalExpectation("-", false),
+      peg$c269 = "/",
+      peg$c270 = peg$literalExpectation("/", false),
+      peg$c271 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c274 = function(typ) { return typ },
-      peg$c275 = "not",
-      peg$c276 = peg$literalExpectation("not", false),
-      peg$c277 = "match",
-      peg$c278 = peg$literalExpectation("match", false),
-      peg$c279 = "select",
-      peg$c280 = peg$literalExpectation("select", false),
-      peg$c281 = function(args, methods) {
+      peg$c272 = function(typ) { return typ },
+      peg$c273 = "not",
+      peg$c274 = peg$literalExpectation("not", false),
+      peg$c275 = "match",
+      peg$c276 = peg$literalExpectation("match", false),
+      peg$c277 = "select",
+      peg$c278 = peg$literalExpectation("select", false),
+      peg$c279 = function(args, methods) {
             return {"kind":"SelectExpr", "selectors":args, "methods": methods}
           },
-      peg$c282 = function(methods) { return methods },
-      peg$c283 = function(typ, expr) {
+      peg$c280 = function(methods) { return methods },
+      peg$c281 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c284 = function(fn, args) {
+      peg$c282 = function(fn, args) {
             return {"kind": "Call", "name": fn, "args": args}
           },
-      peg$c285 = function() { return [] },
-      peg$c286 = function(first, e) { return e },
-      peg$c287 = function(e) { return e },
-      peg$c288 = function() {
+      peg$c283 = function() { return [] },
+      peg$c284 = function(first, e) { return e },
+      peg$c285 = function(e) { return e },
+      peg$c286 = function() {
             return {"kind":"Root"}
           },
-      peg$c289 = "this",
-      peg$c290 = peg$literalExpectation("this", false),
-      peg$c291 = function(field) {
+      peg$c287 = "this",
+      peg$c288 = peg$literalExpectation("this", false),
+      peg$c289 = function(field) {
             return {"kind": "BinaryExpr", "op":".",
                            
             "lhs":{"kind":"Root"},
@@ -785,9 +779,9 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c292 = "]",
-      peg$c293 = peg$literalExpectation("]", false),
-      peg$c294 = function(expr) {
+      peg$c290 = "]",
+      peg$c291 = peg$literalExpectation("]", false),
+      peg$c292 = function(expr) {
             return {"kind": "BinaryExpr", "op":"[",
                            
             "lhs":{"kind":"Root"},
@@ -796,58 +790,58 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c295 = function(from, to) {
+      peg$c293 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c296 = function(to) {
+      peg$c294 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c297 = function(from) {
+      peg$c295 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c298 = function(expr) { return ["[", expr] },
-      peg$c299 = function(id) { return [".", id] },
-      peg$c300 = "}",
-      peg$c301 = peg$literalExpectation("}", false),
-      peg$c302 = function(fields) {
+      peg$c296 = function(expr) { return ["[", expr] },
+      peg$c297 = function(id) { return [".", id] },
+      peg$c298 = "}",
+      peg$c299 = peg$literalExpectation("}", false),
+      peg$c300 = function(fields) {
             return {"kind":"RecordExpr", "fields":fields }
           },
-      peg$c303 = function(first, rest) {
+      peg$c301 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c304 = function(name, value) {
+      peg$c302 = function(name, value) {
             return {"name": name, "value": value}
           },
-      peg$c305 = function(exprs) {
+      peg$c303 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c306 = "|[",
-      peg$c307 = peg$literalExpectation("|[", false),
-      peg$c308 = "]|",
-      peg$c309 = peg$literalExpectation("]|", false),
-      peg$c310 = function(exprs) {
+      peg$c304 = "|[",
+      peg$c305 = peg$literalExpectation("|[", false),
+      peg$c306 = "]|",
+      peg$c307 = peg$literalExpectation("]|", false),
+      peg$c308 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c311 = "|{",
-      peg$c312 = peg$literalExpectation("|{", false),
-      peg$c313 = "}|",
-      peg$c314 = peg$literalExpectation("}|", false),
-      peg$c315 = function(exprs) {
+      peg$c309 = "|{",
+      peg$c310 = peg$literalExpectation("|{", false),
+      peg$c311 = "}|",
+      peg$c312 = peg$literalExpectation("}|", false),
+      peg$c313 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c316 = function(key, value) {
+      peg$c314 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c317 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c315 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -869,13 +863,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c318 = function(assignments) { return assignments },
-      peg$c319 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c320 = function(table, alias) {
+      peg$c316 = function(assignments) { return assignments },
+      peg$c317 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c318 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c321 = function(first, join) { return join },
-      peg$c322 = function(style, table, alias, leftKey, rightKey) {
+      peg$c319 = function(first, join) { return join },
+      peg$c320 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -893,274 +887,274 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c323 = function(style) { return style },
-      peg$c324 = function(keys, order) {
+      peg$c321 = function(style) { return style },
+      peg$c322 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c325 = function(dir) { return dir },
-      peg$c326 = function(count) { return count },
-      peg$c327 = peg$literalExpectation("select", true),
-      peg$c328 = function() { return "select" },
-      peg$c329 = "as",
-      peg$c330 = peg$literalExpectation("as", true),
-      peg$c331 = function() { return "as" },
-      peg$c332 = function() { return "from" },
-      peg$c333 = function() { return "join" },
-      peg$c334 = peg$literalExpectation("where", true),
-      peg$c335 = function() { return "where" },
-      peg$c336 = "group",
-      peg$c337 = peg$literalExpectation("group", true),
-      peg$c338 = function() { return "group" },
-      peg$c339 = "having",
-      peg$c340 = peg$literalExpectation("having", true),
-      peg$c341 = function() { return "having" },
-      peg$c342 = function() { return "order" },
-      peg$c343 = "on",
-      peg$c344 = peg$literalExpectation("on", true),
-      peg$c345 = function() { return "on" },
-      peg$c346 = "limit",
-      peg$c347 = peg$literalExpectation("limit", true),
-      peg$c348 = function() { return "limit" },
-      peg$c349 = function(v) {
+      peg$c323 = function(dir) { return dir },
+      peg$c324 = function(count) { return count },
+      peg$c325 = peg$literalExpectation("select", true),
+      peg$c326 = function() { return "select" },
+      peg$c327 = "as",
+      peg$c328 = peg$literalExpectation("as", true),
+      peg$c329 = function() { return "as" },
+      peg$c330 = function() { return "from" },
+      peg$c331 = function() { return "join" },
+      peg$c332 = peg$literalExpectation("where", true),
+      peg$c333 = function() { return "where" },
+      peg$c334 = "group",
+      peg$c335 = peg$literalExpectation("group", true),
+      peg$c336 = function() { return "group" },
+      peg$c337 = "having",
+      peg$c338 = peg$literalExpectation("having", true),
+      peg$c339 = function() { return "having" },
+      peg$c340 = function() { return "order" },
+      peg$c341 = "on",
+      peg$c342 = peg$literalExpectation("on", true),
+      peg$c343 = function() { return "on" },
+      peg$c344 = "limit",
+      peg$c345 = peg$literalExpectation("limit", true),
+      peg$c346 = function() { return "limit" },
+      peg$c347 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c350 = function(v) {
+      peg$c348 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c351 = function(v) {
+      peg$c349 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c352 = function(v) {
+      peg$c350 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c353 = "true",
-      peg$c354 = peg$literalExpectation("true", false),
-      peg$c355 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c356 = "false",
-      peg$c357 = peg$literalExpectation("false", false),
-      peg$c358 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c359 = "null",
-      peg$c360 = peg$literalExpectation("null", false),
-      peg$c361 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c362 = function(typ) {
+      peg$c351 = "true",
+      peg$c352 = peg$literalExpectation("true", false),
+      peg$c353 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c354 = "false",
+      peg$c355 = peg$literalExpectation("false", false),
+      peg$c356 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c357 = "null",
+      peg$c358 = peg$literalExpectation("null", false),
+      peg$c359 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c360 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c363 = function(name, typ) {
+      peg$c361 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c364 = function(name) {
+      peg$c362 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c365 = function(u) { return u },
-      peg$c366 = function(types) {
+      peg$c363 = function(u) { return u },
+      peg$c364 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c367 = function(fields) {
+      peg$c365 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c368 = function(typ) {
+      peg$c366 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c369 = function(typ) {
+      peg$c367 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c370 = function(keyType, valType) {
+      peg$c368 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c371 = "uint8",
-      peg$c372 = peg$literalExpectation("uint8", false),
-      peg$c373 = "uint16",
-      peg$c374 = peg$literalExpectation("uint16", false),
-      peg$c375 = "uint32",
-      peg$c376 = peg$literalExpectation("uint32", false),
-      peg$c377 = "uint64",
-      peg$c378 = peg$literalExpectation("uint64", false),
-      peg$c379 = "int8",
-      peg$c380 = peg$literalExpectation("int8", false),
-      peg$c381 = "int16",
-      peg$c382 = peg$literalExpectation("int16", false),
-      peg$c383 = "int32",
-      peg$c384 = peg$literalExpectation("int32", false),
-      peg$c385 = "int64",
-      peg$c386 = peg$literalExpectation("int64", false),
-      peg$c387 = "float64",
-      peg$c388 = peg$literalExpectation("float64", false),
-      peg$c389 = "bool",
-      peg$c390 = peg$literalExpectation("bool", false),
-      peg$c391 = "string",
-      peg$c392 = peg$literalExpectation("string", false),
-      peg$c393 = function() {
+      peg$c369 = "uint8",
+      peg$c370 = peg$literalExpectation("uint8", false),
+      peg$c371 = "uint16",
+      peg$c372 = peg$literalExpectation("uint16", false),
+      peg$c373 = "uint32",
+      peg$c374 = peg$literalExpectation("uint32", false),
+      peg$c375 = "uint64",
+      peg$c376 = peg$literalExpectation("uint64", false),
+      peg$c377 = "int8",
+      peg$c378 = peg$literalExpectation("int8", false),
+      peg$c379 = "int16",
+      peg$c380 = peg$literalExpectation("int16", false),
+      peg$c381 = "int32",
+      peg$c382 = peg$literalExpectation("int32", false),
+      peg$c383 = "int64",
+      peg$c384 = peg$literalExpectation("int64", false),
+      peg$c385 = "float64",
+      peg$c386 = peg$literalExpectation("float64", false),
+      peg$c387 = "bool",
+      peg$c388 = peg$literalExpectation("bool", false),
+      peg$c389 = "string",
+      peg$c390 = peg$literalExpectation("string", false),
+      peg$c391 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c394 = "duration",
-      peg$c395 = peg$literalExpectation("duration", false),
-      peg$c396 = "time",
-      peg$c397 = peg$literalExpectation("time", false),
-      peg$c398 = "bytes",
-      peg$c399 = peg$literalExpectation("bytes", false),
-      peg$c400 = "bstring",
-      peg$c401 = peg$literalExpectation("bstring", false),
-      peg$c402 = "ip",
-      peg$c403 = peg$literalExpectation("ip", false),
-      peg$c404 = "net",
-      peg$c405 = peg$literalExpectation("net", false),
-      peg$c406 = "error",
-      peg$c407 = peg$literalExpectation("error", false),
-      peg$c408 = function(name, typ) {
+      peg$c392 = "duration",
+      peg$c393 = peg$literalExpectation("duration", false),
+      peg$c394 = "time",
+      peg$c395 = peg$literalExpectation("time", false),
+      peg$c396 = "bytes",
+      peg$c397 = peg$literalExpectation("bytes", false),
+      peg$c398 = "bstring",
+      peg$c399 = peg$literalExpectation("bstring", false),
+      peg$c400 = "ip",
+      peg$c401 = peg$literalExpectation("ip", false),
+      peg$c402 = "net",
+      peg$c403 = peg$literalExpectation("net", false),
+      peg$c404 = "error",
+      peg$c405 = peg$literalExpectation("error", false),
+      peg$c406 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c409 = "and",
-      peg$c410 = peg$literalExpectation("and", true),
-      peg$c411 = function() { return "and" },
-      peg$c412 = "or",
-      peg$c413 = peg$literalExpectation("or", true),
-      peg$c414 = function() { return "or" },
-      peg$c415 = peg$literalExpectation("in", true),
-      peg$c416 = function() { return "in" },
-      peg$c417 = peg$literalExpectation("not", true),
-      peg$c418 = function() { return "not" },
-      peg$c419 = "by",
-      peg$c420 = peg$literalExpectation("by", true),
-      peg$c421 = function() { return "by" },
-      peg$c422 = /^[A-Za-z_$]/,
-      peg$c423 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c424 = /^[0-9]/,
-      peg$c425 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c426 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c427 = function() {  return text() },
-      peg$c428 = "$",
-      peg$c429 = peg$literalExpectation("$", false),
-      peg$c430 = "\\",
-      peg$c431 = peg$literalExpectation("\\", false),
-      peg$c432 = "T",
-      peg$c433 = peg$literalExpectation("T", false),
-      peg$c434 = function() {
+      peg$c407 = "and",
+      peg$c408 = peg$literalExpectation("and", true),
+      peg$c409 = function() { return "and" },
+      peg$c410 = "or",
+      peg$c411 = peg$literalExpectation("or", true),
+      peg$c412 = function() { return "or" },
+      peg$c413 = peg$literalExpectation("in", true),
+      peg$c414 = function() { return "in" },
+      peg$c415 = peg$literalExpectation("not", true),
+      peg$c416 = function() { return "not" },
+      peg$c417 = "by",
+      peg$c418 = peg$literalExpectation("by", true),
+      peg$c419 = function() { return "by" },
+      peg$c420 = /^[A-Za-z_$]/,
+      peg$c421 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c422 = /^[0-9]/,
+      peg$c423 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c424 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c425 = function() {  return text() },
+      peg$c426 = "$",
+      peg$c427 = peg$literalExpectation("$", false),
+      peg$c428 = "\\",
+      peg$c429 = peg$literalExpectation("\\", false),
+      peg$c430 = "T",
+      peg$c431 = peg$literalExpectation("T", false),
+      peg$c432 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c435 = "Z",
-      peg$c436 = peg$literalExpectation("Z", false),
-      peg$c437 = function() {
+      peg$c433 = "Z",
+      peg$c434 = peg$literalExpectation("Z", false),
+      peg$c435 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c438 = "ns",
-      peg$c439 = peg$literalExpectation("ns", true),
-      peg$c440 = "us",
-      peg$c441 = peg$literalExpectation("us", true),
-      peg$c442 = "ms",
-      peg$c443 = peg$literalExpectation("ms", true),
-      peg$c444 = "s",
-      peg$c445 = peg$literalExpectation("s", true),
-      peg$c446 = "m",
-      peg$c447 = peg$literalExpectation("m", true),
-      peg$c448 = "h",
-      peg$c449 = peg$literalExpectation("h", true),
-      peg$c450 = "d",
-      peg$c451 = peg$literalExpectation("d", true),
-      peg$c452 = "w",
-      peg$c453 = peg$literalExpectation("w", true),
-      peg$c454 = "y",
-      peg$c455 = peg$literalExpectation("y", true),
-      peg$c456 = function(a, b) {
+      peg$c436 = "ns",
+      peg$c437 = peg$literalExpectation("ns", true),
+      peg$c438 = "us",
+      peg$c439 = peg$literalExpectation("us", true),
+      peg$c440 = "ms",
+      peg$c441 = peg$literalExpectation("ms", true),
+      peg$c442 = "s",
+      peg$c443 = peg$literalExpectation("s", true),
+      peg$c444 = "m",
+      peg$c445 = peg$literalExpectation("m", true),
+      peg$c446 = "h",
+      peg$c447 = peg$literalExpectation("h", true),
+      peg$c448 = "d",
+      peg$c449 = peg$literalExpectation("d", true),
+      peg$c450 = "w",
+      peg$c451 = peg$literalExpectation("w", true),
+      peg$c452 = "y",
+      peg$c453 = peg$literalExpectation("y", true),
+      peg$c454 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c457 = "::",
-      peg$c458 = peg$literalExpectation("::", false),
-      peg$c459 = function(a, b, d, e) {
+      peg$c455 = "::",
+      peg$c456 = peg$literalExpectation("::", false),
+      peg$c457 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c460 = function(a, b) {
+      peg$c458 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c461 = function(a, b) {
+      peg$c459 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c462 = function() {
+      peg$c460 = function() {
             return "::"
           },
-      peg$c463 = function(v) { return ":" + v },
-      peg$c464 = function(v) { return v + ":" },
-      peg$c465 = function(a, m) {
+      peg$c461 = function(v) { return ":" + v },
+      peg$c462 = function(v) { return v + ":" },
+      peg$c463 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c466 = function(a, m) {
+      peg$c464 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c467 = function(s) { return parseInt(s) },
-      peg$c468 = function() {
+      peg$c465 = function(s) { return parseInt(s) },
+      peg$c466 = function() {
             return text()
           },
-      peg$c469 = "e",
-      peg$c470 = peg$literalExpectation("e", true),
-      peg$c471 = /^[+\-]/,
-      peg$c472 = peg$classExpectation(["+", "-"], false, false),
-      peg$c473 = /^[0-9a-fA-F]/,
-      peg$c474 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c475 = "\"",
-      peg$c476 = peg$literalExpectation("\"", false),
-      peg$c477 = function(v) { return joinChars(v) },
-      peg$c478 = "'",
-      peg$c479 = peg$literalExpectation("'", false),
-      peg$c480 = peg$anyExpectation(),
-      peg$c481 = function(head, tail) { return head + joinChars(tail) },
-      peg$c482 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c483 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c484 = function(head, tail) {
+      peg$c467 = "e",
+      peg$c468 = peg$literalExpectation("e", true),
+      peg$c469 = /^[+\-]/,
+      peg$c470 = peg$classExpectation(["+", "-"], false, false),
+      peg$c471 = /^[0-9a-fA-F]/,
+      peg$c472 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c473 = "\"",
+      peg$c474 = peg$literalExpectation("\"", false),
+      peg$c475 = function(v) { return joinChars(v) },
+      peg$c476 = "'",
+      peg$c477 = peg$literalExpectation("'", false),
+      peg$c478 = peg$anyExpectation(),
+      peg$c479 = function(head, tail) { return head + joinChars(tail) },
+      peg$c480 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c481 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c482 = function(head, tail) {
             return reglob$1.Reglob(head + joinChars(tail))
           },
-      peg$c485 = function() { return "*"},
-      peg$c486 = function() { return "=" },
-      peg$c487 = function() { return "\\*" },
-      peg$c488 = "x",
-      peg$c489 = peg$literalExpectation("x", false),
-      peg$c490 = function() { return "\\" + text() },
-      peg$c491 = "b",
-      peg$c492 = peg$literalExpectation("b", false),
-      peg$c493 = function() { return "\b" },
-      peg$c494 = "f",
-      peg$c495 = peg$literalExpectation("f", false),
-      peg$c496 = function() { return "\f" },
-      peg$c497 = "n",
-      peg$c498 = peg$literalExpectation("n", false),
-      peg$c499 = function() { return "\n" },
-      peg$c500 = "r",
-      peg$c501 = peg$literalExpectation("r", false),
-      peg$c502 = function() { return "\r" },
-      peg$c503 = "t",
-      peg$c504 = peg$literalExpectation("t", false),
-      peg$c505 = function() { return "\t" },
-      peg$c506 = "v",
-      peg$c507 = peg$literalExpectation("v", false),
-      peg$c508 = function() { return "\v" },
-      peg$c509 = function() { return "*" },
-      peg$c510 = "u",
-      peg$c511 = peg$literalExpectation("u", false),
-      peg$c512 = function(chars) {
+      peg$c483 = function() { return "*"},
+      peg$c484 = function() { return "=" },
+      peg$c485 = function() { return "\\*" },
+      peg$c486 = "x",
+      peg$c487 = peg$literalExpectation("x", false),
+      peg$c488 = function() { return "\\" + text() },
+      peg$c489 = "b",
+      peg$c490 = peg$literalExpectation("b", false),
+      peg$c491 = function() { return "\b" },
+      peg$c492 = "f",
+      peg$c493 = peg$literalExpectation("f", false),
+      peg$c494 = function() { return "\f" },
+      peg$c495 = "n",
+      peg$c496 = peg$literalExpectation("n", false),
+      peg$c497 = function() { return "\n" },
+      peg$c498 = "r",
+      peg$c499 = peg$literalExpectation("r", false),
+      peg$c500 = function() { return "\r" },
+      peg$c501 = "t",
+      peg$c502 = peg$literalExpectation("t", false),
+      peg$c503 = function() { return "\t" },
+      peg$c504 = "v",
+      peg$c505 = peg$literalExpectation("v", false),
+      peg$c506 = function() { return "\v" },
+      peg$c507 = function() { return "*" },
+      peg$c508 = "u",
+      peg$c509 = peg$literalExpectation("u", false),
+      peg$c510 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c513 = /^[^\/\\]/,
-      peg$c514 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c515 = "\\/",
-      peg$c516 = peg$literalExpectation("\\/", false),
-      peg$c517 = /^[\0-\x1F\\]/,
-      peg$c518 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c519 = peg$otherExpectation("whitespace"),
-      peg$c520 = "\t",
-      peg$c521 = peg$literalExpectation("\t", false),
-      peg$c522 = "\x0B",
-      peg$c523 = peg$literalExpectation("\x0B", false),
-      peg$c524 = "\f",
-      peg$c525 = peg$literalExpectation("\f", false),
-      peg$c526 = " ",
-      peg$c527 = peg$literalExpectation(" ", false),
-      peg$c528 = "\xA0",
-      peg$c529 = peg$literalExpectation("\xA0", false),
-      peg$c530 = "\uFEFF",
-      peg$c531 = peg$literalExpectation("\uFEFF", false),
-      peg$c532 = /^[\n\r\u2028\u2029]/,
-      peg$c533 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c534 = peg$otherExpectation("comment"),
-      peg$c539 = "//",
-      peg$c540 = peg$literalExpectation("//", false),
+      peg$c511 = /^[^\/\\]/,
+      peg$c512 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c513 = "\\/",
+      peg$c514 = peg$literalExpectation("\\/", false),
+      peg$c515 = /^[\0-\x1F\\]/,
+      peg$c516 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c517 = peg$otherExpectation("whitespace"),
+      peg$c518 = "\t",
+      peg$c519 = peg$literalExpectation("\t", false),
+      peg$c520 = "\x0B",
+      peg$c521 = peg$literalExpectation("\x0B", false),
+      peg$c522 = "\f",
+      peg$c523 = peg$literalExpectation("\f", false),
+      peg$c524 = " ",
+      peg$c525 = peg$literalExpectation(" ", false),
+      peg$c526 = "\xA0",
+      peg$c527 = peg$literalExpectation("\xA0", false),
+      peg$c528 = "\uFEFF",
+      peg$c529 = peg$literalExpectation("\uFEFF", false),
+      peg$c530 = /^[\n\r\u2028\u2029]/,
+      peg$c531 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c532 = peg$otherExpectation("comment"),
+      peg$c537 = "//",
+      peg$c538 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1644,101 +1638,35 @@ function peg$parse(input, options) {
   }
 
   function peg$parseParallel() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c16) {
-      s1 = peg$c16;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c17); }
-    }
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseSequential();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c7;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c8); }
-            }
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
-              if (s6 !== peg$FAILED) {
-                s7 = [];
-                s8 = peg$parseParallel();
-                if (s8 !== peg$FAILED) {
-                  while (s8 !== peg$FAILED) {
-                    s7.push(s8);
-                    s8 = peg$parseParallel();
-                  }
-                } else {
-                  s7 = peg$FAILED;
-                }
-                if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c18(s3, s7);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
       if (input.substr(peg$currPos, 2) === peg$c16) {
-        s1 = peg$c16;
+        s2 = peg$c16;
         peg$currPos += 2;
       } else {
-        s1 = peg$FAILED;
+        s2 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseSequential();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseSequential();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse__();
+            if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 59) {
-                s5 = peg$c7;
+                s6 = peg$c7;
                 peg$currPos++;
               } else {
-                s5 = peg$FAILED;
+                s6 = peg$FAILED;
                 if (peg$silentFails === 0) { peg$fail(peg$c8); }
               }
-              if (s5 !== peg$FAILED) {
+              if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c19(s3);
+                s1 = peg$c18(s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1760,44 +1688,53 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     return s0;
   }
 
   function peg$parseSwitchBranch() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    s1 = peg$parseDefaultToken();
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
+      s2 = peg$parseSearchBoolean();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c16) {
-          s3 = peg$c16;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
-        }
+        s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          if (input.substr(peg$currPos, 2) === peg$c16) {
+            s4 = peg$c16;
+            peg$currPos += 2;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseSequential();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
+              s6 = peg$parseSequential();
               if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 59) {
-                  s7 = peg$c7;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c8); }
-                }
+                s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c20(s5);
-                  s0 = s1;
+                  if (input.charCodeAt(peg$currPos) === 59) {
+                    s8 = peg$c7;
+                    peg$currPos++;
+                  } else {
+                    s8 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                  }
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c19(s2, s6);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1828,35 +1765,41 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseSearchBoolean();
+      s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
+        s2 = peg$parseDefaultToken();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c16) {
-            s3 = peg$c16;
-            peg$currPos += 2;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
-          }
+          s3 = peg$parse__();
           if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
+            if (input.substr(peg$currPos, 2) === peg$c16) {
+              s4 = peg$c16;
+              peg$currPos += 2;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseSequential();
+              s5 = peg$parse__();
               if (s5 !== peg$FAILED) {
-                s6 = peg$parse__();
+                s6 = peg$parseSequential();
                 if (s6 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 59) {
-                    s7 = peg$c7;
-                    peg$currPos++;
-                  } else {
-                    s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
-                  }
+                  s7 = peg$parse__();
                   if (s7 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c21(s1, s5);
-                    s0 = s1;
+                    if (input.charCodeAt(peg$currPos) === 59) {
+                      s8 = peg$c7;
+                      peg$currPos++;
+                    } else {
+                      s8 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                    }
+                    if (s8 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c20(s6);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1890,135 +1833,50 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSwitch() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSwitchBranch();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseSwitch();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parseSwitch();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c18(s1, s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseSwitchBranch();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c19(s1);
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
   function peg$parseDefaultToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c22) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c21) {
       s0 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c23); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseFromTrunks() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFromTrunk();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseFromTrunks();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parseFromTrunks();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c18(s1, s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseFromTrunk();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c19(s1);
-      }
-      s0 = s1;
+      if (peg$silentFails === 0) { peg$fail(peg$c22); }
     }
 
     return s0;
   }
 
   function peg$parseFromTrunk() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    s1 = peg$parseFromSource();
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseFromTrunkSeq();
+      s2 = peg$parseFromSource();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
+        s3 = peg$parseFromTrunkSeq();
+        if (s3 === peg$FAILED) {
+          s3 = null;
+        }
         if (s3 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 59) {
-            s4 = peg$c7;
-            peg$currPos++;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c8); }
-          }
+          s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c24(s1, s2);
-            s0 = s1;
+            if (input.charCodeAt(peg$currPos) === 59) {
+              s5 = peg$c7;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c8); }
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c23(s2, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -2058,7 +1916,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequential();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c25(s4);
+            s1 = peg$c24(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2078,10 +1936,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c27();
+        s1 = peg$c26();
       }
       s0 = s1;
     }
@@ -2107,48 +1965,51 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOperation() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c28) {
-      s1 = peg$c28;
+    if (input.substr(peg$currPos, 5) === peg$c27) {
+      s1 = peg$c27;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c29); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          s4 = [];
+          s5 = peg$parseParallel();
+          if (s5 !== peg$FAILED) {
+            while (s5 !== peg$FAILED) {
+              s4.push(s5);
+              s5 = peg$parseParallel();
+            }
+          } else {
+            s4 = peg$FAILED;
+          }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseParallel();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
+              if (input.charCodeAt(peg$currPos) === 41) {
+                s6 = peg$c31;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c32); }
+              }
               if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c32;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
-                }
-                if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c34(s5);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
+                peg$savedPos = s0;
+                s1 = peg$c33(s4);
+                s0 = s1;
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2175,45 +2036,48 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c35) {
-        s1 = peg$c35;
+      if (input.substr(peg$currPos, 6) === peg$c34) {
+        s1 = peg$c34;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c30;
+            s3 = peg$c29;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
+            s4 = [];
+            s5 = peg$parseSwitchBranch();
+            if (s5 !== peg$FAILED) {
+              while (s5 !== peg$FAILED) {
+                s4.push(s5);
+                s5 = peg$parseSwitchBranch();
+              }
+            } else {
+              s4 = peg$FAILED;
+            }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseSwitch();
+              s5 = peg$parse__();
               if (s5 !== peg$FAILED) {
-                s6 = peg$parse__();
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s6 = peg$c31;
+                  peg$currPos++;
+                } else {
+                  s6 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
+                }
                 if (s6 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c32;
-                    peg$currPos++;
-                  } else {
-                    s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
-                  }
-                  if (s7 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c37(s5);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
+                  peg$savedPos = s0;
+                  s1 = peg$c36(s4);
+                  s0 = s1;
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -2240,45 +2104,48 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c38) {
-          s1 = peg$c38;
+        if (input.substr(peg$currPos, 4) === peg$c37) {
+          s1 = peg$c37;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c39); }
+          if (peg$silentFails === 0) { peg$fail(peg$c38); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s3 = peg$c30;
+              s3 = peg$c29;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c31); }
+              if (peg$silentFails === 0) { peg$fail(peg$c30); }
             }
             if (s3 !== peg$FAILED) {
-              s4 = peg$parse__();
+              s4 = [];
+              s5 = peg$parseFromTrunk();
+              if (s5 !== peg$FAILED) {
+                while (s5 !== peg$FAILED) {
+                  s4.push(s5);
+                  s5 = peg$parseFromTrunk();
+                }
+              } else {
+                s4 = peg$FAILED;
+              }
               if (s4 !== peg$FAILED) {
-                s5 = peg$parseFromTrunks();
+                s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
-                  s6 = peg$parse__();
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s6 = peg$c31;
+                    peg$currPos++;
+                  } else {
+                    s6 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c32); }
+                  }
                   if (s6 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 41) {
-                      s7 = peg$c32;
-                      peg$currPos++;
-                    } else {
-                      s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c33); }
-                    }
-                    if (s7 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c40(s5);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
+                    peg$savedPos = s0;
+                    s1 = peg$c39(s4);
+                    s0 = s1;
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -2321,7 +2188,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c41(s1);
+                s1 = peg$c40(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2347,7 +2214,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c42(s1);
+                  s1 = peg$c41(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2373,7 +2240,7 @@ function peg$parse(input, options) {
                   }
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c43(s1);
+                    s1 = peg$c42(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -2409,12 +2276,12 @@ function peg$parse(input, options) {
           if (peg$silentFails === 0) { peg$fail(peg$c17); }
         }
         if (s2 === peg$FAILED) {
-          if (peg$c44.test(input.charAt(peg$currPos))) {
+          if (peg$c43.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c45); }
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
           }
           if (s2 === peg$FAILED) {
             s2 = peg$parseEOF();
@@ -2441,29 +2308,29 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 124) {
-      s1 = peg$c46;
+      s1 = peg$c45;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      if (peg$silentFails === 0) { peg$fail(peg$c46); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s3 = peg$c48;
+        s3 = peg$c47;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        if (peg$silentFails === 0) { peg$fail(peg$c48); }
       }
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s3 = peg$c50;
+          s3 = peg$c49;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
       }
       peg$silentFails--;
@@ -2530,35 +2397,35 @@ function peg$parse(input, options) {
           s2 = peg$parseMultiplicativeOperator();
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s2 = peg$c52;
+              s2 = peg$c51;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c53); }
+              if (peg$silentFails === 0) { peg$fail(peg$c52); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s2 = peg$c30;
+                s2 = peg$c29;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                if (peg$silentFails === 0) { peg$fail(peg$c30); }
               }
               if (s2 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s2 = peg$c50;
+                  s2 = peg$c49;
                   peg$currPos++;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c51); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c50); }
                 }
                 if (s2 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 7) === peg$c54) {
-                    s2 = peg$c54;
+                  if (input.substr(peg$currPos, 7) === peg$c53) {
+                    s2 = peg$c53;
                     peg$currPos += 7;
                   } else {
                     s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c54); }
                   }
                 }
               }
@@ -2585,60 +2452,60 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c56) {
-      s1 = peg$c56;
+    if (input.substr(peg$currPos, 2) === peg$c55) {
+      s1 = peg$c55;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c57); }
+      if (peg$silentFails === 0) { peg$fail(peg$c56); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c58) {
-        s1 = peg$c58;
+      if (input.substr(peg$currPos, 2) === peg$c57) {
+        s1 = peg$c57;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c60) {
-          s1 = peg$c60;
+        if (input.substr(peg$currPos, 2) === peg$c59) {
+          s1 = peg$c59;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c61); }
+          if (peg$silentFails === 0) { peg$fail(peg$c60); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c62) {
-            s1 = peg$c62;
+          if (input.substr(peg$currPos, 2) === peg$c61) {
+            s1 = peg$c61;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c63); }
+            if (peg$silentFails === 0) { peg$fail(peg$c62); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c64;
+              s1 = peg$c63;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c65); }
+              if (peg$silentFails === 0) { peg$fail(peg$c64); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c66) {
-                s1 = peg$c66;
+              if (input.substr(peg$currPos, 2) === peg$c65) {
+                s1 = peg$c65;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c67); }
+                if (peg$silentFails === 0) { peg$fail(peg$c66); }
               }
               if (s1 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 62) {
-                  s1 = peg$c68;
+                  s1 = peg$c67;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c68); }
                 }
               }
             }
@@ -2648,7 +2515,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -2663,12 +2530,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseByToken();
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c71) {
-          s2 = peg$c71;
+        if (input.substr(peg$currPos, 5) === peg$c70) {
+          s2 = peg$c70;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c72); }
+          if (peg$silentFails === 0) { peg$fail(peg$c71); }
         }
       }
       if (s2 !== peg$FAILED) {
@@ -2693,11 +2560,11 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s2 = peg$c73;
+          s2 = peg$c72;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -2729,7 +2596,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c75(s1, s2);
+        s1 = peg$c74(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2756,7 +2623,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchAnd();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c76(s4);
+            s1 = peg$c75(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2810,7 +2677,7 @@ function peg$parse(input, options) {
           s6 = peg$parseSearchFactor();
           if (s6 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c77(s1, s6);
+            s4 = peg$c76(s1, s6);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2851,7 +2718,7 @@ function peg$parse(input, options) {
             s6 = peg$parseSearchFactor();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c77(s1, s6);
+              s4 = peg$c76(s1, s6);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2868,7 +2735,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s1, s2);
+        s1 = peg$c77(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2904,11 +2771,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c79;
+        s2 = peg$c78;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2928,7 +2795,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c81(s2);
+        s1 = peg$c80(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2943,11 +2810,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c30;
+          s1 = peg$c29;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -2957,15 +2824,15 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c32;
+                  s5 = peg$c31;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c82(s3);
+                  s1 = peg$c81(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3025,7 +2892,7 @@ function peg$parse(input, options) {
       s2 = peg$parsePatternSearch();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c88(s2);
+        s1 = peg$c87(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3076,7 +2943,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c89(s2);
+            s1 = peg$c88(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3093,11 +2960,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c83;
+          s1 = peg$c82;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
@@ -3112,7 +2979,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c90();
+            s1 = peg$c89();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3151,7 +3018,7 @@ function peg$parse(input, options) {
         s2 = peg$parseKeyWord();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c91(s2);
+          s1 = peg$c90(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3173,7 +3040,7 @@ function peg$parse(input, options) {
     s1 = peg$parsePattern();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c92(s1);
+      s1 = peg$c91(s1);
     }
     s0 = s1;
 
@@ -3188,12 +3055,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c54) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c53) {
           s3 = input.substr(peg$currPos, 7);
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c93); }
+          if (peg$silentFails === 0) { peg$fail(peg$c92); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3201,7 +3068,7 @@ function peg$parse(input, options) {
             s5 = peg$parsePattern();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c94(s1, s5);
+              s1 = peg$c93(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3255,20 +3122,20 @@ function peg$parse(input, options) {
               if (s0 === peg$FAILED) {
                 s0 = peg$parseDefaultToken();
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c95) {
-                    s0 = peg$c95;
+                  if (input.substr(peg$currPos, 5) === peg$c94) {
+                    s0 = peg$c94;
                     peg$currPos += 5;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c95); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c54) {
+                    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c53) {
                       s0 = input.substr(peg$currPos, 7);
                       peg$currPos += 7;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c92); }
                     }
                   }
                 }
@@ -3295,7 +3162,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLimitArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c97(s2, s3, s4);
+            s1 = peg$c96(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3343,7 +3210,7 @@ function peg$parse(input, options) {
               s5 = peg$parseLimitArg();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c98(s2, s3, s4, s5);
+                s1 = peg$c97(s2, s3, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3374,12 +3241,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c99) {
-      s1 = peg$c99;
+    if (input.substr(peg$currPos, 9) === peg$c98) {
+      s1 = peg$c98;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3395,7 +3262,7 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$c26;
+      s0 = peg$c25;
     }
 
     return s0;
@@ -3405,12 +3272,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c101) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c100) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c102); }
+      if (peg$silentFails === 0) { peg$fail(peg$c101); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3420,7 +3287,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c103(s3);
+            s1 = peg$c102(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3440,10 +3307,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -3462,7 +3329,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c105(s3);
+          s1 = peg$c104(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3486,22 +3353,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c106) {
-        s2 = peg$c106;
+      if (input.substr(peg$currPos, 4) === peg$c105) {
+        s2 = peg$c105;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c108) {
-            s4 = peg$c108;
+          if (input.substr(peg$currPos, 6) === peg$c107) {
+            s4 = peg$c107;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c109); }
+            if (peg$silentFails === 0) { peg$fail(peg$c108); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3509,7 +3376,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c110(s6);
+                s1 = peg$c109(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3537,10 +3404,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c111();
+        s1 = peg$c110();
       }
       s0 = s1;
     }
@@ -3557,7 +3424,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112(s1);
+        s1 = peg$c111(s1);
       }
       s0 = s1;
     }
@@ -3576,11 +3443,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3588,7 +3455,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c113(s1, s7);
+              s4 = peg$c112(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3612,11 +3479,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3624,7 +3491,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c113(s1, s7);
+                s4 = peg$c112(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3645,7 +3512,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3667,12 +3534,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c115) {
-          s3 = peg$c115;
+        if (input.substr(peg$currPos, 2) === peg$c114) {
+          s3 = peg$c114;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c116); }
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3680,7 +3547,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAgg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c117(s1, s5);
+              s1 = peg$c116(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3707,7 +3574,7 @@ function peg$parse(input, options) {
       s1 = peg$parseAgg();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c118(s1);
+        s1 = peg$c117(s1);
       }
       s0 = s1;
     }
@@ -3735,11 +3602,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c30;
+            s4 = peg$c29;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -3752,11 +3619,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c32;
+                    s8 = peg$c31;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c32); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$currPos;
@@ -3765,11 +3632,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c119;
+                        s12 = peg$c118;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c119); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3796,7 +3663,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c121(s2, s6, s10);
+                        s1 = peg$c120(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3862,12 +3729,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c122) {
-        s2 = peg$c122;
+      if (input.substr(peg$currPos, 5) === peg$c121) {
+        s2 = peg$c121;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+        if (peg$silentFails === 0) { peg$fail(peg$c122); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3875,7 +3742,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s4);
+            s1 = peg$c81(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3908,11 +3775,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3943,11 +3810,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3975,7 +3842,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c124(s1, s2);
+        s1 = peg$c123(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4055,12 +3922,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c125) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -4071,7 +3938,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c127(s2, s5);
+            s4 = peg$c126(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -4086,7 +3953,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c128(s2, s3);
+          s1 = peg$c127(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4115,7 +3982,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c42(s4);
+        s3 = peg$c41(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -4133,7 +4000,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c42(s4);
+          s3 = peg$c41(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4146,7 +4013,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c129(s1);
+      s1 = peg$c128(s1);
     }
     s0 = s1;
 
@@ -4157,55 +4024,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c130) {
-      s1 = peg$c130;
+    if (input.substr(peg$currPos, 2) === peg$c129) {
+      s1 = peg$c129;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c131); }
+      if (peg$silentFails === 0) { peg$fail(peg$c130); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c132();
+      s1 = peg$c131();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c133) {
-        s1 = peg$c133;
+      if (input.substr(peg$currPos, 6) === peg$c132) {
+        s1 = peg$c132;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c134); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c135) {
-            s4 = peg$c135;
+          if (input.substr(peg$currPos, 5) === peg$c134) {
+            s4 = peg$c134;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c136); }
+            if (peg$silentFails === 0) { peg$fail(peg$c135); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c137) {
-              s4 = peg$c137;
+            if (input.substr(peg$currPos, 4) === peg$c136) {
+              s4 = peg$c136;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c138); }
+              if (peg$silentFails === 0) { peg$fail(peg$c137); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c70();
+            s4 = peg$c69();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c139(s3);
+            s1 = peg$c138(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4228,12 +4095,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c140) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c139) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4242,7 +4109,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c142(s4);
+          s3 = peg$c141(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4259,12 +4126,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c143) {
-            s5 = peg$c143;
+          if (input.substr(peg$currPos, 6) === peg$c142) {
+            s5 = peg$c142;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c144); }
+            if (peg$silentFails === 0) { peg$fail(peg$c143); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -4287,7 +4154,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c145(s2, s3, s6);
+              s5 = peg$c144(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -4302,7 +4169,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c146(s2, s3, s4);
+            s1 = peg$c145(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4328,12 +4195,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c146) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c147); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4341,7 +4208,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c149(s3);
+          s1 = peg$c148(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4363,12 +4230,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c149) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4376,7 +4243,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c152(s3);
+          s1 = peg$c151(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4398,12 +4265,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c152) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c154); }
+      if (peg$silentFails === 0) { peg$fail(peg$c153); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4411,7 +4278,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c155(s3);
+          s1 = peg$c154(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4433,12 +4300,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c156) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c155) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c156); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4446,7 +4313,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c158(s3);
+          s1 = peg$c157(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4462,16 +4329,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c156) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c155) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c157); }
+        if (peg$silentFails === 0) { peg$fail(peg$c156); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c159();
+        s1 = peg$c158();
       }
       s0 = s1;
     }
@@ -4483,12 +4350,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c159) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c161); }
+      if (peg$silentFails === 0) { peg$fail(peg$c160); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4496,7 +4363,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c162(s3);
+          s1 = peg$c161(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4512,16 +4379,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c159) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c161); }
+        if (peg$silentFails === 0) { peg$fail(peg$c160); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c163();
+        s1 = peg$c162();
       }
       s0 = s1;
     }
@@ -4533,12 +4400,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c164) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c163) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c165); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4546,7 +4413,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c166(s3);
+          s1 = peg$c165(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4571,7 +4438,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSearchBoolean();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c43(s1);
+      s1 = peg$c42(s1);
     }
     s0 = s1;
 
@@ -4582,26 +4449,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c167) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c168); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c169) {
-          s3 = peg$c169;
+        if (input.substr(peg$currPos, 2) === peg$c168) {
+          s3 = peg$c168;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c170); }
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c171();
+          s1 = peg$c170();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4617,16 +4484,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c167) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c168); }
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172();
+        s1 = peg$c171();
       }
       s0 = s1;
     }
@@ -4638,12 +4505,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c173) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c172) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c174); }
+      if (peg$silentFails === 0) { peg$fail(peg$c173); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4651,7 +4518,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c175(s3);
+          s1 = peg$c174(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4673,12 +4540,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c176) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c175) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+      if (peg$silentFails === 0) { peg$fail(peg$c176); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4690,11 +4557,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c73;
+              s7 = peg$c72;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              if (peg$silentFails === 0) { peg$fail(peg$c73); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -4702,7 +4569,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c178(s3, s9);
+                  s6 = peg$c177(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4726,11 +4593,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c73;
+                s7 = peg$c72;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                if (peg$silentFails === 0) { peg$fail(peg$c73); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -4738,7 +4605,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c178(s3, s9);
+                    s6 = peg$c177(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4759,7 +4626,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c179(s3, s4);
+            s1 = peg$c178(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4785,12 +4652,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c179) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c180); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4799,11 +4666,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c30;
+          s5 = peg$c29;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4825,7 +4692,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c182();
+        s1 = peg$c181();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4843,16 +4710,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c183) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c182) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c184); }
+      if (peg$silentFails === 0) { peg$fail(peg$c183); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c185();
+      s1 = peg$c184();
     }
     s0 = s1;
 
@@ -4865,12 +4732,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseJoinStyle();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c185) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4915,7 +4782,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c188(s1, s6, s10, s11);
+                          s1 = peg$c187(s1, s6, s10, s11);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -4965,12 +4832,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parseJoinStyle();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c185) {
           s2 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5001,7 +4868,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c189(s1, s6, s7);
+                    s1 = peg$c188(s1, s6, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5040,18 +4907,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c190) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c189) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c191); }
+      if (peg$silentFails === 0) { peg$fail(peg$c190); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c192();
+        s1 = peg$c191();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5063,18 +4930,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c193) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c192) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c194); }
+        if (peg$silentFails === 0) { peg$fail(peg$c193); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c195();
+          s1 = peg$c194();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5086,18 +4953,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c196) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c195) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c198();
+            s1 = peg$c197();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5109,10 +4976,10 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$c26;
+          s1 = peg$c25;
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c192();
+            s1 = peg$c191();
           }
           s0 = s1;
         }
@@ -5129,25 +4996,25 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c30;
+        s1 = peg$c29;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c31); }
+        if (peg$silentFails === 0) { peg$fail(peg$c30); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c32;
+            s3 = peg$c31;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c33); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s2);
+            s1 = peg$c81(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5170,18 +5037,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c199) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c198) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c200); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSampleExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c201(s2);
+        s1 = peg$c200(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5204,7 +5071,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c202(s2);
+        s1 = peg$c201(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5216,10 +5083,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c203();
+        s1 = peg$c202();
       }
       s0 = s1;
     }
@@ -5234,7 +5101,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFromAny();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c204(s1);
+      s1 = peg$c203(s1);
     }
     s0 = s1;
 
@@ -5259,12 +5126,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c205) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c204) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c206); }
+      if (peg$silentFails === 0) { peg$fail(peg$c205); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5276,7 +5143,7 @@ function peg$parse(input, options) {
             s5 = peg$parseLayoutArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c207(s3, s4, s5);
+              s1 = peg$c206(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5306,12 +5173,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c37) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c208); }
+      if (peg$silentFails === 0) { peg$fail(peg$c207); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5319,7 +5186,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePoolBody();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c209(s3);
+          s1 = peg$c208(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5350,7 +5217,7 @@ function peg$parse(input, options) {
           s4 = peg$parseOrderArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c210(s1, s2, s3, s4);
+            s1 = peg$c209(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5376,12 +5243,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c211) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c210) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c212); }
+      if (peg$silentFails === 0) { peg$fail(peg$c211); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5393,7 +5260,7 @@ function peg$parse(input, options) {
             s5 = peg$parseLayoutArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c213(s3, s4, s5);
+              s1 = peg$c212(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5423,27 +5290,27 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c214) {
-      s1 = peg$c214;
+    if (input.substr(peg$currPos, 5) === peg$c213) {
+      s1 = peg$c213;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+      if (peg$silentFails === 0) { peg$fail(peg$c214); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c216) {
-        s1 = peg$c216;
+      if (input.substr(peg$currPos, 6) === peg$c215) {
+        s1 = peg$c215;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c216); }
       }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePath();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5470,22 +5337,22 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c218.test(input.charAt(peg$currPos))) {
+      if (peg$c217.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c219); }
+        if (peg$silentFails === 0) { peg$fail(peg$c218); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c218.test(input.charAt(peg$currPos))) {
+          if (peg$c217.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c219); }
+            if (peg$silentFails === 0) { peg$fail(peg$c218); }
           }
         }
       } else {
@@ -5493,7 +5360,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
     }
@@ -5507,12 +5374,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c220) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c219) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c221); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5520,7 +5387,7 @@ function peg$parse(input, options) {
           s4 = peg$parseKSUID();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c222(s4);
+            s1 = peg$c221(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5540,10 +5407,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -5556,22 +5423,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c223.test(input.charAt(peg$currPos))) {
+    if (peg$c222.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c224); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c223.test(input.charAt(peg$currPos))) {
+        if (peg$c222.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c224); }
+          if (peg$silentFails === 0) { peg$fail(peg$c223); }
         }
       }
     } else {
@@ -5579,7 +5446,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -5592,12 +5459,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c225) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c224) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c226); }
+        if (peg$silentFails === 0) { peg$fail(peg$c225); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5606,12 +5473,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c227) {
+              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c226) {
                 s6 = input.substr(peg$currPos, 2);
                 peg$currPos += 2;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c228); }
+                if (peg$silentFails === 0) { peg$fail(peg$c227); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parse_();
@@ -5619,7 +5486,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseLiteral();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c229(s4, s8);
+                    s1 = peg$c228(s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5655,10 +5522,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -5673,7 +5540,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c231(s1);
+      s1 = peg$c230(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5681,7 +5548,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKSUID();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c222(s1);
+        s1 = peg$c221(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -5689,7 +5556,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c232(s1);
+          s1 = peg$c18(s1);
         }
         s0 = s1;
       }
@@ -5704,12 +5571,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c231) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c234); }
+        if (peg$silentFails === 0) { peg$fail(peg$c232); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5719,7 +5586,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c235(s4, s5);
+              s1 = peg$c233(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5743,10 +5610,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -5760,12 +5627,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c236) {
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c234) {
         s2 = input.substr(peg$currPos, 6);
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c237); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5773,7 +5640,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s4);
+            s1 = peg$c229(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5793,10 +5660,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c238();
+        s1 = peg$c236();
       }
       s0 = s1;
     }
@@ -5808,38 +5675,38 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c239) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c237) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c241();
+      s1 = peg$c239();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c242) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c243); }
+        if (peg$silentFails === 0) { peg$fail(peg$c241); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c244();
+        s1 = peg$c242();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c26;
+        s1 = peg$c25;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c241();
+          s1 = peg$c239();
         }
         s0 = s1;
       }
@@ -5854,26 +5721,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c231) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c234); }
+        if (peg$silentFails === 0) { peg$fail(peg$c232); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c243) {
             s4 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c246); }
+            if (peg$silentFails === 0) { peg$fail(peg$c244); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c241();
+            s1 = peg$c239();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5895,26 +5762,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c231) {
           s2 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c234); }
+          if (peg$silentFails === 0) { peg$fail(peg$c232); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c245) {
               s4 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c248); }
+              if (peg$silentFails === 0) { peg$fail(peg$c246); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c244();
+              s1 = peg$c242();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5934,10 +5801,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c26;
+        s1 = peg$c25;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c238();
+          s1 = peg$c236();
         }
         s0 = s1;
       }
@@ -5950,16 +5817,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c249) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c250); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c251();
+      s1 = peg$c249();
     }
     s0 = s1;
 
@@ -5970,12 +5837,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c252) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c250) {
       s1 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5987,7 +5854,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAsArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c254(s3, s4, s5);
+              s1 = peg$c252(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6026,7 +5893,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c255(s4);
+            s1 = peg$c253(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6061,7 +5928,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c256(s4);
+            s1 = peg$c254(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6081,10 +5948,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c27();
+        s1 = peg$c26();
       }
       s0 = s1;
     }
@@ -6103,11 +5970,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6138,11 +6005,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6170,7 +6037,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c258(s1, s2);
+        s1 = peg$c256(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6192,12 +6059,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c115) {
-          s3 = peg$c115;
+        if (input.substr(peg$currPos, 2) === peg$c114) {
+          s3 = peg$c114;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c116); }
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6205,7 +6072,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c259(s1, s5);
+              s1 = peg$c257(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6248,11 +6115,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c260;
+          s3 = peg$c258;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c261); }
+          if (peg$silentFails === 0) { peg$fail(peg$c259); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6262,11 +6129,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c52;
+                  s7 = peg$c51;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c52); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -6274,7 +6141,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c262(s1, s5, s9);
+                      s1 = peg$c260(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6336,7 +6203,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6366,7 +6233,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6387,7 +6254,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6418,7 +6285,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6448,7 +6315,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6469,7 +6336,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6502,7 +6369,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c265(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6532,7 +6399,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRelativeExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s3;
-                  s4 = peg$c265(s1, s5, s7);
+                  s4 = peg$c263(s1, s5, s7);
                   s3 = s4;
                 } else {
                   peg$currPos = s3;
@@ -6553,7 +6420,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c264(s1, s2);
+          s1 = peg$c262(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6572,30 +6439,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c56) {
-      s1 = peg$c56;
+    if (input.substr(peg$currPos, 2) === peg$c55) {
+      s1 = peg$c55;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c57); }
+      if (peg$silentFails === 0) { peg$fail(peg$c56); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c266();
+      s1 = peg$c264();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c58) {
-        s1 = peg$c58;
+      if (input.substr(peg$currPos, 2) === peg$c57) {
+        s1 = peg$c57;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
     }
@@ -6609,16 +6476,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c60) {
-        s1 = peg$c60;
+      if (input.substr(peg$currPos, 2) === peg$c59) {
+        s1 = peg$c59;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c60); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
     }
@@ -6643,7 +6510,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6673,7 +6540,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6694,7 +6561,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6712,43 +6579,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c62) {
-      s1 = peg$c62;
+    if (input.substr(peg$currPos, 2) === peg$c61) {
+      s1 = peg$c61;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c63); }
+      if (peg$silentFails === 0) { peg$fail(peg$c62); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c64;
+        s1 = peg$c63;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c65); }
+        if (peg$silentFails === 0) { peg$fail(peg$c64); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c66) {
-          s1 = peg$c66;
+        if (input.substr(peg$currPos, 2) === peg$c65) {
+          s1 = peg$c65;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c67); }
+          if (peg$silentFails === 0) { peg$fail(peg$c66); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c68;
+            s1 = peg$c67;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c69); }
+            if (peg$silentFails === 0) { peg$fail(peg$c68); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -6772,7 +6639,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6802,7 +6669,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6823,7 +6690,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6842,24 +6709,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c267;
+      s1 = peg$c265;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c269;
+        s1 = peg$c267;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c270); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -6883,7 +6750,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6913,7 +6780,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6934,7 +6801,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6953,24 +6820,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c83;
+      s1 = peg$c82;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c271;
+        s1 = peg$c269;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c272); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -6982,11 +6849,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c79;
+      s1 = peg$c78;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c79); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -6994,7 +6861,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c273(s3);
+          s1 = peg$c271(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7031,11 +6898,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s5 = peg$c30;
+              s5 = peg$c29;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c31); }
+              if (peg$silentFails === 0) { peg$fail(peg$c30); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -7057,7 +6924,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s1);
+            s1 = peg$c272(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7079,7 +6946,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c75(s1, s2);
+              s1 = peg$c74(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7101,7 +6968,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c75(s1, s2);
+                s1 = peg$c74(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7134,11 +7001,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -7162,28 +7029,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c275) {
-      s0 = peg$c275;
+    if (input.substr(peg$currPos, 3) === peg$c273) {
+      s0 = peg$c273;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c277) {
-        s0 = peg$c277;
+      if (input.substr(peg$currPos, 5) === peg$c275) {
+        s0 = peg$c275;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c279) {
-          s0 = peg$c279;
+        if (input.substr(peg$currPos, 6) === peg$c277) {
+          s0 = peg$c277;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c280); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -7204,36 +7071,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c277) {
-      s1 = peg$c277;
+    if (input.substr(peg$currPos, 5) === peg$c275) {
+      s1 = peg$c275;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c32;
+              s5 = peg$c31;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c33); }
+              if (peg$silentFails === 0) { peg$fail(peg$c32); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c82(s4);
+              s1 = peg$c81(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7263,22 +7130,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c279) {
-      s1 = peg$c279;
+    if (input.substr(peg$currPos, 6) === peg$c277) {
+      s1 = peg$c277;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7288,17 +7155,17 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c32;
+                  s7 = peg$c31;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parseMethods();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c281(s5, s8);
+                    s1 = peg$c279(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7352,15 +7219,15 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c282(s1);
+      s1 = peg$c280(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -7375,11 +7242,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c119;
+        s2 = peg$c118;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7387,7 +7254,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFunction();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c41(s4);
+            s1 = peg$c40(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7418,11 +7285,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7432,15 +7299,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c32;
+                  s7 = peg$c31;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c283(s1, s5);
+                  s1 = peg$c281(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7494,11 +7361,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c30;
+            s4 = peg$c29;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -7508,15 +7375,15 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c32;
+                    s8 = peg$c31;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c32); }
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c284(s2, s6);
+                    s1 = peg$c282(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7563,7 +7430,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c285();
+        s1 = peg$c283();
       }
       s0 = s1;
     }
@@ -7582,11 +7449,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -7594,7 +7461,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c286(s1, s7);
+              s4 = peg$c284(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7618,11 +7485,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -7630,7 +7497,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c286(s1, s7);
+                s4 = peg$c284(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7651,7 +7518,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7683,7 +7550,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExprPattern();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c287(s2);
+        s1 = peg$c285(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7711,7 +7578,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c75(s1, s2);
+        s1 = peg$c74(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7733,7 +7600,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c75(s1, s2);
+          s1 = peg$c74(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7755,7 +7622,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c75(s1, s2);
+            s1 = peg$c74(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7768,15 +7635,15 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 46) {
-            s1 = peg$c119;
+            s1 = peg$c118;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c120); }
+            if (peg$silentFails === 0) { peg$fail(peg$c119); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c288();
+            s1 = peg$c286();
           }
           s0 = s1;
         }
@@ -7790,16 +7657,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c289) {
-      s1 = peg$c289;
+    if (input.substr(peg$currPos, 4) === peg$c287) {
+      s1 = peg$c287;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c203();
+      s1 = peg$c202();
     }
     s0 = s1;
 
@@ -7811,17 +7678,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c119;
+      s1 = peg$c118;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c120); }
+      if (peg$silentFails === 0) { peg$fail(peg$c119); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c291(s2);
+        s1 = peg$c289(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7834,33 +7701,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c119;
+        s1 = peg$c118;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c50;
+          s2 = peg$c49;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c292;
+              s4 = peg$c290;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c293); }
+              if (peg$silentFails === 0) { peg$fail(peg$c291); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c294(s3);
+              s1 = peg$c292(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7888,11 +7755,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c50;
+      s1 = peg$c49;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -7900,11 +7767,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c52;
+            s4 = peg$c51;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -7912,15 +7779,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c292;
+                  s7 = peg$c290;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c291); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c295(s2, s6);
+                  s1 = peg$c293(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7953,21 +7820,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c50;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c52;
+            s3 = peg$c51;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -7975,15 +7842,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c292;
+                  s6 = peg$c290;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c291); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c296(s5);
+                  s1 = peg$c294(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8012,11 +7879,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c50;
+          s1 = peg$c49;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseAdditiveExpr();
@@ -8024,25 +7891,25 @@ function peg$parse(input, options) {
             s3 = peg$parse__();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c52;
+                s4 = peg$c51;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                if (peg$silentFails === 0) { peg$fail(peg$c52); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c292;
+                    s6 = peg$c290;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c291); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c297(s2);
+                    s1 = peg$c295(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8071,25 +7938,25 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c50;
+            s1 = peg$c49;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c51); }
+            if (peg$silentFails === 0) { peg$fail(peg$c50); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c292;
+                s3 = peg$c290;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                if (peg$silentFails === 0) { peg$fail(peg$c291); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c298(s2);
+                s1 = peg$c296(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8106,21 +7973,21 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c119;
+              s1 = peg$c118;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c120); }
+              if (peg$silentFails === 0) { peg$fail(peg$c119); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
               peg$silentFails++;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s3 = peg$c119;
+                s3 = peg$c118;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c119); }
               }
               peg$silentFails--;
               if (s3 === peg$FAILED) {
@@ -8133,7 +8000,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c299(s3);
+                  s1 = peg$c297(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8170,11 +8037,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 40) {
-                s1 = peg$c30;
+                s1 = peg$c29;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                if (peg$silentFails === 0) { peg$fail(peg$c30); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -8184,15 +8051,15 @@ function peg$parse(input, options) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s5 = peg$c32;
+                        s5 = peg$c31;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c32); }
                       }
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c82(s3);
+                        s1 = peg$c81(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -8228,11 +8095,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c48;
+      s1 = peg$c47;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c48); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8242,15 +8109,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c300;
+              s5 = peg$c298;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c302(s3);
+              s1 = peg$c300(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8290,7 +8157,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8311,11 +8178,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8323,7 +8190,7 @@ function peg$parse(input, options) {
           s4 = peg$parseField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c41(s4);
+            s1 = peg$c40(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8354,11 +8221,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c52;
+          s3 = peg$c51;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8366,7 +8233,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c304(s1, s5);
+              s1 = peg$c302(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8397,11 +8264,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c50;
+      s1 = peg$c49;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8411,15 +8278,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c292;
+              s5 = peg$c290;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c293); }
+              if (peg$silentFails === 0) { peg$fail(peg$c291); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305(s3);
+              s1 = peg$c303(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8449,12 +8316,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c306) {
-      s1 = peg$c306;
+    if (input.substr(peg$currPos, 2) === peg$c304) {
+      s1 = peg$c304;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c307); }
+      if (peg$silentFails === 0) { peg$fail(peg$c305); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8463,16 +8330,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c308) {
-              s5 = peg$c308;
+            if (input.substr(peg$currPos, 2) === peg$c306) {
+              s5 = peg$c306;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c309); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c310(s3);
+              s1 = peg$c308(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8502,12 +8369,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c311) {
-      s1 = peg$c311;
+    if (input.substr(peg$currPos, 2) === peg$c309) {
+      s1 = peg$c309;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c312); }
+      if (peg$silentFails === 0) { peg$fail(peg$c310); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8516,16 +8383,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c313) {
-              s5 = peg$c313;
+            if (input.substr(peg$currPos, 2) === peg$c311) {
+              s5 = peg$c311;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c314); }
+              if (peg$silentFails === 0) { peg$fail(peg$c312); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s3);
+              s1 = peg$c313(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8565,7 +8432,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8580,7 +8447,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c285();
+        s1 = peg$c283();
       }
       s0 = s1;
     }
@@ -8595,11 +8462,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8607,7 +8474,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c287(s4);
+            s1 = peg$c285(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8638,11 +8505,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c52;
+          s3 = peg$c51;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8650,7 +8517,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c316(s1, s5);
+              s1 = peg$c314(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8697,7 +8564,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c317(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c315(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8744,15 +8611,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 42) {
-          s3 = peg$c83;
+          s3 = peg$c82;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104();
+          s1 = peg$c103();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8775,7 +8642,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c318(s3);
+            s1 = peg$c316(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8809,7 +8676,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319(s1, s5);
+              s1 = peg$c317(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8836,7 +8703,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112(s1);
+        s1 = peg$c111(s1);
       }
       s0 = s1;
     }
@@ -8855,11 +8722,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -8867,7 +8734,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSQLAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c113(s1, s7);
+              s4 = peg$c112(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8891,11 +8758,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -8903,7 +8770,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSQLAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c113(s1, s7);
+                s4 = peg$c112(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8924,7 +8791,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8953,7 +8820,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSQLAlias();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s4, s5);
+              s1 = peg$c318(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8984,15 +8851,15 @@ function peg$parse(input, options) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 42) {
-              s4 = peg$c83;
+              s4 = peg$c82;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c84); }
+              if (peg$silentFails === 0) { peg$fail(peg$c83); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c104();
+              s1 = peg$c103();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9012,10 +8879,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c26;
+        s1 = peg$c25;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104();
+          s1 = peg$c103();
         }
         s0 = s1;
       }
@@ -9037,7 +8904,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c222(s4);
+            s1 = peg$c221(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9062,7 +8929,7 @@ function peg$parse(input, options) {
         s2 = peg$parseDerefExpr();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c222(s2);
+          s1 = peg$c221(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9074,10 +8941,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c26;
+        s1 = peg$c25;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104();
+          s1 = peg$c103();
         }
         s0 = s1;
       }
@@ -9097,7 +8964,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c321(s1, s4);
+        s4 = peg$c319(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9106,13 +8973,13 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c321(s1, s4);
+          s4 = peg$c319(s1, s4);
         }
         s3 = s4;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9124,10 +8991,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9174,7 +9041,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c322(s1, s5, s6, s10, s14);
+                                s1 = peg$c320(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9251,7 +9118,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c323(s2);
+        s1 = peg$c321(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9263,10 +9130,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c192();
+        s1 = peg$c191();
       }
       s0 = s1;
     }
@@ -9287,7 +9154,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s4);
+            s1 = peg$c81(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9307,10 +9174,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9335,7 +9202,7 @@ function peg$parse(input, options) {
               s6 = peg$parseFieldExprs();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c105(s6);
+                s1 = peg$c104(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9363,10 +9230,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9387,7 +9254,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s4);
+            s1 = peg$c81(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9407,10 +9274,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9437,7 +9304,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c324(s6, s7);
+                  s1 = peg$c322(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9469,10 +9336,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9492,7 +9359,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c325(s2);
+        s1 = peg$c323(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9504,10 +9371,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c241();
+        s1 = peg$c239();
       }
       s0 = s1;
     }
@@ -9528,7 +9395,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s4);
+            s1 = peg$c324(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9548,10 +9415,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c111();
+        s1 = peg$c110();
       }
       s0 = s1;
     }
@@ -9563,16 +9430,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c279) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c277) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328();
+      s1 = peg$c326();
     }
     s0 = s1;
 
@@ -9583,16 +9450,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c329) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c327) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c328); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c331();
+      s1 = peg$c329();
     }
     s0 = s1;
 
@@ -9603,16 +9470,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c37) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c208); }
+      if (peg$silentFails === 0) { peg$fail(peg$c207); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c332();
+      s1 = peg$c330();
     }
     s0 = s1;
 
@@ -9623,16 +9490,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c185) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c187); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c333();
+      s1 = peg$c331();
     }
     s0 = s1;
 
@@ -9643,16 +9510,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c122) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c121) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c334); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c335();
+      s1 = peg$c333();
     }
     s0 = s1;
 
@@ -9663,16 +9530,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c336) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c334) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c337); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c338();
+      s1 = peg$c336();
     }
     s0 = s1;
 
@@ -9683,16 +9550,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c337) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341();
+      s1 = peg$c339();
     }
     s0 = s1;
 
@@ -9703,16 +9570,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c231) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c232); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c340();
     }
     s0 = s1;
 
@@ -9723,16 +9590,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c343) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c341) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c345();
+      s1 = peg$c343();
     }
     s0 = s1;
 
@@ -9743,16 +9610,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c344) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -9763,16 +9630,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c243) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c241();
+      s1 = peg$c239();
     }
     s0 = s1;
 
@@ -9783,16 +9650,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c245) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c248); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c244();
+      s1 = peg$c242();
     }
     s0 = s1;
 
@@ -9803,16 +9670,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c193) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c192) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      if (peg$silentFails === 0) { peg$fail(peg$c193); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c195();
+      s1 = peg$c194();
     }
     s0 = s1;
 
@@ -9823,16 +9690,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c196) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c195) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c197); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c198();
+      s1 = peg$c197();
     }
     s0 = s1;
 
@@ -9843,16 +9710,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c190) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c189) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c191); }
+      if (peg$silentFails === 0) { peg$fail(peg$c190); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c192();
+      s1 = peg$c191();
     }
     s0 = s1;
 
@@ -9936,7 +9803,7 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c91(s1);
+      s1 = peg$c90(s1);
     }
     s0 = s1;
 
@@ -9961,7 +9828,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c349(s1);
+        s1 = peg$c347(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9976,7 +9843,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c349(s1);
+        s1 = peg$c347(s1);
       }
       s0 = s1;
     }
@@ -10002,7 +9869,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1);
+        s1 = peg$c348(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10017,7 +9884,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1);
+        s1 = peg$c348(s1);
       }
       s0 = s1;
     }
@@ -10032,7 +9899,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351(s1);
+      s1 = peg$c349(s1);
     }
     s0 = s1;
 
@@ -10046,7 +9913,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c352(s1);
+      s1 = peg$c350(s1);
     }
     s0 = s1;
 
@@ -10057,30 +9924,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c353) {
-      s1 = peg$c353;
+    if (input.substr(peg$currPos, 4) === peg$c351) {
+      s1 = peg$c351;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c355();
+      s1 = peg$c353();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c356) {
-        s1 = peg$c356;
+      if (input.substr(peg$currPos, 5) === peg$c354) {
+        s1 = peg$c354;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c357); }
+        if (peg$silentFails === 0) { peg$fail(peg$c355); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c358();
+        s1 = peg$c356();
       }
       s0 = s1;
     }
@@ -10092,16 +9959,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c359) {
-      s1 = peg$c359;
+    if (input.substr(peg$currPos, 4) === peg$c357) {
+      s1 = peg$c357;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c358); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c361();
+      s1 = peg$c359();
     }
     s0 = s1;
 
@@ -10140,7 +10007,7 @@ function peg$parse(input, options) {
       s2 = peg$parseTypeExternal();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c362(s2);
+        s1 = peg$c360(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10187,7 +10054,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s1);
+            s1 = peg$c272(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10232,11 +10099,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -10246,15 +10113,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c32;
+                  s7 = peg$c31;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c255(s5);
+                  s1 = peg$c253(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10297,11 +10164,11 @@ function peg$parse(input, options) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c30;
+            s3 = peg$c29;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -10311,15 +10178,15 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c32;
+                    s7 = peg$c31;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c32); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c274(s5);
+                    s1 = peg$c272(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10372,7 +10239,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c231(s1);
+        s1 = peg$c230(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10399,11 +10266,11 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s5 = peg$c30;
+                s5 = peg$c29;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                if (peg$silentFails === 0) { peg$fail(peg$c30); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse__();
@@ -10413,15 +10280,15 @@ function peg$parse(input, options) {
                     s8 = peg$parse__();
                     if (s8 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s9 = peg$c32;
+                        s9 = peg$c31;
                         peg$currPos++;
                       } else {
                         s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c32); }
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c363(s1, s7);
+                        s1 = peg$c361(s1, s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10464,17 +10331,17 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c364(s1);
+          s1 = peg$c362(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c30;
+            s1 = peg$c29;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10482,15 +10349,15 @@ function peg$parse(input, options) {
               s3 = peg$parseTypeUnion();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s4 = peg$c32;
+                  s4 = peg$c31;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c365(s3);
+                  s1 = peg$c363(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10522,7 +10389,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c366(s1);
+      s1 = peg$c364(s1);
     }
     s0 = s1;
 
@@ -10547,7 +10414,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10568,11 +10435,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -10580,7 +10447,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s4);
+            s1 = peg$c272(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10607,11 +10474,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c48;
+      s1 = peg$c47;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c48); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -10621,15 +10488,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c300;
+              s5 = peg$c298;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c367(s3);
+              s1 = peg$c365(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10654,11 +10521,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c50;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -10668,15 +10535,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c292;
+                s5 = peg$c290;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                if (peg$silentFails === 0) { peg$fail(peg$c291); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c368(s3);
+                s1 = peg$c366(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10700,12 +10567,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c306) {
-          s1 = peg$c306;
+        if (input.substr(peg$currPos, 2) === peg$c304) {
+          s1 = peg$c304;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c305); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10714,16 +10581,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c308) {
-                  s5 = peg$c308;
+                if (input.substr(peg$currPos, 2) === peg$c306) {
+                  s5 = peg$c306;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c307); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c369(s3);
+                  s1 = peg$c367(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10747,12 +10614,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c311) {
-            s1 = peg$c311;
+          if (input.substr(peg$currPos, 2) === peg$c309) {
+            s1 = peg$c309;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c312); }
+            if (peg$silentFails === 0) { peg$fail(peg$c310); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10762,11 +10629,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c73;
+                    s5 = peg$c72;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c73); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -10775,16 +10642,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c313) {
-                            s9 = peg$c313;
+                          if (input.substr(peg$currPos, 2) === peg$c311) {
+                            s9 = peg$c311;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c314); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c312); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c370(s3, s7);
+                            s1 = peg$c368(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10834,11 +10701,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c48;
+      s1 = peg$c47;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c48); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -10848,15 +10715,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c300;
+              s5 = peg$c298;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c367(s3);
+              s1 = peg$c365(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10881,11 +10748,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c50;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -10895,15 +10762,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c292;
+                s5 = peg$c290;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                if (peg$silentFails === 0) { peg$fail(peg$c291); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c368(s3);
+                s1 = peg$c366(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10927,12 +10794,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c306) {
-          s1 = peg$c306;
+        if (input.substr(peg$currPos, 2) === peg$c304) {
+          s1 = peg$c304;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c305); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10941,16 +10808,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c308) {
-                  s5 = peg$c308;
+                if (input.substr(peg$currPos, 2) === peg$c306) {
+                  s5 = peg$c306;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c307); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c369(s3);
+                  s1 = peg$c367(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10974,12 +10841,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c311) {
-            s1 = peg$c311;
+          if (input.substr(peg$currPos, 2) === peg$c309) {
+            s1 = peg$c309;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c312); }
+            if (peg$silentFails === 0) { peg$fail(peg$c310); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10989,11 +10856,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c73;
+                    s5 = peg$c72;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c73); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -11002,16 +10869,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c313) {
-                            s9 = peg$c313;
+                          if (input.substr(peg$currPos, 2) === peg$c311) {
+                            s9 = peg$c311;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c314); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c312); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c370(s3, s7);
+                            s1 = peg$c368(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11071,92 +10938,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c371) {
-      s1 = peg$c371;
+    if (input.substr(peg$currPos, 5) === peg$c369) {
+      s1 = peg$c369;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c373) {
-        s1 = peg$c373;
+      if (input.substr(peg$currPos, 6) === peg$c371) {
+        s1 = peg$c371;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c374); }
+        if (peg$silentFails === 0) { peg$fail(peg$c372); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c375) {
-          s1 = peg$c375;
+        if (input.substr(peg$currPos, 6) === peg$c373) {
+          s1 = peg$c373;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c376); }
+          if (peg$silentFails === 0) { peg$fail(peg$c374); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c377) {
-            s1 = peg$c377;
+          if (input.substr(peg$currPos, 6) === peg$c375) {
+            s1 = peg$c375;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c378); }
+            if (peg$silentFails === 0) { peg$fail(peg$c376); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c379) {
-              s1 = peg$c379;
+            if (input.substr(peg$currPos, 4) === peg$c377) {
+              s1 = peg$c377;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c380); }
+              if (peg$silentFails === 0) { peg$fail(peg$c378); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c381) {
-                s1 = peg$c381;
+              if (input.substr(peg$currPos, 5) === peg$c379) {
+                s1 = peg$c379;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c382); }
+                if (peg$silentFails === 0) { peg$fail(peg$c380); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c383) {
-                  s1 = peg$c383;
+                if (input.substr(peg$currPos, 5) === peg$c381) {
+                  s1 = peg$c381;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c384); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c382); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c385) {
-                    s1 = peg$c385;
+                  if (input.substr(peg$currPos, 5) === peg$c383) {
+                    s1 = peg$c383;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c384); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c387) {
-                      s1 = peg$c387;
+                    if (input.substr(peg$currPos, 7) === peg$c385) {
+                      s1 = peg$c385;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c386); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c389) {
-                        s1 = peg$c389;
+                      if (input.substr(peg$currPos, 4) === peg$c387) {
+                        s1 = peg$c387;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c388); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c391) {
-                          s1 = peg$c391;
+                        if (input.substr(peg$currPos, 6) === peg$c389) {
+                          s1 = peg$c389;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c392); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c390); }
                         }
                       }
                     }
@@ -11170,7 +11037,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c393();
+      s1 = peg$c391();
     }
     s0 = s1;
 
@@ -11181,52 +11048,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c394) {
-      s1 = peg$c394;
+    if (input.substr(peg$currPos, 8) === peg$c392) {
+      s1 = peg$c392;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c396) {
-        s1 = peg$c396;
+      if (input.substr(peg$currPos, 4) === peg$c394) {
+        s1 = peg$c394;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c397); }
+        if (peg$silentFails === 0) { peg$fail(peg$c395); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c398) {
-          s1 = peg$c398;
+        if (input.substr(peg$currPos, 5) === peg$c396) {
+          s1 = peg$c396;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c399); }
+          if (peg$silentFails === 0) { peg$fail(peg$c397); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c400) {
-            s1 = peg$c400;
+          if (input.substr(peg$currPos, 7) === peg$c398) {
+            s1 = peg$c398;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c401); }
+            if (peg$silentFails === 0) { peg$fail(peg$c399); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c402) {
-              s1 = peg$c402;
+            if (input.substr(peg$currPos, 2) === peg$c400) {
+              s1 = peg$c400;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c403); }
+              if (peg$silentFails === 0) { peg$fail(peg$c401); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c404) {
-                s1 = peg$c404;
+              if (input.substr(peg$currPos, 3) === peg$c402) {
+                s1 = peg$c402;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c405); }
+                if (peg$silentFails === 0) { peg$fail(peg$c403); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11237,20 +11104,20 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c406) {
-                    s1 = peg$c406;
+                  if (input.substr(peg$currPos, 5) === peg$c404) {
+                    s1 = peg$c404;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c407); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c405); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c359) {
-                      s1 = peg$c359;
+                    if (input.substr(peg$currPos, 4) === peg$c357) {
+                      s1 = peg$c357;
                       peg$currPos += 4;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c358); }
                     }
                   }
                 }
@@ -11262,7 +11129,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c393();
+      s1 = peg$c391();
     }
     s0 = s1;
 
@@ -11283,7 +11150,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11304,11 +11171,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -11316,7 +11183,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s4);
+            s1 = peg$c272(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11347,11 +11214,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c52;
+          s3 = peg$c51;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -11359,7 +11226,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c408(s1, s5);
+              s1 = peg$c406(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11400,12 +11267,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c409) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c407) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11420,7 +11287,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c411();
+        s1 = peg$c409();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11438,7 +11305,45 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c412) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c410) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c412();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseInToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c59) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
@@ -11472,13 +11377,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseInToken() {
+  function peg$parseNotToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c273) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c415); }
@@ -11510,54 +11415,16 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseNotToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c275) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c417); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c418();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parseByToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c419) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c417) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c420); }
+      if (peg$silentFails === 0) { peg$fail(peg$c418); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11572,7 +11439,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c421();
+        s1 = peg$c419();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11589,12 +11456,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c422.test(input.charAt(peg$currPos))) {
+    if (peg$c420.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c423); }
+      if (peg$silentFails === 0) { peg$fail(peg$c421); }
     }
 
     return s0;
@@ -11605,12 +11472,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
     }
 
@@ -11624,7 +11491,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c426(s1);
+      s1 = peg$c424(s1);
     }
     s0 = s1;
 
@@ -11679,7 +11546,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c427();
+          s1 = peg$c425();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11696,31 +11563,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c428;
+        s1 = peg$c426;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c429); }
+        if (peg$silentFails === 0) { peg$fail(peg$c427); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c430;
+          s1 = peg$c428;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+          if (peg$silentFails === 0) { peg$fail(peg$c429); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c222(s2);
+            s1 = peg$c221(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11741,7 +11608,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c70();
+            s1 = peg$c69();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -11754,11 +11621,11 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s5 = peg$c30;
+                  s5 = peg$c29;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c30); }
                 }
                 if (s5 !== peg$FAILED) {
                   s4 = [s4, s5];
@@ -11780,7 +11647,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c222(s1);
+                s1 = peg$c221(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11822,17 +11689,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c432;
+        s2 = peg$c430;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c433); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c434();
+          s1 = peg$c432();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11857,21 +11724,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c269;
+        s2 = peg$c267;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c270); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c269;
+            s4 = peg$c267;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c270); }
+            if (peg$silentFails === 0) { peg$fail(peg$c268); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -11906,36 +11773,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c424.test(input.charAt(peg$currPos))) {
+    if (peg$c422.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c424.test(input.charAt(peg$currPos))) {
+        if (peg$c422.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c425); }
+          if (peg$silentFails === 0) { peg$fail(peg$c423); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c424.test(input.charAt(peg$currPos))) {
+          if (peg$c422.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c425); }
+            if (peg$silentFails === 0) { peg$fail(peg$c423); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -11964,20 +11831,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c424.test(input.charAt(peg$currPos))) {
+    if (peg$c422.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12023,51 +11890,51 @@ function peg$parse(input, options) {
     s1 = peg$parseD2();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c52;
+        s2 = peg$c51;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c52;
+            s4 = peg$c51;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
             if (s5 !== peg$FAILED) {
               s6 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c119;
+                s7 = peg$c118;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c119); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c424.test(input.charAt(peg$currPos))) {
+                if (peg$c422.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c424.test(input.charAt(peg$currPos))) {
+                    if (peg$c422.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c423); }
                     }
                   }
                 } else {
@@ -12122,69 +11989,69 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c435;
+      s0 = peg$c433;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c436); }
+      if (peg$silentFails === 0) { peg$fail(peg$c434); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c267;
+        s1 = peg$c265;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c266); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c269;
+          s1 = peg$c267;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c268); }
         }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseD2();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c52;
+            s3 = peg$c51;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parseD2();
             if (s4 !== peg$FAILED) {
               s5 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c119;
+                s6 = peg$c118;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c119); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c424.test(input.charAt(peg$currPos))) {
+                if (peg$c422.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c424.test(input.charAt(peg$currPos))) {
+                    if (peg$c422.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c423); }
                     }
                   }
                 } else {
@@ -12237,11 +12104,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c269;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c270); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12287,7 +12154,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c437();
+        s1 = peg$c435();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12309,11 +12176,11 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c119;
+        s3 = peg$c118;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseUInt();
@@ -12349,76 +12216,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c438) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c436) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c439); }
+      if (peg$silentFails === 0) { peg$fail(peg$c437); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c440) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c438) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c441); }
+        if (peg$silentFails === 0) { peg$fail(peg$c439); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c442) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c440) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c443); }
+          if (peg$silentFails === 0) { peg$fail(peg$c441); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c444) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c442) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c445); }
+            if (peg$silentFails === 0) { peg$fail(peg$c443); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c446) {
+            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c444) {
               s0 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c447); }
+              if (peg$silentFails === 0) { peg$fail(peg$c445); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c448) {
+              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c446) {
                 s0 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c449); }
+                if (peg$silentFails === 0) { peg$fail(peg$c447); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c450) {
+                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c448) {
                   s0 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c451); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c449); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c452) {
+                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c450) {
                     s0 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c453); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c451); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c454) {
+                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c452) {
                       s0 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c455); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c453); }
                     }
                   }
                 }
@@ -12439,37 +12306,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c119;
+        s2 = peg$c118;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c119;
+            s4 = peg$c118;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c120); }
+            if (peg$silentFails === 0) { peg$fail(peg$c119); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c119;
+                s6 = peg$c118;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c119); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c70();
+                  s1 = peg$c69();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -12513,11 +12380,11 @@ function peg$parse(input, options) {
     s3 = peg$parseHex();
     if (s3 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s4 = peg$c52;
+        s4 = peg$c51;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parseHex();
@@ -12527,11 +12394,11 @@ function peg$parse(input, options) {
           s7 = peg$parseHexDigit();
           if (s7 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s7 = peg$c52;
+              s7 = peg$c51;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c53); }
+              if (peg$silentFails === 0) { peg$fail(peg$c52); }
             }
           }
           peg$silentFails--;
@@ -12603,7 +12470,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c456(s1, s2);
+        s1 = peg$c454(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12624,12 +12491,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c457) {
-            s3 = peg$c457;
+          if (input.substr(peg$currPos, 2) === peg$c455) {
+            s3 = peg$c455;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c458); }
+            if (peg$silentFails === 0) { peg$fail(peg$c456); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12642,7 +12509,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c459(s1, s2, s4, s5);
+                s1 = peg$c457(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12666,12 +12533,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c457) {
-          s1 = peg$c457;
+        if (input.substr(peg$currPos, 2) === peg$c455) {
+          s1 = peg$c455;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c458); }
+          if (peg$silentFails === 0) { peg$fail(peg$c456); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12684,7 +12551,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c460(s2, s3);
+              s1 = peg$c458(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12709,16 +12576,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c457) {
-                s3 = peg$c457;
+              if (input.substr(peg$currPos, 2) === peg$c455) {
+                s3 = peg$c455;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c458); }
+                if (peg$silentFails === 0) { peg$fail(peg$c456); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c461(s1, s2);
+                s1 = peg$c459(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12734,16 +12601,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c457) {
-              s1 = peg$c457;
+            if (input.substr(peg$currPos, 2) === peg$c455) {
+              s1 = peg$c455;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c458); }
+              if (peg$silentFails === 0) { peg$fail(peg$c456); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c462();
+              s1 = peg$c460();
             }
             s0 = s1;
           }
@@ -12770,17 +12637,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c52;
+      s1 = peg$c51;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c52); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c463(s2);
+        s1 = peg$c461(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12801,15 +12668,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c52;
+        s2 = peg$c51;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c464(s1);
+        s1 = peg$c462(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12830,17 +12697,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c271;
+        s2 = peg$c269;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c272); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c465(s1, s3);
+          s1 = peg$c463(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12865,17 +12732,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c271;
+        s2 = peg$c269;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c272); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c466(s1, s3);
+          s1 = peg$c464(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12900,7 +12767,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c467(s1);
+      s1 = peg$c465(s1);
     }
     s0 = s1;
 
@@ -12923,22 +12790,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c424.test(input.charAt(peg$currPos))) {
+    if (peg$c422.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c424.test(input.charAt(peg$currPos))) {
+        if (peg$c422.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c425); }
+          if (peg$silentFails === 0) { peg$fail(peg$c423); }
         }
       }
     } else {
@@ -12946,7 +12813,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -12958,17 +12825,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c269;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c270); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12987,33 +12854,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c269;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c270); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c424.test(input.charAt(peg$currPos))) {
+          if (peg$c422.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c425); }
+            if (peg$silentFails === 0) { peg$fail(peg$c423); }
           }
         }
       } else {
@@ -13021,30 +12888,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c119;
+          s3 = peg$c118;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c120); }
+          if (peg$silentFails === 0) { peg$fail(peg$c119); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c424.test(input.charAt(peg$currPos))) {
+          if (peg$c422.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c425); }
+            if (peg$silentFails === 0) { peg$fail(peg$c423); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c424.test(input.charAt(peg$currPos))) {
+              if (peg$c422.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                if (peg$silentFails === 0) { peg$fail(peg$c423); }
               }
             }
           } else {
@@ -13057,7 +12924,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c468();
+              s1 = peg$c466();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13082,41 +12949,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c269;
+        s1 = peg$c267;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c270); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c119;
+          s2 = peg$c118;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c120); }
+          if (peg$silentFails === 0) { peg$fail(peg$c119); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c424.test(input.charAt(peg$currPos))) {
+          if (peg$c422.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c425); }
+            if (peg$silentFails === 0) { peg$fail(peg$c423); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c424.test(input.charAt(peg$currPos))) {
+              if (peg$c422.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                if (peg$silentFails === 0) { peg$fail(peg$c423); }
               }
             }
           } else {
@@ -13129,7 +12996,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c468();
+              s1 = peg$c466();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13156,20 +13023,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c469) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c467) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c470); }
+      if (peg$silentFails === 0) { peg$fail(peg$c468); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c471.test(input.charAt(peg$currPos))) {
+      if (peg$c469.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c472); }
+        if (peg$silentFails === 0) { peg$fail(peg$c470); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13211,7 +13078,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -13221,12 +13088,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c473.test(input.charAt(peg$currPos))) {
+    if (peg$c471.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c474); }
+      if (peg$silentFails === 0) { peg$fail(peg$c472); }
     }
 
     return s0;
@@ -13237,11 +13104,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c475;
+      s1 = peg$c473;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c474); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13252,15 +13119,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c475;
+          s3 = peg$c473;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c476); }
+          if (peg$silentFails === 0) { peg$fail(peg$c474); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c477(s2);
+          s1 = peg$c475(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13277,11 +13144,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c478;
+        s1 = peg$c476;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c479); }
+        if (peg$silentFails === 0) { peg$fail(peg$c477); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13292,15 +13159,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c478;
+            s3 = peg$c476;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c479); }
+            if (peg$silentFails === 0) { peg$fail(peg$c477); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c477(s2);
+            s1 = peg$c475(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13326,11 +13193,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c475;
+      s2 = peg$c473;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c474); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13348,11 +13215,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c478); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13365,17 +13232,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c430;
+        s1 = peg$c428;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c431); }
+        if (peg$silentFails === 0) { peg$fail(peg$c429); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c232(s2);
+          s1 = peg$c18(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13404,7 +13271,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c481(s1, s2);
+        s1 = peg$c479(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13433,16 +13300,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c482.test(input.charAt(peg$currPos))) {
+    if (peg$c480.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c483); }
+      if (peg$silentFails === 0) { peg$fail(peg$c481); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -13454,12 +13321,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
     }
 
@@ -13471,11 +13338,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c430;
+      s1 = peg$c428;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c431); }
+      if (peg$silentFails === 0) { peg$fail(peg$c429); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13484,7 +13351,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c232(s2);
+        s1 = peg$c18(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13534,7 +13401,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c484(s3, s4);
+            s1 = peg$c482(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13562,20 +13429,20 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     if (input.charCodeAt(peg$currPos) === 42) {
-      s2 = peg$c83;
+      s2 = peg$c82;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c83;
+        s2 = peg$c82;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -13607,11 +13474,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c83;
+        s2 = peg$c82;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13637,15 +13504,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c83;
+          s1 = peg$c82;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c485();
+          s1 = peg$c483();
         }
         s0 = s1;
       }
@@ -13659,12 +13526,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
     }
 
@@ -13676,11 +13543,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c430;
+      s1 = peg$c428;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c431); }
+      if (peg$silentFails === 0) { peg$fail(peg$c429); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -13689,7 +13556,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c232(s2);
+        s1 = peg$c18(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13716,30 +13583,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c486();
+      s1 = peg$c484();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c83;
+        s1 = peg$c82;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c487();
+        s1 = peg$c485();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c471.test(input.charAt(peg$currPos))) {
+        if (peg$c469.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c472); }
+          if (peg$silentFails === 0) { peg$fail(peg$c470); }
         }
       }
     }
@@ -13754,11 +13621,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c478;
+      s2 = peg$c476;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c479); }
+      if (peg$silentFails === 0) { peg$fail(peg$c477); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13776,11 +13643,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c478); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13793,17 +13660,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c430;
+        s1 = peg$c428;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c431); }
+        if (peg$silentFails === 0) { peg$fail(peg$c429); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c232(s2);
+          s1 = peg$c18(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13823,11 +13690,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c488;
+      s1 = peg$c486;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c489); }
+      if (peg$silentFails === 0) { peg$fail(peg$c487); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -13835,7 +13702,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c490();
+          s1 = peg$c488();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13863,116 +13730,116 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c478;
+      s0 = peg$c476;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c479); }
+      if (peg$silentFails === 0) { peg$fail(peg$c477); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c475;
+        s1 = peg$c473;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c476); }
+        if (peg$silentFails === 0) { peg$fail(peg$c474); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c430;
+          s0 = peg$c428;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+          if (peg$silentFails === 0) { peg$fail(peg$c429); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c491;
+            s1 = peg$c489;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c492); }
+            if (peg$silentFails === 0) { peg$fail(peg$c490); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c493();
+            s1 = peg$c491();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c494;
+              s1 = peg$c492;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c495); }
+              if (peg$silentFails === 0) { peg$fail(peg$c493); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c496();
+              s1 = peg$c494();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c497;
+                s1 = peg$c495;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c498); }
+                if (peg$silentFails === 0) { peg$fail(peg$c496); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c499();
+                s1 = peg$c497();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c500;
+                  s1 = peg$c498;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c501); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c499); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c502();
+                  s1 = peg$c500();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c503;
+                    s1 = peg$c501;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c504); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c502); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c505();
+                    s1 = peg$c503();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c506;
+                      s1 = peg$c504;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c507); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c505); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c508();
+                      s1 = peg$c506();
                     }
                     s0 = s1;
                   }
@@ -14000,30 +13867,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c486();
+      s1 = peg$c484();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c83;
+        s1 = peg$c82;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c509();
+        s1 = peg$c507();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c471.test(input.charAt(peg$currPos))) {
+        if (peg$c469.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c472); }
+          if (peg$silentFails === 0) { peg$fail(peg$c470); }
         }
       }
     }
@@ -14036,11 +13903,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c510;
+      s1 = peg$c508;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c511); }
+      if (peg$silentFails === 0) { peg$fail(peg$c509); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14072,7 +13939,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c512(s2);
+        s1 = peg$c510(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14085,19 +13952,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c510;
+        s1 = peg$c508;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c511); }
+        if (peg$silentFails === 0) { peg$fail(peg$c509); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c48;
+          s2 = peg$c47;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          if (peg$silentFails === 0) { peg$fail(peg$c48); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -14156,15 +14023,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c300;
+              s4 = peg$c298;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c512(s3);
+              s1 = peg$c510(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14192,21 +14059,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c271;
+      s1 = peg$c269;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c271;
+          s3 = peg$c269;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c272); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14221,7 +14088,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c209(s2);
+            s1 = peg$c208(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14248,39 +14115,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c513.test(input.charAt(peg$currPos))) {
+    if (peg$c511.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c512); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c515) {
-        s2 = peg$c515;
+      if (input.substr(peg$currPos, 2) === peg$c513) {
+        s2 = peg$c513;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c513.test(input.charAt(peg$currPos))) {
+        if (peg$c511.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c514); }
+          if (peg$silentFails === 0) { peg$fail(peg$c512); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c515) {
-            s2 = peg$c515;
+          if (input.substr(peg$currPos, 2) === peg$c513) {
+            s2 = peg$c513;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c516); }
+            if (peg$silentFails === 0) { peg$fail(peg$c514); }
           }
         }
       }
@@ -14289,7 +14156,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -14299,12 +14166,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c517.test(input.charAt(peg$currPos))) {
+    if (peg$c515.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c518); }
+      if (peg$silentFails === 0) { peg$fail(peg$c516); }
     }
 
     return s0;
@@ -14362,7 +14229,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c478); }
     }
 
     return s0;
@@ -14373,51 +14240,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c520;
+      s0 = peg$c518;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c521); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c522;
+        s0 = peg$c520;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c523); }
+        if (peg$silentFails === 0) { peg$fail(peg$c521); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c524;
+          s0 = peg$c522;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c525); }
+          if (peg$silentFails === 0) { peg$fail(peg$c523); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c526;
+            s0 = peg$c524;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c527); }
+            if (peg$silentFails === 0) { peg$fail(peg$c525); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c528;
+              s0 = peg$c526;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c529); }
+              if (peg$silentFails === 0) { peg$fail(peg$c527); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c530;
+                s0 = peg$c528;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c531); }
+                if (peg$silentFails === 0) { peg$fail(peg$c529); }
               }
             }
           }
@@ -14426,7 +14293,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -14435,12 +14302,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c532.test(input.charAt(peg$currPos))) {
+    if (peg$c530.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c533); }
+      if (peg$silentFails === 0) { peg$fail(peg$c531); }
     }
 
     return s0;
@@ -14453,7 +14320,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c534); }
+      if (peg$silentFails === 0) { peg$fail(peg$c532); }
     }
 
     return s0;
@@ -14463,12 +14330,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c539) {
-      s1 = peg$c539;
+    if (input.substr(peg$currPos, 2) === peg$c537) {
+      s1 = peg$c537;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c540); }
+      if (peg$silentFails === 0) { peg$fail(peg$c538); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14586,7 +14453,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c478); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -316,175 +316,176 @@ function peg$parse(input, options) {
             return {"kind": "Sequential", "procs": [op]}
           },
       peg$c15 = function(p) { return p },
-      peg$c16 = function(first, rest) {
-            return [first, ... rest]
+      peg$c16 = "=>",
+      peg$c17 = peg$literalExpectation("=>", false),
+      peg$c18 = function(first, rest) {
+            return [first, ... rest[0]]
           },
-      peg$c17 = function(first) {
+      peg$c19 = function(first) {
             return [first]
           },
-      peg$c18 = "=>",
-      peg$c19 = peg$literalExpectation("=>", false),
-      peg$c20 = function(ch) { return ch },
+      peg$c20 = function(proc) {
+            return {"expr": {"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}
+          },
       peg$c21 = function(e, proc) {
             return {"expr": e, "proc": proc}
           },
-      peg$c22 = function(proc) {
-            return {"expr": {"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}
-          },
-      peg$c23 = "case",
-      peg$c24 = peg$literalExpectation("case", true),
-      peg$c25 = "default",
-      peg$c26 = peg$literalExpectation("default", true),
-      peg$c27 = function(source, seq) {
+      peg$c22 = "default",
+      peg$c23 = peg$literalExpectation("default", true),
+      peg$c24 = function(source, seq) {
             return {"kind": "Trunk", "source": source, "seq":seq }
           },
-      peg$c28 = function(seq) { return seq },
-      peg$c29 = "",
-      peg$c30 = function() { return null},
-      peg$c31 = function(trunk) { return trunk },
-      peg$c32 = "split",
-      peg$c33 = peg$literalExpectation("split", false),
-      peg$c34 = "(",
-      peg$c35 = peg$literalExpectation("(", false),
-      peg$c36 = ")",
-      peg$c37 = peg$literalExpectation(")", false),
-      peg$c38 = function(procArray) {
+      peg$c25 = function(seq) { return seq },
+      peg$c26 = "",
+      peg$c27 = function() { return null},
+      peg$c28 = "split",
+      peg$c29 = peg$literalExpectation("split", false),
+      peg$c30 = "(",
+      peg$c31 = peg$literalExpectation("(", false),
+      peg$c32 = ")",
+      peg$c33 = peg$literalExpectation(")", false),
+      peg$c34 = function(procArray) {
             return {"kind": "Parallel", "procs": procArray}
           },
-      peg$c39 = "switch",
-      peg$c40 = peg$literalExpectation("switch", false),
-      peg$c41 = function(caseArray) {
+      peg$c35 = "switch",
+      peg$c36 = peg$literalExpectation("switch", false),
+      peg$c37 = function(caseArray) {
             return {"kind": "Switch", "cases": caseArray}
           },
-      peg$c42 = "from",
-      peg$c43 = peg$literalExpectation("from", false),
-      peg$c44 = function(trunks) {
+      peg$c38 = "from",
+      peg$c39 = peg$literalExpectation("from", false),
+      peg$c40 = function(trunks) {
             return {"kind": "From", "trunks": trunks}
           },
-      peg$c45 = function(f) { return f },
-      peg$c46 = function(a) { return a },
-      peg$c47 = function(expr) {
+      peg$c41 = function(f) { return f },
+      peg$c42 = function(a) { return a },
+      peg$c43 = function(expr) {
             return {"kind": "Filter", "expr": expr}
           },
-      peg$c48 = "|",
-      peg$c49 = peg$literalExpectation("|", false),
-      peg$c50 = "{",
-      peg$c51 = peg$literalExpectation("{", false),
-      peg$c52 = "[",
-      peg$c53 = peg$literalExpectation("[", false),
-      peg$c54 = ":",
-      peg$c55 = peg$literalExpectation(":", false),
-      peg$c56 = "matches",
-      peg$c57 = peg$literalExpectation("matches", false),
-      peg$c58 = "==",
-      peg$c59 = peg$literalExpectation("==", false),
-      peg$c60 = "!=",
-      peg$c61 = peg$literalExpectation("!=", false),
-      peg$c62 = "in",
-      peg$c63 = peg$literalExpectation("in", false),
-      peg$c64 = "<=",
-      peg$c65 = peg$literalExpectation("<=", false),
-      peg$c66 = "<",
-      peg$c67 = peg$literalExpectation("<", false),
-      peg$c68 = ">=",
-      peg$c69 = peg$literalExpectation(">=", false),
-      peg$c70 = ">",
-      peg$c71 = peg$literalExpectation(">", false),
-      peg$c72 = function() { return text() },
-      peg$c73 = "-with",
-      peg$c74 = peg$literalExpectation("-with", false),
-      peg$c75 = ",",
-      peg$c76 = peg$literalExpectation(",", false),
-      peg$c77 = function(first, rest) {
+      peg$c44 = /^[);]/,
+      peg$c45 = peg$classExpectation([")", ";"], false, false),
+      peg$c46 = "|",
+      peg$c47 = peg$literalExpectation("|", false),
+      peg$c48 = "{",
+      peg$c49 = peg$literalExpectation("{", false),
+      peg$c50 = "[",
+      peg$c51 = peg$literalExpectation("[", false),
+      peg$c52 = ":",
+      peg$c53 = peg$literalExpectation(":", false),
+      peg$c54 = "matches",
+      peg$c55 = peg$literalExpectation("matches", false),
+      peg$c56 = "==",
+      peg$c57 = peg$literalExpectation("==", false),
+      peg$c58 = "!=",
+      peg$c59 = peg$literalExpectation("!=", false),
+      peg$c60 = "in",
+      peg$c61 = peg$literalExpectation("in", false),
+      peg$c62 = "<=",
+      peg$c63 = peg$literalExpectation("<=", false),
+      peg$c64 = "<",
+      peg$c65 = peg$literalExpectation("<", false),
+      peg$c66 = ">=",
+      peg$c67 = peg$literalExpectation(">=", false),
+      peg$c68 = ">",
+      peg$c69 = peg$literalExpectation(">", false),
+      peg$c70 = function() { return text() },
+      peg$c71 = "-with",
+      peg$c72 = peg$literalExpectation("-with", false),
+      peg$c73 = ",",
+      peg$c74 = peg$literalExpectation(",", false),
+      peg$c75 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c78 = function(t) { return ["or", t] },
-      peg$c79 = function(first, expr) { return ["and", expr] },
-      peg$c80 = function(first, rest) {
+      peg$c76 = function(t) { return ["or", t] },
+      peg$c77 = function(first, expr) { return ["and", expr] },
+      peg$c78 = function(first, rest) {
             return makeBinaryExprChain(first,rest)
           },
-      peg$c81 = "!",
-      peg$c82 = peg$literalExpectation("!", false),
-      peg$c83 = function(e) {
+      peg$c79 = "!",
+      peg$c80 = peg$literalExpectation("!", false),
+      peg$c81 = function(e) {
             return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c84 = function(expr) { return expr },
-      peg$c85 = "*",
-      peg$c86 = peg$literalExpectation("*", false),
-      peg$c90 = function(search) { return search },
-      peg$c91 = function(v) {
+      peg$c82 = function(expr) { return expr },
+      peg$c83 = "*",
+      peg$c84 = peg$literalExpectation("*", false),
+      peg$c88 = function(search) { return search },
+      peg$c89 = function(v) {
             return {"kind": "Search", "text": text(), "value": v}
           },
-      peg$c92 = function() {
+      peg$c90 = function() {
             return {"kind": "Primitive", "type": "bool", "text": "true"}
           },
-      peg$c93 = function(v) {
+      peg$c91 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": v}
           },
-      peg$c94 = function(pattern) {
+      peg$c92 = function(pattern) {
             return {"kind": "RegexpSearch", "pattern": pattern}
           },
-      peg$c95 = peg$literalExpectation("matches", true),
-      peg$c96 = function(f, pattern) {
+      peg$c93 = peg$literalExpectation("matches", true),
+      peg$c94 = function(f, pattern) {
             return {"kind": "RegexpMatch", "pattern": pattern, "expr": f}
           },
-      peg$c97 = "type(",
-      peg$c98 = peg$literalExpectation("type(", false),
-      peg$c99 = function(every, keys, limit) {
+      peg$c95 = "type(",
+      peg$c96 = peg$literalExpectation("type(", false),
+      peg$c97 = function(every, keys, limit) {
             return {"kind": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
           },
-      peg$c100 = function(every, aggs, keys, limit) {
+      peg$c98 = function(every, aggs, keys, limit) {
             let p = {"kind": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
             }
             return p
           },
-      peg$c101 = "summarize",
-      peg$c102 = peg$literalExpectation("summarize", false),
-      peg$c103 = "every",
-      peg$c104 = peg$literalExpectation("every", true),
-      peg$c105 = function(dur) { return dur },
-      peg$c106 = function() { return null },
-      peg$c107 = function(columns) { return columns },
-      peg$c108 = "with",
-      peg$c109 = peg$literalExpectation("with", false),
-      peg$c110 = "-limit",
-      peg$c111 = peg$literalExpectation("-limit", false),
-      peg$c112 = function(limit) { return limit },
-      peg$c113 = function() { return 0 },
-      peg$c114 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c115 = function(first, expr) { return expr },
-      peg$c116 = ":=",
-      peg$c117 = peg$literalExpectation(":=", false),
-      peg$c118 = function(lval, agg) {
+      peg$c99 = "summarize",
+      peg$c100 = peg$literalExpectation("summarize", false),
+      peg$c101 = "every",
+      peg$c102 = peg$literalExpectation("every", true),
+      peg$c103 = function(dur) { return dur },
+      peg$c104 = function() { return null },
+      peg$c105 = function(columns) { return columns },
+      peg$c106 = "with",
+      peg$c107 = peg$literalExpectation("with", false),
+      peg$c108 = "-limit",
+      peg$c109 = peg$literalExpectation("-limit", false),
+      peg$c110 = function(limit) { return limit },
+      peg$c111 = function() { return 0 },
+      peg$c112 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c113 = function(first, expr) { return expr },
+      peg$c114 = function(first, rest) {
+            return [first, ... rest]
+          },
+      peg$c115 = ":=",
+      peg$c116 = peg$literalExpectation(":=", false),
+      peg$c117 = function(lval, agg) {
             return {"kind": "Assignment", "lhs": lval, "rhs": agg}
           },
-      peg$c119 = function(agg) {
+      peg$c118 = function(agg) {
             return {"kind": "Assignment", "lhs": null, "rhs": agg}
           },
-      peg$c120 = ".",
-      peg$c121 = peg$literalExpectation(".", false),
-      peg$c122 = function(op, expr, where) {
+      peg$c119 = ".",
+      peg$c120 = peg$literalExpectation(".", false),
+      peg$c121 = function(op, expr, where) {
             let r = {"kind": "Agg", "name": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c123 = "where",
-      peg$c124 = peg$literalExpectation("where", false),
-      peg$c125 = function(first, rest) {
+      peg$c122 = "where",
+      peg$c123 = peg$literalExpectation("where", false),
+      peg$c124 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c126 = "sort",
-      peg$c127 = peg$literalExpectation("sort", true),
-      peg$c128 = function(args, l) { return l },
-      peg$c129 = function(args, list) {
+      peg$c125 = "sort",
+      peg$c126 = peg$literalExpectation("sort", true),
+      peg$c127 = function(args, l) { return l },
+      peg$c128 = function(args, list) {
             let argm = args;
             let proc = {"kind": "Sort", "args": list, "order": "asc", "nullsfirst": false};
             if ( "r" in argm) {
@@ -497,24 +498,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c130 = function(args) { return makeArgMap(args) },
-      peg$c131 = "-r",
-      peg$c132 = peg$literalExpectation("-r", false),
-      peg$c133 = function() { return {"name": "r", "value": null} },
-      peg$c134 = "-nulls",
-      peg$c135 = peg$literalExpectation("-nulls", false),
-      peg$c136 = "first",
-      peg$c137 = peg$literalExpectation("first", false),
-      peg$c138 = "last",
-      peg$c139 = peg$literalExpectation("last", false),
-      peg$c140 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c141 = "top",
-      peg$c142 = peg$literalExpectation("top", true),
-      peg$c143 = function(n) { return n},
-      peg$c144 = "-flush",
-      peg$c145 = peg$literalExpectation("-flush", false),
-      peg$c146 = function(limit, flush, f) { return f },
-      peg$c147 = function(limit, flush, fields) {
+      peg$c129 = function(args) { return makeArgMap(args) },
+      peg$c130 = "-r",
+      peg$c131 = peg$literalExpectation("-r", false),
+      peg$c132 = function() { return {"name": "r", "value": null} },
+      peg$c133 = "-nulls",
+      peg$c134 = peg$literalExpectation("-nulls", false),
+      peg$c135 = "first",
+      peg$c136 = peg$literalExpectation("first", false),
+      peg$c137 = "last",
+      peg$c138 = peg$literalExpectation("last", false),
+      peg$c139 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c140 = "top",
+      peg$c141 = peg$literalExpectation("top", true),
+      peg$c142 = function(n) { return n},
+      peg$c143 = "-flush",
+      peg$c144 = peg$literalExpectation("-flush", false),
+      peg$c145 = function(limit, flush, f) { return f },
+      peg$c146 = function(limit, flush, fields) {
             let proc = {"kind": "Top", "limit": 0, "args": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
@@ -527,93 +528,93 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c148 = "cut",
-      peg$c149 = peg$literalExpectation("cut", true),
-      peg$c150 = function(args) {
+      peg$c147 = "cut",
+      peg$c148 = peg$literalExpectation("cut", true),
+      peg$c149 = function(args) {
             return {"kind": "Cut", "args": args}
           },
-      peg$c151 = "pick",
-      peg$c152 = peg$literalExpectation("pick", true),
-      peg$c153 = function(args) {
+      peg$c150 = "pick",
+      peg$c151 = peg$literalExpectation("pick", true),
+      peg$c152 = function(args) {
             return {"kind": "Pick", "args": args}
           },
-      peg$c154 = "drop",
-      peg$c155 = peg$literalExpectation("drop", true),
-      peg$c156 = function(args) {
+      peg$c153 = "drop",
+      peg$c154 = peg$literalExpectation("drop", true),
+      peg$c155 = function(args) {
             return {"kind": "Drop", "args": args}
           },
-      peg$c157 = "head",
-      peg$c158 = peg$literalExpectation("head", true),
-      peg$c159 = function(count) { return {"kind": "Head", "count": count} },
-      peg$c160 = function() { return {"kind": "Head", "count": 1} },
-      peg$c161 = "tail",
-      peg$c162 = peg$literalExpectation("tail", true),
-      peg$c163 = function(count) { return {"kind": "Tail", "count": count} },
-      peg$c164 = function() { return {"kind": "Tail", "count": 1} },
-      peg$c165 = "filter",
-      peg$c166 = peg$literalExpectation("filter", true),
-      peg$c167 = function(op) {
+      peg$c156 = "head",
+      peg$c157 = peg$literalExpectation("head", true),
+      peg$c158 = function(count) { return {"kind": "Head", "count": count} },
+      peg$c159 = function() { return {"kind": "Head", "count": 1} },
+      peg$c160 = "tail",
+      peg$c161 = peg$literalExpectation("tail", true),
+      peg$c162 = function(count) { return {"kind": "Tail", "count": count} },
+      peg$c163 = function() { return {"kind": "Tail", "count": 1} },
+      peg$c164 = "filter",
+      peg$c165 = peg$literalExpectation("filter", true),
+      peg$c166 = function(op) {
             return op
           },
-      peg$c168 = "uniq",
-      peg$c169 = peg$literalExpectation("uniq", true),
-      peg$c170 = "-c",
-      peg$c171 = peg$literalExpectation("-c", false),
-      peg$c172 = function() {
+      peg$c167 = "uniq",
+      peg$c168 = peg$literalExpectation("uniq", true),
+      peg$c169 = "-c",
+      peg$c170 = peg$literalExpectation("-c", false),
+      peg$c171 = function() {
             return {"kind": "Uniq", "cflag": true}
           },
-      peg$c173 = function() {
+      peg$c172 = function() {
             return {"kind": "Uniq", "cflag": false}
           },
-      peg$c174 = "put",
-      peg$c175 = peg$literalExpectation("put", true),
-      peg$c176 = function(args) {
+      peg$c173 = "put",
+      peg$c174 = peg$literalExpectation("put", true),
+      peg$c175 = function(args) {
             return {"kind": "Put", "args": args}
           },
-      peg$c177 = "rename",
-      peg$c178 = peg$literalExpectation("rename", true),
-      peg$c179 = function(first, cl) { return cl },
-      peg$c180 = function(first, rest) {
+      peg$c176 = "rename",
+      peg$c177 = peg$literalExpectation("rename", true),
+      peg$c178 = function(first, cl) { return cl },
+      peg$c179 = function(first, rest) {
             return {"kind": "Rename", "args": [first, ... rest]}
           },
-      peg$c181 = "fuse",
-      peg$c182 = peg$literalExpectation("fuse", true),
-      peg$c183 = function() {
+      peg$c180 = "fuse",
+      peg$c181 = peg$literalExpectation("fuse", true),
+      peg$c182 = function() {
             return {"kind": "Fuse"}
           },
-      peg$c184 = "shape",
-      peg$c185 = peg$literalExpectation("shape", true),
-      peg$c186 = function() {
+      peg$c183 = "shape",
+      peg$c184 = peg$literalExpectation("shape", true),
+      peg$c185 = function() {
             return {"kind": "Shape"}
           },
-      peg$c187 = "join",
-      peg$c188 = peg$literalExpectation("join", true),
-      peg$c189 = function(style, leftKey, rightKey, columns) {
+      peg$c186 = "join",
+      peg$c187 = peg$literalExpectation("join", true),
+      peg$c188 = function(style, leftKey, rightKey, columns) {
             let proc = {"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": null};
             if (columns) {
               proc["args"] = columns[1];
             }
             return proc
           },
-      peg$c190 = function(style, key, columns) {
+      peg$c189 = function(style, key, columns) {
             let proc = {"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": null};
             if (columns) {
               proc["args"] = columns[1];
             }
             return proc
           },
-      peg$c191 = "inner",
-      peg$c192 = peg$literalExpectation("inner", true),
-      peg$c193 = function() { return "inner" },
-      peg$c194 = "left",
-      peg$c195 = peg$literalExpectation("left", true),
-      peg$c196 = function() { return "left" },
-      peg$c197 = "right",
-      peg$c198 = peg$literalExpectation("right", true),
-      peg$c199 = function() { return "right" },
-      peg$c200 = "sample",
-      peg$c201 = peg$literalExpectation("sample", true),
-      peg$c202 = function(e) {
+      peg$c190 = "inner",
+      peg$c191 = peg$literalExpectation("inner", true),
+      peg$c192 = function() { return "inner" },
+      peg$c193 = "left",
+      peg$c194 = peg$literalExpectation("left", true),
+      peg$c195 = function() { return "left" },
+      peg$c196 = "right",
+      peg$c197 = peg$literalExpectation("right", true),
+      peg$c198 = function() { return "right" },
+      peg$c199 = "sample",
+      peg$c200 = peg$literalExpectation("sample", true),
+      peg$c201 = function(e) {
             return {"kind": "Sequential", "procs": [
               
             {"kind": "Summarize",
@@ -649,78 +650,78 @@ function peg$parse(input, options) {
             "rhs": {"kind": "ID", "name": "sample"}}]}]}
           
           },
-      peg$c203 = function(lval) { return lval},
-      peg$c204 = function() { return {"kind":"Root"} },
-      peg$c205 = function(source) {
+      peg$c202 = function(lval) { return lval},
+      peg$c203 = function() { return {"kind":"Root"} },
+      peg$c204 = function(source) {
             return {"kind":"From", "trunks": [{"kind": "Trunk","source": source}]}
           },
-      peg$c206 = "file",
-      peg$c207 = peg$literalExpectation("file", true),
-      peg$c208 = function(path, format, layout) {
+      peg$c205 = "file",
+      peg$c206 = peg$literalExpectation("file", true),
+      peg$c207 = function(path, format, layout) {
             return {"kind": "File", "path": path, "format": format, "layout": layout }
           },
-      peg$c209 = peg$literalExpectation("from", true),
-      peg$c210 = function(body) { return body },
-      peg$c211 = function(name, at, over, order) {
+      peg$c208 = peg$literalExpectation("from", true),
+      peg$c209 = function(body) { return body },
+      peg$c210 = function(name, at, over, order) {
             return {"kind": "Pool", "name": name, "at": at, "range": over, "scan_order": order}
           },
-      peg$c212 = "get",
-      peg$c213 = peg$literalExpectation("get", true),
-      peg$c214 = function(url, format, layout) {
+      peg$c211 = "get",
+      peg$c212 = peg$literalExpectation("get", true),
+      peg$c213 = function(url, format, layout) {
             return {"kind": "HTTP", "url": url, "format": format, "layout": layout }
           },
-      peg$c215 = "http:",
-      peg$c216 = peg$literalExpectation("http:", false),
-      peg$c217 = "https:",
-      peg$c218 = peg$literalExpectation("https:", false),
-      peg$c219 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?;:[\]{}~|+\-]/,
-      peg$c220 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ";", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
-      peg$c221 = "at",
-      peg$c222 = peg$literalExpectation("at", true),
-      peg$c223 = function(id) { return id },
-      peg$c224 = /^[0-9a-zA-Z]/,
-      peg$c225 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
-      peg$c226 = "over",
-      peg$c227 = peg$literalExpectation("over", true),
-      peg$c228 = "to",
-      peg$c229 = peg$literalExpectation("to", true),
-      peg$c230 = function(lower, upper) {
+      peg$c214 = "http:",
+      peg$c215 = peg$literalExpectation("http:", false),
+      peg$c216 = "https:",
+      peg$c217 = peg$literalExpectation("https:", false),
+      peg$c218 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
+      peg$c219 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
+      peg$c220 = "at",
+      peg$c221 = peg$literalExpectation("at", true),
+      peg$c222 = function(id) { return id },
+      peg$c223 = /^[0-9a-zA-Z]/,
+      peg$c224 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
+      peg$c225 = "over",
+      peg$c226 = peg$literalExpectation("over", true),
+      peg$c227 = "to",
+      peg$c228 = peg$literalExpectation("to", true),
+      peg$c229 = function(lower, upper) {
             return {"kind":"Range","lower": lower, "upper": upper}
           },
-      peg$c231 = function(val) { return val },
-      peg$c232 = function(name) { return name },
-      peg$c233 = function(s) { return s },
-      peg$c234 = "order",
-      peg$c235 = peg$literalExpectation("order", true),
-      peg$c236 = function(keys, order) {
+      peg$c230 = function(val) { return val },
+      peg$c231 = function(name) { return name },
+      peg$c232 = function(s) { return s },
+      peg$c233 = "order",
+      peg$c234 = peg$literalExpectation("order", true),
+      peg$c235 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c237 = "format",
-      peg$c238 = peg$literalExpectation("format", true),
-      peg$c239 = function() { return "" },
-      peg$c240 = ":asc",
-      peg$c241 = peg$literalExpectation(":asc", true),
-      peg$c242 = function() { return "asc" },
-      peg$c243 = ":desc",
-      peg$c244 = peg$literalExpectation(":desc", true),
-      peg$c245 = function() { return "desc" },
-      peg$c246 = "asc",
-      peg$c247 = peg$literalExpectation("asc", true),
-      peg$c248 = "desc",
-      peg$c249 = peg$literalExpectation("desc", true),
-      peg$c250 = "pass",
-      peg$c251 = peg$literalExpectation("pass", true),
-      peg$c252 = function() {
+      peg$c236 = "format",
+      peg$c237 = peg$literalExpectation("format", true),
+      peg$c238 = function() { return "" },
+      peg$c239 = ":asc",
+      peg$c240 = peg$literalExpectation(":asc", true),
+      peg$c241 = function() { return "asc" },
+      peg$c242 = ":desc",
+      peg$c243 = peg$literalExpectation(":desc", true),
+      peg$c244 = function() { return "desc" },
+      peg$c245 = "asc",
+      peg$c246 = peg$literalExpectation("asc", true),
+      peg$c247 = "desc",
+      peg$c248 = peg$literalExpectation("desc", true),
+      peg$c249 = "pass",
+      peg$c250 = peg$literalExpectation("pass", true),
+      peg$c251 = function() {
             return {"kind":"Pass"}
           },
-      peg$c253 = "explode",
-      peg$c254 = peg$literalExpectation("explode", true),
-      peg$c255 = function(args, typ, as) {
+      peg$c252 = "explode",
+      peg$c253 = peg$literalExpectation("explode", true),
+      peg$c254 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c256 = function(typ) { return typ},
-      peg$c257 = function(lhs) { return lhs },
-      peg$c259 = function(first, rest) {
+      peg$c255 = function(typ) { return typ},
+      peg$c256 = function(lhs) { return lhs },
+      peg$c258 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -729,53 +730,53 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c260 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c261 = "?",
-      peg$c262 = peg$literalExpectation("?", false),
-      peg$c263 = function(condition, thenClause, elseClause) {
+      peg$c259 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c260 = "?",
+      peg$c261 = peg$literalExpectation("?", false),
+      peg$c262 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c264 = function(first, op, expr) { return [op, expr] },
-      peg$c265 = function(first, rest) {
+      peg$c263 = function(first, op, expr) { return [op, expr] },
+      peg$c264 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c266 = function(first, comp, expr) { return [comp, expr] },
-      peg$c267 = function() { return "="},
-      peg$c268 = "+",
-      peg$c269 = peg$literalExpectation("+", false),
-      peg$c270 = "-",
-      peg$c271 = peg$literalExpectation("-", false),
-      peg$c272 = "/",
-      peg$c273 = peg$literalExpectation("/", false),
-      peg$c274 = function(e) {
+      peg$c265 = function(first, comp, expr) { return [comp, expr] },
+      peg$c266 = function() { return "="},
+      peg$c267 = "+",
+      peg$c268 = peg$literalExpectation("+", false),
+      peg$c269 = "-",
+      peg$c270 = peg$literalExpectation("-", false),
+      peg$c271 = "/",
+      peg$c272 = peg$literalExpectation("/", false),
+      peg$c273 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c275 = function(typ) { return typ },
-      peg$c276 = "not",
-      peg$c277 = peg$literalExpectation("not", false),
-      peg$c278 = "match",
-      peg$c279 = peg$literalExpectation("match", false),
-      peg$c280 = "select",
-      peg$c281 = peg$literalExpectation("select", false),
-      peg$c282 = function(args, methods) {
+      peg$c274 = function(typ) { return typ },
+      peg$c275 = "not",
+      peg$c276 = peg$literalExpectation("not", false),
+      peg$c277 = "match",
+      peg$c278 = peg$literalExpectation("match", false),
+      peg$c279 = "select",
+      peg$c280 = peg$literalExpectation("select", false),
+      peg$c281 = function(args, methods) {
             return {"kind":"SelectExpr", "selectors":args, "methods": methods}
           },
-      peg$c283 = function(methods) { return methods },
-      peg$c284 = function(typ, expr) {
+      peg$c282 = function(methods) { return methods },
+      peg$c283 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c285 = function(fn, args) {
+      peg$c284 = function(fn, args) {
             return {"kind": "Call", "name": fn, "args": args}
           },
-      peg$c286 = function() { return [] },
-      peg$c287 = function(first, e) { return e },
-      peg$c288 = function(e) { return e },
-      peg$c289 = function() {
+      peg$c285 = function() { return [] },
+      peg$c286 = function(first, e) { return e },
+      peg$c287 = function(e) { return e },
+      peg$c288 = function() {
             return {"kind":"Root"}
           },
-      peg$c290 = "this",
-      peg$c291 = peg$literalExpectation("this", false),
-      peg$c292 = function(field) {
+      peg$c289 = "this",
+      peg$c290 = peg$literalExpectation("this", false),
+      peg$c291 = function(field) {
             return {"kind": "BinaryExpr", "op":".",
                            
             "lhs":{"kind":"Root"},
@@ -784,9 +785,9 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c293 = "]",
-      peg$c294 = peg$literalExpectation("]", false),
-      peg$c295 = function(expr) {
+      peg$c292 = "]",
+      peg$c293 = peg$literalExpectation("]", false),
+      peg$c294 = function(expr) {
             return {"kind": "BinaryExpr", "op":"[",
                            
             "lhs":{"kind":"Root"},
@@ -795,58 +796,58 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c296 = function(from, to) {
+      peg$c295 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c297 = function(to) {
+      peg$c296 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c298 = function(from) {
+      peg$c297 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c299 = function(expr) { return ["[", expr] },
-      peg$c300 = function(id) { return [".", id] },
-      peg$c301 = "}",
-      peg$c302 = peg$literalExpectation("}", false),
-      peg$c303 = function(fields) {
+      peg$c298 = function(expr) { return ["[", expr] },
+      peg$c299 = function(id) { return [".", id] },
+      peg$c300 = "}",
+      peg$c301 = peg$literalExpectation("}", false),
+      peg$c302 = function(fields) {
             return {"kind":"RecordExpr", "fields":fields }
           },
-      peg$c304 = function(first, rest) {
+      peg$c303 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c305 = function(name, value) {
+      peg$c304 = function(name, value) {
             return {"name": name, "value": value}
           },
-      peg$c306 = function(exprs) {
+      peg$c305 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c307 = "|[",
-      peg$c308 = peg$literalExpectation("|[", false),
-      peg$c309 = "]|",
-      peg$c310 = peg$literalExpectation("]|", false),
-      peg$c311 = function(exprs) {
+      peg$c306 = "|[",
+      peg$c307 = peg$literalExpectation("|[", false),
+      peg$c308 = "]|",
+      peg$c309 = peg$literalExpectation("]|", false),
+      peg$c310 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c312 = "|{",
-      peg$c313 = peg$literalExpectation("|{", false),
-      peg$c314 = "}|",
-      peg$c315 = peg$literalExpectation("}|", false),
-      peg$c316 = function(exprs) {
+      peg$c311 = "|{",
+      peg$c312 = peg$literalExpectation("|{", false),
+      peg$c313 = "}|",
+      peg$c314 = peg$literalExpectation("}|", false),
+      peg$c315 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c317 = function(key, value) {
+      peg$c316 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c318 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c317 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -868,13 +869,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c319 = function(assignments) { return assignments },
-      peg$c320 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c321 = function(table, alias) {
+      peg$c318 = function(assignments) { return assignments },
+      peg$c319 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c320 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c322 = function(first, join) { return join },
-      peg$c323 = function(style, table, alias, leftKey, rightKey) {
+      peg$c321 = function(first, join) { return join },
+      peg$c322 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -892,274 +893,274 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c324 = function(style) { return style },
-      peg$c325 = function(keys, order) {
+      peg$c323 = function(style) { return style },
+      peg$c324 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c326 = function(dir) { return dir },
-      peg$c327 = function(count) { return count },
-      peg$c328 = peg$literalExpectation("select", true),
-      peg$c329 = function() { return "select" },
-      peg$c330 = "as",
-      peg$c331 = peg$literalExpectation("as", true),
-      peg$c332 = function() { return "as" },
-      peg$c333 = function() { return "from" },
-      peg$c334 = function() { return "join" },
-      peg$c335 = peg$literalExpectation("where", true),
-      peg$c336 = function() { return "where" },
-      peg$c337 = "group",
-      peg$c338 = peg$literalExpectation("group", true),
-      peg$c339 = function() { return "group" },
-      peg$c340 = "having",
-      peg$c341 = peg$literalExpectation("having", true),
-      peg$c342 = function() { return "having" },
-      peg$c343 = function() { return "order" },
-      peg$c344 = "on",
-      peg$c345 = peg$literalExpectation("on", true),
-      peg$c346 = function() { return "on" },
-      peg$c347 = "limit",
-      peg$c348 = peg$literalExpectation("limit", true),
-      peg$c349 = function() { return "limit" },
-      peg$c350 = function(v) {
+      peg$c325 = function(dir) { return dir },
+      peg$c326 = function(count) { return count },
+      peg$c327 = peg$literalExpectation("select", true),
+      peg$c328 = function() { return "select" },
+      peg$c329 = "as",
+      peg$c330 = peg$literalExpectation("as", true),
+      peg$c331 = function() { return "as" },
+      peg$c332 = function() { return "from" },
+      peg$c333 = function() { return "join" },
+      peg$c334 = peg$literalExpectation("where", true),
+      peg$c335 = function() { return "where" },
+      peg$c336 = "group",
+      peg$c337 = peg$literalExpectation("group", true),
+      peg$c338 = function() { return "group" },
+      peg$c339 = "having",
+      peg$c340 = peg$literalExpectation("having", true),
+      peg$c341 = function() { return "having" },
+      peg$c342 = function() { return "order" },
+      peg$c343 = "on",
+      peg$c344 = peg$literalExpectation("on", true),
+      peg$c345 = function() { return "on" },
+      peg$c346 = "limit",
+      peg$c347 = peg$literalExpectation("limit", true),
+      peg$c348 = function() { return "limit" },
+      peg$c349 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c351 = function(v) {
+      peg$c350 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c352 = function(v) {
+      peg$c351 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c353 = function(v) {
+      peg$c352 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c354 = "true",
-      peg$c355 = peg$literalExpectation("true", false),
-      peg$c356 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c357 = "false",
-      peg$c358 = peg$literalExpectation("false", false),
-      peg$c359 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c360 = "null",
-      peg$c361 = peg$literalExpectation("null", false),
-      peg$c362 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c363 = function(typ) {
+      peg$c353 = "true",
+      peg$c354 = peg$literalExpectation("true", false),
+      peg$c355 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c356 = "false",
+      peg$c357 = peg$literalExpectation("false", false),
+      peg$c358 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c359 = "null",
+      peg$c360 = peg$literalExpectation("null", false),
+      peg$c361 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c362 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c364 = function(name, typ) {
+      peg$c363 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c365 = function(name) {
+      peg$c364 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c366 = function(u) { return u },
-      peg$c367 = function(types) {
+      peg$c365 = function(u) { return u },
+      peg$c366 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c368 = function(fields) {
+      peg$c367 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c369 = function(typ) {
+      peg$c368 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c370 = function(typ) {
+      peg$c369 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c371 = function(keyType, valType) {
+      peg$c370 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c372 = "uint8",
-      peg$c373 = peg$literalExpectation("uint8", false),
-      peg$c374 = "uint16",
-      peg$c375 = peg$literalExpectation("uint16", false),
-      peg$c376 = "uint32",
-      peg$c377 = peg$literalExpectation("uint32", false),
-      peg$c378 = "uint64",
-      peg$c379 = peg$literalExpectation("uint64", false),
-      peg$c380 = "int8",
-      peg$c381 = peg$literalExpectation("int8", false),
-      peg$c382 = "int16",
-      peg$c383 = peg$literalExpectation("int16", false),
-      peg$c384 = "int32",
-      peg$c385 = peg$literalExpectation("int32", false),
-      peg$c386 = "int64",
-      peg$c387 = peg$literalExpectation("int64", false),
-      peg$c388 = "float64",
-      peg$c389 = peg$literalExpectation("float64", false),
-      peg$c390 = "bool",
-      peg$c391 = peg$literalExpectation("bool", false),
-      peg$c392 = "string",
-      peg$c393 = peg$literalExpectation("string", false),
-      peg$c394 = function() {
+      peg$c371 = "uint8",
+      peg$c372 = peg$literalExpectation("uint8", false),
+      peg$c373 = "uint16",
+      peg$c374 = peg$literalExpectation("uint16", false),
+      peg$c375 = "uint32",
+      peg$c376 = peg$literalExpectation("uint32", false),
+      peg$c377 = "uint64",
+      peg$c378 = peg$literalExpectation("uint64", false),
+      peg$c379 = "int8",
+      peg$c380 = peg$literalExpectation("int8", false),
+      peg$c381 = "int16",
+      peg$c382 = peg$literalExpectation("int16", false),
+      peg$c383 = "int32",
+      peg$c384 = peg$literalExpectation("int32", false),
+      peg$c385 = "int64",
+      peg$c386 = peg$literalExpectation("int64", false),
+      peg$c387 = "float64",
+      peg$c388 = peg$literalExpectation("float64", false),
+      peg$c389 = "bool",
+      peg$c390 = peg$literalExpectation("bool", false),
+      peg$c391 = "string",
+      peg$c392 = peg$literalExpectation("string", false),
+      peg$c393 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c395 = "duration",
-      peg$c396 = peg$literalExpectation("duration", false),
-      peg$c397 = "time",
-      peg$c398 = peg$literalExpectation("time", false),
-      peg$c399 = "bytes",
-      peg$c400 = peg$literalExpectation("bytes", false),
-      peg$c401 = "bstring",
-      peg$c402 = peg$literalExpectation("bstring", false),
-      peg$c403 = "ip",
-      peg$c404 = peg$literalExpectation("ip", false),
-      peg$c405 = "net",
-      peg$c406 = peg$literalExpectation("net", false),
-      peg$c407 = "error",
-      peg$c408 = peg$literalExpectation("error", false),
-      peg$c409 = function(name, typ) {
+      peg$c394 = "duration",
+      peg$c395 = peg$literalExpectation("duration", false),
+      peg$c396 = "time",
+      peg$c397 = peg$literalExpectation("time", false),
+      peg$c398 = "bytes",
+      peg$c399 = peg$literalExpectation("bytes", false),
+      peg$c400 = "bstring",
+      peg$c401 = peg$literalExpectation("bstring", false),
+      peg$c402 = "ip",
+      peg$c403 = peg$literalExpectation("ip", false),
+      peg$c404 = "net",
+      peg$c405 = peg$literalExpectation("net", false),
+      peg$c406 = "error",
+      peg$c407 = peg$literalExpectation("error", false),
+      peg$c408 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c410 = "and",
-      peg$c411 = peg$literalExpectation("and", true),
-      peg$c412 = function() { return "and" },
-      peg$c413 = "or",
-      peg$c414 = peg$literalExpectation("or", true),
-      peg$c415 = function() { return "or" },
-      peg$c416 = peg$literalExpectation("in", true),
-      peg$c417 = function() { return "in" },
-      peg$c418 = peg$literalExpectation("not", true),
-      peg$c419 = function() { return "not" },
-      peg$c420 = "by",
-      peg$c421 = peg$literalExpectation("by", true),
-      peg$c422 = function() { return "by" },
-      peg$c423 = /^[A-Za-z_$]/,
-      peg$c424 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c425 = /^[0-9]/,
-      peg$c426 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c427 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c428 = function() {  return text() },
-      peg$c429 = "$",
-      peg$c430 = peg$literalExpectation("$", false),
-      peg$c431 = "\\",
-      peg$c432 = peg$literalExpectation("\\", false),
-      peg$c433 = "T",
-      peg$c434 = peg$literalExpectation("T", false),
-      peg$c435 = function() {
+      peg$c409 = "and",
+      peg$c410 = peg$literalExpectation("and", true),
+      peg$c411 = function() { return "and" },
+      peg$c412 = "or",
+      peg$c413 = peg$literalExpectation("or", true),
+      peg$c414 = function() { return "or" },
+      peg$c415 = peg$literalExpectation("in", true),
+      peg$c416 = function() { return "in" },
+      peg$c417 = peg$literalExpectation("not", true),
+      peg$c418 = function() { return "not" },
+      peg$c419 = "by",
+      peg$c420 = peg$literalExpectation("by", true),
+      peg$c421 = function() { return "by" },
+      peg$c422 = /^[A-Za-z_$]/,
+      peg$c423 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c424 = /^[0-9]/,
+      peg$c425 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c426 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c427 = function() {  return text() },
+      peg$c428 = "$",
+      peg$c429 = peg$literalExpectation("$", false),
+      peg$c430 = "\\",
+      peg$c431 = peg$literalExpectation("\\", false),
+      peg$c432 = "T",
+      peg$c433 = peg$literalExpectation("T", false),
+      peg$c434 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c436 = "Z",
-      peg$c437 = peg$literalExpectation("Z", false),
-      peg$c438 = function() {
+      peg$c435 = "Z",
+      peg$c436 = peg$literalExpectation("Z", false),
+      peg$c437 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c439 = "ns",
-      peg$c440 = peg$literalExpectation("ns", true),
-      peg$c441 = "us",
-      peg$c442 = peg$literalExpectation("us", true),
-      peg$c443 = "ms",
-      peg$c444 = peg$literalExpectation("ms", true),
-      peg$c445 = "s",
-      peg$c446 = peg$literalExpectation("s", true),
-      peg$c447 = "m",
-      peg$c448 = peg$literalExpectation("m", true),
-      peg$c449 = "h",
-      peg$c450 = peg$literalExpectation("h", true),
-      peg$c451 = "d",
-      peg$c452 = peg$literalExpectation("d", true),
-      peg$c453 = "w",
-      peg$c454 = peg$literalExpectation("w", true),
-      peg$c455 = "y",
-      peg$c456 = peg$literalExpectation("y", true),
-      peg$c457 = function(a, b) {
+      peg$c438 = "ns",
+      peg$c439 = peg$literalExpectation("ns", true),
+      peg$c440 = "us",
+      peg$c441 = peg$literalExpectation("us", true),
+      peg$c442 = "ms",
+      peg$c443 = peg$literalExpectation("ms", true),
+      peg$c444 = "s",
+      peg$c445 = peg$literalExpectation("s", true),
+      peg$c446 = "m",
+      peg$c447 = peg$literalExpectation("m", true),
+      peg$c448 = "h",
+      peg$c449 = peg$literalExpectation("h", true),
+      peg$c450 = "d",
+      peg$c451 = peg$literalExpectation("d", true),
+      peg$c452 = "w",
+      peg$c453 = peg$literalExpectation("w", true),
+      peg$c454 = "y",
+      peg$c455 = peg$literalExpectation("y", true),
+      peg$c456 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c458 = "::",
-      peg$c459 = peg$literalExpectation("::", false),
-      peg$c460 = function(a, b, d, e) {
+      peg$c457 = "::",
+      peg$c458 = peg$literalExpectation("::", false),
+      peg$c459 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c461 = function(a, b) {
+      peg$c460 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c462 = function(a, b) {
+      peg$c461 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c463 = function() {
+      peg$c462 = function() {
             return "::"
           },
-      peg$c464 = function(v) { return ":" + v },
-      peg$c465 = function(v) { return v + ":" },
-      peg$c466 = function(a, m) {
+      peg$c463 = function(v) { return ":" + v },
+      peg$c464 = function(v) { return v + ":" },
+      peg$c465 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c467 = function(a, m) {
+      peg$c466 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c468 = function(s) { return parseInt(s) },
-      peg$c469 = function() {
+      peg$c467 = function(s) { return parseInt(s) },
+      peg$c468 = function() {
             return text()
           },
-      peg$c470 = "e",
-      peg$c471 = peg$literalExpectation("e", true),
-      peg$c472 = /^[+\-]/,
-      peg$c473 = peg$classExpectation(["+", "-"], false, false),
-      peg$c474 = /^[0-9a-fA-F]/,
-      peg$c475 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c476 = "\"",
-      peg$c477 = peg$literalExpectation("\"", false),
-      peg$c478 = function(v) { return joinChars(v) },
-      peg$c479 = "'",
-      peg$c480 = peg$literalExpectation("'", false),
-      peg$c481 = peg$anyExpectation(),
-      peg$c482 = function(head, tail) { return head + joinChars(tail) },
-      peg$c483 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c484 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c485 = function(head, tail) {
+      peg$c469 = "e",
+      peg$c470 = peg$literalExpectation("e", true),
+      peg$c471 = /^[+\-]/,
+      peg$c472 = peg$classExpectation(["+", "-"], false, false),
+      peg$c473 = /^[0-9a-fA-F]/,
+      peg$c474 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c475 = "\"",
+      peg$c476 = peg$literalExpectation("\"", false),
+      peg$c477 = function(v) { return joinChars(v) },
+      peg$c478 = "'",
+      peg$c479 = peg$literalExpectation("'", false),
+      peg$c480 = peg$anyExpectation(),
+      peg$c481 = function(head, tail) { return head + joinChars(tail) },
+      peg$c482 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c483 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c484 = function(head, tail) {
             return reglob$1.Reglob(head + joinChars(tail))
           },
-      peg$c486 = function() { return "*"},
-      peg$c487 = function() { return "=" },
-      peg$c488 = function() { return "\\*" },
-      peg$c489 = "x",
-      peg$c490 = peg$literalExpectation("x", false),
-      peg$c491 = function() { return "\\" + text() },
-      peg$c492 = "b",
-      peg$c493 = peg$literalExpectation("b", false),
-      peg$c494 = function() { return "\b" },
-      peg$c495 = "f",
-      peg$c496 = peg$literalExpectation("f", false),
-      peg$c497 = function() { return "\f" },
-      peg$c498 = "n",
-      peg$c499 = peg$literalExpectation("n", false),
-      peg$c500 = function() { return "\n" },
-      peg$c501 = "r",
-      peg$c502 = peg$literalExpectation("r", false),
-      peg$c503 = function() { return "\r" },
-      peg$c504 = "t",
-      peg$c505 = peg$literalExpectation("t", false),
-      peg$c506 = function() { return "\t" },
-      peg$c507 = "v",
-      peg$c508 = peg$literalExpectation("v", false),
-      peg$c509 = function() { return "\v" },
-      peg$c510 = function() { return "*" },
-      peg$c511 = "u",
-      peg$c512 = peg$literalExpectation("u", false),
-      peg$c513 = function(chars) {
+      peg$c485 = function() { return "*"},
+      peg$c486 = function() { return "=" },
+      peg$c487 = function() { return "\\*" },
+      peg$c488 = "x",
+      peg$c489 = peg$literalExpectation("x", false),
+      peg$c490 = function() { return "\\" + text() },
+      peg$c491 = "b",
+      peg$c492 = peg$literalExpectation("b", false),
+      peg$c493 = function() { return "\b" },
+      peg$c494 = "f",
+      peg$c495 = peg$literalExpectation("f", false),
+      peg$c496 = function() { return "\f" },
+      peg$c497 = "n",
+      peg$c498 = peg$literalExpectation("n", false),
+      peg$c499 = function() { return "\n" },
+      peg$c500 = "r",
+      peg$c501 = peg$literalExpectation("r", false),
+      peg$c502 = function() { return "\r" },
+      peg$c503 = "t",
+      peg$c504 = peg$literalExpectation("t", false),
+      peg$c505 = function() { return "\t" },
+      peg$c506 = "v",
+      peg$c507 = peg$literalExpectation("v", false),
+      peg$c508 = function() { return "\v" },
+      peg$c509 = function() { return "*" },
+      peg$c510 = "u",
+      peg$c511 = peg$literalExpectation("u", false),
+      peg$c512 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c514 = /^[^\/\\]/,
-      peg$c515 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c516 = "\\/",
-      peg$c517 = peg$literalExpectation("\\/", false),
-      peg$c518 = /^[\0-\x1F\\]/,
-      peg$c519 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c520 = peg$otherExpectation("whitespace"),
-      peg$c521 = "\t",
-      peg$c522 = peg$literalExpectation("\t", false),
-      peg$c523 = "\x0B",
-      peg$c524 = peg$literalExpectation("\x0B", false),
-      peg$c525 = "\f",
-      peg$c526 = peg$literalExpectation("\f", false),
-      peg$c527 = " ",
-      peg$c528 = peg$literalExpectation(" ", false),
-      peg$c529 = "\xA0",
-      peg$c530 = peg$literalExpectation("\xA0", false),
-      peg$c531 = "\uFEFF",
-      peg$c532 = peg$literalExpectation("\uFEFF", false),
-      peg$c533 = /^[\n\r\u2028\u2029]/,
-      peg$c534 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c535 = peg$otherExpectation("comment"),
-      peg$c540 = "//",
-      peg$c541 = peg$literalExpectation("//", false),
+      peg$c513 = /^[^\/\\]/,
+      peg$c514 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c515 = "\\/",
+      peg$c516 = peg$literalExpectation("\\/", false),
+      peg$c517 = /^[\0-\x1F\\]/,
+      peg$c518 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c519 = peg$otherExpectation("whitespace"),
+      peg$c520 = "\t",
+      peg$c521 = peg$literalExpectation("\t", false),
+      peg$c522 = "\x0B",
+      peg$c523 = peg$literalExpectation("\x0B", false),
+      peg$c524 = "\f",
+      peg$c525 = peg$literalExpectation("\f", false),
+      peg$c526 = " ",
+      peg$c527 = peg$literalExpectation(" ", false),
+      peg$c528 = "\xA0",
+      peg$c529 = peg$literalExpectation("\xA0", false),
+      peg$c530 = "\uFEFF",
+      peg$c531 = peg$literalExpectation("\uFEFF", false),
+      peg$c532 = /^[\n\r\u2028\u2029]/,
+      peg$c533 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c534 = peg$otherExpectation("comment"),
+      peg$c539 = "//",
+      peg$c540 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1643,120 +1644,47 @@ function peg$parse(input, options) {
   }
 
   function peg$parseParallel() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSequential();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseParallelTail();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseParallelTail();
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseSequential();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c17(s1);
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseParallelTail() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c18) {
-        s2 = peg$c18;
-        peg$currPos += 2;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseSequential();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c20(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseSwitchBranch() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    s1 = peg$parse__();
+    if (input.substr(peg$currPos, 2) === peg$c16) {
+      s1 = peg$c16;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c17); }
+    }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseCaseToken();
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
+        s3 = peg$parseSequential();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseSearchBoolean();
+          s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parse__();
+            if (input.charCodeAt(peg$currPos) === 59) {
+              s5 = peg$c7;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c8); }
+            }
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c18) {
-                s6 = peg$c18;
-                peg$currPos += 2;
-              } else {
-                s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c19); }
-              }
+              s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
-                s7 = peg$parse__();
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parseSequential();
-                  if (s8 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c21(s4, s8);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
+                s7 = [];
+                s8 = peg$parseParallel();
+                if (s8 !== peg$FAILED) {
+                  while (s8 !== peg$FAILED) {
+                    s7.push(s8);
+                    s8 = peg$parseParallel();
                   }
+                } else {
+                  s7 = peg$FAILED;
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c18(s3, s7);
+                  s0 = s1;
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1787,27 +1715,152 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parse__();
+      if (input.substr(peg$currPos, 2) === peg$c16) {
+        s1 = peg$c16;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+      }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseDefaultToken();
+        s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parse__();
+          s3 = peg$parseSequential();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c18) {
-              s4 = peg$c18;
-              peg$currPos += 2;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c19); }
-            }
+            s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parse__();
+              if (input.charCodeAt(peg$currPos) === 59) {
+                s5 = peg$c7;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c8); }
+              }
               if (s5 !== peg$FAILED) {
-                s6 = peg$parseSequential();
-                if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c19(s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSwitchBranch() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseDefaultToken();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c16) {
+          s3 = peg$c16;
+          peg$currPos += 2;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseSequential();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 59) {
+                  s7 = peg$c7;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                }
+                if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c22(s6);
+                  s1 = peg$c20(s5);
                   s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseSearchBoolean();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__();
+        if (s2 !== peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c16) {
+            s3 = peg$c16;
+            peg$currPos += 2;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseSequential();
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parse__();
+                if (s6 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 59) {
+                    s7 = peg$c7;
+                    peg$currPos++;
+                  } else {
+                    s7 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                  }
+                  if (s7 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c21(s1, s5);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1838,25 +1891,31 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSwitch() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parseSwitchBranch();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseSwitchBranch();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseSwitchBranch();
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
-        s0 = s1;
+        s3 = [];
+        s4 = peg$parseSwitch();
+        if (s4 !== peg$FAILED) {
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parseSwitch();
+          }
+        } else {
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c18(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1870,23 +1929,9 @@ function peg$parse(input, options) {
       s1 = peg$parseSwitchBranch();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c17(s1);
+        s1 = peg$c19(s1);
       }
       s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseCaseToken() {
-    var s0;
-
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c23) {
-      s0 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c24); }
     }
 
     return s0;
@@ -1895,37 +1940,43 @@ function peg$parse(input, options) {
   function peg$parseDefaultToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c25) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c22) {
       s0 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c26); }
+      if (peg$silentFails === 0) { peg$fail(peg$c23); }
     }
 
     return s0;
   }
 
   function peg$parseFromTrunks() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parseFromTrunk();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseFromTrunkTail();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseFromTrunkTail();
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
-        s0 = s1;
+        s3 = [];
+        s4 = peg$parseFromTrunks();
+        if (s4 !== peg$FAILED) {
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parseFromTrunks();
+          }
+        } else {
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c18(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1939,7 +1990,7 @@ function peg$parse(input, options) {
       s1 = peg$parseFromTrunk();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c17(s1);
+        s1 = peg$c19(s1);
       }
       s0 = s1;
     }
@@ -1948,16 +1999,34 @@ function peg$parse(input, options) {
   }
 
   function peg$parseFromTrunk() {
-    var s0, s1, s2;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parseFromSource();
     if (s1 !== peg$FAILED) {
       s2 = peg$parseFromTrunkSeq();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c27(s1, s2);
-        s0 = s1;
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 59) {
+            s4 = peg$c7;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c8); }
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c24(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1976,12 +2045,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c18) {
-        s2 = peg$c18;
+      if (input.substr(peg$currPos, 2) === peg$c16) {
+        s2 = peg$c16;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1989,7 +2058,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequential();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c28(s4);
+            s1 = peg$c25(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2009,61 +2078,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c30();
+        s1 = peg$c27();
       }
       s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFromTrunkTail() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$currPos;
-    s2 = peg$parse__();
-    if (s2 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 59) {
-        s3 = peg$c7;
-        peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c8); }
-      }
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s2 = [s2, s3, s4];
-          s1 = s2;
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s1;
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseFromTrunk();
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c31(s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
     }
 
     return s0;
@@ -2087,62 +2107,44 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOperation() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c32) {
-      s1 = peg$c32;
+    if (input.substr(peg$currPos, 5) === peg$c28) {
+      s1 = peg$c28;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c33); }
+      if (peg$silentFails === 0) { peg$fail(peg$c29); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c18) {
-              s5 = peg$c18;
-              peg$currPos += 2;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c19); }
-            }
+            s5 = peg$parseParallel();
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
-                s7 = peg$parseParallel();
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c32;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                }
                 if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
-                  if (s8 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 41) {
-                      s9 = peg$c36;
-                      peg$currPos++;
-                    } else {
-                      s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c37); }
-                    }
-                    if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c38(s7);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
+                  peg$savedPos = s0;
+                  s1 = peg$c34(s5);
+                  s0 = s1;
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -2173,22 +2175,22 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c39) {
-        s1 = peg$c39;
+      if (input.substr(peg$currPos, 6) === peg$c35) {
+        s1 = peg$c35;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c36); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c34;
+            s3 = peg$c30;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -2198,15 +2200,15 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c36;
+                    s7 = peg$c32;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c41(s5);
+                    s1 = peg$c37(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -2238,22 +2240,22 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c42) {
-          s1 = peg$c42;
+        if (input.substr(peg$currPos, 4) === peg$c38) {
+          s1 = peg$c38;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c43); }
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s3 = peg$c34;
+              s3 = peg$c30;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c35); }
+              if (peg$silentFails === 0) { peg$fail(peg$c31); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
@@ -2262,38 +2264,17 @@ function peg$parse(input, options) {
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parse__();
                   if (s6 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 59) {
-                      s7 = peg$c7;
+                    if (input.charCodeAt(peg$currPos) === 41) {
+                      s7 = peg$c32;
                       peg$currPos++;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c8); }
-                    }
-                    if (s7 === peg$FAILED) {
-                      s7 = null;
+                      if (peg$silentFails === 0) { peg$fail(peg$c33); }
                     }
                     if (s7 !== peg$FAILED) {
-                      s8 = peg$parse__();
-                      if (s8 !== peg$FAILED) {
-                        if (input.charCodeAt(peg$currPos) === 41) {
-                          s9 = peg$c36;
-                          peg$currPos++;
-                        } else {
-                          s9 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c37); }
-                        }
-                        if (s9 !== peg$FAILED) {
-                          peg$savedPos = s0;
-                          s1 = peg$c44(s5);
-                          s0 = s1;
-                        } else {
-                          peg$currPos = s0;
-                          s0 = peg$FAILED;
-                        }
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
+                      peg$savedPos = s0;
+                      s1 = peg$c40(s5);
+                      s0 = s1;
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -2340,7 +2321,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c45(s1);
+                s1 = peg$c41(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2366,7 +2347,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c46(s1);
+                  s1 = peg$c42(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2392,7 +2373,7 @@ function peg$parse(input, options) {
                   }
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c47(s1);
+                    s1 = peg$c43(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -2420,20 +2401,20 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePipe();
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c18) {
-          s2 = peg$c18;
+        if (input.substr(peg$currPos, 2) === peg$c16) {
+          s2 = peg$c16;
           peg$currPos += 2;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c19); }
+          if (peg$silentFails === 0) { peg$fail(peg$c17); }
         }
         if (s2 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 41) {
-            s2 = peg$c36;
+          if (peg$c44.test(input.charAt(peg$currPos))) {
+            s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c37); }
+            if (peg$silentFails === 0) { peg$fail(peg$c45); }
           }
           if (s2 === peg$FAILED) {
             s2 = peg$parseEOF();
@@ -2460,29 +2441,29 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 124) {
-      s1 = peg$c48;
+      s1 = peg$c46;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s3 = peg$c50;
+        s3 = peg$c48;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
       }
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s3 = peg$c52;
+          s3 = peg$c50;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
       }
       peg$silentFails--;
@@ -2516,12 +2497,12 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c18) {
-        s4 = peg$c18;
+      if (input.substr(peg$currPos, 2) === peg$c16) {
+        s4 = peg$c16;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       peg$silentFails--;
       if (s4 === peg$FAILED) {
@@ -2549,35 +2530,35 @@ function peg$parse(input, options) {
           s2 = peg$parseMultiplicativeOperator();
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s2 = peg$c54;
+              s2 = peg$c52;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s2 = peg$c34;
+                s2 = peg$c30;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                if (peg$silentFails === 0) { peg$fail(peg$c31); }
               }
               if (s2 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s2 = peg$c52;
+                  s2 = peg$c50;
                   peg$currPos++;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c51); }
                 }
                 if (s2 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 7) === peg$c56) {
-                    s2 = peg$c56;
+                  if (input.substr(peg$currPos, 7) === peg$c54) {
+                    s2 = peg$c54;
                     peg$currPos += 7;
                   } else {
                     s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c57); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c55); }
                   }
                 }
               }
@@ -2604,60 +2585,60 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c58) {
-      s1 = peg$c58;
+    if (input.substr(peg$currPos, 2) === peg$c56) {
+      s1 = peg$c56;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c60) {
-        s1 = peg$c60;
+      if (input.substr(peg$currPos, 2) === peg$c58) {
+        s1 = peg$c58;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c59); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c62) {
-          s1 = peg$c62;
+        if (input.substr(peg$currPos, 2) === peg$c60) {
+          s1 = peg$c60;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c63); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c64) {
-            s1 = peg$c64;
+          if (input.substr(peg$currPos, 2) === peg$c62) {
+            s1 = peg$c62;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
+            if (peg$silentFails === 0) { peg$fail(peg$c63); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c66;
+              s1 = peg$c64;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c67); }
+              if (peg$silentFails === 0) { peg$fail(peg$c65); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c68) {
-                s1 = peg$c68;
+              if (input.substr(peg$currPos, 2) === peg$c66) {
+                s1 = peg$c66;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                if (peg$silentFails === 0) { peg$fail(peg$c67); }
               }
               if (s1 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 62) {
-                  s1 = peg$c70;
+                  s1 = peg$c68;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c71); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c69); }
                 }
               }
             }
@@ -2667,7 +2648,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -2682,12 +2663,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseByToken();
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c73) {
-          s2 = peg$c73;
+        if (input.substr(peg$currPos, 5) === peg$c71) {
+          s2 = peg$c71;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c72); }
         }
       }
       if (s2 !== peg$FAILED) {
@@ -2712,11 +2693,11 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s2 = peg$c75;
+          s2 = peg$c73;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -2748,7 +2729,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c77(s1, s2);
+        s1 = peg$c75(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2775,7 +2756,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchAnd();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c78(s4);
+            s1 = peg$c76(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2829,7 +2810,7 @@ function peg$parse(input, options) {
           s6 = peg$parseSearchFactor();
           if (s6 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c79(s1, s6);
+            s4 = peg$c77(s1, s6);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2870,7 +2851,7 @@ function peg$parse(input, options) {
             s6 = peg$parseSearchFactor();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s6);
+              s4 = peg$c77(s1, s6);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2887,7 +2868,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c78(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2923,11 +2904,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c81;
+        s2 = peg$c79;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2947,7 +2928,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c83(s2);
+        s1 = peg$c81(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2962,11 +2943,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c34;
+          s1 = peg$c30;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -2976,15 +2957,15 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c36;
+                  s5 = peg$c32;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c84(s3);
+                  s1 = peg$c82(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3044,7 +3025,7 @@ function peg$parse(input, options) {
       s2 = peg$parsePatternSearch();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c90(s2);
+        s1 = peg$c88(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3095,7 +3076,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c91(s2);
+            s1 = peg$c89(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3112,11 +3093,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c85;
+          s1 = peg$c83;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
@@ -3131,7 +3112,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c92();
+            s1 = peg$c90();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3170,7 +3151,7 @@ function peg$parse(input, options) {
         s2 = peg$parseKeyWord();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c93(s2);
+          s1 = peg$c91(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3192,7 +3173,7 @@ function peg$parse(input, options) {
     s1 = peg$parsePattern();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c94(s1);
+      s1 = peg$c92(s1);
     }
     s0 = s1;
 
@@ -3207,12 +3188,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c56) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c54) {
           s3 = input.substr(peg$currPos, 7);
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c95); }
+          if (peg$silentFails === 0) { peg$fail(peg$c93); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3220,7 +3201,7 @@ function peg$parse(input, options) {
             s5 = peg$parsePattern();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c96(s1, s5);
+              s1 = peg$c94(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3272,25 +3253,22 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$parseByToken();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseCaseToken();
+                s0 = peg$parseDefaultToken();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseDefaultToken();
+                  if (input.substr(peg$currPos, 5) === peg$c95) {
+                    s0 = peg$c95;
+                    peg$currPos += 5;
+                  } else {
+                    s0 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                  }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c97) {
-                      s0 = peg$c97;
-                      peg$currPos += 5;
+                    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c54) {
+                      s0 = input.substr(peg$currPos, 7);
+                      peg$currPos += 7;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c98); }
-                    }
-                    if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c56) {
-                        s0 = input.substr(peg$currPos, 7);
-                        peg$currPos += 7;
-                      } else {
-                        s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c95); }
-                      }
+                      if (peg$silentFails === 0) { peg$fail(peg$c93); }
                     }
                   }
                 }
@@ -3317,7 +3295,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLimitArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c99(s2, s3, s4);
+            s1 = peg$c97(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3365,7 +3343,7 @@ function peg$parse(input, options) {
               s5 = peg$parseLimitArg();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c100(s2, s3, s4, s5);
+                s1 = peg$c98(s2, s3, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3396,12 +3374,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c101) {
-      s1 = peg$c101;
+    if (input.substr(peg$currPos, 9) === peg$c99) {
+      s1 = peg$c99;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c102); }
+      if (peg$silentFails === 0) { peg$fail(peg$c100); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3417,7 +3395,7 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$c29;
+      s0 = peg$c26;
     }
 
     return s0;
@@ -3427,12 +3405,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c103) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c101) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c104); }
+      if (peg$silentFails === 0) { peg$fail(peg$c102); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3442,7 +3420,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c105(s3);
+            s1 = peg$c103(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3462,10 +3440,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -3484,7 +3462,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c107(s3);
+          s1 = peg$c105(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3508,22 +3486,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c108) {
-        s2 = peg$c108;
+      if (input.substr(peg$currPos, 4) === peg$c106) {
+        s2 = peg$c106;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c109); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c110) {
-            s4 = peg$c110;
+          if (input.substr(peg$currPos, 6) === peg$c108) {
+            s4 = peg$c108;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c111); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3531,7 +3509,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c112(s6);
+                s1 = peg$c110(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3559,10 +3537,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113();
+        s1 = peg$c111();
       }
       s0 = s1;
     }
@@ -3579,7 +3557,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1);
+        s1 = peg$c112(s1);
       }
       s0 = s1;
     }
@@ -3598,11 +3576,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3610,7 +3588,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c115(s1, s7);
+              s4 = peg$c113(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3634,11 +3612,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3646,7 +3624,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c115(s1, s7);
+                s4 = peg$c113(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3667,7 +3645,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3689,12 +3667,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c116) {
-          s3 = peg$c116;
+        if (input.substr(peg$currPos, 2) === peg$c115) {
+          s3 = peg$c115;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c116); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3702,7 +3680,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAgg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c118(s1, s5);
+              s1 = peg$c117(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3729,7 +3707,7 @@ function peg$parse(input, options) {
       s1 = peg$parseAgg();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c119(s1);
+        s1 = peg$c118(s1);
       }
       s0 = s1;
     }
@@ -3757,11 +3735,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c34;
+            s4 = peg$c30;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -3774,11 +3752,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c36;
+                    s8 = peg$c32;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$currPos;
@@ -3787,11 +3765,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c120;
+                        s12 = peg$c119;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c120); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3818,7 +3796,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c122(s2, s6, s10);
+                        s1 = peg$c121(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3884,12 +3862,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c123) {
-        s2 = peg$c123;
+      if (input.substr(peg$currPos, 5) === peg$c122) {
+        s2 = peg$c122;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c124); }
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3897,7 +3875,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c84(s4);
+            s1 = peg$c82(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3930,11 +3908,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3965,11 +3943,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3997,7 +3975,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c125(s1, s2);
+        s1 = peg$c124(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4077,12 +4055,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c125) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      if (peg$silentFails === 0) { peg$fail(peg$c126); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -4093,7 +4071,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c128(s2, s5);
+            s4 = peg$c127(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -4108,7 +4086,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c129(s2, s3);
+          s1 = peg$c128(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4137,7 +4115,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c46(s4);
+        s3 = peg$c42(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -4155,7 +4133,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c46(s4);
+          s3 = peg$c42(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4168,7 +4146,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c130(s1);
+      s1 = peg$c129(s1);
     }
     s0 = s1;
 
@@ -4179,55 +4157,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c131) {
-      s1 = peg$c131;
+    if (input.substr(peg$currPos, 2) === peg$c130) {
+      s1 = peg$c130;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c132); }
+      if (peg$silentFails === 0) { peg$fail(peg$c131); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c133();
+      s1 = peg$c132();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c134) {
-        s1 = peg$c134;
+      if (input.substr(peg$currPos, 6) === peg$c133) {
+        s1 = peg$c133;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c135); }
+        if (peg$silentFails === 0) { peg$fail(peg$c134); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c136) {
-            s4 = peg$c136;
+          if (input.substr(peg$currPos, 5) === peg$c135) {
+            s4 = peg$c135;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c137); }
+            if (peg$silentFails === 0) { peg$fail(peg$c136); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c138) {
-              s4 = peg$c138;
+            if (input.substr(peg$currPos, 4) === peg$c137) {
+              s4 = peg$c137;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c139); }
+              if (peg$silentFails === 0) { peg$fail(peg$c138); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c72();
+            s4 = peg$c70();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c140(s3);
+            s1 = peg$c139(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4250,12 +4228,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c141) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c140) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c142); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4264,7 +4242,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c143(s4);
+          s3 = peg$c142(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4281,12 +4259,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c144) {
-            s5 = peg$c144;
+          if (input.substr(peg$currPos, 6) === peg$c143) {
+            s5 = peg$c143;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c145); }
+            if (peg$silentFails === 0) { peg$fail(peg$c144); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -4309,7 +4287,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c146(s2, s3, s6);
+              s5 = peg$c145(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -4324,7 +4302,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c147(s2, s3, s4);
+            s1 = peg$c146(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4350,12 +4328,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c148) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c147) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c149); }
+      if (peg$silentFails === 0) { peg$fail(peg$c148); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4363,7 +4341,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c150(s3);
+          s1 = peg$c149(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4385,12 +4363,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c152); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4398,7 +4376,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c153(s3);
+          s1 = peg$c152(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4420,12 +4398,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c154); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4433,7 +4411,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c156(s3);
+          s1 = peg$c155(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4455,12 +4433,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c157) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c156) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c158); }
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4468,7 +4446,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c159(s3);
+          s1 = peg$c158(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4484,16 +4462,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c157) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c156) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c158); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c160();
+        s1 = peg$c159();
       }
       s0 = s1;
     }
@@ -4505,12 +4483,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c161) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c162); }
+      if (peg$silentFails === 0) { peg$fail(peg$c161); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4518,7 +4496,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c163(s3);
+          s1 = peg$c162(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4534,16 +4512,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c161) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c162); }
+        if (peg$silentFails === 0) { peg$fail(peg$c161); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c164();
+        s1 = peg$c163();
       }
       s0 = s1;
     }
@@ -4555,12 +4533,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c165) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c164) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c166); }
+      if (peg$silentFails === 0) { peg$fail(peg$c165); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4568,7 +4546,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c167(s3);
+          s1 = peg$c166(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4593,7 +4571,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSearchBoolean();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c43(s1);
     }
     s0 = s1;
 
@@ -4604,26 +4582,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c168) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c167) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c168); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c170) {
-          s3 = peg$c170;
+        if (input.substr(peg$currPos, 2) === peg$c169) {
+          s3 = peg$c169;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c171); }
+          if (peg$silentFails === 0) { peg$fail(peg$c170); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c172();
+          s1 = peg$c171();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4639,16 +4617,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c168) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c167) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c169); }
+        if (peg$silentFails === 0) { peg$fail(peg$c168); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c173();
+        s1 = peg$c172();
       }
       s0 = s1;
     }
@@ -4660,12 +4638,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c174) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c173) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      if (peg$silentFails === 0) { peg$fail(peg$c174); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4673,7 +4651,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s3);
+          s1 = peg$c175(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4695,12 +4673,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c177) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c176) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c178); }
+      if (peg$silentFails === 0) { peg$fail(peg$c177); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4712,11 +4690,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c75;
+              s7 = peg$c73;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c76); }
+              if (peg$silentFails === 0) { peg$fail(peg$c74); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -4724,7 +4702,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c179(s3, s9);
+                  s6 = peg$c178(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4748,11 +4726,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c75;
+                s7 = peg$c73;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                if (peg$silentFails === 0) { peg$fail(peg$c74); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -4760,7 +4738,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c179(s3, s9);
+                    s6 = peg$c178(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4781,7 +4759,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c180(s3, s4);
+            s1 = peg$c179(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4807,12 +4785,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c181) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c182); }
+      if (peg$silentFails === 0) { peg$fail(peg$c181); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4821,11 +4799,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c34;
+          s5 = peg$c30;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4847,7 +4825,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c183();
+        s1 = peg$c182();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4865,16 +4843,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c184) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c183) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
+      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c186();
+      s1 = peg$c185();
     }
     s0 = s1;
 
@@ -4887,12 +4865,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseJoinStyle();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c188); }
+        if (peg$silentFails === 0) { peg$fail(peg$c187); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4937,7 +4915,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c189(s1, s6, s10, s11);
+                          s1 = peg$c188(s1, s6, s10, s11);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -4987,12 +4965,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parseJoinStyle();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
           s2 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c188); }
+          if (peg$silentFails === 0) { peg$fail(peg$c187); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5023,7 +5001,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c190(s1, s6, s7);
+                    s1 = peg$c189(s1, s6, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5062,18 +5040,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c191) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c190) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
+      if (peg$silentFails === 0) { peg$fail(peg$c191); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c193();
+        s1 = peg$c192();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5085,18 +5063,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c194) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c193) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c194); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c196();
+          s1 = peg$c195();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5108,18 +5086,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c197) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c196) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c198); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c199();
+            s1 = peg$c198();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5131,10 +5109,10 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$c29;
+          s1 = peg$c26;
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c193();
+            s1 = peg$c192();
           }
           s0 = s1;
         }
@@ -5151,25 +5129,25 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c34;
+        s1 = peg$c30;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c36;
+            s3 = peg$c32;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c37); }
+            if (peg$silentFails === 0) { peg$fail(peg$c33); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c84(s2);
+            s1 = peg$c82(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5192,18 +5170,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c200) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c199) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c201); }
+      if (peg$silentFails === 0) { peg$fail(peg$c200); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSampleExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c202(s2);
+        s1 = peg$c201(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5226,7 +5204,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c203(s2);
+        s1 = peg$c202(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5238,10 +5216,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c204();
+        s1 = peg$c203();
       }
       s0 = s1;
     }
@@ -5256,7 +5234,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFromAny();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c205(s1);
+      s1 = peg$c204(s1);
     }
     s0 = s1;
 
@@ -5281,12 +5259,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c206) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c205) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c207); }
+      if (peg$silentFails === 0) { peg$fail(peg$c206); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5298,7 +5276,7 @@ function peg$parse(input, options) {
             s5 = peg$parseLayoutArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c208(s3, s4, s5);
+              s1 = peg$c207(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5328,12 +5306,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c42) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c209); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5341,7 +5319,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePoolBody();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c210(s3);
+          s1 = peg$c209(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5372,7 +5350,7 @@ function peg$parse(input, options) {
           s4 = peg$parseOrderArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c211(s1, s2, s3, s4);
+            s1 = peg$c210(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5398,12 +5376,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c212) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c211) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c213); }
+      if (peg$silentFails === 0) { peg$fail(peg$c212); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5415,7 +5393,7 @@ function peg$parse(input, options) {
             s5 = peg$parseLayoutArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c214(s3, s4, s5);
+              s1 = peg$c213(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5445,27 +5423,27 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c215) {
-      s1 = peg$c215;
+    if (input.substr(peg$currPos, 5) === peg$c214) {
+      s1 = peg$c214;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c216); }
+      if (peg$silentFails === 0) { peg$fail(peg$c215); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c217) {
-        s1 = peg$c217;
+      if (input.substr(peg$currPos, 6) === peg$c216) {
+        s1 = peg$c216;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c218); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePath();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5480,7 +5458,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parsePath() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = peg$parseQuotedString();
@@ -5492,50 +5470,32 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c219.test(input.charAt(peg$currPos))) {
+      if (peg$c218.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c220); }
+        if (peg$silentFails === 0) { peg$fail(peg$c219); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c219.test(input.charAt(peg$currPos))) {
+          if (peg$c218.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c220); }
+            if (peg$silentFails === 0) { peg$fail(peg$c219); }
           }
         }
       } else {
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        s3 = peg$parseEOT();
-        peg$silentFails--;
-        if (s3 !== peg$FAILED) {
-          peg$currPos = s2;
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c72();
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
+        peg$savedPos = s0;
+        s1 = peg$c70();
       }
+      s0 = s1;
     }
 
     return s0;
@@ -5547,12 +5507,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c221) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c220) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c222); }
+        if (peg$silentFails === 0) { peg$fail(peg$c221); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5560,7 +5520,7 @@ function peg$parse(input, options) {
           s4 = peg$parseKSUID();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c223(s4);
+            s1 = peg$c222(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5580,10 +5540,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -5596,22 +5556,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c224.test(input.charAt(peg$currPos))) {
+    if (peg$c223.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c225); }
+      if (peg$silentFails === 0) { peg$fail(peg$c224); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c224.test(input.charAt(peg$currPos))) {
+        if (peg$c223.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c225); }
+          if (peg$silentFails === 0) { peg$fail(peg$c224); }
         }
       }
     } else {
@@ -5619,7 +5579,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -5632,12 +5592,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c226) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c225) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c226); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5646,12 +5606,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
+              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c227) {
                 s6 = input.substr(peg$currPos, 2);
                 peg$currPos += 2;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c229); }
+                if (peg$silentFails === 0) { peg$fail(peg$c228); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parse_();
@@ -5659,7 +5619,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseLiteral();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c230(s4, s8);
+                    s1 = peg$c229(s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5695,10 +5655,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -5713,7 +5673,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c232(s1);
+      s1 = peg$c231(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5721,7 +5681,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKSUID();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c223(s1);
+        s1 = peg$c222(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -5729,7 +5689,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c233(s1);
+          s1 = peg$c232(s1);
         }
         s0 = s1;
       }
@@ -5744,12 +5704,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c234) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c235); }
+        if (peg$silentFails === 0) { peg$fail(peg$c234); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5759,7 +5719,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c236(s4, s5);
+              s1 = peg$c235(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5783,10 +5743,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -5800,12 +5760,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c237) {
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c236) {
         s2 = input.substr(peg$currPos, 6);
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c238); }
+        if (peg$silentFails === 0) { peg$fail(peg$c237); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5813,7 +5773,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c231(s4);
+            s1 = peg$c230(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5833,10 +5793,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c239();
+        s1 = peg$c238();
       }
       s0 = s1;
     }
@@ -5848,38 +5808,38 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c239) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c242();
+      s1 = peg$c241();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c243) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c242) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c244); }
+        if (peg$silentFails === 0) { peg$fail(peg$c243); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245();
+        s1 = peg$c244();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c29;
+        s1 = peg$c26;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c242();
+          s1 = peg$c241();
         }
         s0 = s1;
       }
@@ -5894,26 +5854,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c234) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c235); }
+        if (peg$silentFails === 0) { peg$fail(peg$c234); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c246) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
             s4 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c247); }
+            if (peg$silentFails === 0) { peg$fail(peg$c246); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c242();
+            s1 = peg$c241();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5935,26 +5895,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c234) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
           s2 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c235); }
+          if (peg$silentFails === 0) { peg$fail(peg$c234); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c248) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
               s4 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c248); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c245();
+              s1 = peg$c244();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5974,10 +5934,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c29;
+        s1 = peg$c26;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c239();
+          s1 = peg$c238();
         }
         s0 = s1;
       }
@@ -5990,16 +5950,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c250) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c249) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c251); }
+      if (peg$silentFails === 0) { peg$fail(peg$c250); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c252();
+      s1 = peg$c251();
     }
     s0 = s1;
 
@@ -6010,12 +5970,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c253) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c252) {
       s1 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6027,7 +5987,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAsArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c255(s3, s4, s5);
+              s1 = peg$c254(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6066,7 +6026,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c256(s4);
+            s1 = peg$c255(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6101,7 +6061,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c257(s4);
+            s1 = peg$c256(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6121,10 +6081,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c30();
+        s1 = peg$c27();
       }
       s0 = s1;
     }
@@ -6143,11 +6103,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6178,11 +6138,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6210,7 +6170,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c259(s1, s2);
+        s1 = peg$c258(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6232,12 +6192,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c116) {
-          s3 = peg$c116;
+        if (input.substr(peg$currPos, 2) === peg$c115) {
+          s3 = peg$c115;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c116); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6245,7 +6205,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c260(s1, s5);
+              s1 = peg$c259(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6288,11 +6248,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c261;
+          s3 = peg$c260;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c262); }
+          if (peg$silentFails === 0) { peg$fail(peg$c261); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6302,11 +6262,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c54;
+                  s7 = peg$c52;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -6314,7 +6274,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c263(s1, s5, s9);
+                      s1 = peg$c262(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6376,7 +6336,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6406,7 +6366,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6427,7 +6387,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6458,7 +6418,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6488,7 +6448,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6509,7 +6469,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6542,7 +6502,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c266(s1, s5, s7);
+                s4 = peg$c265(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6572,7 +6532,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRelativeExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s3;
-                  s4 = peg$c266(s1, s5, s7);
+                  s4 = peg$c265(s1, s5, s7);
                   s3 = s4;
                 } else {
                   peg$currPos = s3;
@@ -6593,7 +6553,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c265(s1, s2);
+          s1 = peg$c264(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6612,30 +6572,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c58) {
-      s1 = peg$c58;
+    if (input.substr(peg$currPos, 2) === peg$c56) {
+      s1 = peg$c56;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c267();
+      s1 = peg$c266();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c60) {
-        s1 = peg$c60;
+      if (input.substr(peg$currPos, 2) === peg$c58) {
+        s1 = peg$c58;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c59); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
       }
       s0 = s1;
     }
@@ -6649,16 +6609,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c62) {
-        s1 = peg$c62;
+      if (input.substr(peg$currPos, 2) === peg$c60) {
+        s1 = peg$c60;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
       }
       s0 = s1;
     }
@@ -6683,7 +6643,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6713,7 +6673,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6734,7 +6694,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6752,43 +6712,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c64) {
-      s1 = peg$c64;
+    if (input.substr(peg$currPos, 2) === peg$c62) {
+      s1 = peg$c62;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c63); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c66;
+        s1 = peg$c64;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c67); }
+        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c68) {
-          s1 = peg$c68;
+        if (input.substr(peg$currPos, 2) === peg$c66) {
+          s1 = peg$c66;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c67); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c70;
+            s1 = peg$c68;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c71); }
+            if (peg$silentFails === 0) { peg$fail(peg$c69); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -6812,7 +6772,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6842,7 +6802,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6863,7 +6823,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6882,24 +6842,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c268;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c269); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c270;
+        s1 = peg$c269;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c271); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -6923,7 +6883,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6953,7 +6913,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6974,7 +6934,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6993,24 +6953,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c85;
+      s1 = peg$c83;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c272;
+        s1 = peg$c271;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c273); }
+        if (peg$silentFails === 0) { peg$fail(peg$c272); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7022,11 +6982,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c81;
+      s1 = peg$c79;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7034,7 +6994,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c274(s3);
+          s1 = peg$c273(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7071,11 +7031,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s5 = peg$c34;
+              s5 = peg$c30;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c35); }
+              if (peg$silentFails === 0) { peg$fail(peg$c31); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -7097,7 +7057,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s1);
+            s1 = peg$c274(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7119,7 +7079,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c77(s1, s2);
+              s1 = peg$c75(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7141,7 +7101,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c77(s1, s2);
+                s1 = peg$c75(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7174,11 +7134,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -7202,28 +7162,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c276) {
-      s0 = peg$c276;
+    if (input.substr(peg$currPos, 3) === peg$c275) {
+      s0 = peg$c275;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c278) {
-        s0 = peg$c278;
+      if (input.substr(peg$currPos, 5) === peg$c277) {
+        s0 = peg$c277;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c280) {
-          s0 = peg$c280;
+        if (input.substr(peg$currPos, 6) === peg$c279) {
+          s0 = peg$c279;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -7244,36 +7204,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c278) {
-      s1 = peg$c278;
+    if (input.substr(peg$currPos, 5) === peg$c277) {
+      s1 = peg$c277;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c36;
+              s5 = peg$c32;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c37); }
+              if (peg$silentFails === 0) { peg$fail(peg$c33); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c84(s4);
+              s1 = peg$c82(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7303,22 +7263,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c280) {
-      s1 = peg$c280;
+    if (input.substr(peg$currPos, 6) === peg$c279) {
+      s1 = peg$c279;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+      if (peg$silentFails === 0) { peg$fail(peg$c280); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7328,17 +7288,17 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c36;
+                  s7 = peg$c32;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parseMethods();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c282(s5, s8);
+                    s1 = peg$c281(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7392,15 +7352,15 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c283(s1);
+      s1 = peg$c282(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -7415,11 +7375,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c120;
+        s2 = peg$c119;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7427,7 +7387,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFunction();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c45(s4);
+            s1 = peg$c41(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7458,11 +7418,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7472,15 +7432,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c36;
+                  s7 = peg$c32;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c284(s1, s5);
+                  s1 = peg$c283(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7534,11 +7494,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c34;
+            s4 = peg$c30;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -7548,15 +7508,15 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c36;
+                    s8 = peg$c32;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c285(s2, s6);
+                    s1 = peg$c284(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7603,7 +7563,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c286();
+        s1 = peg$c285();
       }
       s0 = s1;
     }
@@ -7622,11 +7582,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -7634,7 +7594,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c287(s1, s7);
+              s4 = peg$c286(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7658,11 +7618,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -7670,7 +7630,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c287(s1, s7);
+                s4 = peg$c286(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7691,7 +7651,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7723,7 +7683,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExprPattern();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c288(s2);
+        s1 = peg$c287(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7751,7 +7711,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c77(s1, s2);
+        s1 = peg$c75(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7773,7 +7733,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c77(s1, s2);
+          s1 = peg$c75(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7795,7 +7755,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c77(s1, s2);
+            s1 = peg$c75(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7808,15 +7768,15 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 46) {
-            s1 = peg$c120;
+            s1 = peg$c119;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c120); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c289();
+            s1 = peg$c288();
           }
           s0 = s1;
         }
@@ -7830,16 +7790,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c290) {
-      s1 = peg$c290;
+    if (input.substr(peg$currPos, 4) === peg$c289) {
+      s1 = peg$c289;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c290); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c204();
+      s1 = peg$c203();
     }
     s0 = s1;
 
@@ -7851,17 +7811,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c120;
+      s1 = peg$c119;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c120); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c292(s2);
+        s1 = peg$c291(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7874,33 +7834,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c120;
+        s1 = peg$c119;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c52;
+          s2 = peg$c50;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c293;
+              s4 = peg$c292;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c294); }
+              if (peg$silentFails === 0) { peg$fail(peg$c293); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c295(s3);
+              s1 = peg$c294(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7928,11 +7888,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c52;
+      s1 = peg$c50;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c51); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -7940,11 +7900,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c54;
+            s4 = peg$c52;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -7952,15 +7912,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c293;
+                  s7 = peg$c292;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c296(s2, s6);
+                  s1 = peg$c295(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7993,21 +7953,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c52;
+        s1 = peg$c50;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c54;
+            s3 = peg$c52;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -8015,15 +7975,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c293;
+                  s6 = peg$c292;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c297(s5);
+                  s1 = peg$c296(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8052,11 +8012,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c52;
+          s1 = peg$c50;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseAdditiveExpr();
@@ -8064,25 +8024,25 @@ function peg$parse(input, options) {
             s3 = peg$parse__();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c54;
+                s4 = peg$c52;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                if (peg$silentFails === 0) { peg$fail(peg$c53); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c293;
+                    s6 = peg$c292;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c293); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c298(s2);
+                    s1 = peg$c297(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8111,25 +8071,25 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c52;
+            s1 = peg$c50;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c51); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c293;
+                s3 = peg$c292;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                if (peg$silentFails === 0) { peg$fail(peg$c293); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c299(s2);
+                s1 = peg$c298(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8146,21 +8106,21 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c120;
+              s1 = peg$c119;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c121); }
+              if (peg$silentFails === 0) { peg$fail(peg$c120); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
               peg$silentFails++;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s3 = peg$c120;
+                s3 = peg$c119;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               peg$silentFails--;
               if (s3 === peg$FAILED) {
@@ -8173,7 +8133,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c300(s3);
+                  s1 = peg$c299(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8210,11 +8170,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 40) {
-                s1 = peg$c34;
+                s1 = peg$c30;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                if (peg$silentFails === 0) { peg$fail(peg$c31); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -8224,15 +8184,15 @@ function peg$parse(input, options) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s5 = peg$c36;
+                        s5 = peg$c32;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c33); }
                       }
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c84(s3);
+                        s1 = peg$c82(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -8268,11 +8228,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c50;
+      s1 = peg$c48;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8282,15 +8242,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c301;
+              s5 = peg$c300;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s3);
+              s1 = peg$c302(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8330,7 +8290,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8351,11 +8311,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8363,7 +8323,7 @@ function peg$parse(input, options) {
           s4 = peg$parseField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c45(s4);
+            s1 = peg$c41(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8394,11 +8354,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c54;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8406,7 +8366,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305(s1, s5);
+              s1 = peg$c304(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8437,11 +8397,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c52;
+      s1 = peg$c50;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c51); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8451,15 +8411,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c293;
+              s5 = peg$c292;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c294); }
+              if (peg$silentFails === 0) { peg$fail(peg$c293); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c306(s3);
+              s1 = peg$c305(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8489,12 +8449,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c307) {
-      s1 = peg$c307;
+    if (input.substr(peg$currPos, 2) === peg$c306) {
+      s1 = peg$c306;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c308); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8503,16 +8463,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c309) {
-              s5 = peg$c309;
+            if (input.substr(peg$currPos, 2) === peg$c308) {
+              s5 = peg$c308;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s3);
+              s1 = peg$c310(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8542,12 +8502,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c312) {
-      s1 = peg$c312;
+    if (input.substr(peg$currPos, 2) === peg$c311) {
+      s1 = peg$c311;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8556,16 +8516,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c314) {
-              s5 = peg$c314;
+            if (input.substr(peg$currPos, 2) === peg$c313) {
+              s5 = peg$c313;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c315); }
+              if (peg$silentFails === 0) { peg$fail(peg$c314); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c316(s3);
+              s1 = peg$c315(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8605,7 +8565,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8620,7 +8580,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c286();
+        s1 = peg$c285();
       }
       s0 = s1;
     }
@@ -8635,11 +8595,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8647,7 +8607,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c288(s4);
+            s1 = peg$c287(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8678,11 +8638,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c54;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8690,7 +8650,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c317(s1, s5);
+              s1 = peg$c316(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8737,7 +8697,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c318(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c317(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8784,15 +8744,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 42) {
-          s3 = peg$c85;
+          s3 = peg$c83;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106();
+          s1 = peg$c104();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8815,7 +8775,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c319(s3);
+            s1 = peg$c318(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8849,7 +8809,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s1, s5);
+              s1 = peg$c319(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8876,7 +8836,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1);
+        s1 = peg$c112(s1);
       }
       s0 = s1;
     }
@@ -8895,11 +8855,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -8907,7 +8867,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSQLAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c115(s1, s7);
+              s4 = peg$c113(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8931,11 +8891,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -8943,7 +8903,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSQLAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c115(s1, s7);
+                s4 = peg$c113(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8964,7 +8924,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8993,7 +8953,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSQLAlias();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c321(s4, s5);
+              s1 = peg$c320(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9024,15 +8984,15 @@ function peg$parse(input, options) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 42) {
-              s4 = peg$c85;
+              s4 = peg$c83;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c86); }
+              if (peg$silentFails === 0) { peg$fail(peg$c84); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c106();
+              s1 = peg$c104();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9052,10 +9012,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c29;
+        s1 = peg$c26;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106();
+          s1 = peg$c104();
         }
         s0 = s1;
       }
@@ -9077,7 +9037,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c223(s4);
+            s1 = peg$c222(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9102,7 +9062,7 @@ function peg$parse(input, options) {
         s2 = peg$parseDerefExpr();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c223(s2);
+          s1 = peg$c222(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9114,10 +9074,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c29;
+        s1 = peg$c26;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106();
+          s1 = peg$c104();
         }
         s0 = s1;
       }
@@ -9137,7 +9097,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c322(s1, s4);
+        s4 = peg$c321(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9146,13 +9106,13 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c322(s1, s4);
+          s4 = peg$c321(s1, s4);
         }
         s3 = s4;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9164,10 +9124,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9214,7 +9174,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c323(s1, s5, s6, s10, s14);
+                                s1 = peg$c322(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9291,7 +9251,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c324(s2);
+        s1 = peg$c323(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9303,10 +9263,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c193();
+        s1 = peg$c192();
       }
       s0 = s1;
     }
@@ -9327,7 +9287,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c84(s4);
+            s1 = peg$c82(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9347,10 +9307,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9375,7 +9335,7 @@ function peg$parse(input, options) {
               s6 = peg$parseFieldExprs();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c107(s6);
+                s1 = peg$c105(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9403,10 +9363,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9427,7 +9387,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c84(s4);
+            s1 = peg$c82(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9447,10 +9407,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9477,7 +9437,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c325(s6, s7);
+                  s1 = peg$c324(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9509,10 +9469,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9532,7 +9492,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c326(s2);
+        s1 = peg$c325(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9544,10 +9504,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c242();
+        s1 = peg$c241();
       }
       s0 = s1;
     }
@@ -9568,7 +9528,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c327(s4);
+            s1 = peg$c326(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9588,10 +9548,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113();
+        s1 = peg$c111();
       }
       s0 = s1;
     }
@@ -9603,16 +9563,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c280) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c279) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c329();
+      s1 = peg$c328();
     }
     s0 = s1;
 
@@ -9623,16 +9583,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c330) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c329) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c332();
+      s1 = peg$c331();
     }
     s0 = s1;
 
@@ -9643,16 +9603,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c42) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c209); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c333();
+      s1 = peg$c332();
     }
     s0 = s1;
 
@@ -9663,16 +9623,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+      if (peg$silentFails === 0) { peg$fail(peg$c187); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c334();
+      s1 = peg$c333();
     }
     s0 = s1;
 
@@ -9683,16 +9643,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c123) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c122) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c336();
+      s1 = peg$c335();
     }
     s0 = s1;
 
@@ -9703,16 +9663,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c337) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c336) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339();
+      s1 = peg$c338();
     }
     s0 = s1;
 
@@ -9723,16 +9683,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c340) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c339) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c341();
     }
     s0 = s1;
 
@@ -9743,16 +9703,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c234) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c343();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -9763,16 +9723,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c344) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c343) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c346();
+      s1 = peg$c345();
     }
     s0 = s1;
 
@@ -9783,16 +9743,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c347) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c349();
+      s1 = peg$c348();
     }
     s0 = s1;
 
@@ -9803,16 +9763,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c246) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c242();
+      s1 = peg$c241();
     }
     s0 = s1;
 
@@ -9823,16 +9783,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c248) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c245();
+      s1 = peg$c244();
     }
     s0 = s1;
 
@@ -9843,16 +9803,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c194) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c193) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c196();
+      s1 = peg$c195();
     }
     s0 = s1;
 
@@ -9863,16 +9823,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c197) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c196) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c198); }
+      if (peg$silentFails === 0) { peg$fail(peg$c197); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c199();
+      s1 = peg$c198();
     }
     s0 = s1;
 
@@ -9883,16 +9843,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c191) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c190) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
+      if (peg$silentFails === 0) { peg$fail(peg$c191); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c193();
+      s1 = peg$c192();
     }
     s0 = s1;
 
@@ -9976,7 +9936,7 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c93(s1);
+      s1 = peg$c91(s1);
     }
     s0 = s1;
 
@@ -10001,7 +9961,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1);
+        s1 = peg$c349(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10016,7 +9976,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1);
+        s1 = peg$c349(s1);
       }
       s0 = s1;
     }
@@ -10042,7 +10002,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351(s1);
+        s1 = peg$c350(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10057,7 +10017,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351(s1);
+        s1 = peg$c350(s1);
       }
       s0 = s1;
     }
@@ -10072,7 +10032,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c352(s1);
+      s1 = peg$c351(s1);
     }
     s0 = s1;
 
@@ -10086,7 +10046,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c353(s1);
+      s1 = peg$c352(s1);
     }
     s0 = s1;
 
@@ -10097,30 +10057,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c354) {
-      s1 = peg$c354;
+    if (input.substr(peg$currPos, 4) === peg$c353) {
+      s1 = peg$c353;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c354); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c355();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c357) {
-        s1 = peg$c357;
+      if (input.substr(peg$currPos, 5) === peg$c356) {
+        s1 = peg$c356;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c358); }
+        if (peg$silentFails === 0) { peg$fail(peg$c357); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359();
+        s1 = peg$c358();
       }
       s0 = s1;
     }
@@ -10132,16 +10092,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c360) {
-      s1 = peg$c360;
+    if (input.substr(peg$currPos, 4) === peg$c359) {
+      s1 = peg$c359;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10180,7 +10140,7 @@ function peg$parse(input, options) {
       s2 = peg$parseTypeExternal();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c363(s2);
+        s1 = peg$c362(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10227,7 +10187,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s1);
+            s1 = peg$c274(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10272,11 +10232,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -10286,15 +10246,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c36;
+                  s7 = peg$c32;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c256(s5);
+                  s1 = peg$c255(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10337,11 +10297,11 @@ function peg$parse(input, options) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c34;
+            s3 = peg$c30;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -10351,15 +10311,15 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c36;
+                    s7 = peg$c32;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c275(s5);
+                    s1 = peg$c274(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10412,7 +10372,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c232(s1);
+        s1 = peg$c231(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10439,11 +10399,11 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s5 = peg$c34;
+                s5 = peg$c30;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                if (peg$silentFails === 0) { peg$fail(peg$c31); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse__();
@@ -10453,15 +10413,15 @@ function peg$parse(input, options) {
                     s8 = peg$parse__();
                     if (s8 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s9 = peg$c36;
+                        s9 = peg$c32;
                         peg$currPos++;
                       } else {
                         s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c33); }
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c364(s1, s7);
+                        s1 = peg$c363(s1, s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10504,17 +10464,17 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c365(s1);
+          s1 = peg$c364(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c34;
+            s1 = peg$c30;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10522,15 +10482,15 @@ function peg$parse(input, options) {
               s3 = peg$parseTypeUnion();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s4 = peg$c36;
+                  s4 = peg$c32;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c366(s3);
+                  s1 = peg$c365(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10562,7 +10522,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c367(s1);
+      s1 = peg$c366(s1);
     }
     s0 = s1;
 
@@ -10587,7 +10547,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10608,11 +10568,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -10620,7 +10580,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s4);
+            s1 = peg$c274(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10647,11 +10607,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c50;
+      s1 = peg$c48;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -10661,15 +10621,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c301;
+              s5 = peg$c300;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c368(s3);
+              s1 = peg$c367(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10694,11 +10654,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c52;
+        s1 = peg$c50;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -10708,15 +10668,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c293;
+                s5 = peg$c292;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                if (peg$silentFails === 0) { peg$fail(peg$c293); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c369(s3);
+                s1 = peg$c368(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10740,12 +10700,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c307) {
-          s1 = peg$c307;
+        if (input.substr(peg$currPos, 2) === peg$c306) {
+          s1 = peg$c306;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c308); }
+          if (peg$silentFails === 0) { peg$fail(peg$c307); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10754,16 +10714,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c309) {
-                  s5 = peg$c309;
+                if (input.substr(peg$currPos, 2) === peg$c308) {
+                  s5 = peg$c308;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c310); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c309); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c370(s3);
+                  s1 = peg$c369(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10787,12 +10747,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c312) {
-            s1 = peg$c312;
+          if (input.substr(peg$currPos, 2) === peg$c311) {
+            s1 = peg$c311;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c313); }
+            if (peg$silentFails === 0) { peg$fail(peg$c312); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10802,11 +10762,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c75;
+                    s5 = peg$c73;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c74); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -10815,16 +10775,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c314) {
-                            s9 = peg$c314;
+                          if (input.substr(peg$currPos, 2) === peg$c313) {
+                            s9 = peg$c313;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c315); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c314); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c371(s3, s7);
+                            s1 = peg$c370(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10874,11 +10834,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c50;
+      s1 = peg$c48;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -10888,15 +10848,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c301;
+              s5 = peg$c300;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c368(s3);
+              s1 = peg$c367(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10921,11 +10881,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c52;
+        s1 = peg$c50;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -10935,15 +10895,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c293;
+                s5 = peg$c292;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                if (peg$silentFails === 0) { peg$fail(peg$c293); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c369(s3);
+                s1 = peg$c368(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10967,12 +10927,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c307) {
-          s1 = peg$c307;
+        if (input.substr(peg$currPos, 2) === peg$c306) {
+          s1 = peg$c306;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c308); }
+          if (peg$silentFails === 0) { peg$fail(peg$c307); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10981,16 +10941,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c309) {
-                  s5 = peg$c309;
+                if (input.substr(peg$currPos, 2) === peg$c308) {
+                  s5 = peg$c308;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c310); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c309); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c370(s3);
+                  s1 = peg$c369(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11014,12 +10974,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c312) {
-            s1 = peg$c312;
+          if (input.substr(peg$currPos, 2) === peg$c311) {
+            s1 = peg$c311;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c313); }
+            if (peg$silentFails === 0) { peg$fail(peg$c312); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11029,11 +10989,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c75;
+                    s5 = peg$c73;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c74); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -11042,16 +11002,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c314) {
-                            s9 = peg$c314;
+                          if (input.substr(peg$currPos, 2) === peg$c313) {
+                            s9 = peg$c313;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c315); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c314); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c371(s3, s7);
+                            s1 = peg$c370(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11111,92 +11071,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c372) {
-      s1 = peg$c372;
+    if (input.substr(peg$currPos, 5) === peg$c371) {
+      s1 = peg$c371;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c374) {
-        s1 = peg$c374;
+      if (input.substr(peg$currPos, 6) === peg$c373) {
+        s1 = peg$c373;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c375); }
+        if (peg$silentFails === 0) { peg$fail(peg$c374); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c376) {
-          s1 = peg$c376;
+        if (input.substr(peg$currPos, 6) === peg$c375) {
+          s1 = peg$c375;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c377); }
+          if (peg$silentFails === 0) { peg$fail(peg$c376); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c378) {
-            s1 = peg$c378;
+          if (input.substr(peg$currPos, 6) === peg$c377) {
+            s1 = peg$c377;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c379); }
+            if (peg$silentFails === 0) { peg$fail(peg$c378); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c380) {
-              s1 = peg$c380;
+            if (input.substr(peg$currPos, 4) === peg$c379) {
+              s1 = peg$c379;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c381); }
+              if (peg$silentFails === 0) { peg$fail(peg$c380); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c382) {
-                s1 = peg$c382;
+              if (input.substr(peg$currPos, 5) === peg$c381) {
+                s1 = peg$c381;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c383); }
+                if (peg$silentFails === 0) { peg$fail(peg$c382); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c384) {
-                  s1 = peg$c384;
+                if (input.substr(peg$currPos, 5) === peg$c383) {
+                  s1 = peg$c383;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c385); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c384); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c386) {
-                    s1 = peg$c386;
+                  if (input.substr(peg$currPos, 5) === peg$c385) {
+                    s1 = peg$c385;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c387); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c386); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c388) {
-                      s1 = peg$c388;
+                    if (input.substr(peg$currPos, 7) === peg$c387) {
+                      s1 = peg$c387;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c388); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c390) {
-                        s1 = peg$c390;
+                      if (input.substr(peg$currPos, 4) === peg$c389) {
+                        s1 = peg$c389;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c391); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c390); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c392) {
-                          s1 = peg$c392;
+                        if (input.substr(peg$currPos, 6) === peg$c391) {
+                          s1 = peg$c391;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c392); }
                         }
                       }
                     }
@@ -11210,7 +11170,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c394();
+      s1 = peg$c393();
     }
     s0 = s1;
 
@@ -11221,52 +11181,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c395) {
-      s1 = peg$c395;
+    if (input.substr(peg$currPos, 8) === peg$c394) {
+      s1 = peg$c394;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c396); }
+      if (peg$silentFails === 0) { peg$fail(peg$c395); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c397) {
-        s1 = peg$c397;
+      if (input.substr(peg$currPos, 4) === peg$c396) {
+        s1 = peg$c396;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c398); }
+        if (peg$silentFails === 0) { peg$fail(peg$c397); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c399) {
-          s1 = peg$c399;
+        if (input.substr(peg$currPos, 5) === peg$c398) {
+          s1 = peg$c398;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c400); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c401) {
-            s1 = peg$c401;
+          if (input.substr(peg$currPos, 7) === peg$c400) {
+            s1 = peg$c400;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c402); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c403) {
-              s1 = peg$c403;
+            if (input.substr(peg$currPos, 2) === peg$c402) {
+              s1 = peg$c402;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c404); }
+              if (peg$silentFails === 0) { peg$fail(peg$c403); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c405) {
-                s1 = peg$c405;
+              if (input.substr(peg$currPos, 3) === peg$c404) {
+                s1 = peg$c404;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c406); }
+                if (peg$silentFails === 0) { peg$fail(peg$c405); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11277,20 +11237,20 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c407) {
-                    s1 = peg$c407;
+                  if (input.substr(peg$currPos, 5) === peg$c406) {
+                    s1 = peg$c406;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c408); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c407); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c360) {
-                      s1 = peg$c360;
+                    if (input.substr(peg$currPos, 4) === peg$c359) {
+                      s1 = peg$c359;
                       peg$currPos += 4;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c360); }
                     }
                   }
                 }
@@ -11302,7 +11262,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c394();
+      s1 = peg$c393();
     }
     s0 = s1;
 
@@ -11323,7 +11283,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11344,11 +11304,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -11356,7 +11316,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s4);
+            s1 = peg$c274(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11387,11 +11347,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c54;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -11399,7 +11359,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c409(s1, s5);
+              s1 = peg$c408(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11440,12 +11400,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c410) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c409) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c410); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11460,7 +11420,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c412();
+        s1 = peg$c411();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11478,12 +11438,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c413) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c412) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c414); }
+      if (peg$silentFails === 0) { peg$fail(peg$c413); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11498,7 +11458,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c415();
+        s1 = peg$c414();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11516,12 +11476,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c62) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c415); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11536,7 +11496,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c417();
+        s1 = peg$c416();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11554,12 +11514,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c276) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c275) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c418); }
+      if (peg$silentFails === 0) { peg$fail(peg$c417); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11574,7 +11534,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c419();
+        s1 = peg$c418();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11592,12 +11552,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c420) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c419) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11612,7 +11572,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c422();
+        s1 = peg$c421();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11629,12 +11589,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c423.test(input.charAt(peg$currPos))) {
+    if (peg$c422.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c424); }
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
     }
 
     return s0;
@@ -11645,12 +11605,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
     }
 
@@ -11664,7 +11624,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c427(s1);
+      s1 = peg$c426(s1);
     }
     s0 = s1;
 
@@ -11719,7 +11679,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c428();
+          s1 = peg$c427();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11736,31 +11696,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c429;
+        s1 = peg$c428;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c430); }
+        if (peg$silentFails === 0) { peg$fail(peg$c429); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c431;
+          s1 = peg$c430;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c432); }
+          if (peg$silentFails === 0) { peg$fail(peg$c431); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c223(s2);
+            s1 = peg$c222(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11781,7 +11741,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c72();
+            s1 = peg$c70();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -11794,11 +11754,11 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s5 = peg$c34;
+                  s5 = peg$c30;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c31); }
                 }
                 if (s5 !== peg$FAILED) {
                   s4 = [s4, s5];
@@ -11820,7 +11780,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c223(s1);
+                s1 = peg$c222(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11862,17 +11822,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c433;
+        s2 = peg$c432;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c434); }
+        if (peg$silentFails === 0) { peg$fail(peg$c433); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c435();
+          s1 = peg$c434();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11897,21 +11857,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c270;
+        s2 = peg$c269;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c271); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c270;
+            s4 = peg$c269;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c271); }
+            if (peg$silentFails === 0) { peg$fail(peg$c270); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -11946,36 +11906,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c425.test(input.charAt(peg$currPos))) {
+    if (peg$c424.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c425.test(input.charAt(peg$currPos))) {
+        if (peg$c424.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c426); }
+          if (peg$silentFails === 0) { peg$fail(peg$c425); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c425.test(input.charAt(peg$currPos))) {
+          if (peg$c424.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c426); }
+            if (peg$silentFails === 0) { peg$fail(peg$c425); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12004,20 +11964,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c425.test(input.charAt(peg$currPos))) {
+    if (peg$c424.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12063,51 +12023,51 @@ function peg$parse(input, options) {
     s1 = peg$parseD2();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c54;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c54;
+            s4 = peg$c52;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
             if (s5 !== peg$FAILED) {
               s6 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c120;
+                s7 = peg$c119;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c425.test(input.charAt(peg$currPos))) {
+                if (peg$c424.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c425.test(input.charAt(peg$currPos))) {
+                    if (peg$c424.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
                     }
                   }
                 } else {
@@ -12162,69 +12122,69 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c436;
+      s0 = peg$c435;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c437); }
+      if (peg$silentFails === 0) { peg$fail(peg$c436); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c268;
+        s1 = peg$c267;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c269); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c270;
+          s1 = peg$c269;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c271); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseD2();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c54;
+            s3 = peg$c52;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parseD2();
             if (s4 !== peg$FAILED) {
               s5 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c120;
+                s6 = peg$c119;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c425.test(input.charAt(peg$currPos))) {
+                if (peg$c424.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c425.test(input.charAt(peg$currPos))) {
+                    if (peg$c424.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
                     }
                   }
                 } else {
@@ -12277,11 +12237,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c270;
+      s1 = peg$c269;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12327,7 +12287,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c438();
+        s1 = peg$c437();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12349,11 +12309,11 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c120;
+        s3 = peg$c119;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseUInt();
@@ -12389,76 +12349,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c439) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c438) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c440); }
+      if (peg$silentFails === 0) { peg$fail(peg$c439); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c441) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c440) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c442); }
+        if (peg$silentFails === 0) { peg$fail(peg$c441); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c443) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c442) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c444); }
+          if (peg$silentFails === 0) { peg$fail(peg$c443); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c445) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c444) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c446); }
+            if (peg$silentFails === 0) { peg$fail(peg$c445); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c447) {
+            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c446) {
               s0 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c448); }
+              if (peg$silentFails === 0) { peg$fail(peg$c447); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c449) {
+              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c448) {
                 s0 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                if (peg$silentFails === 0) { peg$fail(peg$c449); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c451) {
+                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c450) {
                   s0 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c452); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c451); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c453) {
+                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c452) {
                     s0 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c454); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c453); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c455) {
+                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c454) {
                       s0 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c456); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c455); }
                     }
                   }
                 }
@@ -12479,37 +12439,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c120;
+        s2 = peg$c119;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c120;
+            s4 = peg$c119;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c120); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c120;
+                s6 = peg$c119;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c72();
+                  s1 = peg$c70();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -12553,11 +12513,11 @@ function peg$parse(input, options) {
     s3 = peg$parseHex();
     if (s3 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s4 = peg$c54;
+        s4 = peg$c52;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parseHex();
@@ -12567,11 +12527,11 @@ function peg$parse(input, options) {
           s7 = peg$parseHexDigit();
           if (s7 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s7 = peg$c54;
+              s7 = peg$c52;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
           }
           peg$silentFails--;
@@ -12643,7 +12603,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c457(s1, s2);
+        s1 = peg$c456(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12664,12 +12624,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c458) {
-            s3 = peg$c458;
+          if (input.substr(peg$currPos, 2) === peg$c457) {
+            s3 = peg$c457;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c459); }
+            if (peg$silentFails === 0) { peg$fail(peg$c458); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12682,7 +12642,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c460(s1, s2, s4, s5);
+                s1 = peg$c459(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12706,12 +12666,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c458) {
-          s1 = peg$c458;
+        if (input.substr(peg$currPos, 2) === peg$c457) {
+          s1 = peg$c457;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c459); }
+          if (peg$silentFails === 0) { peg$fail(peg$c458); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12724,7 +12684,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c461(s2, s3);
+              s1 = peg$c460(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12749,16 +12709,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c458) {
-                s3 = peg$c458;
+              if (input.substr(peg$currPos, 2) === peg$c457) {
+                s3 = peg$c457;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c459); }
+                if (peg$silentFails === 0) { peg$fail(peg$c458); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c462(s1, s2);
+                s1 = peg$c461(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12774,16 +12734,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c458) {
-              s1 = peg$c458;
+            if (input.substr(peg$currPos, 2) === peg$c457) {
+              s1 = peg$c457;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c459); }
+              if (peg$silentFails === 0) { peg$fail(peg$c458); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c463();
+              s1 = peg$c462();
             }
             s0 = s1;
           }
@@ -12810,17 +12770,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c54;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c464(s2);
+        s1 = peg$c463(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12841,15 +12801,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c54;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c465(s1);
+        s1 = peg$c464(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12870,17 +12830,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c272;
+        s2 = peg$c271;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c273); }
+        if (peg$silentFails === 0) { peg$fail(peg$c272); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c466(s1, s3);
+          s1 = peg$c465(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12905,17 +12865,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c272;
+        s2 = peg$c271;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c273); }
+        if (peg$silentFails === 0) { peg$fail(peg$c272); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c467(s1, s3);
+          s1 = peg$c466(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12940,7 +12900,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c468(s1);
+      s1 = peg$c467(s1);
     }
     s0 = s1;
 
@@ -12963,22 +12923,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c425.test(input.charAt(peg$currPos))) {
+    if (peg$c424.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c425.test(input.charAt(peg$currPos))) {
+        if (peg$c424.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c426); }
+          if (peg$silentFails === 0) { peg$fail(peg$c425); }
         }
       }
     } else {
@@ -12986,7 +12946,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -12998,17 +12958,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c270;
+      s1 = peg$c269;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13027,33 +12987,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c270;
+      s1 = peg$c269;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c425.test(input.charAt(peg$currPos))) {
+          if (peg$c424.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c426); }
+            if (peg$silentFails === 0) { peg$fail(peg$c425); }
           }
         }
       } else {
@@ -13061,30 +13021,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c120;
+          s3 = peg$c119;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c120); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c425.test(input.charAt(peg$currPos))) {
+          if (peg$c424.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c426); }
+            if (peg$silentFails === 0) { peg$fail(peg$c425); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c425.test(input.charAt(peg$currPos))) {
+              if (peg$c424.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                if (peg$silentFails === 0) { peg$fail(peg$c425); }
               }
             }
           } else {
@@ -13097,7 +13057,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c469();
+              s1 = peg$c468();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13122,41 +13082,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c270;
+        s1 = peg$c269;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c271); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c120;
+          s2 = peg$c119;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c120); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c425.test(input.charAt(peg$currPos))) {
+          if (peg$c424.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c426); }
+            if (peg$silentFails === 0) { peg$fail(peg$c425); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c425.test(input.charAt(peg$currPos))) {
+              if (peg$c424.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                if (peg$silentFails === 0) { peg$fail(peg$c425); }
               }
             }
           } else {
@@ -13169,7 +13129,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c469();
+              s1 = peg$c468();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13196,20 +13156,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c470) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c469) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c470); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c472.test(input.charAt(peg$currPos))) {
+      if (peg$c471.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c473); }
+        if (peg$silentFails === 0) { peg$fail(peg$c472); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13251,7 +13211,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13261,12 +13221,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c474.test(input.charAt(peg$currPos))) {
+    if (peg$c473.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c474); }
     }
 
     return s0;
@@ -13277,11 +13237,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c476;
+      s1 = peg$c475;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c477); }
+      if (peg$silentFails === 0) { peg$fail(peg$c476); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13292,15 +13252,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c476;
+          s3 = peg$c475;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c477); }
+          if (peg$silentFails === 0) { peg$fail(peg$c476); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c478(s2);
+          s1 = peg$c477(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13317,11 +13277,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c479;
+        s1 = peg$c478;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c479); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13332,15 +13292,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c479;
+            s3 = peg$c478;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c480); }
+            if (peg$silentFails === 0) { peg$fail(peg$c479); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c478(s2);
+            s1 = peg$c477(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13366,11 +13326,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c476;
+      s2 = peg$c475;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c477); }
+      if (peg$silentFails === 0) { peg$fail(peg$c476); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13388,11 +13348,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c481); }
+        if (peg$silentFails === 0) { peg$fail(peg$c480); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13405,17 +13365,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c431;
+        s1 = peg$c430;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c432); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c233(s2);
+          s1 = peg$c232(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13444,7 +13404,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c482(s1, s2);
+        s1 = peg$c481(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13473,16 +13433,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c483.test(input.charAt(peg$currPos))) {
+    if (peg$c482.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c484); }
+      if (peg$silentFails === 0) { peg$fail(peg$c483); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13494,12 +13454,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
     }
 
@@ -13511,11 +13471,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c431;
+      s1 = peg$c430;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c432); }
+      if (peg$silentFails === 0) { peg$fail(peg$c431); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13524,7 +13484,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c233(s2);
+        s1 = peg$c232(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13574,7 +13534,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c485(s3, s4);
+            s1 = peg$c484(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13602,20 +13562,20 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     if (input.charCodeAt(peg$currPos) === 42) {
-      s2 = peg$c85;
+      s2 = peg$c83;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c85;
+        s2 = peg$c83;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -13647,11 +13607,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c85;
+        s2 = peg$c83;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13677,15 +13637,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c85;
+          s1 = peg$c83;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c486();
+          s1 = peg$c485();
         }
         s0 = s1;
       }
@@ -13699,12 +13659,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
     }
 
@@ -13716,11 +13676,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c431;
+      s1 = peg$c430;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c432); }
+      if (peg$silentFails === 0) { peg$fail(peg$c431); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -13729,7 +13689,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c233(s2);
+        s1 = peg$c232(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13756,30 +13716,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c487();
+      s1 = peg$c486();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c85;
+        s1 = peg$c83;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c488();
+        s1 = peg$c487();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c472.test(input.charAt(peg$currPos))) {
+        if (peg$c471.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c473); }
+          if (peg$silentFails === 0) { peg$fail(peg$c472); }
         }
       }
     }
@@ -13794,11 +13754,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c479;
+      s2 = peg$c478;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c479); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13816,11 +13776,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c481); }
+        if (peg$silentFails === 0) { peg$fail(peg$c480); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13833,17 +13793,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c431;
+        s1 = peg$c430;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c432); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c233(s2);
+          s1 = peg$c232(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13863,11 +13823,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c489;
+      s1 = peg$c488;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c490); }
+      if (peg$silentFails === 0) { peg$fail(peg$c489); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -13875,7 +13835,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c491();
+          s1 = peg$c490();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13903,116 +13863,116 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c479;
+      s0 = peg$c478;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c479); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c476;
+        s1 = peg$c475;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c477); }
+        if (peg$silentFails === 0) { peg$fail(peg$c476); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c431;
+          s0 = peg$c430;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c432); }
+          if (peg$silentFails === 0) { peg$fail(peg$c431); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c492;
+            s1 = peg$c491;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c494();
+            s1 = peg$c493();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c495;
+              s1 = peg$c494;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c496); }
+              if (peg$silentFails === 0) { peg$fail(peg$c495); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c497();
+              s1 = peg$c496();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c498;
+                s1 = peg$c497;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c499); }
+                if (peg$silentFails === 0) { peg$fail(peg$c498); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c500();
+                s1 = peg$c499();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c501;
+                  s1 = peg$c500;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c502); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c501); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c503();
+                  s1 = peg$c502();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c504;
+                    s1 = peg$c503;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c505); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c504); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c506();
+                    s1 = peg$c505();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c507;
+                      s1 = peg$c506;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c508); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c507); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c509();
+                      s1 = peg$c508();
                     }
                     s0 = s1;
                   }
@@ -14040,30 +14000,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c487();
+      s1 = peg$c486();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c85;
+        s1 = peg$c83;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c510();
+        s1 = peg$c509();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c472.test(input.charAt(peg$currPos))) {
+        if (peg$c471.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c473); }
+          if (peg$silentFails === 0) { peg$fail(peg$c472); }
         }
       }
     }
@@ -14076,11 +14036,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c511;
+      s1 = peg$c510;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c512); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14112,7 +14072,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c513(s2);
+        s1 = peg$c512(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14125,19 +14085,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c511;
+        s1 = peg$c510;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c512); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c50;
+          s2 = peg$c48;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -14196,15 +14156,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c301;
+              s4 = peg$c300;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c513(s3);
+              s1 = peg$c512(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14232,21 +14192,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c272;
+      s1 = peg$c271;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c273); }
+      if (peg$silentFails === 0) { peg$fail(peg$c272); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c272;
+          s3 = peg$c271;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c272); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14261,7 +14221,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c210(s2);
+            s1 = peg$c209(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14288,39 +14248,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c514.test(input.charAt(peg$currPos))) {
+    if (peg$c513.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c515); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c516) {
-        s2 = peg$c516;
+      if (input.substr(peg$currPos, 2) === peg$c515) {
+        s2 = peg$c515;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c517); }
+        if (peg$silentFails === 0) { peg$fail(peg$c516); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c514.test(input.charAt(peg$currPos))) {
+        if (peg$c513.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c515); }
+          if (peg$silentFails === 0) { peg$fail(peg$c514); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c516) {
-            s2 = peg$c516;
+          if (input.substr(peg$currPos, 2) === peg$c515) {
+            s2 = peg$c515;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c517); }
+            if (peg$silentFails === 0) { peg$fail(peg$c516); }
           }
         }
       }
@@ -14329,7 +14289,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -14339,12 +14299,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c518.test(input.charAt(peg$currPos))) {
+    if (peg$c517.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c518); }
     }
 
     return s0;
@@ -14402,7 +14362,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c481); }
+      if (peg$silentFails === 0) { peg$fail(peg$c480); }
     }
 
     return s0;
@@ -14413,51 +14373,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c521;
+      s0 = peg$c520;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c521); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c523;
+        s0 = peg$c522;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c523); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c525;
+          s0 = peg$c524;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c526); }
+          if (peg$silentFails === 0) { peg$fail(peg$c525); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c527;
+            s0 = peg$c526;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c527); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c529;
+              s0 = peg$c528;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c530); }
+              if (peg$silentFails === 0) { peg$fail(peg$c529); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c531;
+                s0 = peg$c530;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c532); }
+                if (peg$silentFails === 0) { peg$fail(peg$c531); }
               }
             }
           }
@@ -14466,7 +14426,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c520); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
 
     return s0;
@@ -14475,12 +14435,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c533.test(input.charAt(peg$currPos))) {
+    if (peg$c532.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c534); }
+      if (peg$silentFails === 0) { peg$fail(peg$c533); }
     }
 
     return s0;
@@ -14493,7 +14453,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c535); }
+      if (peg$silentFails === 0) { peg$fail(peg$c534); }
     }
 
     return s0;
@@ -14503,12 +14463,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c540) {
-      s1 = peg$c540;
+    if (input.substr(peg$currPos, 2) === peg$c539) {
+      s1 = peg$c539;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c541); }
+      if (peg$silentFails === 0) { peg$fail(peg$c540); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14626,7 +14586,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c481); }
+      if (peg$silentFails === 0) { peg$fail(peg$c480); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -369,92 +369,41 @@ var g = &grammar{
 		{
 			name: "Parallel",
 			pos:  position{line: 44, col: 1, offset: 1484},
-			expr: &choiceExpr{
+			expr: &actionExpr{
 				pos: position{line: 45, col: 5, offset: 1497},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 45, col: 5, offset: 1497},
-						run: (*parser).callonParallel2,
-						expr: &seqExpr{
-							pos: position{line: 45, col: 5, offset: 1497},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 45, col: 5, offset: 1497},
-									val:        "=>",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 45, col: 10, offset: 1502},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 45, col: 13, offset: 1505},
-									label: "first",
-									expr: &ruleRefExpr{
-										pos:  position{line: 45, col: 19, offset: 1511},
-										name: "Sequential",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 45, col: 30, offset: 1522},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 45, col: 33, offset: 1525},
-									val:        ";",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 45, col: 37, offset: 1529},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 45, col: 40, offset: 1532},
-									label: "rest",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 45, col: 45, offset: 1537},
-										expr: &ruleRefExpr{
-											pos:  position{line: 45, col: 45, offset: 1537},
-											name: "Parallel",
-										},
-									},
-								},
+				run: (*parser).callonParallel1,
+				expr: &seqExpr{
+					pos: position{line: 45, col: 5, offset: 1497},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 45, col: 5, offset: 1497},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 45, col: 8, offset: 1500},
+							val:        "=>",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 45, col: 13, offset: 1505},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 45, col: 16, offset: 1508},
+							label: "s",
+							expr: &ruleRefExpr{
+								pos:  position{line: 45, col: 18, offset: 1510},
+								name: "Sequential",
 							},
 						},
-					},
-					&actionExpr{
-						pos: position{line: 48, col: 5, offset: 1653},
-						run: (*parser).callonParallel14,
-						expr: &seqExpr{
-							pos: position{line: 48, col: 5, offset: 1653},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 48, col: 5, offset: 1653},
-									val:        "=>",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 48, col: 10, offset: 1658},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 48, col: 13, offset: 1661},
-									label: "first",
-									expr: &ruleRefExpr{
-										pos:  position{line: 48, col: 19, offset: 1667},
-										name: "Sequential",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 48, col: 30, offset: 1678},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 48, col: 33, offset: 1681},
-									val:        ";",
-									ignoreCase: false,
-								},
-							},
+						&ruleRefExpr{
+							pos:  position{line: 45, col: 29, offset: 1521},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 45, col: 32, offset: 1524},
+							val:        ";",
+							ignoreCase: false,
 						},
 					},
 				},
@@ -462,150 +411,105 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchBranch",
-			pos:  position{line: 52, col: 1, offset: 1733},
+			pos:  position{line: 47, col: 1, offset: 1547},
 			expr: &choiceExpr{
-				pos: position{line: 53, col: 6, offset: 1751},
+				pos: position{line: 48, col: 5, offset: 1564},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 53, col: 6, offset: 1751},
+						pos: position{line: 48, col: 5, offset: 1564},
 						run: (*parser).callonSwitchBranch2,
 						expr: &seqExpr{
-							pos: position{line: 53, col: 6, offset: 1751},
+							pos: position{line: 48, col: 5, offset: 1564},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 53, col: 6, offset: 1751},
-									name: "DefaultToken",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 53, col: 19, offset: 1764},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 53, col: 22, offset: 1767},
-									val:        "=>",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 53, col: 27, offset: 1772},
+									pos:  position{line: 48, col: 5, offset: 1564},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 53, col: 30, offset: 1775},
-									label: "proc",
-									expr: &ruleRefExpr{
-										pos:  position{line: 53, col: 35, offset: 1780},
-										name: "Sequential",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 53, col: 46, offset: 1791},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 53, col: 49, offset: 1794},
-									val:        ";",
-									ignoreCase: false,
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 56, col: 5, offset: 1950},
-						run: (*parser).callonSwitchBranch12,
-						expr: &seqExpr{
-							pos: position{line: 56, col: 5, offset: 1950},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 56, col: 5, offset: 1950},
+									pos:   position{line: 48, col: 8, offset: 1567},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 7, offset: 1952},
+										pos:  position{line: 48, col: 10, offset: 1569},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 21, offset: 1966},
+									pos:  position{line: 48, col: 24, offset: 1583},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 56, col: 24, offset: 1969},
+									pos:        position{line: 48, col: 27, offset: 1586},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 29, offset: 1974},
+									pos:  position{line: 48, col: 32, offset: 1591},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 56, col: 32, offset: 1977},
+									pos:   position{line: 48, col: 35, offset: 1594},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 37, offset: 1982},
+										pos:  position{line: 48, col: 40, offset: 1599},
 										name: "Sequential",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 48, offset: 1993},
+									pos:  position{line: 48, col: 51, offset: 1610},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 56, col: 51, offset: 1996},
+									pos:        position{line: 48, col: 54, offset: 1613},
 									val:        ";",
 									ignoreCase: false,
 								},
 							},
 						},
 					},
-				},
-			},
-		},
-		{
-			name: "Switch",
-			pos:  position{line: 60, col: 1, offset: 2075},
-			expr: &choiceExpr{
-				pos: position{line: 61, col: 5, offset: 2086},
-				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 61, col: 5, offset: 2086},
-						run: (*parser).callonSwitch2,
+						pos: position{line: 51, col: 5, offset: 1695},
+						run: (*parser).callonSwitchBranch14,
 						expr: &seqExpr{
-							pos: position{line: 61, col: 5, offset: 2086},
+							pos: position{line: 51, col: 5, offset: 1695},
 							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 61, col: 5, offset: 2086},
-									label: "first",
-									expr: &ruleRefExpr{
-										pos:  position{line: 61, col: 11, offset: 2092},
-										name: "SwitchBranch",
-									},
+								&ruleRefExpr{
+									pos:  position{line: 51, col: 5, offset: 1695},
+									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 61, col: 24, offset: 2105},
+									pos:  position{line: 51, col: 8, offset: 1698},
+									name: "DefaultToken",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 51, col: 21, offset: 1711},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 51, col: 24, offset: 1714},
+									val:        "=>",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 51, col: 29, offset: 1719},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 61, col: 27, offset: 2108},
-									label: "rest",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 61, col: 32, offset: 2113},
-										expr: &ruleRefExpr{
-											pos:  position{line: 61, col: 32, offset: 2113},
-											name: "Switch",
-										},
+									pos:   position{line: 51, col: 32, offset: 1722},
+									label: "proc",
+									expr: &ruleRefExpr{
+										pos:  position{line: 51, col: 37, offset: 1727},
+										name: "Sequential",
 									},
 								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 64, col: 5, offset: 2227},
-						run: (*parser).callonSwitch10,
-						expr: &labeledExpr{
-							pos:   position{line: 64, col: 5, offset: 2227},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 64, col: 11, offset: 2233},
-								name: "SwitchBranch",
+								&ruleRefExpr{
+									pos:  position{line: 51, col: 48, offset: 1738},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 51, col: 51, offset: 1741},
+									val:        ";",
+									ignoreCase: false,
+								},
 							},
 						},
 					},
@@ -614,97 +518,51 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultToken",
-			pos:  position{line: 68, col: 1, offset: 2294},
+			pos:  position{line: 55, col: 1, offset: 1894},
 			expr: &litMatcher{
-				pos:        position{line: 68, col: 16, offset: 2309},
+				pos:        position{line: 55, col: 16, offset: 1909},
 				val:        "default",
 				ignoreCase: true,
 			},
 		},
 		{
-			name: "FromTrunks",
-			pos:  position{line: 70, col: 1, offset: 2321},
-			expr: &choiceExpr{
-				pos: position{line: 71, col: 5, offset: 2336},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 71, col: 5, offset: 2336},
-						run: (*parser).callonFromTrunks2,
-						expr: &seqExpr{
-							pos: position{line: 71, col: 5, offset: 2336},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 71, col: 5, offset: 2336},
-									label: "first",
-									expr: &ruleRefExpr{
-										pos:  position{line: 71, col: 11, offset: 2342},
-										name: "FromTrunk",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 71, col: 21, offset: 2352},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 71, col: 24, offset: 2355},
-									label: "rest",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 71, col: 29, offset: 2360},
-										expr: &ruleRefExpr{
-											pos:  position{line: 71, col: 29, offset: 2360},
-											name: "FromTrunks",
-										},
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 74, col: 5, offset: 2478},
-						run: (*parser).callonFromTrunks10,
-						expr: &labeledExpr{
-							pos:   position{line: 74, col: 5, offset: 2478},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 74, col: 11, offset: 2484},
-								name: "FromTrunk",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "FromTrunk",
-			pos:  position{line: 78, col: 1, offset: 2542},
+			pos:  position{line: 57, col: 1, offset: 1921},
 			expr: &actionExpr{
-				pos: position{line: 79, col: 5, offset: 2556},
+				pos: position{line: 58, col: 5, offset: 1935},
 				run: (*parser).callonFromTrunk1,
 				expr: &seqExpr{
-					pos: position{line: 79, col: 5, offset: 2556},
+					pos: position{line: 58, col: 5, offset: 1935},
 					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 58, col: 5, offset: 1935},
+							name: "__",
+						},
 						&labeledExpr{
-							pos:   position{line: 79, col: 5, offset: 2556},
+							pos:   position{line: 58, col: 8, offset: 1938},
 							label: "source",
 							expr: &ruleRefExpr{
-								pos:  position{line: 79, col: 12, offset: 2563},
+								pos:  position{line: 58, col: 15, offset: 1945},
 								name: "FromSource",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 79, col: 23, offset: 2574},
+							pos:   position{line: 58, col: 27, offset: 1957},
 							label: "seq",
-							expr: &ruleRefExpr{
-								pos:  position{line: 79, col: 27, offset: 2578},
-								name: "FromTrunkSeq",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 58, col: 31, offset: 1961},
+								expr: &ruleRefExpr{
+									pos:  position{line: 58, col: 31, offset: 1961},
+									name: "FromTrunkSeq",
+								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 79, col: 40, offset: 2591},
+							pos:  position{line: 58, col: 45, offset: 1975},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 79, col: 43, offset: 2594},
+							pos:        position{line: 58, col: 48, offset: 1978},
 							val:        ";",
 							ignoreCase: false,
 						},
@@ -714,34 +572,34 @@ var g = &grammar{
 		},
 		{
 			name: "FromTrunkSeq",
-			pos:  position{line: 83, col: 1, offset: 2695},
+			pos:  position{line: 62, col: 1, offset: 2079},
 			expr: &choiceExpr{
-				pos: position{line: 84, col: 5, offset: 2712},
+				pos: position{line: 63, col: 5, offset: 2096},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 84, col: 5, offset: 2712},
+						pos: position{line: 63, col: 5, offset: 2096},
 						run: (*parser).callonFromTrunkSeq2,
 						expr: &seqExpr{
-							pos: position{line: 84, col: 5, offset: 2712},
+							pos: position{line: 63, col: 5, offset: 2096},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 84, col: 5, offset: 2712},
+									pos:  position{line: 63, col: 5, offset: 2096},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 84, col: 8, offset: 2715},
+									pos:        position{line: 63, col: 8, offset: 2099},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 84, col: 13, offset: 2720},
+									pos:  position{line: 63, col: 13, offset: 2104},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 84, col: 16, offset: 2723},
+									pos:   position{line: 63, col: 16, offset: 2107},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 20, offset: 2727},
+										pos:  position{line: 63, col: 20, offset: 2111},
 										name: "Sequential",
 									},
 								},
@@ -749,10 +607,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 85, col: 5, offset: 2762},
+						pos: position{line: 64, col: 5, offset: 2146},
 						run: (*parser).callonFromTrunkSeq9,
 						expr: &litMatcher{
-							pos:        position{line: 85, col: 5, offset: 2762},
+							pos:        position{line: 64, col: 5, offset: 2146},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -762,24 +620,24 @@ var g = &grammar{
 		},
 		{
 			name: "FromSource",
-			pos:  position{line: 87, col: 1, offset: 2785},
+			pos:  position{line: 66, col: 1, offset: 2169},
 			expr: &choiceExpr{
-				pos: position{line: 88, col: 5, offset: 2800},
+				pos: position{line: 67, col: 5, offset: 2184},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 88, col: 5, offset: 2800},
+						pos:  position{line: 67, col: 5, offset: 2184},
 						name: "FileProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 89, col: 5, offset: 2813},
+						pos:  position{line: 68, col: 5, offset: 2197},
 						name: "HTTPProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 90, col: 5, offset: 2826},
+						pos:  position{line: 69, col: 5, offset: 2210},
 						name: "PassProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 91, col: 5, offset: 2839},
+						pos:  position{line: 70, col: 5, offset: 2223},
 						name: "PoolBody",
 					},
 				},
@@ -787,48 +645,47 @@ var g = &grammar{
 		},
 		{
 			name: "Operation",
-			pos:  position{line: 93, col: 1, offset: 2849},
+			pos:  position{line: 72, col: 1, offset: 2233},
 			expr: &choiceExpr{
-				pos: position{line: 94, col: 5, offset: 2863},
+				pos: position{line: 73, col: 5, offset: 2247},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 94, col: 5, offset: 2863},
+						pos: position{line: 73, col: 5, offset: 2247},
 						run: (*parser).callonOperation2,
 						expr: &seqExpr{
-							pos: position{line: 94, col: 5, offset: 2863},
+							pos: position{line: 73, col: 5, offset: 2247},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 94, col: 5, offset: 2863},
+									pos:        position{line: 73, col: 5, offset: 2247},
 									val:        "split",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 94, col: 13, offset: 2871},
+									pos:  position{line: 73, col: 13, offset: 2255},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 94, col: 16, offset: 2874},
+									pos:        position{line: 73, col: 16, offset: 2258},
 									val:        "(",
 									ignoreCase: false,
 								},
-								&ruleRefExpr{
-									pos:  position{line: 94, col: 20, offset: 2878},
-									name: "__",
-								},
 								&labeledExpr{
-									pos:   position{line: 94, col: 23, offset: 2881},
+									pos:   position{line: 73, col: 20, offset: 2262},
 									label: "procArray",
-									expr: &ruleRefExpr{
-										pos:  position{line: 94, col: 33, offset: 2891},
-										name: "Parallel",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 73, col: 30, offset: 2272},
+										expr: &ruleRefExpr{
+											pos:  position{line: 73, col: 30, offset: 2272},
+											name: "Parallel",
+										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 94, col: 42, offset: 2900},
+									pos:  position{line: 73, col: 40, offset: 2282},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 94, col: 45, offset: 2903},
+									pos:        position{line: 73, col: 43, offset: 2285},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -836,43 +693,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 97, col: 5, offset: 3000},
+						pos: position{line: 76, col: 5, offset: 2382},
 						run: (*parser).callonOperation12,
 						expr: &seqExpr{
-							pos: position{line: 97, col: 5, offset: 3000},
+							pos: position{line: 76, col: 5, offset: 2382},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 97, col: 5, offset: 3000},
+									pos:        position{line: 76, col: 5, offset: 2382},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 97, col: 14, offset: 3009},
+									pos:  position{line: 76, col: 14, offset: 2391},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 97, col: 17, offset: 3012},
+									pos:        position{line: 76, col: 17, offset: 2394},
 									val:        "(",
 									ignoreCase: false,
 								},
-								&ruleRefExpr{
-									pos:  position{line: 97, col: 21, offset: 3016},
-									name: "__",
-								},
 								&labeledExpr{
-									pos:   position{line: 97, col: 24, offset: 3019},
+									pos:   position{line: 76, col: 21, offset: 2398},
 									label: "caseArray",
-									expr: &ruleRefExpr{
-										pos:  position{line: 97, col: 34, offset: 3029},
-										name: "Switch",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 76, col: 31, offset: 2408},
+										expr: &ruleRefExpr{
+											pos:  position{line: 76, col: 31, offset: 2408},
+											name: "SwitchBranch",
+										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 97, col: 41, offset: 3036},
+									pos:  position{line: 76, col: 45, offset: 2422},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 97, col: 44, offset: 3039},
+									pos:        position{line: 76, col: 48, offset: 2425},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -880,43 +736,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 100, col: 5, offset: 3134},
+						pos: position{line: 79, col: 5, offset: 2520},
 						run: (*parser).callonOperation22,
 						expr: &seqExpr{
-							pos: position{line: 100, col: 5, offset: 3134},
+							pos: position{line: 79, col: 5, offset: 2520},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 100, col: 5, offset: 3134},
+									pos:        position{line: 79, col: 5, offset: 2520},
 									val:        "from",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 100, col: 12, offset: 3141},
+									pos:  position{line: 79, col: 12, offset: 2527},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 15, offset: 3144},
+									pos:        position{line: 79, col: 15, offset: 2530},
 									val:        "(",
 									ignoreCase: false,
 								},
-								&ruleRefExpr{
-									pos:  position{line: 100, col: 19, offset: 3148},
-									name: "__",
-								},
 								&labeledExpr{
-									pos:   position{line: 100, col: 22, offset: 3151},
+									pos:   position{line: 79, col: 19, offset: 2534},
 									label: "trunks",
-									expr: &ruleRefExpr{
-										pos:  position{line: 100, col: 29, offset: 3158},
-										name: "FromTrunks",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 79, col: 26, offset: 2541},
+										expr: &ruleRefExpr{
+											pos:  position{line: 79, col: 26, offset: 2541},
+											name: "FromTrunk",
+										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 100, col: 40, offset: 3169},
+									pos:  position{line: 79, col: 37, offset: 2552},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 43, offset: 3172},
+									pos:        position{line: 79, col: 40, offset: 2555},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -924,27 +779,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 103, col: 5, offset: 3263},
+						pos:  position{line: 82, col: 5, offset: 2646},
 						name: "Operator",
 					},
 					&actionExpr{
-						pos: position{line: 104, col: 5, offset: 3276},
+						pos: position{line: 83, col: 5, offset: 2659},
 						run: (*parser).callonOperation33,
 						expr: &seqExpr{
-							pos: position{line: 104, col: 5, offset: 3276},
+							pos: position{line: 83, col: 5, offset: 2659},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 104, col: 5, offset: 3276},
+									pos:   position{line: 83, col: 5, offset: 2659},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 104, col: 7, offset: 3278},
+										pos:  position{line: 83, col: 7, offset: 2661},
 										name: "Function",
 									},
 								},
 								&andExpr{
-									pos: position{line: 104, col: 16, offset: 3287},
+									pos: position{line: 83, col: 16, offset: 2670},
 									expr: &ruleRefExpr{
-										pos:  position{line: 104, col: 17, offset: 3288},
+										pos:  position{line: 83, col: 17, offset: 2671},
 										name: "EndOfOp",
 									},
 								},
@@ -952,23 +807,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 105, col: 5, offset: 3318},
+						pos: position{line: 84, col: 5, offset: 2701},
 						run: (*parser).callonOperation39,
 						expr: &seqExpr{
-							pos: position{line: 105, col: 5, offset: 3318},
+							pos: position{line: 84, col: 5, offset: 2701},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 105, col: 5, offset: 3318},
+									pos:   position{line: 84, col: 5, offset: 2701},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 105, col: 7, offset: 3320},
+										pos:  position{line: 84, col: 7, offset: 2703},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 105, col: 19, offset: 3332},
+									pos: position{line: 84, col: 19, offset: 2715},
 									expr: &ruleRefExpr{
-										pos:  position{line: 105, col: 20, offset: 3333},
+										pos:  position{line: 84, col: 20, offset: 2716},
 										name: "EndOfOp",
 									},
 								},
@@ -976,23 +831,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 106, col: 5, offset: 3364},
+						pos: position{line: 85, col: 5, offset: 2747},
 						run: (*parser).callonOperation45,
 						expr: &seqExpr{
-							pos: position{line: 106, col: 5, offset: 3364},
+							pos: position{line: 85, col: 5, offset: 2747},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 106, col: 5, offset: 3364},
+									pos:   position{line: 85, col: 5, offset: 2747},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 106, col: 10, offset: 3369},
+										pos:  position{line: 85, col: 10, offset: 2752},
 										name: "SearchBoolean",
 									},
 								},
 								&notExpr{
-									pos: position{line: 106, col: 24, offset: 3383},
+									pos: position{line: 85, col: 24, offset: 2766},
 									expr: &ruleRefExpr{
-										pos:  position{line: 106, col: 25, offset: 3384},
+										pos:  position{line: 85, col: 25, offset: 2767},
 										name: "AggGuard",
 									},
 								},
@@ -1004,35 +859,35 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 110, col: 1, offset: 3475},
+			pos:  position{line: 89, col: 1, offset: 2858},
 			expr: &seqExpr{
-				pos: position{line: 110, col: 11, offset: 3485},
+				pos: position{line: 89, col: 11, offset: 2868},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 110, col: 11, offset: 3485},
+						pos:  position{line: 89, col: 11, offset: 2868},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 110, col: 15, offset: 3489},
+						pos: position{line: 89, col: 15, offset: 2872},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 110, col: 15, offset: 3489},
+								pos:  position{line: 89, col: 15, offset: 2872},
 								name: "Pipe",
 							},
 							&litMatcher{
-								pos:        position{line: 110, col: 22, offset: 3496},
+								pos:        position{line: 89, col: 22, offset: 2879},
 								val:        "=>",
 								ignoreCase: false,
 							},
 							&charClassMatcher{
-								pos:        position{line: 110, col: 29, offset: 3503},
+								pos:        position{line: 89, col: 29, offset: 2886},
 								val:        "[);]",
 								chars:      []rune{')', ';'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 110, col: 36, offset: 3510},
+								pos:  position{line: 89, col: 36, offset: 2893},
 								name: "EOF",
 							},
 						},
@@ -1042,27 +897,27 @@ var g = &grammar{
 		},
 		{
 			name: "Pipe",
-			pos:  position{line: 111, col: 1, offset: 3515},
+			pos:  position{line: 90, col: 1, offset: 2898},
 			expr: &seqExpr{
-				pos: position{line: 111, col: 8, offset: 3522},
+				pos: position{line: 90, col: 8, offset: 2905},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 111, col: 8, offset: 3522},
+						pos:        position{line: 90, col: 8, offset: 2905},
 						val:        "|",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 111, col: 12, offset: 3526},
+						pos: position{line: 90, col: 12, offset: 2909},
 						expr: &choiceExpr{
-							pos: position{line: 111, col: 14, offset: 3528},
+							pos: position{line: 90, col: 14, offset: 2911},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 111, col: 14, offset: 3528},
+									pos:        position{line: 90, col: 14, offset: 2911},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 111, col: 20, offset: 3534},
+									pos:        position{line: 90, col: 20, offset: 2917},
 									val:        "[",
 									ignoreCase: false,
 								},
@@ -1074,59 +929,59 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 113, col: 1, offset: 3540},
+			pos:  position{line: 92, col: 1, offset: 2923},
 			expr: &seqExpr{
-				pos: position{line: 113, col: 13, offset: 3552},
+				pos: position{line: 92, col: 13, offset: 2935},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 113, col: 13, offset: 3552},
+						pos:  position{line: 92, col: 13, offset: 2935},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 113, col: 17, offset: 3556},
+						pos: position{line: 92, col: 17, offset: 2939},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 113, col: 18, offset: 3557},
+								pos: position{line: 92, col: 18, offset: 2940},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 113, col: 18, offset: 3557},
+										pos: position{line: 92, col: 18, offset: 2940},
 										expr: &litMatcher{
-											pos:        position{line: 113, col: 19, offset: 3558},
+											pos:        position{line: 92, col: 19, offset: 2941},
 											val:        "=>",
 											ignoreCase: false,
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 113, col: 24, offset: 3563},
+										pos:  position{line: 92, col: 24, offset: 2946},
 										name: "Comparator",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 113, col: 38, offset: 3577},
+								pos:  position{line: 92, col: 38, offset: 2960},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 113, col: 57, offset: 3596},
+								pos:  position{line: 92, col: 57, offset: 2979},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 113, col: 82, offset: 3621},
+								pos:        position{line: 92, col: 82, offset: 3004},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 113, col: 88, offset: 3627},
+								pos:        position{line: 92, col: 88, offset: 3010},
 								val:        "(",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 113, col: 94, offset: 3633},
+								pos:        position{line: 92, col: 94, offset: 3016},
 								val:        "[",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 113, col: 100, offset: 3639},
+								pos:        position{line: 92, col: 100, offset: 3022},
 								val:        "matches",
 								ignoreCase: false,
 							},
@@ -1137,45 +992,45 @@ var g = &grammar{
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 115, col: 1, offset: 3651},
+			pos:  position{line: 94, col: 1, offset: 3034},
 			expr: &actionExpr{
-				pos: position{line: 115, col: 14, offset: 3664},
+				pos: position{line: 94, col: 14, offset: 3047},
 				run: (*parser).callonComparator1,
 				expr: &choiceExpr{
-					pos: position{line: 115, col: 15, offset: 3665},
+					pos: position{line: 94, col: 15, offset: 3048},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 115, col: 15, offset: 3665},
+							pos:        position{line: 94, col: 15, offset: 3048},
 							val:        "==",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 115, col: 22, offset: 3672},
+							pos:        position{line: 94, col: 22, offset: 3055},
 							val:        "!=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 115, col: 29, offset: 3679},
+							pos:        position{line: 94, col: 29, offset: 3062},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 115, col: 36, offset: 3686},
+							pos:        position{line: 94, col: 36, offset: 3069},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 115, col: 43, offset: 3693},
+							pos:        position{line: 94, col: 43, offset: 3076},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 115, col: 49, offset: 3699},
+							pos:        position{line: 94, col: 49, offset: 3082},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 115, col: 56, offset: 3706},
+							pos:        position{line: 94, col: 56, offset: 3089},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1185,46 +1040,46 @@ var g = &grammar{
 		},
 		{
 			name: "AggGuard",
-			pos:  position{line: 117, col: 1, offset: 3743},
+			pos:  position{line: 96, col: 1, offset: 3126},
 			expr: &choiceExpr{
-				pos: position{line: 117, col: 12, offset: 3754},
+				pos: position{line: 96, col: 12, offset: 3137},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 117, col: 13, offset: 3755},
+						pos: position{line: 96, col: 13, offset: 3138},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 117, col: 13, offset: 3755},
+								pos:  position{line: 96, col: 13, offset: 3138},
 								name: "_",
 							},
 							&choiceExpr{
-								pos: position{line: 117, col: 16, offset: 3758},
+								pos: position{line: 96, col: 16, offset: 3141},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 117, col: 16, offset: 3758},
+										pos:  position{line: 96, col: 16, offset: 3141},
 										name: "ByToken",
 									},
 									&litMatcher{
-										pos:        position{line: 117, col: 26, offset: 3768},
+										pos:        position{line: 96, col: 26, offset: 3151},
 										val:        "-with",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 117, col: 35, offset: 3777},
+								pos:  position{line: 96, col: 35, offset: 3160},
 								name: "EOT",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 117, col: 43, offset: 3785},
+						pos: position{line: 96, col: 43, offset: 3168},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 117, col: 43, offset: 3785},
+								pos:  position{line: 96, col: 43, offset: 3168},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 117, col: 46, offset: 3788},
+								pos:        position{line: 96, col: 46, offset: 3171},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -1235,28 +1090,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 119, col: 1, offset: 3794},
+			pos:  position{line: 98, col: 1, offset: 3177},
 			expr: &actionExpr{
-				pos: position{line: 120, col: 5, offset: 3812},
+				pos: position{line: 99, col: 5, offset: 3195},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 120, col: 5, offset: 3812},
+					pos: position{line: 99, col: 5, offset: 3195},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 120, col: 5, offset: 3812},
+							pos:   position{line: 99, col: 5, offset: 3195},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 120, col: 11, offset: 3818},
+								pos:  position{line: 99, col: 11, offset: 3201},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 120, col: 21, offset: 3828},
+							pos:   position{line: 99, col: 21, offset: 3211},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 120, col: 26, offset: 3833},
+								pos: position{line: 99, col: 26, offset: 3216},
 								expr: &ruleRefExpr{
-									pos:  position{line: 120, col: 26, offset: 3833},
+									pos:  position{line: 99, col: 26, offset: 3216},
 									name: "SearchOrTerm",
 								},
 							},
@@ -1267,30 +1122,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 124, col: 1, offset: 3907},
+			pos:  position{line: 103, col: 1, offset: 3290},
 			expr: &actionExpr{
-				pos: position{line: 124, col: 16, offset: 3922},
+				pos: position{line: 103, col: 16, offset: 3305},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 124, col: 16, offset: 3922},
+					pos: position{line: 103, col: 16, offset: 3305},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 124, col: 16, offset: 3922},
+							pos:  position{line: 103, col: 16, offset: 3305},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 124, col: 18, offset: 3924},
+							pos:  position{line: 103, col: 18, offset: 3307},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 124, col: 26, offset: 3932},
+							pos:  position{line: 103, col: 26, offset: 3315},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 124, col: 28, offset: 3934},
+							pos:   position{line: 103, col: 28, offset: 3317},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 124, col: 30, offset: 3936},
+								pos:  position{line: 103, col: 30, offset: 3319},
 								name: "SearchAnd",
 							},
 						},
@@ -1300,57 +1155,57 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 126, col: 1, offset: 3986},
+			pos:  position{line: 105, col: 1, offset: 3369},
 			expr: &actionExpr{
-				pos: position{line: 127, col: 5, offset: 4000},
+				pos: position{line: 106, col: 5, offset: 3383},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 127, col: 5, offset: 4000},
+					pos: position{line: 106, col: 5, offset: 3383},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 127, col: 5, offset: 4000},
+							pos:   position{line: 106, col: 5, offset: 3383},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 127, col: 11, offset: 4006},
+								pos:  position{line: 106, col: 11, offset: 3389},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 128, col: 5, offset: 4023},
+							pos:   position{line: 107, col: 5, offset: 3406},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 128, col: 10, offset: 4028},
+								pos: position{line: 107, col: 10, offset: 3411},
 								expr: &actionExpr{
-									pos: position{line: 128, col: 11, offset: 4029},
+									pos: position{line: 107, col: 11, offset: 3412},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 128, col: 11, offset: 4029},
+										pos: position{line: 107, col: 11, offset: 3412},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 128, col: 11, offset: 4029},
+												pos: position{line: 107, col: 11, offset: 3412},
 												expr: &seqExpr{
-													pos: position{line: 128, col: 12, offset: 4030},
+													pos: position{line: 107, col: 12, offset: 3413},
 													exprs: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 128, col: 12, offset: 4030},
+															pos:  position{line: 107, col: 12, offset: 3413},
 															name: "_",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 128, col: 14, offset: 4032},
+															pos:  position{line: 107, col: 14, offset: 3415},
 															name: "AndToken",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 128, col: 25, offset: 4043},
+												pos:  position{line: 107, col: 25, offset: 3426},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 128, col: 27, offset: 4045},
+												pos:   position{line: 107, col: 27, offset: 3428},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 128, col: 32, offset: 4050},
+													pos:  position{line: 107, col: 32, offset: 3433},
 													name: "SearchFactor",
 												},
 											},
@@ -1365,42 +1220,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 132, col: 1, offset: 4166},
+			pos:  position{line: 111, col: 1, offset: 3549},
 			expr: &choiceExpr{
-				pos: position{line: 133, col: 5, offset: 4183},
+				pos: position{line: 112, col: 5, offset: 3566},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 133, col: 5, offset: 4183},
+						pos: position{line: 112, col: 5, offset: 3566},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 133, col: 5, offset: 4183},
+							pos: position{line: 112, col: 5, offset: 3566},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 133, col: 6, offset: 4184},
+									pos: position{line: 112, col: 6, offset: 3567},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 133, col: 6, offset: 4184},
+											pos: position{line: 112, col: 6, offset: 3567},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 133, col: 6, offset: 4184},
+													pos:  position{line: 112, col: 6, offset: 3567},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 133, col: 15, offset: 4193},
+													pos:  position{line: 112, col: 15, offset: 3576},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 133, col: 19, offset: 4197},
+											pos: position{line: 112, col: 19, offset: 3580},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 133, col: 19, offset: 4197},
+													pos:        position{line: 112, col: 19, offset: 3580},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 133, col: 23, offset: 4201},
+													pos:  position{line: 112, col: 23, offset: 3584},
 													name: "__",
 												},
 											},
@@ -1408,10 +1263,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 133, col: 27, offset: 4205},
+									pos:   position{line: 112, col: 27, offset: 3588},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 133, col: 29, offset: 4207},
+										pos:  position{line: 112, col: 29, offset: 3590},
 										name: "SearchFactor",
 									},
 								},
@@ -1419,38 +1274,38 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 136, col: 5, offset: 4319},
+						pos:  position{line: 115, col: 5, offset: 3702},
 						name: "SearchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 137, col: 5, offset: 4334},
+						pos: position{line: 116, col: 5, offset: 3717},
 						run: (*parser).callonSearchFactor14,
 						expr: &seqExpr{
-							pos: position{line: 137, col: 5, offset: 4334},
+							pos: position{line: 116, col: 5, offset: 3717},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 137, col: 5, offset: 4334},
+									pos:        position{line: 116, col: 5, offset: 3717},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 137, col: 9, offset: 4338},
+									pos:  position{line: 116, col: 9, offset: 3721},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 137, col: 12, offset: 4341},
+									pos:   position{line: 116, col: 12, offset: 3724},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 137, col: 17, offset: 4346},
+										pos:  position{line: 116, col: 17, offset: 3729},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 137, col: 31, offset: 4360},
+									pos:  position{line: 116, col: 31, offset: 3743},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 137, col: 34, offset: 4363},
+									pos:        position{line: 116, col: 34, offset: 3746},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1462,42 +1317,42 @@ var g = &grammar{
 		},
 		{
 			name: "TBD",
-			pos:  position{line: 140, col: 1, offset: 4390},
+			pos:  position{line: 119, col: 1, offset: 3773},
 			expr: &choiceExpr{
-				pos: position{line: 141, col: 5, offset: 4398},
+				pos: position{line: 120, col: 5, offset: 3781},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 141, col: 5, offset: 4398},
+						pos: position{line: 120, col: 5, offset: 3781},
 						run: (*parser).callonTBD2,
 						expr: &seqExpr{
-							pos: position{line: 141, col: 5, offset: 4398},
+							pos: position{line: 120, col: 5, offset: 3781},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 141, col: 5, offset: 4398},
+									pos:        position{line: 120, col: 5, offset: 3781},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 141, col: 9, offset: 4402},
+									pos:  position{line: 120, col: 9, offset: 3785},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 141, col: 12, offset: 4405},
+									pos:   position{line: 120, col: 12, offset: 3788},
 									label: "compareOp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 141, col: 22, offset: 4415},
+										pos:  position{line: 120, col: 22, offset: 3798},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 141, col: 36, offset: 4429},
+									pos:  position{line: 120, col: 36, offset: 3812},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 141, col: 39, offset: 4432},
+									pos:   position{line: 120, col: 39, offset: 3815},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 141, col: 41, offset: 4434},
+										pos:  position{line: 120, col: 41, offset: 3817},
 										name: "Expr",
 									},
 								},
@@ -1505,23 +1360,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 168, col: 5, offset: 5116},
+						pos: position{line: 147, col: 5, offset: 4499},
 						run: (*parser).callonTBD11,
 						expr: &seqExpr{
-							pos: position{line: 168, col: 5, offset: 5116},
+							pos: position{line: 147, col: 5, offset: 4499},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 168, col: 5, offset: 5116},
+									pos:   position{line: 147, col: 5, offset: 4499},
 									label: "match",
 									expr: &ruleRefExpr{
-										pos:  position{line: 168, col: 11, offset: 5122},
+										pos:  position{line: 147, col: 11, offset: 4505},
 										name: "PatternMatch",
 									},
 								},
 								&notExpr{
-									pos: position{line: 168, col: 24, offset: 5135},
+									pos: position{line: 147, col: 24, offset: 4518},
 									expr: &ruleRefExpr{
-										pos:  position{line: 168, col: 25, offset: 5136},
+										pos:  position{line: 147, col: 25, offset: 4519},
 										name: "ExprGuard",
 									},
 								},
@@ -1529,33 +1384,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 169, col: 5, offset: 5172},
+						pos: position{line: 148, col: 5, offset: 4555},
 						run: (*parser).callonTBD17,
 						expr: &seqExpr{
-							pos: position{line: 169, col: 5, offset: 5172},
+							pos: position{line: 148, col: 5, offset: 4555},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 169, col: 5, offset: 5172},
+									pos:   position{line: 148, col: 5, offset: 4555},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 169, col: 7, offset: 5174},
+										pos:  position{line: 148, col: 7, offset: 4557},
 										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 169, col: 19, offset: 5186},
+									pos:  position{line: 148, col: 19, offset: 4569},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 169, col: 21, offset: 5188},
+									pos:  position{line: 148, col: 21, offset: 4571},
 									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 169, col: 29, offset: 5196},
+									pos:  position{line: 148, col: 29, offset: 4579},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 169, col: 31, offset: 5198},
+									pos:        position{line: 148, col: 31, offset: 4581},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -1567,37 +1422,37 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 197, col: 1, offset: 5877},
+			pos:  position{line: 176, col: 1, offset: 5260},
 			expr: &choiceExpr{
-				pos: position{line: 198, col: 5, offset: 5892},
+				pos: position{line: 177, col: 5, offset: 5275},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 198, col: 5, offset: 5892},
+						pos: position{line: 177, col: 5, offset: 5275},
 						run: (*parser).callonSearchExpr2,
 						expr: &seqExpr{
-							pos: position{line: 198, col: 5, offset: 5892},
+							pos: position{line: 177, col: 5, offset: 5275},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 198, col: 5, offset: 5892},
+									pos: position{line: 177, col: 5, offset: 5275},
 									expr: &seqExpr{
-										pos: position{line: 198, col: 7, offset: 5894},
+										pos: position{line: 177, col: 7, offset: 5277},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 198, col: 7, offset: 5894},
+												pos:  position{line: 177, col: 7, offset: 5277},
 												name: "SearchGuard",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 198, col: 19, offset: 5906},
+												pos:  position{line: 177, col: 19, offset: 5289},
 												name: "EOT",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 198, col: 24, offset: 5911},
+									pos:   position{line: 177, col: 24, offset: 5294},
 									label: "search",
 									expr: &ruleRefExpr{
-										pos:  position{line: 198, col: 31, offset: 5918},
+										pos:  position{line: 177, col: 31, offset: 5301},
 										name: "PatternSearch",
 									},
 								},
@@ -1605,39 +1460,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 199, col: 5, offset: 5959},
+						pos: position{line: 178, col: 5, offset: 5342},
 						run: (*parser).callonSearchExpr10,
 						expr: &seqExpr{
-							pos: position{line: 199, col: 5, offset: 5959},
+							pos: position{line: 178, col: 5, offset: 5342},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 199, col: 5, offset: 5959},
+									pos: position{line: 178, col: 5, offset: 5342},
 									expr: &seqExpr{
-										pos: position{line: 199, col: 7, offset: 5961},
+										pos: position{line: 178, col: 7, offset: 5344},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 199, col: 7, offset: 5961},
+												pos:  position{line: 178, col: 7, offset: 5344},
 												name: "SearchGuard",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 199, col: 19, offset: 5973},
+												pos:  position{line: 178, col: 19, offset: 5356},
 												name: "EOT",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 199, col: 24, offset: 5978},
+									pos:   position{line: 178, col: 24, offset: 5361},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 199, col: 26, offset: 5980},
+										pos:  position{line: 178, col: 26, offset: 5363},
 										name: "SearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 199, col: 38, offset: 5992},
+									pos: position{line: 178, col: 38, offset: 5375},
 									expr: &ruleRefExpr{
-										pos:  position{line: 199, col: 39, offset: 5993},
+										pos:  position{line: 178, col: 39, offset: 5376},
 										name: "ExprGuard",
 									},
 								},
@@ -1645,20 +1500,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 202, col: 5, offset: 6110},
+						pos: position{line: 181, col: 5, offset: 5493},
 						run: (*parser).callonSearchExpr20,
 						expr: &seqExpr{
-							pos: position{line: 202, col: 5, offset: 6110},
+							pos: position{line: 181, col: 5, offset: 5493},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 202, col: 5, offset: 6110},
+									pos:        position{line: 181, col: 5, offset: 5493},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 202, col: 9, offset: 6114},
+									pos: position{line: 181, col: 9, offset: 5497},
 									expr: &ruleRefExpr{
-										pos:  position{line: 202, col: 10, offset: 6115},
+										pos:  position{line: 181, col: 10, offset: 5498},
 										name: "ExprGuard",
 									},
 								},
@@ -1666,7 +1521,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 5, offset: 6231},
+						pos:  position{line: 184, col: 5, offset: 5614},
 						name: "EqualityCompareExpr",
 					},
 				},
@@ -1674,32 +1529,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 207, col: 1, offset: 6252},
+			pos:  position{line: 186, col: 1, offset: 5635},
 			expr: &choiceExpr{
-				pos: position{line: 208, col: 5, offset: 6268},
+				pos: position{line: 187, col: 5, offset: 5651},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 208, col: 5, offset: 6268},
+						pos:  position{line: 187, col: 5, offset: 5651},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 209, col: 5, offset: 6280},
+						pos: position{line: 188, col: 5, offset: 5663},
 						run: (*parser).callonSearchValue3,
 						expr: &seqExpr{
-							pos: position{line: 209, col: 5, offset: 6280},
+							pos: position{line: 188, col: 5, offset: 5663},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 209, col: 5, offset: 6280},
+									pos: position{line: 188, col: 5, offset: 5663},
 									expr: &ruleRefExpr{
-										pos:  position{line: 209, col: 6, offset: 6281},
+										pos:  position{line: 188, col: 6, offset: 5664},
 										name: "Regexp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 209, col: 13, offset: 6288},
+									pos:   position{line: 188, col: 13, offset: 5671},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 209, col: 15, offset: 6290},
+										pos:  position{line: 188, col: 15, offset: 5673},
 										name: "KeyWord",
 									},
 								},
@@ -1711,15 +1566,15 @@ var g = &grammar{
 		},
 		{
 			name: "PatternSearch",
-			pos:  position{line: 213, col: 1, offset: 6398},
+			pos:  position{line: 192, col: 1, offset: 5781},
 			expr: &actionExpr{
-				pos: position{line: 214, col: 5, offset: 6416},
+				pos: position{line: 193, col: 5, offset: 5799},
 				run: (*parser).callonPatternSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 214, col: 5, offset: 6416},
+					pos:   position{line: 193, col: 5, offset: 5799},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 214, col: 13, offset: 6424},
+						pos:  position{line: 193, col: 13, offset: 5807},
 						name: "Pattern",
 					},
 				},
@@ -1727,39 +1582,39 @@ var g = &grammar{
 		},
 		{
 			name: "PatternMatch",
-			pos:  position{line: 218, col: 1, offset: 6526},
+			pos:  position{line: 197, col: 1, offset: 5909},
 			expr: &actionExpr{
-				pos: position{line: 219, col: 5, offset: 6543},
+				pos: position{line: 198, col: 5, offset: 5926},
 				run: (*parser).callonPatternMatch1,
 				expr: &seqExpr{
-					pos: position{line: 219, col: 5, offset: 6543},
+					pos: position{line: 198, col: 5, offset: 5926},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 219, col: 5, offset: 6543},
+							pos:   position{line: 198, col: 5, offset: 5926},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 219, col: 7, offset: 6545},
+								pos:  position{line: 198, col: 7, offset: 5928},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 219, col: 12, offset: 6550},
+							pos:  position{line: 198, col: 12, offset: 5933},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 219, col: 14, offset: 6552},
+							pos:        position{line: 198, col: 14, offset: 5935},
 							val:        "matches",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 219, col: 25, offset: 6563},
+							pos:  position{line: 198, col: 25, offset: 5946},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 219, col: 28, offset: 6566},
+							pos:   position{line: 198, col: 28, offset: 5949},
 							label: "pattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 219, col: 36, offset: 6574},
+								pos:  position{line: 198, col: 36, offset: 5957},
 								name: "Pattern",
 							},
 						},
@@ -1769,16 +1624,16 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 223, col: 1, offset: 6686},
+			pos:  position{line: 202, col: 1, offset: 6069},
 			expr: &choiceExpr{
-				pos: position{line: 223, col: 11, offset: 6696},
+				pos: position{line: 202, col: 11, offset: 6079},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 223, col: 11, offset: 6696},
+						pos:  position{line: 202, col: 11, offset: 6079},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 223, col: 20, offset: 6705},
+						pos:  position{line: 202, col: 20, offset: 6088},
 						name: "Glob",
 					},
 				},
@@ -1786,45 +1641,45 @@ var g = &grammar{
 		},
 		{
 			name: "SearchGuard",
-			pos:  position{line: 225, col: 1, offset: 6711},
+			pos:  position{line: 204, col: 1, offset: 6094},
 			expr: &choiceExpr{
-				pos: position{line: 226, col: 5, offset: 6727},
+				pos: position{line: 205, col: 5, offset: 6110},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 226, col: 5, offset: 6727},
+						pos:  position{line: 205, col: 5, offset: 6110},
 						name: "SQLTokenSentinels",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 227, col: 5, offset: 6749},
+						pos:  position{line: 206, col: 5, offset: 6132},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 228, col: 5, offset: 6762},
+						pos:  position{line: 207, col: 5, offset: 6145},
 						name: "OrToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 229, col: 5, offset: 6774},
+						pos:  position{line: 208, col: 5, offset: 6157},
 						name: "NotToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 230, col: 5, offset: 6787},
+						pos:  position{line: 209, col: 5, offset: 6170},
 						name: "InToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 231, col: 5, offset: 6799},
+						pos:  position{line: 210, col: 5, offset: 6182},
 						name: "ByToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 232, col: 5, offset: 6811},
+						pos:  position{line: 211, col: 5, offset: 6194},
 						name: "DefaultToken",
 					},
 					&litMatcher{
-						pos:        position{line: 233, col: 5, offset: 6828},
+						pos:        position{line: 212, col: 5, offset: 6211},
 						val:        "type(",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 234, col: 5, offset: 6840},
+						pos:        position{line: 213, col: 5, offset: 6223},
 						val:        "matches",
 						ignoreCase: true,
 					},
@@ -1833,41 +1688,41 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 238, col: 1, offset: 6878},
+			pos:  position{line: 217, col: 1, offset: 6261},
 			expr: &choiceExpr{
-				pos: position{line: 239, col: 5, offset: 6894},
+				pos: position{line: 218, col: 5, offset: 6277},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 239, col: 5, offset: 6894},
+						pos: position{line: 218, col: 5, offset: 6277},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 239, col: 5, offset: 6894},
+							pos: position{line: 218, col: 5, offset: 6277},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 239, col: 5, offset: 6894},
+									pos:  position{line: 218, col: 5, offset: 6277},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 239, col: 15, offset: 6904},
+									pos:   position{line: 218, col: 15, offset: 6287},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 239, col: 21, offset: 6910},
+										pos:  position{line: 218, col: 21, offset: 6293},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 239, col: 30, offset: 6919},
+									pos:   position{line: 218, col: 30, offset: 6302},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 239, col: 35, offset: 6924},
+										pos:  position{line: 218, col: 35, offset: 6307},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 239, col: 47, offset: 6936},
+									pos:   position{line: 218, col: 47, offset: 6319},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 239, col: 53, offset: 6942},
+										pos:  position{line: 218, col: 53, offset: 6325},
 										name: "LimitArg",
 									},
 								},
@@ -1875,45 +1730,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 242, col: 5, offset: 7087},
+						pos: position{line: 221, col: 5, offset: 6470},
 						run: (*parser).callonAggregation11,
 						expr: &seqExpr{
-							pos: position{line: 242, col: 5, offset: 7087},
+							pos: position{line: 221, col: 5, offset: 6470},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 242, col: 5, offset: 7087},
+									pos:  position{line: 221, col: 5, offset: 6470},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 242, col: 15, offset: 7097},
+									pos:   position{line: 221, col: 15, offset: 6480},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 242, col: 21, offset: 7103},
+										pos:  position{line: 221, col: 21, offset: 6486},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 242, col: 30, offset: 7112},
+									pos:   position{line: 221, col: 30, offset: 6495},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 242, col: 35, offset: 7117},
+										pos:  position{line: 221, col: 35, offset: 6500},
 										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 242, col: 50, offset: 7132},
+									pos:   position{line: 221, col: 50, offset: 6515},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 242, col: 55, offset: 7137},
+										pos: position{line: 221, col: 55, offset: 6520},
 										expr: &seqExpr{
-											pos: position{line: 242, col: 56, offset: 7138},
+											pos: position{line: 221, col: 56, offset: 6521},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 242, col: 56, offset: 7138},
+													pos:  position{line: 221, col: 56, offset: 6521},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 242, col: 58, offset: 7140},
+													pos:  position{line: 221, col: 58, offset: 6523},
 													name: "GroupByKeys",
 												},
 											},
@@ -1921,10 +1776,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 242, col: 72, offset: 7154},
+									pos:   position{line: 221, col: 72, offset: 6537},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 242, col: 78, offset: 7160},
+										pos:  position{line: 221, col: 78, offset: 6543},
 										name: "LimitArg",
 									},
 								},
@@ -1936,26 +1791,26 @@ var g = &grammar{
 		},
 		{
 			name: "Summarize",
-			pos:  position{line: 250, col: 1, offset: 7393},
+			pos:  position{line: 229, col: 1, offset: 6776},
 			expr: &choiceExpr{
-				pos: position{line: 250, col: 13, offset: 7405},
+				pos: position{line: 229, col: 13, offset: 6788},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 250, col: 13, offset: 7405},
+						pos: position{line: 229, col: 13, offset: 6788},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 250, col: 13, offset: 7405},
+								pos:        position{line: 229, col: 13, offset: 6788},
 								val:        "summarize",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 250, col: 25, offset: 7417},
+								pos:  position{line: 229, col: 25, offset: 6800},
 								name: "_",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 250, col: 29, offset: 7421},
+						pos:        position{line: 229, col: 29, offset: 6804},
 						val:        "",
 						ignoreCase: false,
 					},
@@ -1964,45 +1819,45 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 252, col: 1, offset: 7425},
+			pos:  position{line: 231, col: 1, offset: 6808},
 			expr: &choiceExpr{
-				pos: position{line: 253, col: 5, offset: 7438},
+				pos: position{line: 232, col: 5, offset: 6821},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 253, col: 5, offset: 7438},
+						pos: position{line: 232, col: 5, offset: 6821},
 						run: (*parser).callonEveryDur2,
 						expr: &seqExpr{
-							pos: position{line: 253, col: 5, offset: 7438},
+							pos: position{line: 232, col: 5, offset: 6821},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 253, col: 5, offset: 7438},
+									pos:        position{line: 232, col: 5, offset: 6821},
 									val:        "every",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 253, col: 14, offset: 7447},
+									pos:  position{line: 232, col: 14, offset: 6830},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 253, col: 16, offset: 7449},
+									pos:   position{line: 232, col: 16, offset: 6832},
 									label: "dur",
 									expr: &ruleRefExpr{
-										pos:  position{line: 253, col: 20, offset: 7453},
+										pos:  position{line: 232, col: 20, offset: 6836},
 										name: "Duration",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 253, col: 29, offset: 7462},
+									pos:  position{line: 232, col: 29, offset: 6845},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 254, col: 5, offset: 7488},
+						pos: position{line: 233, col: 5, offset: 6871},
 						run: (*parser).callonEveryDur9,
 						expr: &litMatcher{
-							pos:        position{line: 254, col: 5, offset: 7488},
+							pos:        position{line: 233, col: 5, offset: 6871},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2012,26 +1867,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 256, col: 1, offset: 7513},
+			pos:  position{line: 235, col: 1, offset: 6896},
 			expr: &actionExpr{
-				pos: position{line: 257, col: 5, offset: 7529},
+				pos: position{line: 236, col: 5, offset: 6912},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 257, col: 5, offset: 7529},
+					pos: position{line: 236, col: 5, offset: 6912},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 257, col: 5, offset: 7529},
+							pos:  position{line: 236, col: 5, offset: 6912},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 257, col: 13, offset: 7537},
+							pos:  position{line: 236, col: 13, offset: 6920},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 257, col: 15, offset: 7539},
+							pos:   position{line: 236, col: 15, offset: 6922},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 257, col: 23, offset: 7547},
+								pos:  position{line: 236, col: 23, offset: 6930},
 								name: "FlexAssignments",
 							},
 						},
@@ -2041,43 +1896,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 259, col: 1, offset: 7588},
+			pos:  position{line: 238, col: 1, offset: 6971},
 			expr: &choiceExpr{
-				pos: position{line: 260, col: 5, offset: 7601},
+				pos: position{line: 239, col: 5, offset: 6984},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 260, col: 5, offset: 7601},
+						pos: position{line: 239, col: 5, offset: 6984},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 260, col: 5, offset: 7601},
+							pos: position{line: 239, col: 5, offset: 6984},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 260, col: 5, offset: 7601},
+									pos:  position{line: 239, col: 5, offset: 6984},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 260, col: 7, offset: 7603},
+									pos:        position{line: 239, col: 7, offset: 6986},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 260, col: 14, offset: 7610},
+									pos:  position{line: 239, col: 14, offset: 6993},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 260, col: 16, offset: 7612},
+									pos:        position{line: 239, col: 16, offset: 6995},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 260, col: 25, offset: 7621},
+									pos:  position{line: 239, col: 25, offset: 7004},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 260, col: 27, offset: 7623},
+									pos:   position{line: 239, col: 27, offset: 7006},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 260, col: 33, offset: 7629},
+										pos:  position{line: 239, col: 33, offset: 7012},
 										name: "UInt",
 									},
 								},
@@ -2085,10 +1940,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 7660},
+						pos: position{line: 240, col: 5, offset: 7043},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 261, col: 5, offset: 7660},
+							pos:        position{line: 240, col: 5, offset: 7043},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2098,22 +1953,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 266, col: 1, offset: 7920},
+			pos:  position{line: 245, col: 1, offset: 7303},
 			expr: &choiceExpr{
-				pos: position{line: 267, col: 5, offset: 7939},
+				pos: position{line: 246, col: 5, offset: 7322},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 267, col: 5, offset: 7939},
+						pos:  position{line: 246, col: 5, offset: 7322},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 268, col: 5, offset: 7954},
+						pos: position{line: 247, col: 5, offset: 7337},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 268, col: 5, offset: 7954},
+							pos:   position{line: 247, col: 5, offset: 7337},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 268, col: 10, offset: 7959},
+								pos:  position{line: 247, col: 10, offset: 7342},
 								name: "Expr",
 							},
 						},
@@ -2123,50 +1978,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 270, col: 1, offset: 8051},
+			pos:  position{line: 249, col: 1, offset: 7434},
 			expr: &actionExpr{
-				pos: position{line: 271, col: 5, offset: 8071},
+				pos: position{line: 250, col: 5, offset: 7454},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 271, col: 5, offset: 8071},
+					pos: position{line: 250, col: 5, offset: 7454},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 271, col: 5, offset: 8071},
+							pos:   position{line: 250, col: 5, offset: 7454},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 11, offset: 8077},
+								pos:  position{line: 250, col: 11, offset: 7460},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 271, col: 26, offset: 8092},
+							pos:   position{line: 250, col: 26, offset: 7475},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 271, col: 31, offset: 8097},
+								pos: position{line: 250, col: 31, offset: 7480},
 								expr: &actionExpr{
-									pos: position{line: 271, col: 32, offset: 8098},
+									pos: position{line: 250, col: 32, offset: 7481},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 271, col: 32, offset: 8098},
+										pos: position{line: 250, col: 32, offset: 7481},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 271, col: 32, offset: 8098},
+												pos:  position{line: 250, col: 32, offset: 7481},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 271, col: 35, offset: 8101},
+												pos:        position{line: 250, col: 35, offset: 7484},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 271, col: 39, offset: 8105},
+												pos:  position{line: 250, col: 39, offset: 7488},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 271, col: 42, offset: 8108},
+												pos:   position{line: 250, col: 42, offset: 7491},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 271, col: 47, offset: 8113},
+													pos:  position{line: 250, col: 47, offset: 7496},
 													name: "FlexAssignment",
 												},
 											},
@@ -2181,42 +2036,42 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignment",
-			pos:  position{line: 275, col: 1, offset: 8235},
+			pos:  position{line: 254, col: 1, offset: 7618},
 			expr: &choiceExpr{
-				pos: position{line: 276, col: 5, offset: 8253},
+				pos: position{line: 255, col: 5, offset: 7636},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 276, col: 5, offset: 8253},
+						pos: position{line: 255, col: 5, offset: 7636},
 						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 276, col: 5, offset: 8253},
+							pos: position{line: 255, col: 5, offset: 7636},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 276, col: 5, offset: 8253},
+									pos:   position{line: 255, col: 5, offset: 7636},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 276, col: 10, offset: 8258},
+										pos:  position{line: 255, col: 10, offset: 7641},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 276, col: 15, offset: 8263},
+									pos:  position{line: 255, col: 15, offset: 7646},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 276, col: 18, offset: 8266},
+									pos:        position{line: 255, col: 18, offset: 7649},
 									val:        ":=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 276, col: 23, offset: 8271},
+									pos:  position{line: 255, col: 23, offset: 7654},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 276, col: 26, offset: 8274},
+									pos:   position{line: 255, col: 26, offset: 7657},
 									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 276, col: 30, offset: 8278},
+										pos:  position{line: 255, col: 30, offset: 7661},
 										name: "Agg",
 									},
 								},
@@ -2224,13 +2079,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 279, col: 5, offset: 8382},
+						pos: position{line: 258, col: 5, offset: 7765},
 						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 279, col: 5, offset: 8382},
+							pos:   position{line: 258, col: 5, offset: 7765},
 							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 9, offset: 8386},
+								pos:  position{line: 258, col: 9, offset: 7769},
 								name: "Agg",
 							},
 						},
@@ -2240,72 +2095,72 @@ var g = &grammar{
 		},
 		{
 			name: "Agg",
-			pos:  position{line: 283, col: 1, offset: 8486},
+			pos:  position{line: 262, col: 1, offset: 7869},
 			expr: &actionExpr{
-				pos: position{line: 284, col: 5, offset: 8494},
+				pos: position{line: 263, col: 5, offset: 7877},
 				run: (*parser).callonAgg1,
 				expr: &seqExpr{
-					pos: position{line: 284, col: 5, offset: 8494},
+					pos: position{line: 263, col: 5, offset: 7877},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 284, col: 5, offset: 8494},
+							pos: position{line: 263, col: 5, offset: 7877},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 6, offset: 8495},
+								pos:  position{line: 263, col: 6, offset: 7878},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 284, col: 16, offset: 8505},
+							pos:   position{line: 263, col: 16, offset: 7888},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 19, offset: 8508},
+								pos:  position{line: 263, col: 19, offset: 7891},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 284, col: 27, offset: 8516},
+							pos:  position{line: 263, col: 27, offset: 7899},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 284, col: 30, offset: 8519},
+							pos:        position{line: 263, col: 30, offset: 7902},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 284, col: 34, offset: 8523},
+							pos:  position{line: 263, col: 34, offset: 7906},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 284, col: 37, offset: 8526},
+							pos:   position{line: 263, col: 37, offset: 7909},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 284, col: 42, offset: 8531},
+								pos: position{line: 263, col: 42, offset: 7914},
 								expr: &ruleRefExpr{
-									pos:  position{line: 284, col: 42, offset: 8531},
+									pos:  position{line: 263, col: 42, offset: 7914},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 284, col: 49, offset: 8538},
+							pos:  position{line: 263, col: 49, offset: 7921},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 284, col: 52, offset: 8541},
+							pos:        position{line: 263, col: 52, offset: 7924},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 284, col: 56, offset: 8545},
+							pos: position{line: 263, col: 56, offset: 7928},
 							expr: &seqExpr{
-								pos: position{line: 284, col: 58, offset: 8547},
+								pos: position{line: 263, col: 58, offset: 7930},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 284, col: 58, offset: 8547},
+										pos:  position{line: 263, col: 58, offset: 7930},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 284, col: 61, offset: 8550},
+										pos:        position{line: 263, col: 61, offset: 7933},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -2313,12 +2168,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 284, col: 66, offset: 8555},
+							pos:   position{line: 263, col: 66, offset: 7938},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 284, col: 72, offset: 8561},
+								pos: position{line: 263, col: 72, offset: 7944},
 								expr: &ruleRefExpr{
-									pos:  position{line: 284, col: 72, offset: 8561},
+									pos:  position{line: 263, col: 72, offset: 7944},
 									name: "WhereClause",
 								},
 							},
@@ -2329,20 +2184,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 292, col: 1, offset: 8751},
+			pos:  position{line: 271, col: 1, offset: 8134},
 			expr: &choiceExpr{
-				pos: position{line: 293, col: 5, offset: 8763},
+				pos: position{line: 272, col: 5, offset: 8146},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 5, offset: 8763},
+						pos:  position{line: 272, col: 5, offset: 8146},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 5, offset: 8782},
+						pos:  position{line: 273, col: 5, offset: 8165},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 5, offset: 8795},
+						pos:  position{line: 274, col: 5, offset: 8178},
 						name: "OrToken",
 					},
 				},
@@ -2350,31 +2205,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 297, col: 1, offset: 8804},
+			pos:  position{line: 276, col: 1, offset: 8187},
 			expr: &actionExpr{
-				pos: position{line: 297, col: 15, offset: 8818},
+				pos: position{line: 276, col: 15, offset: 8201},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 297, col: 15, offset: 8818},
+					pos: position{line: 276, col: 15, offset: 8201},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 297, col: 15, offset: 8818},
+							pos:  position{line: 276, col: 15, offset: 8201},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 297, col: 17, offset: 8820},
+							pos:        position{line: 276, col: 17, offset: 8203},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 297, col: 25, offset: 8828},
+							pos:  position{line: 276, col: 25, offset: 8211},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 297, col: 27, offset: 8830},
+							pos:   position{line: 276, col: 27, offset: 8213},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 297, col: 32, offset: 8835},
+								pos:  position{line: 276, col: 32, offset: 8218},
 								name: "SearchBoolean",
 							},
 						},
@@ -2384,44 +2239,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 299, col: 1, offset: 8871},
+			pos:  position{line: 278, col: 1, offset: 8254},
 			expr: &actionExpr{
-				pos: position{line: 300, col: 5, offset: 8890},
+				pos: position{line: 279, col: 5, offset: 8273},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 300, col: 5, offset: 8890},
+					pos: position{line: 279, col: 5, offset: 8273},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 300, col: 5, offset: 8890},
+							pos:   position{line: 279, col: 5, offset: 8273},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 300, col: 11, offset: 8896},
+								pos:  position{line: 279, col: 11, offset: 8279},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 300, col: 25, offset: 8910},
+							pos:   position{line: 279, col: 25, offset: 8293},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 300, col: 30, offset: 8915},
+								pos: position{line: 279, col: 30, offset: 8298},
 								expr: &seqExpr{
-									pos: position{line: 300, col: 31, offset: 8916},
+									pos: position{line: 279, col: 31, offset: 8299},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 300, col: 31, offset: 8916},
+											pos:  position{line: 279, col: 31, offset: 8299},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 300, col: 34, offset: 8919},
+											pos:        position{line: 279, col: 34, offset: 8302},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 300, col: 38, offset: 8923},
+											pos:  position{line: 279, col: 38, offset: 8306},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 300, col: 41, offset: 8926},
+											pos:  position{line: 279, col: 41, offset: 8309},
 											name: "AggAssignment",
 										},
 									},
@@ -2434,84 +2289,84 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 310, col: 1, offset: 9162},
+			pos:  position{line: 289, col: 1, offset: 8545},
 			expr: &choiceExpr{
-				pos: position{line: 311, col: 5, offset: 9175},
+				pos: position{line: 290, col: 5, offset: 8558},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 5, offset: 9175},
+						pos:  position{line: 290, col: 5, offset: 8558},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 312, col: 5, offset: 9188},
+						pos:  position{line: 291, col: 5, offset: 8571},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 313, col: 5, offset: 9200},
+						pos:  position{line: 292, col: 5, offset: 8583},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 314, col: 5, offset: 9212},
+						pos:  position{line: 293, col: 5, offset: 8595},
 						name: "PickProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 315, col: 5, offset: 9225},
+						pos:  position{line: 294, col: 5, offset: 8608},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 316, col: 5, offset: 9238},
+						pos:  position{line: 295, col: 5, offset: 8621},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 5, offset: 9251},
+						pos:  position{line: 296, col: 5, offset: 8634},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 318, col: 5, offset: 9264},
+						pos:  position{line: 297, col: 5, offset: 8647},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 319, col: 5, offset: 9279},
+						pos:  position{line: 298, col: 5, offset: 8662},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 5, offset: 9292},
+						pos:  position{line: 299, col: 5, offset: 8675},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 321, col: 5, offset: 9304},
+						pos:  position{line: 300, col: 5, offset: 8687},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 5, offset: 9319},
+						pos:  position{line: 301, col: 5, offset: 8702},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 5, offset: 9332},
+						pos:  position{line: 302, col: 5, offset: 8715},
 						name: "ShapeProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 324, col: 5, offset: 9346},
+						pos:  position{line: 303, col: 5, offset: 8729},
 						name: "JoinProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 325, col: 5, offset: 9359},
+						pos:  position{line: 304, col: 5, offset: 8742},
 						name: "SampleProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 326, col: 5, offset: 9374},
+						pos:  position{line: 305, col: 5, offset: 8757},
 						name: "SQLProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 327, col: 5, offset: 9386},
+						pos:  position{line: 306, col: 5, offset: 8769},
 						name: "FromProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 328, col: 5, offset: 9399},
+						pos:  position{line: 307, col: 5, offset: 8782},
 						name: "PassProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 329, col: 5, offset: 9412},
+						pos:  position{line: 308, col: 5, offset: 8795},
 						name: "ExplodeProc",
 					},
 				},
@@ -2519,46 +2374,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 331, col: 1, offset: 9425},
+			pos:  position{line: 310, col: 1, offset: 8808},
 			expr: &actionExpr{
-				pos: position{line: 332, col: 5, offset: 9438},
+				pos: position{line: 311, col: 5, offset: 8821},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 332, col: 5, offset: 9438},
+					pos: position{line: 311, col: 5, offset: 8821},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 332, col: 5, offset: 9438},
+							pos:        position{line: 311, col: 5, offset: 8821},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 13, offset: 9446},
+							pos:   position{line: 311, col: 13, offset: 8829},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 332, col: 18, offset: 9451},
+								pos:  position{line: 311, col: 18, offset: 8834},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 27, offset: 9460},
+							pos:   position{line: 311, col: 27, offset: 8843},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 332, col: 32, offset: 9465},
+								pos: position{line: 311, col: 32, offset: 8848},
 								expr: &actionExpr{
-									pos: position{line: 332, col: 33, offset: 9466},
+									pos: position{line: 311, col: 33, offset: 8849},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 332, col: 33, offset: 9466},
+										pos: position{line: 311, col: 33, offset: 8849},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 332, col: 33, offset: 9466},
+												pos:  position{line: 311, col: 33, offset: 8849},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 332, col: 35, offset: 9468},
+												pos:   position{line: 311, col: 35, offset: 8851},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 332, col: 37, offset: 9470},
+													pos:  position{line: 311, col: 37, offset: 8853},
 													name: "Exprs",
 												},
 											},
@@ -2573,30 +2428,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 346, col: 1, offset: 9889},
+			pos:  position{line: 325, col: 1, offset: 9272},
 			expr: &actionExpr{
-				pos: position{line: 346, col: 12, offset: 9900},
+				pos: position{line: 325, col: 12, offset: 9283},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 346, col: 12, offset: 9900},
+					pos:   position{line: 325, col: 12, offset: 9283},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 346, col: 17, offset: 9905},
+						pos: position{line: 325, col: 17, offset: 9288},
 						expr: &actionExpr{
-							pos: position{line: 346, col: 18, offset: 9906},
+							pos: position{line: 325, col: 18, offset: 9289},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 346, col: 18, offset: 9906},
+								pos: position{line: 325, col: 18, offset: 9289},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 346, col: 18, offset: 9906},
+										pos:  position{line: 325, col: 18, offset: 9289},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 346, col: 20, offset: 9908},
+										pos:   position{line: 325, col: 20, offset: 9291},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 346, col: 22, offset: 9910},
+											pos:  position{line: 325, col: 22, offset: 9293},
 											name: "SortArg",
 										},
 									},
@@ -2609,50 +2464,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 348, col: 1, offset: 9966},
+			pos:  position{line: 327, col: 1, offset: 9349},
 			expr: &choiceExpr{
-				pos: position{line: 349, col: 5, offset: 9978},
+				pos: position{line: 328, col: 5, offset: 9361},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 349, col: 5, offset: 9978},
+						pos: position{line: 328, col: 5, offset: 9361},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 349, col: 5, offset: 9978},
+							pos:        position{line: 328, col: 5, offset: 9361},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 350, col: 5, offset: 10053},
+						pos: position{line: 329, col: 5, offset: 9436},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 350, col: 5, offset: 10053},
+							pos: position{line: 329, col: 5, offset: 9436},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 350, col: 5, offset: 10053},
+									pos:        position{line: 329, col: 5, offset: 9436},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 350, col: 14, offset: 10062},
+									pos:  position{line: 329, col: 14, offset: 9445},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 350, col: 16, offset: 10064},
+									pos:   position{line: 329, col: 16, offset: 9447},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 350, col: 23, offset: 10071},
+										pos: position{line: 329, col: 23, offset: 9454},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 350, col: 24, offset: 10072},
+											pos: position{line: 329, col: 24, offset: 9455},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 350, col: 24, offset: 10072},
+													pos:        position{line: 329, col: 24, offset: 9455},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 350, col: 34, offset: 10082},
+													pos:        position{line: 329, col: 34, offset: 9465},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2668,38 +2523,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 352, col: 1, offset: 10196},
+			pos:  position{line: 331, col: 1, offset: 9579},
 			expr: &actionExpr{
-				pos: position{line: 353, col: 5, offset: 10208},
+				pos: position{line: 332, col: 5, offset: 9591},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 353, col: 5, offset: 10208},
+					pos: position{line: 332, col: 5, offset: 9591},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 353, col: 5, offset: 10208},
+							pos:        position{line: 332, col: 5, offset: 9591},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 12, offset: 10215},
+							pos:   position{line: 332, col: 12, offset: 9598},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 353, col: 18, offset: 10221},
+								pos: position{line: 332, col: 18, offset: 9604},
 								expr: &actionExpr{
-									pos: position{line: 353, col: 19, offset: 10222},
+									pos: position{line: 332, col: 19, offset: 9605},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 353, col: 19, offset: 10222},
+										pos: position{line: 332, col: 19, offset: 9605},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 19, offset: 10222},
+												pos:  position{line: 332, col: 19, offset: 9605},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 353, col: 21, offset: 10224},
+												pos:   position{line: 332, col: 21, offset: 9607},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 353, col: 23, offset: 10226},
+													pos:  position{line: 332, col: 23, offset: 9609},
 													name: "UInt",
 												},
 											},
@@ -2709,19 +2564,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 47, offset: 10250},
+							pos:   position{line: 332, col: 47, offset: 9633},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 353, col: 53, offset: 10256},
+								pos: position{line: 332, col: 53, offset: 9639},
 								expr: &seqExpr{
-									pos: position{line: 353, col: 54, offset: 10257},
+									pos: position{line: 332, col: 54, offset: 9640},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 353, col: 54, offset: 10257},
+											pos:  position{line: 332, col: 54, offset: 9640},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 353, col: 56, offset: 10259},
+											pos:        position{line: 332, col: 56, offset: 9642},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2730,25 +2585,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 67, offset: 10270},
+							pos:   position{line: 332, col: 67, offset: 9653},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 353, col: 74, offset: 10277},
+								pos: position{line: 332, col: 74, offset: 9660},
 								expr: &actionExpr{
-									pos: position{line: 353, col: 75, offset: 10278},
+									pos: position{line: 332, col: 75, offset: 9661},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 353, col: 75, offset: 10278},
+										pos: position{line: 332, col: 75, offset: 9661},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 75, offset: 10278},
+												pos:  position{line: 332, col: 75, offset: 9661},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 353, col: 77, offset: 10280},
+												pos:   position{line: 332, col: 77, offset: 9663},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 353, col: 79, offset: 10282},
+													pos:  position{line: 332, col: 79, offset: 9665},
 													name: "FieldExprs",
 												},
 											},
@@ -2763,27 +2618,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 367, col: 1, offset: 10627},
+			pos:  position{line: 346, col: 1, offset: 10010},
 			expr: &actionExpr{
-				pos: position{line: 368, col: 5, offset: 10639},
+				pos: position{line: 347, col: 5, offset: 10022},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 368, col: 5, offset: 10639},
+					pos: position{line: 347, col: 5, offset: 10022},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 368, col: 5, offset: 10639},
+							pos:        position{line: 347, col: 5, offset: 10022},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 368, col: 12, offset: 10646},
+							pos:  position{line: 347, col: 12, offset: 10029},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 368, col: 14, offset: 10648},
+							pos:   position{line: 347, col: 14, offset: 10031},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 368, col: 19, offset: 10653},
+								pos:  position{line: 347, col: 19, offset: 10036},
 								name: "FlexAssignments",
 							},
 						},
@@ -2793,27 +2648,27 @@ var g = &grammar{
 		},
 		{
 			name: "PickProc",
-			pos:  position{line: 372, col: 1, offset: 10748},
+			pos:  position{line: 351, col: 1, offset: 10131},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 10761},
+				pos: position{line: 352, col: 5, offset: 10144},
 				run: (*parser).callonPickProc1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 5, offset: 10761},
+					pos: position{line: 352, col: 5, offset: 10144},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 373, col: 5, offset: 10761},
+							pos:        position{line: 352, col: 5, offset: 10144},
 							val:        "pick",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 373, col: 13, offset: 10769},
+							pos:  position{line: 352, col: 13, offset: 10152},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 15, offset: 10771},
+							pos:   position{line: 352, col: 15, offset: 10154},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 20, offset: 10776},
+								pos:  position{line: 352, col: 20, offset: 10159},
 								name: "FlexAssignments",
 							},
 						},
@@ -2823,27 +2678,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 377, col: 1, offset: 10872},
+			pos:  position{line: 356, col: 1, offset: 10255},
 			expr: &actionExpr{
-				pos: position{line: 378, col: 5, offset: 10885},
+				pos: position{line: 357, col: 5, offset: 10268},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 378, col: 5, offset: 10885},
+					pos: position{line: 357, col: 5, offset: 10268},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 378, col: 5, offset: 10885},
+							pos:        position{line: 357, col: 5, offset: 10268},
 							val:        "drop",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 378, col: 13, offset: 10893},
+							pos:  position{line: 357, col: 13, offset: 10276},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 378, col: 15, offset: 10895},
+							pos:   position{line: 357, col: 15, offset: 10278},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 20, offset: 10900},
+								pos:  position{line: 357, col: 20, offset: 10283},
 								name: "FieldExprs",
 							},
 						},
@@ -2853,30 +2708,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 382, col: 1, offset: 10991},
+			pos:  position{line: 361, col: 1, offset: 10374},
 			expr: &choiceExpr{
-				pos: position{line: 383, col: 5, offset: 11004},
+				pos: position{line: 362, col: 5, offset: 10387},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 383, col: 5, offset: 11004},
+						pos: position{line: 362, col: 5, offset: 10387},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 383, col: 5, offset: 11004},
+							pos: position{line: 362, col: 5, offset: 10387},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 383, col: 5, offset: 11004},
+									pos:        position{line: 362, col: 5, offset: 10387},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 383, col: 13, offset: 11012},
+									pos:  position{line: 362, col: 13, offset: 10395},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 383, col: 15, offset: 11014},
+									pos:   position{line: 362, col: 15, offset: 10397},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 383, col: 21, offset: 11020},
+										pos:  position{line: 362, col: 21, offset: 10403},
 										name: "UInt",
 									},
 								},
@@ -2884,10 +2739,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 384, col: 5, offset: 11100},
+						pos: position{line: 363, col: 5, offset: 10483},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 384, col: 5, offset: 11100},
+							pos:        position{line: 363, col: 5, offset: 10483},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2897,30 +2752,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 386, col: 1, offset: 11176},
+			pos:  position{line: 365, col: 1, offset: 10559},
 			expr: &choiceExpr{
-				pos: position{line: 387, col: 5, offset: 11189},
+				pos: position{line: 366, col: 5, offset: 10572},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 387, col: 5, offset: 11189},
+						pos: position{line: 366, col: 5, offset: 10572},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 387, col: 5, offset: 11189},
+							pos: position{line: 366, col: 5, offset: 10572},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 387, col: 5, offset: 11189},
+									pos:        position{line: 366, col: 5, offset: 10572},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 387, col: 13, offset: 11197},
+									pos:  position{line: 366, col: 13, offset: 10580},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 387, col: 15, offset: 11199},
+									pos:   position{line: 366, col: 15, offset: 10582},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 387, col: 21, offset: 11205},
+										pos:  position{line: 366, col: 21, offset: 10588},
 										name: "UInt",
 									},
 								},
@@ -2928,10 +2783,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 388, col: 5, offset: 11285},
+						pos: position{line: 367, col: 5, offset: 10668},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 388, col: 5, offset: 11285},
+							pos:        position{line: 367, col: 5, offset: 10668},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2941,27 +2796,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 390, col: 1, offset: 11361},
+			pos:  position{line: 369, col: 1, offset: 10744},
 			expr: &actionExpr{
-				pos: position{line: 391, col: 5, offset: 11376},
+				pos: position{line: 370, col: 5, offset: 10759},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 391, col: 5, offset: 11376},
+					pos: position{line: 370, col: 5, offset: 10759},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 391, col: 5, offset: 11376},
+							pos:        position{line: 370, col: 5, offset: 10759},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 391, col: 15, offset: 11386},
+							pos:  position{line: 370, col: 15, offset: 10769},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 391, col: 17, offset: 11388},
+							pos:   position{line: 370, col: 17, offset: 10771},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 391, col: 20, offset: 11391},
+								pos:  position{line: 370, col: 20, offset: 10774},
 								name: "Filter",
 							},
 						},
@@ -2971,15 +2826,15 @@ var g = &grammar{
 		},
 		{
 			name: "Filter",
-			pos:  position{line: 395, col: 1, offset: 11428},
+			pos:  position{line: 374, col: 1, offset: 10811},
 			expr: &actionExpr{
-				pos: position{line: 396, col: 5, offset: 11439},
+				pos: position{line: 375, col: 5, offset: 10822},
 				run: (*parser).callonFilter1,
 				expr: &labeledExpr{
-					pos:   position{line: 396, col: 5, offset: 11439},
+					pos:   position{line: 375, col: 5, offset: 10822},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 396, col: 10, offset: 11444},
+						pos:  position{line: 375, col: 10, offset: 10827},
 						name: "SearchBoolean",
 					},
 				},
@@ -2987,27 +2842,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 400, col: 1, offset: 11540},
+			pos:  position{line: 379, col: 1, offset: 10923},
 			expr: &choiceExpr{
-				pos: position{line: 401, col: 5, offset: 11553},
+				pos: position{line: 380, col: 5, offset: 10936},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 401, col: 5, offset: 11553},
+						pos: position{line: 380, col: 5, offset: 10936},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 401, col: 5, offset: 11553},
+							pos: position{line: 380, col: 5, offset: 10936},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 401, col: 5, offset: 11553},
+									pos:        position{line: 380, col: 5, offset: 10936},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 401, col: 13, offset: 11561},
+									pos:  position{line: 380, col: 13, offset: 10944},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 401, col: 15, offset: 11563},
+									pos:        position{line: 380, col: 15, offset: 10946},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -3015,10 +2870,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 404, col: 5, offset: 11652},
+						pos: position{line: 383, col: 5, offset: 11035},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 404, col: 5, offset: 11652},
+							pos:        position{line: 383, col: 5, offset: 11035},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -3028,27 +2883,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 408, col: 1, offset: 11742},
+			pos:  position{line: 387, col: 1, offset: 11125},
 			expr: &actionExpr{
-				pos: position{line: 409, col: 5, offset: 11754},
+				pos: position{line: 388, col: 5, offset: 11137},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 409, col: 5, offset: 11754},
+					pos: position{line: 388, col: 5, offset: 11137},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 409, col: 5, offset: 11754},
+							pos:        position{line: 388, col: 5, offset: 11137},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 409, col: 12, offset: 11761},
+							pos:  position{line: 388, col: 12, offset: 11144},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 409, col: 14, offset: 11763},
+							pos:   position{line: 388, col: 14, offset: 11146},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 409, col: 19, offset: 11768},
+								pos:  position{line: 388, col: 19, offset: 11151},
 								name: "FlexAssignments",
 							},
 						},
@@ -3058,59 +2913,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 413, col: 1, offset: 11863},
+			pos:  position{line: 392, col: 1, offset: 11246},
 			expr: &actionExpr{
-				pos: position{line: 414, col: 5, offset: 11878},
+				pos: position{line: 393, col: 5, offset: 11261},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 414, col: 5, offset: 11878},
+					pos: position{line: 393, col: 5, offset: 11261},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 414, col: 5, offset: 11878},
+							pos:        position{line: 393, col: 5, offset: 11261},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 414, col: 15, offset: 11888},
+							pos:  position{line: 393, col: 15, offset: 11271},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 414, col: 17, offset: 11890},
+							pos:   position{line: 393, col: 17, offset: 11273},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 414, col: 23, offset: 11896},
+								pos:  position{line: 393, col: 23, offset: 11279},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 414, col: 34, offset: 11907},
+							pos:   position{line: 393, col: 34, offset: 11290},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 414, col: 39, offset: 11912},
+								pos: position{line: 393, col: 39, offset: 11295},
 								expr: &actionExpr{
-									pos: position{line: 414, col: 40, offset: 11913},
+									pos: position{line: 393, col: 40, offset: 11296},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 414, col: 40, offset: 11913},
+										pos: position{line: 393, col: 40, offset: 11296},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 414, col: 40, offset: 11913},
+												pos:  position{line: 393, col: 40, offset: 11296},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 414, col: 43, offset: 11916},
+												pos:        position{line: 393, col: 43, offset: 11299},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 414, col: 47, offset: 11920},
+												pos:  position{line: 393, col: 47, offset: 11303},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 414, col: 50, offset: 11923},
+												pos:   position{line: 393, col: 50, offset: 11306},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 414, col: 53, offset: 11926},
+													pos:  position{line: 393, col: 53, offset: 11309},
 													name: "Assignment",
 												},
 											},
@@ -3125,29 +2980,29 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 422, col: 1, offset: 12335},
+			pos:  position{line: 401, col: 1, offset: 11718},
 			expr: &actionExpr{
-				pos: position{line: 423, col: 5, offset: 12348},
+				pos: position{line: 402, col: 5, offset: 11731},
 				run: (*parser).callonFuseProc1,
 				expr: &seqExpr{
-					pos: position{line: 423, col: 5, offset: 12348},
+					pos: position{line: 402, col: 5, offset: 11731},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 423, col: 5, offset: 12348},
+							pos:        position{line: 402, col: 5, offset: 11731},
 							val:        "fuse",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 423, col: 13, offset: 12356},
+							pos: position{line: 402, col: 13, offset: 11739},
 							expr: &seqExpr{
-								pos: position{line: 423, col: 15, offset: 12358},
+								pos: position{line: 402, col: 15, offset: 11741},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 423, col: 15, offset: 12358},
+										pos:  position{line: 402, col: 15, offset: 11741},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 423, col: 18, offset: 12361},
+										pos:        position{line: 402, col: 18, offset: 11744},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -3160,12 +3015,12 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeProc",
-			pos:  position{line: 427, col: 1, offset: 12432},
+			pos:  position{line: 406, col: 1, offset: 11815},
 			expr: &actionExpr{
-				pos: position{line: 428, col: 5, offset: 12446},
+				pos: position{line: 407, col: 5, offset: 11829},
 				run: (*parser).callonShapeProc1,
 				expr: &litMatcher{
-					pos:        position{line: 428, col: 5, offset: 12446},
+					pos:        position{line: 407, col: 5, offset: 11829},
 					val:        "shape",
 					ignoreCase: true,
 				},
@@ -3173,84 +3028,84 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 432, col: 1, offset: 12522},
+			pos:  position{line: 411, col: 1, offset: 11905},
 			expr: &choiceExpr{
-				pos: position{line: 433, col: 5, offset: 12535},
+				pos: position{line: 412, col: 5, offset: 11918},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 433, col: 5, offset: 12535},
+						pos: position{line: 412, col: 5, offset: 11918},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 433, col: 5, offset: 12535},
+							pos: position{line: 412, col: 5, offset: 11918},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 433, col: 5, offset: 12535},
+									pos:   position{line: 412, col: 5, offset: 11918},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 433, col: 11, offset: 12541},
+										pos:  position{line: 412, col: 11, offset: 11924},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 433, col: 21, offset: 12551},
+									pos:        position{line: 412, col: 21, offset: 11934},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 433, col: 29, offset: 12559},
+									pos:  position{line: 412, col: 29, offset: 11942},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 433, col: 31, offset: 12561},
+									pos:  position{line: 412, col: 31, offset: 11944},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 433, col: 34, offset: 12564},
+									pos:  position{line: 412, col: 34, offset: 11947},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 433, col: 36, offset: 12566},
+									pos:   position{line: 412, col: 36, offset: 11949},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 433, col: 44, offset: 12574},
+										pos:  position{line: 412, col: 44, offset: 11957},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 433, col: 52, offset: 12582},
+									pos:  position{line: 412, col: 52, offset: 11965},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 433, col: 55, offset: 12585},
+									pos:        position{line: 412, col: 55, offset: 11968},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 433, col: 59, offset: 12589},
+									pos:  position{line: 412, col: 59, offset: 11972},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 433, col: 62, offset: 12592},
+									pos:   position{line: 412, col: 62, offset: 11975},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 433, col: 71, offset: 12601},
+										pos:  position{line: 412, col: 71, offset: 11984},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 433, col: 79, offset: 12609},
+									pos:   position{line: 412, col: 79, offset: 11992},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 433, col: 87, offset: 12617},
+										pos: position{line: 412, col: 87, offset: 12000},
 										expr: &seqExpr{
-											pos: position{line: 433, col: 88, offset: 12618},
+											pos: position{line: 412, col: 88, offset: 12001},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 433, col: 88, offset: 12618},
+													pos:  position{line: 412, col: 88, offset: 12001},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 433, col: 90, offset: 12620},
+													pos:  position{line: 412, col: 90, offset: 12003},
 													name: "FlexAssignments",
 												},
 											},
@@ -3261,58 +3116,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 440, col: 5, offset: 12886},
+						pos: position{line: 419, col: 5, offset: 12269},
 						run: (*parser).callonJoinProc22,
 						expr: &seqExpr{
-							pos: position{line: 440, col: 5, offset: 12886},
+							pos: position{line: 419, col: 5, offset: 12269},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 440, col: 5, offset: 12886},
+									pos:   position{line: 419, col: 5, offset: 12269},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 440, col: 11, offset: 12892},
+										pos:  position{line: 419, col: 11, offset: 12275},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 440, col: 22, offset: 12903},
+									pos:        position{line: 419, col: 22, offset: 12286},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 440, col: 30, offset: 12911},
+									pos:  position{line: 419, col: 30, offset: 12294},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 440, col: 32, offset: 12913},
+									pos:  position{line: 419, col: 32, offset: 12296},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 440, col: 35, offset: 12916},
+									pos:  position{line: 419, col: 35, offset: 12299},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 440, col: 37, offset: 12918},
+									pos:   position{line: 419, col: 37, offset: 12301},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 440, col: 41, offset: 12922},
+										pos:  position{line: 419, col: 41, offset: 12305},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 440, col: 49, offset: 12930},
+									pos:   position{line: 419, col: 49, offset: 12313},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 440, col: 57, offset: 12938},
+										pos: position{line: 419, col: 57, offset: 12321},
 										expr: &seqExpr{
-											pos: position{line: 440, col: 58, offset: 12939},
+											pos: position{line: 419, col: 58, offset: 12322},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 440, col: 58, offset: 12939},
+													pos:  position{line: 419, col: 58, offset: 12322},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 440, col: 60, offset: 12941},
+													pos:  position{line: 419, col: 60, offset: 12324},
 													name: "FlexAssignments",
 												},
 											},
@@ -3327,69 +3182,69 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 448, col: 1, offset: 13195},
+			pos:  position{line: 427, col: 1, offset: 12578},
 			expr: &choiceExpr{
-				pos: position{line: 449, col: 5, offset: 13209},
+				pos: position{line: 428, col: 5, offset: 12592},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 449, col: 5, offset: 13209},
+						pos: position{line: 428, col: 5, offset: 12592},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 449, col: 5, offset: 13209},
+							pos: position{line: 428, col: 5, offset: 12592},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 449, col: 5, offset: 13209},
+									pos:        position{line: 428, col: 5, offset: 12592},
 									val:        "inner",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 14, offset: 13218},
+									pos:  position{line: 428, col: 14, offset: 12601},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 450, col: 5, offset: 13248},
+						pos: position{line: 429, col: 5, offset: 12631},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 450, col: 5, offset: 13248},
+							pos: position{line: 429, col: 5, offset: 12631},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 450, col: 5, offset: 13248},
+									pos:        position{line: 429, col: 5, offset: 12631},
 									val:        "left",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 450, col: 14, offset: 13257},
+									pos:  position{line: 429, col: 14, offset: 12640},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 451, col: 5, offset: 13286},
+						pos: position{line: 430, col: 5, offset: 12669},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 451, col: 5, offset: 13286},
+							pos: position{line: 430, col: 5, offset: 12669},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 451, col: 5, offset: 13286},
+									pos:        position{line: 430, col: 5, offset: 12669},
 									val:        "right",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 451, col: 14, offset: 13295},
+									pos:  position{line: 430, col: 14, offset: 12678},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 452, col: 5, offset: 13325},
+						pos: position{line: 431, col: 5, offset: 12708},
 						run: (*parser).callonJoinStyle14,
 						expr: &litMatcher{
-							pos:        position{line: 452, col: 5, offset: 13325},
+							pos:        position{line: 431, col: 5, offset: 12708},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3399,35 +3254,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 454, col: 1, offset: 13361},
+			pos:  position{line: 433, col: 1, offset: 12744},
 			expr: &choiceExpr{
-				pos: position{line: 455, col: 5, offset: 13373},
+				pos: position{line: 434, col: 5, offset: 12756},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 455, col: 5, offset: 13373},
+						pos:  position{line: 434, col: 5, offset: 12756},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 456, col: 5, offset: 13382},
+						pos: position{line: 435, col: 5, offset: 12765},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 456, col: 5, offset: 13382},
+							pos: position{line: 435, col: 5, offset: 12765},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 456, col: 5, offset: 13382},
+									pos:        position{line: 435, col: 5, offset: 12765},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 456, col: 9, offset: 13386},
+									pos:   position{line: 435, col: 9, offset: 12769},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 456, col: 14, offset: 13391},
+										pos:  position{line: 435, col: 14, offset: 12774},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 456, col: 19, offset: 13396},
+									pos:        position{line: 435, col: 19, offset: 12779},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3439,23 +3294,23 @@ var g = &grammar{
 		},
 		{
 			name: "SampleProc",
-			pos:  position{line: 458, col: 1, offset: 13422},
+			pos:  position{line: 437, col: 1, offset: 12805},
 			expr: &actionExpr{
-				pos: position{line: 459, col: 5, offset: 13437},
+				pos: position{line: 438, col: 5, offset: 12820},
 				run: (*parser).callonSampleProc1,
 				expr: &seqExpr{
-					pos: position{line: 459, col: 5, offset: 13437},
+					pos: position{line: 438, col: 5, offset: 12820},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 459, col: 5, offset: 13437},
+							pos:        position{line: 438, col: 5, offset: 12820},
 							val:        "sample",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 459, col: 15, offset: 13447},
+							pos:   position{line: 438, col: 15, offset: 12830},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 459, col: 17, offset: 13449},
+								pos:  position{line: 438, col: 17, offset: 12832},
 								name: "SampleExpr",
 							},
 						},
@@ -3465,25 +3320,25 @@ var g = &grammar{
 		},
 		{
 			name: "SampleExpr",
-			pos:  position{line: 496, col: 1, offset: 14744},
+			pos:  position{line: 475, col: 1, offset: 14127},
 			expr: &choiceExpr{
-				pos: position{line: 497, col: 5, offset: 14759},
+				pos: position{line: 476, col: 5, offset: 14142},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 497, col: 5, offset: 14759},
+						pos: position{line: 476, col: 5, offset: 14142},
 						run: (*parser).callonSampleExpr2,
 						expr: &seqExpr{
-							pos: position{line: 497, col: 5, offset: 14759},
+							pos: position{line: 476, col: 5, offset: 14142},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 497, col: 5, offset: 14759},
+									pos:  position{line: 476, col: 5, offset: 14142},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 497, col: 7, offset: 14761},
+									pos:   position{line: 476, col: 7, offset: 14144},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 497, col: 12, offset: 14766},
+										pos:  position{line: 476, col: 12, offset: 14149},
 										name: "Lval",
 									},
 								},
@@ -3491,10 +3346,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 498, col: 5, offset: 14795},
+						pos: position{line: 477, col: 5, offset: 14178},
 						run: (*parser).callonSampleExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 498, col: 5, offset: 14795},
+							pos:        position{line: 477, col: 5, offset: 14178},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3504,15 +3359,15 @@ var g = &grammar{
 		},
 		{
 			name: "FromProc",
-			pos:  position{line: 500, col: 1, offset: 14853},
+			pos:  position{line: 479, col: 1, offset: 14236},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 14866},
+				pos: position{line: 480, col: 5, offset: 14249},
 				run: (*parser).callonFromProc1,
 				expr: &labeledExpr{
-					pos:   position{line: 501, col: 5, offset: 14866},
+					pos:   position{line: 480, col: 5, offset: 14249},
 					label: "source",
 					expr: &ruleRefExpr{
-						pos:  position{line: 501, col: 12, offset: 14873},
+						pos:  position{line: 480, col: 12, offset: 14256},
 						name: "FromAny",
 					},
 				},
@@ -3520,20 +3375,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromAny",
-			pos:  position{line: 505, col: 1, offset: 15029},
+			pos:  position{line: 484, col: 1, offset: 14412},
 			expr: &choiceExpr{
-				pos: position{line: 506, col: 5, offset: 15041},
+				pos: position{line: 485, col: 5, offset: 14424},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 506, col: 5, offset: 15041},
+						pos:  position{line: 485, col: 5, offset: 14424},
 						name: "FileProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 507, col: 5, offset: 15054},
+						pos:  position{line: 486, col: 5, offset: 14437},
 						name: "HTTPProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 508, col: 5, offset: 15067},
+						pos:  position{line: 487, col: 5, offset: 14450},
 						name: "PoolProc",
 					},
 				},
@@ -3541,43 +3396,43 @@ var g = &grammar{
 		},
 		{
 			name: "FileProc",
-			pos:  position{line: 510, col: 1, offset: 15077},
+			pos:  position{line: 489, col: 1, offset: 14460},
 			expr: &actionExpr{
-				pos: position{line: 511, col: 5, offset: 15090},
+				pos: position{line: 490, col: 5, offset: 14473},
 				run: (*parser).callonFileProc1,
 				expr: &seqExpr{
-					pos: position{line: 511, col: 5, offset: 15090},
+					pos: position{line: 490, col: 5, offset: 14473},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 511, col: 5, offset: 15090},
+							pos:        position{line: 490, col: 5, offset: 14473},
 							val:        "file",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 511, col: 13, offset: 15098},
+							pos:  position{line: 490, col: 13, offset: 14481},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 511, col: 15, offset: 15100},
+							pos:   position{line: 490, col: 15, offset: 14483},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 511, col: 20, offset: 15105},
+								pos:  position{line: 490, col: 20, offset: 14488},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 511, col: 25, offset: 15110},
+							pos:   position{line: 490, col: 25, offset: 14493},
 							label: "format",
 							expr: &ruleRefExpr{
-								pos:  position{line: 511, col: 32, offset: 15117},
+								pos:  position{line: 490, col: 32, offset: 14500},
 								name: "FormatArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 511, col: 42, offset: 15127},
+							pos:   position{line: 490, col: 42, offset: 14510},
 							label: "layout",
 							expr: &ruleRefExpr{
-								pos:  position{line: 511, col: 49, offset: 15134},
+								pos:  position{line: 490, col: 49, offset: 14517},
 								name: "LayoutArg",
 							},
 						},
@@ -3587,27 +3442,27 @@ var g = &grammar{
 		},
 		{
 			name: "PoolProc",
-			pos:  position{line: 515, col: 1, offset: 15262},
+			pos:  position{line: 494, col: 1, offset: 14645},
 			expr: &actionExpr{
-				pos: position{line: 516, col: 5, offset: 15275},
+				pos: position{line: 495, col: 5, offset: 14658},
 				run: (*parser).callonPoolProc1,
 				expr: &seqExpr{
-					pos: position{line: 516, col: 5, offset: 15275},
+					pos: position{line: 495, col: 5, offset: 14658},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 516, col: 5, offset: 15275},
+							pos:        position{line: 495, col: 5, offset: 14658},
 							val:        "from",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 516, col: 13, offset: 15283},
+							pos:  position{line: 495, col: 13, offset: 14666},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 516, col: 15, offset: 15285},
+							pos:   position{line: 495, col: 15, offset: 14668},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 20, offset: 15290},
+								pos:  position{line: 495, col: 20, offset: 14673},
 								name: "PoolBody",
 							},
 						},
@@ -3617,42 +3472,42 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBody",
-			pos:  position{line: 518, col: 1, offset: 15321},
+			pos:  position{line: 497, col: 1, offset: 14704},
 			expr: &actionExpr{
-				pos: position{line: 519, col: 5, offset: 15334},
+				pos: position{line: 498, col: 5, offset: 14717},
 				run: (*parser).callonPoolBody1,
 				expr: &seqExpr{
-					pos: position{line: 519, col: 5, offset: 15334},
+					pos: position{line: 498, col: 5, offset: 14717},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 519, col: 5, offset: 15334},
+							pos:   position{line: 498, col: 5, offset: 14717},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 519, col: 10, offset: 15339},
+								pos:  position{line: 498, col: 10, offset: 14722},
 								name: "PoolName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 519, col: 19, offset: 15348},
+							pos:   position{line: 498, col: 19, offset: 14731},
 							label: "at",
 							expr: &ruleRefExpr{
-								pos:  position{line: 519, col: 22, offset: 15351},
+								pos:  position{line: 498, col: 22, offset: 14734},
 								name: "PoolAt",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 519, col: 29, offset: 15358},
+							pos:   position{line: 498, col: 29, offset: 14741},
 							label: "over",
 							expr: &ruleRefExpr{
-								pos:  position{line: 519, col: 34, offset: 15363},
+								pos:  position{line: 498, col: 34, offset: 14746},
 								name: "PoolRange",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 519, col: 44, offset: 15373},
+							pos:   position{line: 498, col: 44, offset: 14756},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 519, col: 50, offset: 15379},
+								pos:  position{line: 498, col: 50, offset: 14762},
 								name: "OrderArg",
 							},
 						},
@@ -3662,43 +3517,43 @@ var g = &grammar{
 		},
 		{
 			name: "HTTPProc",
-			pos:  position{line: 523, col: 1, offset: 15514},
+			pos:  position{line: 502, col: 1, offset: 14897},
 			expr: &actionExpr{
-				pos: position{line: 524, col: 5, offset: 15527},
+				pos: position{line: 503, col: 5, offset: 14910},
 				run: (*parser).callonHTTPProc1,
 				expr: &seqExpr{
-					pos: position{line: 524, col: 5, offset: 15527},
+					pos: position{line: 503, col: 5, offset: 14910},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 524, col: 5, offset: 15527},
+							pos:        position{line: 503, col: 5, offset: 14910},
 							val:        "get",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 524, col: 12, offset: 15534},
+							pos:  position{line: 503, col: 12, offset: 14917},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 524, col: 14, offset: 15536},
+							pos:   position{line: 503, col: 14, offset: 14919},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 524, col: 18, offset: 15540},
+								pos:  position{line: 503, col: 18, offset: 14923},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 524, col: 22, offset: 15544},
+							pos:   position{line: 503, col: 22, offset: 14927},
 							label: "format",
 							expr: &ruleRefExpr{
-								pos:  position{line: 524, col: 29, offset: 15551},
+								pos:  position{line: 503, col: 29, offset: 14934},
 								name: "FormatArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 524, col: 39, offset: 15561},
+							pos:   position{line: 503, col: 39, offset: 14944},
 							label: "layout",
 							expr: &ruleRefExpr{
-								pos:  position{line: 524, col: 46, offset: 15568},
+								pos:  position{line: 503, col: 46, offset: 14951},
 								name: "LayoutArg",
 							},
 						},
@@ -3708,30 +3563,30 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 528, col: 1, offset: 15693},
+			pos:  position{line: 507, col: 1, offset: 15076},
 			expr: &actionExpr{
-				pos: position{line: 528, col: 7, offset: 15699},
+				pos: position{line: 507, col: 7, offset: 15082},
 				run: (*parser).callonURL1,
 				expr: &seqExpr{
-					pos: position{line: 528, col: 7, offset: 15699},
+					pos: position{line: 507, col: 7, offset: 15082},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 528, col: 8, offset: 15700},
+							pos: position{line: 507, col: 8, offset: 15083},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 528, col: 8, offset: 15700},
+									pos:        position{line: 507, col: 8, offset: 15083},
 									val:        "http:",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 528, col: 18, offset: 15710},
+									pos:        position{line: 507, col: 18, offset: 15093},
 									val:        "https:",
 									ignoreCase: false,
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 528, col: 28, offset: 15720},
+							pos:  position{line: 507, col: 28, offset: 15103},
 							name: "Path",
 						},
 					},
@@ -3740,29 +3595,29 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 530, col: 1, offset: 15757},
+			pos:  position{line: 509, col: 1, offset: 15140},
 			expr: &choiceExpr{
-				pos: position{line: 531, col: 5, offset: 15766},
+				pos: position{line: 510, col: 5, offset: 15149},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 531, col: 5, offset: 15766},
+						pos: position{line: 510, col: 5, offset: 15149},
 						run: (*parser).callonPath2,
 						expr: &labeledExpr{
-							pos:   position{line: 531, col: 5, offset: 15766},
+							pos:   position{line: 510, col: 5, offset: 15149},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 531, col: 7, offset: 15768},
+								pos:  position{line: 510, col: 7, offset: 15151},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 532, col: 5, offset: 15803},
+						pos: position{line: 511, col: 5, offset: 15186},
 						run: (*parser).callonPath5,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 532, col: 5, offset: 15803},
+							pos: position{line: 511, col: 5, offset: 15186},
 							expr: &charClassMatcher{
-								pos:        position{line: 532, col: 5, offset: 15803},
+								pos:        position{line: 511, col: 5, offset: 15186},
 								val:        "[0-9a-zA-Z!@$%^&*()_=<>,./?:[\\]{}~|+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '(', ')', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '|', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -3776,34 +3631,34 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 534, col: 1, offset: 15875},
+			pos:  position{line: 513, col: 1, offset: 15258},
 			expr: &choiceExpr{
-				pos: position{line: 535, col: 5, offset: 15886},
+				pos: position{line: 514, col: 5, offset: 15269},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 535, col: 5, offset: 15886},
+						pos: position{line: 514, col: 5, offset: 15269},
 						run: (*parser).callonPoolAt2,
 						expr: &seqExpr{
-							pos: position{line: 535, col: 5, offset: 15886},
+							pos: position{line: 514, col: 5, offset: 15269},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 535, col: 5, offset: 15886},
+									pos:  position{line: 514, col: 5, offset: 15269},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 535, col: 7, offset: 15888},
+									pos:        position{line: 514, col: 7, offset: 15271},
 									val:        "at",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 535, col: 13, offset: 15894},
+									pos:  position{line: 514, col: 13, offset: 15277},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 535, col: 15, offset: 15896},
+									pos:   position{line: 514, col: 15, offset: 15279},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 535, col: 18, offset: 15899},
+										pos:  position{line: 514, col: 18, offset: 15282},
 										name: "KSUID",
 									},
 								},
@@ -3811,10 +3666,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 536, col: 5, offset: 15928},
+						pos: position{line: 515, col: 5, offset: 15311},
 						run: (*parser).callonPoolAt9,
 						expr: &litMatcher{
-							pos:        position{line: 536, col: 5, offset: 15928},
+							pos:        position{line: 515, col: 5, offset: 15311},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3824,14 +3679,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 538, col: 1, offset: 15952},
+			pos:  position{line: 517, col: 1, offset: 15335},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 9, offset: 15960},
+				pos: position{line: 517, col: 9, offset: 15343},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 538, col: 9, offset: 15960},
+					pos: position{line: 517, col: 9, offset: 15343},
 					expr: &charClassMatcher{
-						pos:        position{line: 538, col: 10, offset: 15961},
+						pos:        position{line: 517, col: 10, offset: 15344},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -3842,55 +3697,55 @@ var g = &grammar{
 		},
 		{
 			name: "PoolRange",
-			pos:  position{line: 540, col: 1, offset: 16007},
+			pos:  position{line: 519, col: 1, offset: 15390},
 			expr: &choiceExpr{
-				pos: position{line: 541, col: 5, offset: 16021},
+				pos: position{line: 520, col: 5, offset: 15404},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 16021},
+						pos: position{line: 520, col: 5, offset: 15404},
 						run: (*parser).callonPoolRange2,
 						expr: &seqExpr{
-							pos: position{line: 541, col: 5, offset: 16021},
+							pos: position{line: 520, col: 5, offset: 15404},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 5, offset: 16021},
+									pos:  position{line: 520, col: 5, offset: 15404},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 541, col: 7, offset: 16023},
+									pos:        position{line: 520, col: 7, offset: 15406},
 									val:        "over",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 15, offset: 16031},
+									pos:  position{line: 520, col: 15, offset: 15414},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 541, col: 17, offset: 16033},
+									pos:   position{line: 520, col: 17, offset: 15416},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 23, offset: 16039},
+										pos:  position{line: 520, col: 23, offset: 15422},
 										name: "Literal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 31, offset: 16047},
+									pos:  position{line: 520, col: 31, offset: 15430},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 541, col: 33, offset: 16049},
+									pos:        position{line: 520, col: 33, offset: 15432},
 									val:        "to",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 39, offset: 16055},
+									pos:  position{line: 520, col: 39, offset: 15438},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 541, col: 41, offset: 16057},
+									pos:   position{line: 520, col: 41, offset: 15440},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 47, offset: 16063},
+										pos:  position{line: 520, col: 47, offset: 15446},
 										name: "Literal",
 									},
 								},
@@ -3898,10 +3753,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 544, col: 5, offset: 16171},
+						pos: position{line: 523, col: 5, offset: 15554},
 						run: (*parser).callonPoolRange14,
 						expr: &litMatcher{
-							pos:        position{line: 544, col: 5, offset: 16171},
+							pos:        position{line: 523, col: 5, offset: 15554},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3911,34 +3766,34 @@ var g = &grammar{
 		},
 		{
 			name: "PoolTo",
-			pos:  position{line: 546, col: 1, offset: 16195},
+			pos:  position{line: 525, col: 1, offset: 15578},
 			expr: &choiceExpr{
-				pos: position{line: 547, col: 5, offset: 16206},
+				pos: position{line: 526, col: 5, offset: 15589},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 16206},
+						pos: position{line: 526, col: 5, offset: 15589},
 						run: (*parser).callonPoolTo2,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 5, offset: 16206},
+							pos: position{line: 526, col: 5, offset: 15589},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 5, offset: 16206},
+									pos:  position{line: 526, col: 5, offset: 15589},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 547, col: 7, offset: 16208},
+									pos:        position{line: 526, col: 7, offset: 15591},
 									val:        "to",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 13, offset: 16214},
+									pos:  position{line: 526, col: 13, offset: 15597},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 547, col: 15, offset: 16216},
+									pos:   position{line: 526, col: 15, offset: 15599},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 19, offset: 16220},
+										pos:  position{line: 526, col: 19, offset: 15603},
 										name: "Literal",
 									},
 								},
@@ -3946,10 +3801,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 16252},
+						pos: position{line: 527, col: 5, offset: 15635},
 						run: (*parser).callonPoolTo9,
 						expr: &litMatcher{
-							pos:        position{line: 548, col: 5, offset: 16252},
+							pos:        position{line: 527, col: 5, offset: 15635},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3959,42 +3814,42 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 550, col: 1, offset: 16276},
+			pos:  position{line: 529, col: 1, offset: 15659},
 			expr: &choiceExpr{
-				pos: position{line: 551, col: 5, offset: 16289},
+				pos: position{line: 530, col: 5, offset: 15672},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 551, col: 5, offset: 16289},
+						pos: position{line: 530, col: 5, offset: 15672},
 						run: (*parser).callonPoolName2,
 						expr: &labeledExpr{
-							pos:   position{line: 551, col: 5, offset: 16289},
+							pos:   position{line: 530, col: 5, offset: 15672},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 551, col: 10, offset: 16294},
+								pos:  position{line: 530, col: 10, offset: 15677},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 552, col: 5, offset: 16334},
+						pos: position{line: 531, col: 5, offset: 15717},
 						run: (*parser).callonPoolName5,
 						expr: &labeledExpr{
-							pos:   position{line: 552, col: 5, offset: 16334},
+							pos:   position{line: 531, col: 5, offset: 15717},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 552, col: 8, offset: 16337},
+								pos:  position{line: 531, col: 8, offset: 15720},
 								name: "KSUID",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 553, col: 5, offset: 16366},
+						pos: position{line: 532, col: 5, offset: 15749},
 						run: (*parser).callonPoolName8,
 						expr: &labeledExpr{
-							pos:   position{line: 553, col: 5, offset: 16366},
+							pos:   position{line: 532, col: 5, offset: 15749},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 553, col: 7, offset: 16368},
+								pos:  position{line: 532, col: 7, offset: 15751},
 								name: "QuotedString",
 							},
 						},
@@ -4004,42 +3859,42 @@ var g = &grammar{
 		},
 		{
 			name: "LayoutArg",
-			pos:  position{line: 555, col: 1, offset: 16400},
+			pos:  position{line: 534, col: 1, offset: 15783},
 			expr: &choiceExpr{
-				pos: position{line: 556, col: 5, offset: 16414},
+				pos: position{line: 535, col: 5, offset: 15797},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 556, col: 5, offset: 16414},
+						pos: position{line: 535, col: 5, offset: 15797},
 						run: (*parser).callonLayoutArg2,
 						expr: &seqExpr{
-							pos: position{line: 556, col: 5, offset: 16414},
+							pos: position{line: 535, col: 5, offset: 15797},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 556, col: 5, offset: 16414},
+									pos:  position{line: 535, col: 5, offset: 15797},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 556, col: 7, offset: 16416},
+									pos:        position{line: 535, col: 7, offset: 15799},
 									val:        "order",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 556, col: 16, offset: 16425},
+									pos:  position{line: 535, col: 16, offset: 15808},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 556, col: 18, offset: 16427},
+									pos:   position{line: 535, col: 18, offset: 15810},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 556, col: 23, offset: 16432},
+										pos:  position{line: 535, col: 23, offset: 15815},
 										name: "FieldExprs",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 556, col: 34, offset: 16443},
+									pos:   position{line: 535, col: 34, offset: 15826},
 									label: "order",
 									expr: &ruleRefExpr{
-										pos:  position{line: 556, col: 40, offset: 16449},
+										pos:  position{line: 535, col: 40, offset: 15832},
 										name: "OrderSuffix",
 									},
 								},
@@ -4047,10 +3902,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 559, col: 5, offset: 16562},
+						pos: position{line: 538, col: 5, offset: 15945},
 						run: (*parser).callonLayoutArg11,
 						expr: &litMatcher{
-							pos:        position{line: 559, col: 5, offset: 16562},
+							pos:        position{line: 538, col: 5, offset: 15945},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4060,34 +3915,34 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 561, col: 1, offset: 16586},
+			pos:  position{line: 540, col: 1, offset: 15969},
 			expr: &choiceExpr{
-				pos: position{line: 562, col: 5, offset: 16600},
+				pos: position{line: 541, col: 5, offset: 15983},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 562, col: 5, offset: 16600},
+						pos: position{line: 541, col: 5, offset: 15983},
 						run: (*parser).callonFormatArg2,
 						expr: &seqExpr{
-							pos: position{line: 562, col: 5, offset: 16600},
+							pos: position{line: 541, col: 5, offset: 15983},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 562, col: 5, offset: 16600},
+									pos:  position{line: 541, col: 5, offset: 15983},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 562, col: 7, offset: 16602},
+									pos:        position{line: 541, col: 7, offset: 15985},
 									val:        "format",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 562, col: 17, offset: 16612},
+									pos:  position{line: 541, col: 17, offset: 15995},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 562, col: 19, offset: 16614},
+									pos:   position{line: 541, col: 19, offset: 15997},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 562, col: 23, offset: 16618},
+										pos:  position{line: 541, col: 23, offset: 16001},
 										name: "IdentifierName",
 									},
 								},
@@ -4095,10 +3950,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 563, col: 5, offset: 16657},
+						pos: position{line: 542, col: 5, offset: 16040},
 						run: (*parser).callonFormatArg9,
 						expr: &litMatcher{
-							pos:        position{line: 563, col: 5, offset: 16657},
+							pos:        position{line: 542, col: 5, offset: 16040},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4108,33 +3963,33 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 565, col: 1, offset: 16680},
+			pos:  position{line: 544, col: 1, offset: 16063},
 			expr: &choiceExpr{
-				pos: position{line: 566, col: 5, offset: 16696},
+				pos: position{line: 545, col: 5, offset: 16079},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 566, col: 5, offset: 16696},
+						pos: position{line: 545, col: 5, offset: 16079},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 566, col: 5, offset: 16696},
+							pos:        position{line: 545, col: 5, offset: 16079},
 							val:        ":asc",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 567, col: 5, offset: 16731},
+						pos: position{line: 546, col: 5, offset: 16114},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 567, col: 5, offset: 16731},
+							pos:        position{line: 546, col: 5, offset: 16114},
 							val:        ":desc",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 568, col: 5, offset: 16768},
+						pos: position{line: 547, col: 5, offset: 16151},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 568, col: 5, offset: 16768},
+							pos:        position{line: 547, col: 5, offset: 16151},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4144,31 +3999,31 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 570, col: 1, offset: 16794},
+			pos:  position{line: 549, col: 1, offset: 16177},
 			expr: &choiceExpr{
-				pos: position{line: 571, col: 5, offset: 16807},
+				pos: position{line: 550, col: 5, offset: 16190},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 571, col: 5, offset: 16807},
+						pos: position{line: 550, col: 5, offset: 16190},
 						run: (*parser).callonOrderArg2,
 						expr: &seqExpr{
-							pos: position{line: 571, col: 5, offset: 16807},
+							pos: position{line: 550, col: 5, offset: 16190},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 571, col: 5, offset: 16807},
+									pos:  position{line: 550, col: 5, offset: 16190},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 571, col: 7, offset: 16809},
+									pos:        position{line: 550, col: 7, offset: 16192},
 									val:        "order",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 571, col: 16, offset: 16818},
+									pos:  position{line: 550, col: 16, offset: 16201},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 571, col: 18, offset: 16820},
+									pos:        position{line: 550, col: 18, offset: 16203},
 									val:        "asc",
 									ignoreCase: true,
 								},
@@ -4176,26 +4031,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 572, col: 5, offset: 16854},
+						pos: position{line: 551, col: 5, offset: 16237},
 						run: (*parser).callonOrderArg8,
 						expr: &seqExpr{
-							pos: position{line: 572, col: 5, offset: 16854},
+							pos: position{line: 551, col: 5, offset: 16237},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 572, col: 5, offset: 16854},
+									pos:  position{line: 551, col: 5, offset: 16237},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 572, col: 7, offset: 16856},
+									pos:        position{line: 551, col: 7, offset: 16239},
 									val:        "order",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 572, col: 16, offset: 16865},
+									pos:  position{line: 551, col: 16, offset: 16248},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 572, col: 18, offset: 16867},
+									pos:        position{line: 551, col: 18, offset: 16250},
 									val:        "desc",
 									ignoreCase: true,
 								},
@@ -4203,10 +4058,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 573, col: 5, offset: 16903},
+						pos: position{line: 552, col: 5, offset: 16286},
 						run: (*parser).callonOrderArg14,
 						expr: &litMatcher{
-							pos:        position{line: 573, col: 5, offset: 16903},
+							pos:        position{line: 552, col: 5, offset: 16286},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4216,12 +4071,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassProc",
-			pos:  position{line: 575, col: 1, offset: 16926},
+			pos:  position{line: 554, col: 1, offset: 16309},
 			expr: &actionExpr{
-				pos: position{line: 576, col: 5, offset: 16939},
+				pos: position{line: 555, col: 5, offset: 16322},
 				run: (*parser).callonPassProc1,
 				expr: &litMatcher{
-					pos:        position{line: 576, col: 5, offset: 16939},
+					pos:        position{line: 555, col: 5, offset: 16322},
 					val:        "pass",
 					ignoreCase: true,
 				},
@@ -4229,43 +4084,43 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeProc",
-			pos:  position{line: 582, col: 1, offset: 17134},
+			pos:  position{line: 561, col: 1, offset: 16517},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 5, offset: 17150},
+				pos: position{line: 562, col: 5, offset: 16533},
 				run: (*parser).callonExplodeProc1,
 				expr: &seqExpr{
-					pos: position{line: 583, col: 5, offset: 17150},
+					pos: position{line: 562, col: 5, offset: 16533},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 583, col: 5, offset: 17150},
+							pos:        position{line: 562, col: 5, offset: 16533},
 							val:        "explode",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 16, offset: 17161},
+							pos:  position{line: 562, col: 16, offset: 16544},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 18, offset: 17163},
+							pos:   position{line: 562, col: 18, offset: 16546},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 23, offset: 17168},
+								pos:  position{line: 562, col: 23, offset: 16551},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 29, offset: 17174},
+							pos:   position{line: 562, col: 29, offset: 16557},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 33, offset: 17178},
+								pos:  position{line: 562, col: 33, offset: 16561},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 41, offset: 17186},
+							pos:   position{line: 562, col: 41, offset: 16569},
 							label: "as",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 44, offset: 17189},
+								pos:  position{line: 562, col: 44, offset: 16572},
 								name: "AsArg",
 							},
 						},
@@ -4275,30 +4130,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 587, col: 1, offset: 17300},
+			pos:  position{line: 566, col: 1, offset: 16683},
 			expr: &actionExpr{
-				pos: position{line: 588, col: 5, offset: 17312},
+				pos: position{line: 567, col: 5, offset: 16695},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 588, col: 5, offset: 17312},
+					pos: position{line: 567, col: 5, offset: 16695},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 588, col: 5, offset: 17312},
+							pos:  position{line: 567, col: 5, offset: 16695},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 588, col: 7, offset: 17314},
+							pos:  position{line: 567, col: 7, offset: 16697},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 588, col: 10, offset: 17317},
+							pos:  position{line: 567, col: 10, offset: 16700},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 588, col: 12, offset: 17319},
+							pos:   position{line: 567, col: 12, offset: 16702},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 588, col: 16, offset: 17323},
+								pos:  position{line: 567, col: 16, offset: 16706},
 								name: "Type",
 							},
 						},
@@ -4308,33 +4163,33 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 590, col: 1, offset: 17348},
+			pos:  position{line: 569, col: 1, offset: 16731},
 			expr: &choiceExpr{
-				pos: position{line: 591, col: 5, offset: 17358},
+				pos: position{line: 570, col: 5, offset: 16741},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 591, col: 5, offset: 17358},
+						pos: position{line: 570, col: 5, offset: 16741},
 						run: (*parser).callonAsArg2,
 						expr: &seqExpr{
-							pos: position{line: 591, col: 5, offset: 17358},
+							pos: position{line: 570, col: 5, offset: 16741},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 591, col: 5, offset: 17358},
+									pos:  position{line: 570, col: 5, offset: 16741},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 591, col: 7, offset: 17360},
+									pos:  position{line: 570, col: 7, offset: 16743},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 591, col: 10, offset: 17363},
+									pos:  position{line: 570, col: 10, offset: 16746},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 12, offset: 17365},
+									pos:   position{line: 570, col: 12, offset: 16748},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 591, col: 16, offset: 17369},
+										pos:  position{line: 570, col: 16, offset: 16752},
 										name: "Lval",
 									},
 								},
@@ -4342,10 +4197,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 592, col: 5, offset: 17398},
+						pos: position{line: 571, col: 5, offset: 16781},
 						run: (*parser).callonAsArg9,
 						expr: &litMatcher{
-							pos:        position{line: 592, col: 5, offset: 17398},
+							pos:        position{line: 571, col: 5, offset: 16781},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4355,58 +4210,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 596, col: 1, offset: 17446},
+			pos:  position{line: 575, col: 1, offset: 16829},
 			expr: &ruleRefExpr{
-				pos:  position{line: 596, col: 8, offset: 17453},
+				pos:  position{line: 575, col: 8, offset: 16836},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 598, col: 1, offset: 17464},
+			pos:  position{line: 577, col: 1, offset: 16847},
 			expr: &actionExpr{
-				pos: position{line: 599, col: 5, offset: 17474},
+				pos: position{line: 578, col: 5, offset: 16857},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 599, col: 5, offset: 17474},
+					pos: position{line: 578, col: 5, offset: 16857},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 599, col: 5, offset: 17474},
+							pos:   position{line: 578, col: 5, offset: 16857},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 599, col: 11, offset: 17480},
+								pos:  position{line: 578, col: 11, offset: 16863},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 599, col: 16, offset: 17485},
+							pos:   position{line: 578, col: 16, offset: 16868},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 599, col: 21, offset: 17490},
+								pos: position{line: 578, col: 21, offset: 16873},
 								expr: &actionExpr{
-									pos: position{line: 599, col: 22, offset: 17491},
+									pos: position{line: 578, col: 22, offset: 16874},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 599, col: 22, offset: 17491},
+										pos: position{line: 578, col: 22, offset: 16874},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 599, col: 22, offset: 17491},
+												pos:  position{line: 578, col: 22, offset: 16874},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 599, col: 25, offset: 17494},
+												pos:        position{line: 578, col: 25, offset: 16877},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 599, col: 29, offset: 17498},
+												pos:  position{line: 578, col: 29, offset: 16881},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 599, col: 32, offset: 17501},
+												pos:   position{line: 578, col: 32, offset: 16884},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 599, col: 37, offset: 17506},
+													pos:  position{line: 578, col: 37, offset: 16889},
 													name: "Lval",
 												},
 											},
@@ -4421,52 +4276,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 603, col: 1, offset: 17618},
+			pos:  position{line: 582, col: 1, offset: 17001},
 			expr: &ruleRefExpr{
-				pos:  position{line: 603, col: 13, offset: 17630},
+				pos:  position{line: 582, col: 13, offset: 17013},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 605, col: 1, offset: 17636},
+			pos:  position{line: 584, col: 1, offset: 17019},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 5, offset: 17651},
+				pos: position{line: 585, col: 5, offset: 17034},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 5, offset: 17651},
+					pos: position{line: 585, col: 5, offset: 17034},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 606, col: 5, offset: 17651},
+							pos:   position{line: 585, col: 5, offset: 17034},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 11, offset: 17657},
+								pos:  position{line: 585, col: 11, offset: 17040},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 21, offset: 17667},
+							pos:   position{line: 585, col: 21, offset: 17050},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 606, col: 26, offset: 17672},
+								pos: position{line: 585, col: 26, offset: 17055},
 								expr: &seqExpr{
-									pos: position{line: 606, col: 27, offset: 17673},
+									pos: position{line: 585, col: 27, offset: 17056},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 606, col: 27, offset: 17673},
+											pos:  position{line: 585, col: 27, offset: 17056},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 606, col: 30, offset: 17676},
+											pos:        position{line: 585, col: 30, offset: 17059},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 606, col: 34, offset: 17680},
+											pos:  position{line: 585, col: 34, offset: 17063},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 606, col: 37, offset: 17683},
+											pos:  position{line: 585, col: 37, offset: 17066},
 											name: "FieldExpr",
 										},
 									},
@@ -4479,39 +4334,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 616, col: 1, offset: 17882},
+			pos:  position{line: 595, col: 1, offset: 17265},
 			expr: &actionExpr{
-				pos: position{line: 617, col: 5, offset: 17897},
+				pos: position{line: 596, col: 5, offset: 17280},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 617, col: 5, offset: 17897},
+					pos: position{line: 596, col: 5, offset: 17280},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 617, col: 5, offset: 17897},
+							pos:   position{line: 596, col: 5, offset: 17280},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 617, col: 9, offset: 17901},
+								pos:  position{line: 596, col: 9, offset: 17284},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 14, offset: 17906},
+							pos:  position{line: 596, col: 14, offset: 17289},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 617, col: 17, offset: 17909},
+							pos:        position{line: 596, col: 17, offset: 17292},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 22, offset: 17914},
+							pos:  position{line: 596, col: 22, offset: 17297},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 617, col: 25, offset: 17917},
+							pos:   position{line: 596, col: 25, offset: 17300},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 617, col: 29, offset: 17921},
+								pos:  position{line: 596, col: 29, offset: 17304},
 								name: "Expr",
 							},
 						},
@@ -4521,71 +4376,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 619, col: 1, offset: 18012},
+			pos:  position{line: 598, col: 1, offset: 17395},
 			expr: &ruleRefExpr{
-				pos:  position{line: 619, col: 8, offset: 18019},
+				pos:  position{line: 598, col: 8, offset: 17402},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 621, col: 1, offset: 18036},
+			pos:  position{line: 600, col: 1, offset: 17419},
 			expr: &choiceExpr{
-				pos: position{line: 622, col: 5, offset: 18056},
+				pos: position{line: 601, col: 5, offset: 17439},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 622, col: 5, offset: 18056},
+						pos: position{line: 601, col: 5, offset: 17439},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 622, col: 5, offset: 18056},
+							pos: position{line: 601, col: 5, offset: 17439},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 622, col: 5, offset: 18056},
+									pos:   position{line: 601, col: 5, offset: 17439},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 622, col: 15, offset: 18066},
+										pos:  position{line: 601, col: 15, offset: 17449},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 622, col: 29, offset: 18080},
+									pos:  position{line: 601, col: 29, offset: 17463},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 622, col: 32, offset: 18083},
+									pos:        position{line: 601, col: 32, offset: 17466},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 622, col: 36, offset: 18087},
+									pos:  position{line: 601, col: 36, offset: 17470},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 622, col: 39, offset: 18090},
+									pos:   position{line: 601, col: 39, offset: 17473},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 622, col: 50, offset: 18101},
+										pos:  position{line: 601, col: 50, offset: 17484},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 622, col: 55, offset: 18106},
+									pos:  position{line: 601, col: 55, offset: 17489},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 622, col: 58, offset: 18109},
+									pos:        position{line: 601, col: 58, offset: 17492},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 622, col: 62, offset: 18113},
+									pos:  position{line: 601, col: 62, offset: 17496},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 622, col: 65, offset: 18116},
+									pos:   position{line: 601, col: 65, offset: 17499},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 622, col: 76, offset: 18127},
+										pos:  position{line: 601, col: 76, offset: 17510},
 										name: "Expr",
 									},
 								},
@@ -4593,7 +4448,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 625, col: 5, offset: 18267},
+						pos:  position{line: 604, col: 5, offset: 17650},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4601,53 +4456,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 627, col: 1, offset: 18282},
+			pos:  position{line: 606, col: 1, offset: 17665},
 			expr: &actionExpr{
-				pos: position{line: 628, col: 5, offset: 18300},
+				pos: position{line: 607, col: 5, offset: 17683},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 628, col: 5, offset: 18300},
+					pos: position{line: 607, col: 5, offset: 17683},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 628, col: 5, offset: 18300},
+							pos:   position{line: 607, col: 5, offset: 17683},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 628, col: 11, offset: 18306},
+								pos:  position{line: 607, col: 11, offset: 17689},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 5, offset: 18325},
+							pos:   position{line: 608, col: 5, offset: 17708},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 629, col: 10, offset: 18330},
+								pos: position{line: 608, col: 10, offset: 17713},
 								expr: &actionExpr{
-									pos: position{line: 629, col: 11, offset: 18331},
+									pos: position{line: 608, col: 11, offset: 17714},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 629, col: 11, offset: 18331},
+										pos: position{line: 608, col: 11, offset: 17714},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 629, col: 11, offset: 18331},
+												pos:  position{line: 608, col: 11, offset: 17714},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 629, col: 14, offset: 18334},
+												pos:   position{line: 608, col: 14, offset: 17717},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 629, col: 17, offset: 18337},
+													pos:  position{line: 608, col: 17, offset: 17720},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 629, col: 25, offset: 18345},
+												pos:  position{line: 608, col: 25, offset: 17728},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 629, col: 28, offset: 18348},
+												pos:   position{line: 608, col: 28, offset: 17731},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 629, col: 33, offset: 18353},
+													pos:  position{line: 608, col: 33, offset: 17736},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4662,53 +4517,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 633, col: 1, offset: 18471},
+			pos:  position{line: 612, col: 1, offset: 17854},
 			expr: &actionExpr{
-				pos: position{line: 634, col: 5, offset: 18490},
+				pos: position{line: 613, col: 5, offset: 17873},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 634, col: 5, offset: 18490},
+					pos: position{line: 613, col: 5, offset: 17873},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 634, col: 5, offset: 18490},
+							pos:   position{line: 613, col: 5, offset: 17873},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 11, offset: 18496},
+								pos:  position{line: 613, col: 11, offset: 17879},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 635, col: 5, offset: 18520},
+							pos:   position{line: 614, col: 5, offset: 17903},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 635, col: 10, offset: 18525},
+								pos: position{line: 614, col: 10, offset: 17908},
 								expr: &actionExpr{
-									pos: position{line: 635, col: 11, offset: 18526},
+									pos: position{line: 614, col: 11, offset: 17909},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 635, col: 11, offset: 18526},
+										pos: position{line: 614, col: 11, offset: 17909},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 635, col: 11, offset: 18526},
+												pos:  position{line: 614, col: 11, offset: 17909},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 635, col: 14, offset: 18529},
+												pos:   position{line: 614, col: 14, offset: 17912},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 635, col: 17, offset: 18532},
+													pos:  position{line: 614, col: 17, offset: 17915},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 635, col: 26, offset: 18541},
+												pos:  position{line: 614, col: 26, offset: 17924},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 635, col: 29, offset: 18544},
+												pos:   position{line: 614, col: 29, offset: 17927},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 635, col: 34, offset: 18549},
+													pos:  position{line: 614, col: 34, offset: 17932},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -4723,60 +4578,60 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 639, col: 1, offset: 18672},
+			pos:  position{line: 618, col: 1, offset: 18055},
 			expr: &choiceExpr{
-				pos: position{line: 640, col: 5, offset: 18696},
+				pos: position{line: 619, col: 5, offset: 18079},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 640, col: 5, offset: 18696},
+						pos:  position{line: 619, col: 5, offset: 18079},
 						name: "PatternMatch",
 					},
 					&actionExpr{
-						pos: position{line: 641, col: 5, offset: 18713},
+						pos: position{line: 620, col: 5, offset: 18096},
 						run: (*parser).callonEqualityCompareExpr3,
 						expr: &seqExpr{
-							pos: position{line: 641, col: 5, offset: 18713},
+							pos: position{line: 620, col: 5, offset: 18096},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 641, col: 5, offset: 18713},
+									pos:   position{line: 620, col: 5, offset: 18096},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 641, col: 11, offset: 18719},
+										pos:  position{line: 620, col: 11, offset: 18102},
 										name: "RelativeExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 642, col: 5, offset: 18736},
+									pos:   position{line: 621, col: 5, offset: 18119},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 642, col: 10, offset: 18741},
+										pos: position{line: 621, col: 10, offset: 18124},
 										expr: &actionExpr{
-											pos: position{line: 642, col: 11, offset: 18742},
+											pos: position{line: 621, col: 11, offset: 18125},
 											run: (*parser).callonEqualityCompareExpr9,
 											expr: &seqExpr{
-												pos: position{line: 642, col: 11, offset: 18742},
+												pos: position{line: 621, col: 11, offset: 18125},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 642, col: 11, offset: 18742},
+														pos:  position{line: 621, col: 11, offset: 18125},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 642, col: 14, offset: 18745},
+														pos:   position{line: 621, col: 14, offset: 18128},
 														label: "comp",
 														expr: &ruleRefExpr{
-															pos:  position{line: 642, col: 19, offset: 18750},
+															pos:  position{line: 621, col: 19, offset: 18133},
 															name: "EqualityComparator",
 														},
 													},
 													&ruleRefExpr{
-														pos:  position{line: 642, col: 38, offset: 18769},
+														pos:  position{line: 621, col: 38, offset: 18152},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 642, col: 41, offset: 18772},
+														pos:   position{line: 621, col: 41, offset: 18155},
 														label: "expr",
 														expr: &ruleRefExpr{
-															pos:  position{line: 642, col: 46, offset: 18777},
+															pos:  position{line: 621, col: 46, offset: 18160},
 															name: "RelativeExpr",
 														},
 													},
@@ -4793,24 +4648,24 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 646, col: 1, offset: 18895},
+			pos:  position{line: 625, col: 1, offset: 18278},
 			expr: &choiceExpr{
-				pos: position{line: 647, col: 5, offset: 18916},
+				pos: position{line: 626, col: 5, offset: 18299},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 647, col: 5, offset: 18916},
+						pos: position{line: 626, col: 5, offset: 18299},
 						run: (*parser).callonEqualityOperator2,
 						expr: &litMatcher{
-							pos:        position{line: 647, col: 5, offset: 18916},
+							pos:        position{line: 626, col: 5, offset: 18299},
 							val:        "==",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 648, col: 5, offset: 18945},
+						pos: position{line: 627, col: 5, offset: 18328},
 						run: (*parser).callonEqualityOperator4,
 						expr: &litMatcher{
-							pos:        position{line: 648, col: 5, offset: 18945},
+							pos:        position{line: 627, col: 5, offset: 18328},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -4820,19 +4675,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 650, col: 1, offset: 18982},
+			pos:  position{line: 629, col: 1, offset: 18365},
 			expr: &choiceExpr{
-				pos: position{line: 651, col: 5, offset: 19005},
+				pos: position{line: 630, col: 5, offset: 18388},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 651, col: 5, offset: 19005},
+						pos:  position{line: 630, col: 5, offset: 18388},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 652, col: 5, offset: 19026},
+						pos: position{line: 631, col: 5, offset: 18409},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 652, col: 5, offset: 19026},
+							pos:        position{line: 631, col: 5, offset: 18409},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -4842,53 +4697,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 654, col: 1, offset: 19063},
+			pos:  position{line: 633, col: 1, offset: 18446},
 			expr: &actionExpr{
-				pos: position{line: 655, col: 5, offset: 19080},
+				pos: position{line: 634, col: 5, offset: 18463},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 655, col: 5, offset: 19080},
+					pos: position{line: 634, col: 5, offset: 18463},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 655, col: 5, offset: 19080},
+							pos:   position{line: 634, col: 5, offset: 18463},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 655, col: 11, offset: 19086},
+								pos:  position{line: 634, col: 11, offset: 18469},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 656, col: 5, offset: 19103},
+							pos:   position{line: 635, col: 5, offset: 18486},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 656, col: 10, offset: 19108},
+								pos: position{line: 635, col: 10, offset: 18491},
 								expr: &actionExpr{
-									pos: position{line: 656, col: 11, offset: 19109},
+									pos: position{line: 635, col: 11, offset: 18492},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 656, col: 11, offset: 19109},
+										pos: position{line: 635, col: 11, offset: 18492},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 656, col: 11, offset: 19109},
+												pos:  position{line: 635, col: 11, offset: 18492},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 656, col: 14, offset: 19112},
+												pos:   position{line: 635, col: 14, offset: 18495},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 656, col: 17, offset: 19115},
+													pos:  position{line: 635, col: 17, offset: 18498},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 656, col: 34, offset: 19132},
+												pos:  position{line: 635, col: 34, offset: 18515},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 656, col: 37, offset: 19135},
+												pos:   position{line: 635, col: 37, offset: 18518},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 656, col: 42, offset: 19140},
+													pos:  position{line: 635, col: 42, offset: 18523},
 													name: "AdditiveExpr",
 												},
 											},
@@ -4903,30 +4758,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 660, col: 1, offset: 19256},
+			pos:  position{line: 639, col: 1, offset: 18639},
 			expr: &actionExpr{
-				pos: position{line: 660, col: 20, offset: 19275},
+				pos: position{line: 639, col: 20, offset: 18658},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 660, col: 21, offset: 19276},
+					pos: position{line: 639, col: 21, offset: 18659},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 660, col: 21, offset: 19276},
+							pos:        position{line: 639, col: 21, offset: 18659},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 660, col: 28, offset: 19283},
+							pos:        position{line: 639, col: 28, offset: 18666},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 660, col: 34, offset: 19289},
+							pos:        position{line: 639, col: 34, offset: 18672},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 660, col: 41, offset: 19296},
+							pos:        position{line: 639, col: 41, offset: 18679},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -4936,53 +4791,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 662, col: 1, offset: 19333},
+			pos:  position{line: 641, col: 1, offset: 18716},
 			expr: &actionExpr{
-				pos: position{line: 663, col: 5, offset: 19350},
+				pos: position{line: 642, col: 5, offset: 18733},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 663, col: 5, offset: 19350},
+					pos: position{line: 642, col: 5, offset: 18733},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 663, col: 5, offset: 19350},
+							pos:   position{line: 642, col: 5, offset: 18733},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 663, col: 11, offset: 19356},
+								pos:  position{line: 642, col: 11, offset: 18739},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 5, offset: 19379},
+							pos:   position{line: 643, col: 5, offset: 18762},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 664, col: 10, offset: 19384},
+								pos: position{line: 643, col: 10, offset: 18767},
 								expr: &actionExpr{
-									pos: position{line: 664, col: 11, offset: 19385},
+									pos: position{line: 643, col: 11, offset: 18768},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 664, col: 11, offset: 19385},
+										pos: position{line: 643, col: 11, offset: 18768},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 664, col: 11, offset: 19385},
+												pos:  position{line: 643, col: 11, offset: 18768},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 664, col: 14, offset: 19388},
+												pos:   position{line: 643, col: 14, offset: 18771},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 664, col: 17, offset: 19391},
+													pos:  position{line: 643, col: 17, offset: 18774},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 664, col: 34, offset: 19408},
+												pos:  position{line: 643, col: 34, offset: 18791},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 664, col: 37, offset: 19411},
+												pos:   position{line: 643, col: 37, offset: 18794},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 664, col: 42, offset: 19416},
+													pos:  position{line: 643, col: 42, offset: 18799},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -4997,20 +4852,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 668, col: 1, offset: 19538},
+			pos:  position{line: 647, col: 1, offset: 18921},
 			expr: &actionExpr{
-				pos: position{line: 668, col: 20, offset: 19557},
+				pos: position{line: 647, col: 20, offset: 18940},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 668, col: 21, offset: 19558},
+					pos: position{line: 647, col: 21, offset: 18941},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 668, col: 21, offset: 19558},
+							pos:        position{line: 647, col: 21, offset: 18941},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 668, col: 27, offset: 19564},
+							pos:        position{line: 647, col: 27, offset: 18947},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5020,53 +4875,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 670, col: 1, offset: 19601},
+			pos:  position{line: 649, col: 1, offset: 18984},
 			expr: &actionExpr{
-				pos: position{line: 671, col: 5, offset: 19624},
+				pos: position{line: 650, col: 5, offset: 19007},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 671, col: 5, offset: 19624},
+					pos: position{line: 650, col: 5, offset: 19007},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 671, col: 5, offset: 19624},
+							pos:   position{line: 650, col: 5, offset: 19007},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 671, col: 11, offset: 19630},
+								pos:  position{line: 650, col: 11, offset: 19013},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 672, col: 5, offset: 19642},
+							pos:   position{line: 651, col: 5, offset: 19025},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 672, col: 10, offset: 19647},
+								pos: position{line: 651, col: 10, offset: 19030},
 								expr: &actionExpr{
-									pos: position{line: 672, col: 11, offset: 19648},
+									pos: position{line: 651, col: 11, offset: 19031},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 672, col: 11, offset: 19648},
+										pos: position{line: 651, col: 11, offset: 19031},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 672, col: 11, offset: 19648},
+												pos:  position{line: 651, col: 11, offset: 19031},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 672, col: 14, offset: 19651},
+												pos:   position{line: 651, col: 14, offset: 19034},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 672, col: 17, offset: 19654},
+													pos:  position{line: 651, col: 17, offset: 19037},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 672, col: 40, offset: 19677},
+												pos:  position{line: 651, col: 40, offset: 19060},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 672, col: 43, offset: 19680},
+												pos:   position{line: 651, col: 43, offset: 19063},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 672, col: 48, offset: 19685},
+													pos:  position{line: 651, col: 48, offset: 19068},
 													name: "NotExpr",
 												},
 											},
@@ -5081,20 +4936,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 676, col: 1, offset: 19796},
+			pos:  position{line: 655, col: 1, offset: 19179},
 			expr: &actionExpr{
-				pos: position{line: 676, col: 26, offset: 19821},
+				pos: position{line: 655, col: 26, offset: 19204},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 676, col: 27, offset: 19822},
+					pos: position{line: 655, col: 27, offset: 19205},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 676, col: 27, offset: 19822},
+							pos:        position{line: 655, col: 27, offset: 19205},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 676, col: 33, offset: 19828},
+							pos:        position{line: 655, col: 33, offset: 19211},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5104,30 +4959,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 678, col: 1, offset: 19865},
+			pos:  position{line: 657, col: 1, offset: 19248},
 			expr: &choiceExpr{
-				pos: position{line: 679, col: 5, offset: 19877},
+				pos: position{line: 658, col: 5, offset: 19260},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 679, col: 5, offset: 19877},
+						pos: position{line: 658, col: 5, offset: 19260},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 679, col: 5, offset: 19877},
+							pos: position{line: 658, col: 5, offset: 19260},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 679, col: 5, offset: 19877},
+									pos:        position{line: 658, col: 5, offset: 19260},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 679, col: 9, offset: 19881},
+									pos:  position{line: 658, col: 9, offset: 19264},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 679, col: 12, offset: 19884},
+									pos:   position{line: 658, col: 12, offset: 19267},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 679, col: 14, offset: 19886},
+										pos:  position{line: 658, col: 14, offset: 19269},
 										name: "NotExpr",
 									},
 								},
@@ -5135,7 +4990,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 682, col: 5, offset: 19995},
+						pos:  position{line: 661, col: 5, offset: 19378},
 						name: "FuncExpr",
 					},
 				},
@@ -5143,43 +4998,43 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 684, col: 1, offset: 20005},
+			pos:  position{line: 663, col: 1, offset: 19388},
 			expr: &choiceExpr{
-				pos: position{line: 685, col: 5, offset: 20018},
+				pos: position{line: 664, col: 5, offset: 19401},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 685, col: 5, offset: 20018},
+						pos:  position{line: 664, col: 5, offset: 19401},
 						name: "SelectExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 686, col: 5, offset: 20033},
+						pos:  position{line: 665, col: 5, offset: 19416},
 						name: "MatchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 687, col: 5, offset: 20047},
+						pos: position{line: 666, col: 5, offset: 19430},
 						run: (*parser).callonFuncExpr4,
 						expr: &seqExpr{
-							pos: position{line: 687, col: 5, offset: 20047},
+							pos: position{line: 666, col: 5, offset: 19430},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 687, col: 5, offset: 20047},
+									pos:   position{line: 666, col: 5, offset: 19430},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 687, col: 9, offset: 20051},
+										pos:  position{line: 666, col: 9, offset: 19434},
 										name: "TypeLiteral",
 									},
 								},
 								&notExpr{
-									pos: position{line: 687, col: 21, offset: 20063},
+									pos: position{line: 666, col: 21, offset: 19446},
 									expr: &seqExpr{
-										pos: position{line: 687, col: 23, offset: 20065},
+										pos: position{line: 666, col: 23, offset: 19448},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 687, col: 23, offset: 20065},
+												pos:  position{line: 666, col: 23, offset: 19448},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 687, col: 26, offset: 20068},
+												pos:        position{line: 666, col: 26, offset: 19451},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -5190,26 +5045,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 20097},
+						pos: position{line: 667, col: 5, offset: 19480},
 						run: (*parser).callonFuncExpr12,
 						expr: &seqExpr{
-							pos: position{line: 688, col: 5, offset: 20097},
+							pos: position{line: 667, col: 5, offset: 19480},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 688, col: 5, offset: 20097},
+									pos:   position{line: 667, col: 5, offset: 19480},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 688, col: 11, offset: 20103},
+										pos:  position{line: 667, col: 11, offset: 19486},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 688, col: 16, offset: 20108},
+									pos:   position{line: 667, col: 16, offset: 19491},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 688, col: 21, offset: 20113},
+										pos: position{line: 667, col: 21, offset: 19496},
 										expr: &ruleRefExpr{
-											pos:  position{line: 688, col: 22, offset: 20114},
+											pos:  position{line: 667, col: 22, offset: 19497},
 											name: "Deref",
 										},
 									},
@@ -5218,26 +5073,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 691, col: 5, offset: 20185},
+						pos: position{line: 670, col: 5, offset: 19568},
 						run: (*parser).callonFuncExpr19,
 						expr: &seqExpr{
-							pos: position{line: 691, col: 5, offset: 20185},
+							pos: position{line: 670, col: 5, offset: 19568},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 691, col: 5, offset: 20185},
+									pos:   position{line: 670, col: 5, offset: 19568},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 691, col: 11, offset: 20191},
+										pos:  position{line: 670, col: 11, offset: 19574},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 691, col: 20, offset: 20200},
+									pos:   position{line: 670, col: 20, offset: 19583},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 691, col: 25, offset: 20205},
+										pos: position{line: 670, col: 25, offset: 19588},
 										expr: &ruleRefExpr{
-											pos:  position{line: 691, col: 26, offset: 20206},
+											pos:  position{line: 670, col: 26, offset: 19589},
 											name: "Deref",
 										},
 									},
@@ -5246,11 +5101,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 694, col: 5, offset: 20277},
+						pos:  position{line: 673, col: 5, offset: 19660},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 695, col: 5, offset: 20291},
+						pos:  position{line: 674, col: 5, offset: 19674},
 						name: "Primary",
 					},
 				},
@@ -5258,20 +5113,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 697, col: 1, offset: 20300},
+			pos:  position{line: 676, col: 1, offset: 19683},
 			expr: &seqExpr{
-				pos: position{line: 697, col: 13, offset: 20312},
+				pos: position{line: 676, col: 13, offset: 19695},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 697, col: 13, offset: 20312},
+						pos:  position{line: 676, col: 13, offset: 19695},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 697, col: 22, offset: 20321},
+						pos:  position{line: 676, col: 22, offset: 19704},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 697, col: 25, offset: 20324},
+						pos:        position{line: 676, col: 25, offset: 19707},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5280,27 +5135,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 699, col: 1, offset: 20329},
+			pos:  position{line: 678, col: 1, offset: 19712},
 			expr: &choiceExpr{
-				pos: position{line: 700, col: 5, offset: 20342},
+				pos: position{line: 679, col: 5, offset: 19725},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 700, col: 5, offset: 20342},
+						pos:        position{line: 679, col: 5, offset: 19725},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 701, col: 5, offset: 20352},
+						pos:        position{line: 680, col: 5, offset: 19735},
 						val:        "match",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 702, col: 5, offset: 20364},
+						pos:        position{line: 681, col: 5, offset: 19747},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 703, col: 5, offset: 20377},
+						pos:        position{line: 682, col: 5, offset: 19760},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -5309,37 +5164,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 705, col: 1, offset: 20385},
+			pos:  position{line: 684, col: 1, offset: 19768},
 			expr: &actionExpr{
-				pos: position{line: 706, col: 5, offset: 20399},
+				pos: position{line: 685, col: 5, offset: 19782},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 706, col: 5, offset: 20399},
+					pos: position{line: 685, col: 5, offset: 19782},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 706, col: 5, offset: 20399},
+							pos:        position{line: 685, col: 5, offset: 19782},
 							val:        "match",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 706, col: 13, offset: 20407},
+							pos:  position{line: 685, col: 13, offset: 19790},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 706, col: 16, offset: 20410},
+							pos:        position{line: 685, col: 16, offset: 19793},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 706, col: 20, offset: 20414},
+							pos:   position{line: 685, col: 20, offset: 19797},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 706, col: 25, offset: 20419},
+								pos:  position{line: 685, col: 25, offset: 19802},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 706, col: 39, offset: 20433},
+							pos:        position{line: 685, col: 39, offset: 19816},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5349,53 +5204,53 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 708, col: 1, offset: 20459},
+			pos:  position{line: 687, col: 1, offset: 19842},
 			expr: &actionExpr{
-				pos: position{line: 709, col: 5, offset: 20474},
+				pos: position{line: 688, col: 5, offset: 19857},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 709, col: 5, offset: 20474},
+					pos: position{line: 688, col: 5, offset: 19857},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 709, col: 5, offset: 20474},
+							pos:        position{line: 688, col: 5, offset: 19857},
 							val:        "select",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 709, col: 14, offset: 20483},
+							pos:  position{line: 688, col: 14, offset: 19866},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 709, col: 17, offset: 20486},
+							pos:        position{line: 688, col: 17, offset: 19869},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 709, col: 21, offset: 20490},
+							pos:  position{line: 688, col: 21, offset: 19873},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 709, col: 24, offset: 20493},
+							pos:   position{line: 688, col: 24, offset: 19876},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 709, col: 29, offset: 20498},
+								pos:  position{line: 688, col: 29, offset: 19881},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 709, col: 35, offset: 20504},
+							pos:  position{line: 688, col: 35, offset: 19887},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 709, col: 38, offset: 20507},
+							pos:        position{line: 688, col: 38, offset: 19890},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 709, col: 42, offset: 20511},
+							pos:   position{line: 688, col: 42, offset: 19894},
 							label: "methods",
 							expr: &ruleRefExpr{
-								pos:  position{line: 709, col: 50, offset: 20519},
+								pos:  position{line: 688, col: 50, offset: 19902},
 								name: "Methods",
 							},
 						},
@@ -5405,30 +5260,30 @@ var g = &grammar{
 		},
 		{
 			name: "Methods",
-			pos:  position{line: 717, col: 1, offset: 20917},
+			pos:  position{line: 696, col: 1, offset: 20300},
 			expr: &choiceExpr{
-				pos: position{line: 718, col: 5, offset: 20929},
+				pos: position{line: 697, col: 5, offset: 20312},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 718, col: 5, offset: 20929},
+						pos: position{line: 697, col: 5, offset: 20312},
 						run: (*parser).callonMethods2,
 						expr: &labeledExpr{
-							pos:   position{line: 718, col: 5, offset: 20929},
+							pos:   position{line: 697, col: 5, offset: 20312},
 							label: "methods",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 718, col: 13, offset: 20937},
+								pos: position{line: 697, col: 13, offset: 20320},
 								expr: &ruleRefExpr{
-									pos:  position{line: 718, col: 13, offset: 20937},
+									pos:  position{line: 697, col: 13, offset: 20320},
 									name: "Method",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 20973},
+						pos: position{line: 698, col: 5, offset: 20356},
 						run: (*parser).callonMethods6,
 						expr: &litMatcher{
-							pos:        position{line: 719, col: 5, offset: 20973},
+							pos:        position{line: 698, col: 5, offset: 20356},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -5438,31 +5293,31 @@ var g = &grammar{
 		},
 		{
 			name: "Method",
-			pos:  position{line: 721, col: 1, offset: 20997},
+			pos:  position{line: 700, col: 1, offset: 20380},
 			expr: &actionExpr{
-				pos: position{line: 722, col: 5, offset: 21008},
+				pos: position{line: 701, col: 5, offset: 20391},
 				run: (*parser).callonMethod1,
 				expr: &seqExpr{
-					pos: position{line: 722, col: 5, offset: 21008},
+					pos: position{line: 701, col: 5, offset: 20391},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 722, col: 5, offset: 21008},
+							pos:  position{line: 701, col: 5, offset: 20391},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 722, col: 8, offset: 21011},
+							pos:        position{line: 701, col: 8, offset: 20394},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 722, col: 12, offset: 21015},
+							pos:  position{line: 701, col: 12, offset: 20398},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 722, col: 15, offset: 21018},
+							pos:   position{line: 701, col: 15, offset: 20401},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 722, col: 17, offset: 21020},
+								pos:  position{line: 701, col: 17, offset: 20403},
 								name: "Function",
 							},
 						},
@@ -5472,48 +5327,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 724, col: 1, offset: 21048},
+			pos:  position{line: 703, col: 1, offset: 20431},
 			expr: &actionExpr{
-				pos: position{line: 725, col: 5, offset: 21057},
+				pos: position{line: 704, col: 5, offset: 20440},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 725, col: 5, offset: 21057},
+					pos: position{line: 704, col: 5, offset: 20440},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 725, col: 5, offset: 21057},
+							pos:   position{line: 704, col: 5, offset: 20440},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 725, col: 9, offset: 21061},
+								pos:  position{line: 704, col: 9, offset: 20444},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 725, col: 18, offset: 21070},
+							pos:  position{line: 704, col: 18, offset: 20453},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 725, col: 21, offset: 21073},
+							pos:        position{line: 704, col: 21, offset: 20456},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 725, col: 25, offset: 21077},
+							pos:  position{line: 704, col: 25, offset: 20460},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 725, col: 28, offset: 21080},
+							pos:   position{line: 704, col: 28, offset: 20463},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 725, col: 33, offset: 21085},
+								pos:  position{line: 704, col: 33, offset: 20468},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 725, col: 38, offset: 21090},
+							pos:  position{line: 704, col: 38, offset: 20473},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 725, col: 41, offset: 21093},
+							pos:        position{line: 704, col: 41, offset: 20476},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5523,55 +5378,55 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 729, col: 1, offset: 21190},
+			pos:  position{line: 708, col: 1, offset: 20573},
 			expr: &actionExpr{
-				pos: position{line: 730, col: 5, offset: 21203},
+				pos: position{line: 709, col: 5, offset: 20586},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 730, col: 5, offset: 21203},
+					pos: position{line: 709, col: 5, offset: 20586},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 730, col: 5, offset: 21203},
+							pos: position{line: 709, col: 5, offset: 20586},
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 6, offset: 21204},
+								pos:  position{line: 709, col: 6, offset: 20587},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 730, col: 16, offset: 21214},
+							pos:   position{line: 709, col: 16, offset: 20597},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 19, offset: 21217},
+								pos:  position{line: 709, col: 19, offset: 20600},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 730, col: 34, offset: 21232},
+							pos:  position{line: 709, col: 34, offset: 20615},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 730, col: 37, offset: 21235},
+							pos:        position{line: 709, col: 37, offset: 20618},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 730, col: 41, offset: 21239},
+							pos:  position{line: 709, col: 41, offset: 20622},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 730, col: 44, offset: 21242},
+							pos:   position{line: 709, col: 44, offset: 20625},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 49, offset: 21247},
+								pos:  position{line: 709, col: 49, offset: 20630},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 730, col: 63, offset: 21261},
+							pos:  position{line: 709, col: 63, offset: 20644},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 730, col: 66, offset: 21264},
+							pos:        position{line: 709, col: 66, offset: 20647},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5581,19 +5436,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 734, col: 1, offset: 21360},
+			pos:  position{line: 713, col: 1, offset: 20743},
 			expr: &choiceExpr{
-				pos: position{line: 735, col: 5, offset: 21378},
+				pos: position{line: 714, col: 5, offset: 20761},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 735, col: 5, offset: 21378},
+						pos:  position{line: 714, col: 5, offset: 20761},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 736, col: 5, offset: 21388},
+						pos: position{line: 715, col: 5, offset: 20771},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 736, col: 5, offset: 21388},
+							pos:  position{line: 715, col: 5, offset: 20771},
 							name: "__",
 						},
 					},
@@ -5602,50 +5457,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 738, col: 1, offset: 21424},
+			pos:  position{line: 717, col: 1, offset: 20807},
 			expr: &actionExpr{
-				pos: position{line: 739, col: 5, offset: 21434},
+				pos: position{line: 718, col: 5, offset: 20817},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 739, col: 5, offset: 21434},
+					pos: position{line: 718, col: 5, offset: 20817},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 739, col: 5, offset: 21434},
+							pos:   position{line: 718, col: 5, offset: 20817},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 739, col: 11, offset: 21440},
+								pos:  position{line: 718, col: 11, offset: 20823},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 739, col: 16, offset: 21445},
+							pos:   position{line: 718, col: 16, offset: 20828},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 739, col: 21, offset: 21450},
+								pos: position{line: 718, col: 21, offset: 20833},
 								expr: &actionExpr{
-									pos: position{line: 739, col: 22, offset: 21451},
+									pos: position{line: 718, col: 22, offset: 20834},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 739, col: 22, offset: 21451},
+										pos: position{line: 718, col: 22, offset: 20834},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 739, col: 22, offset: 21451},
+												pos:  position{line: 718, col: 22, offset: 20834},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 739, col: 25, offset: 21454},
+												pos:        position{line: 718, col: 25, offset: 20837},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 739, col: 29, offset: 21458},
+												pos:  position{line: 718, col: 29, offset: 20841},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 739, col: 32, offset: 21461},
+												pos:   position{line: 718, col: 32, offset: 20844},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 739, col: 34, offset: 21463},
+													pos:  position{line: 718, col: 34, offset: 20846},
 													name: "Expr",
 												},
 											},
@@ -5660,25 +5515,25 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 743, col: 1, offset: 21572},
+			pos:  position{line: 722, col: 1, offset: 20955},
 			expr: &actionExpr{
-				pos: position{line: 743, col: 13, offset: 21584},
+				pos: position{line: 722, col: 13, offset: 20967},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 743, col: 13, offset: 21584},
+					pos: position{line: 722, col: 13, offset: 20967},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 743, col: 13, offset: 21584},
+							pos: position{line: 722, col: 13, offset: 20967},
 							expr: &ruleRefExpr{
-								pos:  position{line: 743, col: 14, offset: 21585},
+								pos:  position{line: 722, col: 14, offset: 20968},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 743, col: 18, offset: 21589},
+							pos:   position{line: 722, col: 18, offset: 20972},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 743, col: 20, offset: 21591},
+								pos:  position{line: 722, col: 20, offset: 20974},
 								name: "DerefExprPattern",
 							},
 						},
@@ -5688,31 +5543,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExprPattern",
-			pos:  position{line: 745, col: 1, offset: 21627},
+			pos:  position{line: 724, col: 1, offset: 21010},
 			expr: &choiceExpr{
-				pos: position{line: 746, col: 5, offset: 21648},
+				pos: position{line: 725, col: 5, offset: 21031},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 746, col: 5, offset: 21648},
+						pos: position{line: 725, col: 5, offset: 21031},
 						run: (*parser).callonDerefExprPattern2,
 						expr: &seqExpr{
-							pos: position{line: 746, col: 5, offset: 21648},
+							pos: position{line: 725, col: 5, offset: 21031},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 746, col: 5, offset: 21648},
+									pos:   position{line: 725, col: 5, offset: 21031},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 746, col: 11, offset: 21654},
+										pos:  position{line: 725, col: 11, offset: 21037},
 										name: "DotID",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 746, col: 17, offset: 21660},
+									pos:   position{line: 725, col: 17, offset: 21043},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 746, col: 22, offset: 21665},
+										pos: position{line: 725, col: 22, offset: 21048},
 										expr: &ruleRefExpr{
-											pos:  position{line: 746, col: 23, offset: 21666},
+											pos:  position{line: 725, col: 23, offset: 21049},
 											name: "Deref",
 										},
 									},
@@ -5721,26 +5576,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 749, col: 5, offset: 21737},
+						pos: position{line: 728, col: 5, offset: 21120},
 						run: (*parser).callonDerefExprPattern9,
 						expr: &seqExpr{
-							pos: position{line: 749, col: 5, offset: 21737},
+							pos: position{line: 728, col: 5, offset: 21120},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 749, col: 5, offset: 21737},
+									pos:   position{line: 728, col: 5, offset: 21120},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 749, col: 11, offset: 21743},
+										pos:  position{line: 728, col: 11, offset: 21126},
 										name: "RootRecord",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 749, col: 22, offset: 21754},
+									pos:   position{line: 728, col: 22, offset: 21137},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 749, col: 27, offset: 21759},
+										pos: position{line: 728, col: 27, offset: 21142},
 										expr: &ruleRefExpr{
-											pos:  position{line: 749, col: 28, offset: 21760},
+											pos:  position{line: 728, col: 28, offset: 21143},
 											name: "Deref",
 										},
 									},
@@ -5749,26 +5604,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 752, col: 5, offset: 21831},
+						pos: position{line: 731, col: 5, offset: 21214},
 						run: (*parser).callonDerefExprPattern16,
 						expr: &seqExpr{
-							pos: position{line: 752, col: 5, offset: 21831},
+							pos: position{line: 731, col: 5, offset: 21214},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 752, col: 5, offset: 21831},
+									pos:   position{line: 731, col: 5, offset: 21214},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 752, col: 11, offset: 21837},
+										pos:  position{line: 731, col: 11, offset: 21220},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 752, col: 22, offset: 21848},
+									pos:   position{line: 731, col: 22, offset: 21231},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 752, col: 27, offset: 21853},
+										pos: position{line: 731, col: 27, offset: 21236},
 										expr: &ruleRefExpr{
-											pos:  position{line: 752, col: 28, offset: 21854},
+											pos:  position{line: 731, col: 28, offset: 21237},
 											name: "Deref",
 										},
 									},
@@ -5777,10 +5632,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 755, col: 5, offset: 21925},
+						pos: position{line: 734, col: 5, offset: 21308},
 						run: (*parser).callonDerefExprPattern23,
 						expr: &litMatcher{
-							pos:        position{line: 755, col: 5, offset: 21925},
+							pos:        position{line: 734, col: 5, offset: 21308},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -5790,12 +5645,12 @@ var g = &grammar{
 		},
 		{
 			name: "RootRecord",
-			pos:  position{line: 759, col: 1, offset: 21994},
+			pos:  position{line: 738, col: 1, offset: 21377},
 			expr: &actionExpr{
-				pos: position{line: 759, col: 14, offset: 22007},
+				pos: position{line: 738, col: 14, offset: 21390},
 				run: (*parser).callonRootRecord1,
 				expr: &litMatcher{
-					pos:        position{line: 759, col: 14, offset: 22007},
+					pos:        position{line: 738, col: 14, offset: 21390},
 					val:        "this",
 					ignoreCase: false,
 				},
@@ -5803,26 +5658,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotID",
-			pos:  position{line: 761, col: 1, offset: 22069},
+			pos:  position{line: 740, col: 1, offset: 21452},
 			expr: &choiceExpr{
-				pos: position{line: 762, col: 5, offset: 22079},
+				pos: position{line: 741, col: 5, offset: 21462},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 762, col: 5, offset: 22079},
+						pos: position{line: 741, col: 5, offset: 21462},
 						run: (*parser).callonDotID2,
 						expr: &seqExpr{
-							pos: position{line: 762, col: 5, offset: 22079},
+							pos: position{line: 741, col: 5, offset: 21462},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 762, col: 5, offset: 22079},
+									pos:        position{line: 741, col: 5, offset: 21462},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 762, col: 9, offset: 22083},
+									pos:   position{line: 741, col: 9, offset: 21466},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 762, col: 15, offset: 22089},
+										pos:  position{line: 741, col: 15, offset: 21472},
 										name: "Identifier",
 									},
 								},
@@ -5830,31 +5685,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 771, col: 5, offset: 22305},
+						pos: position{line: 750, col: 5, offset: 21688},
 						run: (*parser).callonDotID7,
 						expr: &seqExpr{
-							pos: position{line: 771, col: 5, offset: 22305},
+							pos: position{line: 750, col: 5, offset: 21688},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 771, col: 5, offset: 22305},
+									pos:        position{line: 750, col: 5, offset: 21688},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 771, col: 9, offset: 22309},
+									pos:        position{line: 750, col: 9, offset: 21692},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 771, col: 13, offset: 22313},
+									pos:   position{line: 750, col: 13, offset: 21696},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 771, col: 18, offset: 22318},
+										pos:  position{line: 750, col: 18, offset: 21701},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 771, col: 23, offset: 22323},
+									pos:        position{line: 750, col: 23, offset: 21706},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5866,52 +5721,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 781, col: 1, offset: 22528},
+			pos:  position{line: 760, col: 1, offset: 21911},
 			expr: &choiceExpr{
-				pos: position{line: 782, col: 5, offset: 22538},
+				pos: position{line: 761, col: 5, offset: 21921},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 782, col: 5, offset: 22538},
+						pos: position{line: 761, col: 5, offset: 21921},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 782, col: 5, offset: 22538},
+							pos: position{line: 761, col: 5, offset: 21921},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 782, col: 5, offset: 22538},
+									pos:        position{line: 761, col: 5, offset: 21921},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 782, col: 9, offset: 22542},
+									pos:   position{line: 761, col: 9, offset: 21925},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 782, col: 14, offset: 22547},
+										pos:  position{line: 761, col: 14, offset: 21930},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 27, offset: 22560},
+									pos:  position{line: 761, col: 27, offset: 21943},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 782, col: 30, offset: 22563},
+									pos:        position{line: 761, col: 30, offset: 21946},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 34, offset: 22567},
+									pos:  position{line: 761, col: 34, offset: 21950},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 782, col: 37, offset: 22570},
+									pos:   position{line: 761, col: 37, offset: 21953},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 782, col: 40, offset: 22573},
+										pos:  position{line: 761, col: 40, offset: 21956},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 782, col: 53, offset: 22586},
+									pos:        position{line: 761, col: 53, offset: 21969},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5919,39 +5774,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 788, col: 5, offset: 22757},
+						pos: position{line: 767, col: 5, offset: 22140},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 788, col: 5, offset: 22757},
+							pos: position{line: 767, col: 5, offset: 22140},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 788, col: 5, offset: 22757},
+									pos:        position{line: 767, col: 5, offset: 22140},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 788, col: 9, offset: 22761},
+									pos:  position{line: 767, col: 9, offset: 22144},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 788, col: 12, offset: 22764},
+									pos:        position{line: 767, col: 12, offset: 22147},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 788, col: 16, offset: 22768},
+									pos:  position{line: 767, col: 16, offset: 22151},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 788, col: 19, offset: 22771},
+									pos:   position{line: 767, col: 19, offset: 22154},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 788, col: 22, offset: 22774},
+										pos:  position{line: 767, col: 22, offset: 22157},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 788, col: 35, offset: 22787},
+									pos:        position{line: 767, col: 35, offset: 22170},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5959,39 +5814,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 794, col: 5, offset: 22958},
+						pos: position{line: 773, col: 5, offset: 22341},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 794, col: 5, offset: 22958},
+							pos: position{line: 773, col: 5, offset: 22341},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 794, col: 5, offset: 22958},
+									pos:        position{line: 773, col: 5, offset: 22341},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 794, col: 9, offset: 22962},
+									pos:   position{line: 773, col: 9, offset: 22345},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 794, col: 14, offset: 22967},
+										pos:  position{line: 773, col: 14, offset: 22350},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 794, col: 27, offset: 22980},
+									pos:  position{line: 773, col: 27, offset: 22363},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 794, col: 30, offset: 22983},
+									pos:        position{line: 773, col: 30, offset: 22366},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 794, col: 34, offset: 22987},
+									pos:  position{line: 773, col: 34, offset: 22370},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 794, col: 37, offset: 22990},
+									pos:        position{line: 773, col: 37, offset: 22373},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5999,26 +5854,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 800, col: 5, offset: 23163},
+						pos: position{line: 779, col: 5, offset: 22546},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 800, col: 5, offset: 23163},
+							pos: position{line: 779, col: 5, offset: 22546},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 800, col: 5, offset: 23163},
+									pos:        position{line: 779, col: 5, offset: 22546},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 800, col: 9, offset: 23167},
+									pos:   position{line: 779, col: 9, offset: 22550},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 800, col: 14, offset: 23172},
+										pos:  position{line: 779, col: 14, offset: 22555},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 800, col: 19, offset: 23177},
+									pos:        position{line: 779, col: 19, offset: 22560},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6026,29 +5881,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 801, col: 5, offset: 23226},
+						pos: position{line: 780, col: 5, offset: 22609},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 801, col: 5, offset: 23226},
+							pos: position{line: 780, col: 5, offset: 22609},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 801, col: 5, offset: 23226},
+									pos:        position{line: 780, col: 5, offset: 22609},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 801, col: 9, offset: 23230},
+									pos: position{line: 780, col: 9, offset: 22613},
 									expr: &litMatcher{
-										pos:        position{line: 801, col: 11, offset: 23232},
+										pos:        position{line: 780, col: 11, offset: 22615},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 801, col: 16, offset: 23237},
+									pos:   position{line: 780, col: 16, offset: 22620},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 801, col: 19, offset: 23240},
+										pos:  position{line: 780, col: 19, offset: 22623},
 										name: "Identifier",
 									},
 								},
@@ -6060,59 +5915,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 803, col: 1, offset: 23291},
+			pos:  position{line: 782, col: 1, offset: 22674},
 			expr: &choiceExpr{
-				pos: position{line: 804, col: 5, offset: 23303},
+				pos: position{line: 783, col: 5, offset: 22686},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 804, col: 5, offset: 23303},
+						pos:  position{line: 783, col: 5, offset: 22686},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 805, col: 5, offset: 23315},
+						pos:  position{line: 784, col: 5, offset: 22698},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 806, col: 5, offset: 23326},
+						pos:  position{line: 785, col: 5, offset: 22709},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 807, col: 5, offset: 23336},
+						pos:  position{line: 786, col: 5, offset: 22719},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 808, col: 5, offset: 23344},
+						pos:  position{line: 787, col: 5, offset: 22727},
 						name: "Map",
 					},
 					&actionExpr{
-						pos: position{line: 809, col: 5, offset: 23352},
+						pos: position{line: 788, col: 5, offset: 22735},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 809, col: 5, offset: 23352},
+							pos: position{line: 788, col: 5, offset: 22735},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 809, col: 5, offset: 23352},
+									pos:        position{line: 788, col: 5, offset: 22735},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 809, col: 9, offset: 23356},
+									pos:  position{line: 788, col: 9, offset: 22739},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 809, col: 12, offset: 23359},
+									pos:   position{line: 788, col: 12, offset: 22742},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 809, col: 17, offset: 23364},
+										pos:  position{line: 788, col: 17, offset: 22747},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 809, col: 22, offset: 23369},
+									pos:  position{line: 788, col: 22, offset: 22752},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 809, col: 25, offset: 23372},
+									pos:        position{line: 788, col: 25, offset: 22755},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6124,36 +5979,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 811, col: 1, offset: 23398},
+			pos:  position{line: 790, col: 1, offset: 22781},
 			expr: &actionExpr{
-				pos: position{line: 812, col: 5, offset: 23409},
+				pos: position{line: 791, col: 5, offset: 22792},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 812, col: 5, offset: 23409},
+					pos: position{line: 791, col: 5, offset: 22792},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 812, col: 5, offset: 23409},
+							pos:        position{line: 791, col: 5, offset: 22792},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 812, col: 9, offset: 23413},
+							pos:  position{line: 791, col: 9, offset: 22796},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 812, col: 12, offset: 23416},
+							pos:   position{line: 791, col: 12, offset: 22799},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 812, col: 19, offset: 23423},
+								pos:  position{line: 791, col: 19, offset: 22806},
 								name: "Fields",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 812, col: 26, offset: 23430},
+							pos:  position{line: 791, col: 26, offset: 22813},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 812, col: 29, offset: 23433},
+							pos:        position{line: 791, col: 29, offset: 22816},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6163,28 +6018,28 @@ var g = &grammar{
 		},
 		{
 			name: "Fields",
-			pos:  position{line: 816, col: 1, offset: 23526},
+			pos:  position{line: 795, col: 1, offset: 22909},
 			expr: &actionExpr{
-				pos: position{line: 817, col: 5, offset: 23537},
+				pos: position{line: 796, col: 5, offset: 22920},
 				run: (*parser).callonFields1,
 				expr: &seqExpr{
-					pos: position{line: 817, col: 5, offset: 23537},
+					pos: position{line: 796, col: 5, offset: 22920},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 817, col: 5, offset: 23537},
+							pos:   position{line: 796, col: 5, offset: 22920},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 817, col: 11, offset: 23543},
+								pos:  position{line: 796, col: 11, offset: 22926},
 								name: "Field",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 817, col: 17, offset: 23549},
+							pos:   position{line: 796, col: 17, offset: 22932},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 817, col: 22, offset: 23554},
+								pos: position{line: 796, col: 22, offset: 22937},
 								expr: &ruleRefExpr{
-									pos:  position{line: 817, col: 22, offset: 23554},
+									pos:  position{line: 796, col: 22, offset: 22937},
 									name: "FieldTail",
 								},
 							},
@@ -6195,31 +6050,31 @@ var g = &grammar{
 		},
 		{
 			name: "FieldTail",
-			pos:  position{line: 821, col: 1, offset: 23645},
+			pos:  position{line: 800, col: 1, offset: 23028},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 13, offset: 23657},
+				pos: position{line: 800, col: 13, offset: 23040},
 				run: (*parser).callonFieldTail1,
 				expr: &seqExpr{
-					pos: position{line: 821, col: 13, offset: 23657},
+					pos: position{line: 800, col: 13, offset: 23040},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 13, offset: 23657},
+							pos:  position{line: 800, col: 13, offset: 23040},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 821, col: 16, offset: 23660},
+							pos:        position{line: 800, col: 16, offset: 23043},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 20, offset: 23664},
+							pos:  position{line: 800, col: 20, offset: 23047},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 23, offset: 23667},
+							pos:   position{line: 800, col: 23, offset: 23050},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 821, col: 25, offset: 23669},
+								pos:  position{line: 800, col: 25, offset: 23052},
 								name: "Field",
 							},
 						},
@@ -6229,39 +6084,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 823, col: 1, offset: 23694},
+			pos:  position{line: 802, col: 1, offset: 23077},
 			expr: &actionExpr{
-				pos: position{line: 824, col: 5, offset: 23704},
+				pos: position{line: 803, col: 5, offset: 23087},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 824, col: 5, offset: 23704},
+					pos: position{line: 803, col: 5, offset: 23087},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 824, col: 5, offset: 23704},
+							pos:   position{line: 803, col: 5, offset: 23087},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 824, col: 10, offset: 23709},
+								pos:  position{line: 803, col: 10, offset: 23092},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 824, col: 20, offset: 23719},
+							pos:  position{line: 803, col: 20, offset: 23102},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 824, col: 23, offset: 23722},
+							pos:        position{line: 803, col: 23, offset: 23105},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 824, col: 27, offset: 23726},
+							pos:  position{line: 803, col: 27, offset: 23109},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 824, col: 30, offset: 23729},
+							pos:   position{line: 803, col: 30, offset: 23112},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 824, col: 36, offset: 23735},
+								pos:  position{line: 803, col: 36, offset: 23118},
 								name: "Expr",
 							},
 						},
@@ -6271,36 +6126,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 828, col: 1, offset: 23820},
+			pos:  position{line: 807, col: 1, offset: 23203},
 			expr: &actionExpr{
-				pos: position{line: 829, col: 5, offset: 23830},
+				pos: position{line: 808, col: 5, offset: 23213},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 829, col: 5, offset: 23830},
+					pos: position{line: 808, col: 5, offset: 23213},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 829, col: 5, offset: 23830},
+							pos:        position{line: 808, col: 5, offset: 23213},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 829, col: 9, offset: 23834},
+							pos:  position{line: 808, col: 9, offset: 23217},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 829, col: 12, offset: 23837},
+							pos:   position{line: 808, col: 12, offset: 23220},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 829, col: 18, offset: 23843},
+								pos:  position{line: 808, col: 18, offset: 23226},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 829, col: 32, offset: 23857},
+							pos:  position{line: 808, col: 32, offset: 23240},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 829, col: 35, offset: 23860},
+							pos:        position{line: 808, col: 35, offset: 23243},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6310,36 +6165,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 833, col: 1, offset: 23950},
+			pos:  position{line: 812, col: 1, offset: 23333},
 			expr: &actionExpr{
-				pos: position{line: 834, col: 5, offset: 23958},
+				pos: position{line: 813, col: 5, offset: 23341},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 834, col: 5, offset: 23958},
+					pos: position{line: 813, col: 5, offset: 23341},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 834, col: 5, offset: 23958},
+							pos:        position{line: 813, col: 5, offset: 23341},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 834, col: 10, offset: 23963},
+							pos:  position{line: 813, col: 10, offset: 23346},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 834, col: 13, offset: 23966},
+							pos:   position{line: 813, col: 13, offset: 23349},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 834, col: 19, offset: 23972},
+								pos:  position{line: 813, col: 19, offset: 23355},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 834, col: 33, offset: 23986},
+							pos:  position{line: 813, col: 33, offset: 23369},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 834, col: 36, offset: 23989},
+							pos:        position{line: 813, col: 36, offset: 23372},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6349,36 +6204,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 838, col: 1, offset: 24078},
+			pos:  position{line: 817, col: 1, offset: 23461},
 			expr: &actionExpr{
-				pos: position{line: 839, col: 5, offset: 24086},
+				pos: position{line: 818, col: 5, offset: 23469},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 839, col: 5, offset: 24086},
+					pos: position{line: 818, col: 5, offset: 23469},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 839, col: 5, offset: 24086},
+							pos:        position{line: 818, col: 5, offset: 23469},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 839, col: 10, offset: 24091},
+							pos:  position{line: 818, col: 10, offset: 23474},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 839, col: 13, offset: 24094},
+							pos:   position{line: 818, col: 13, offset: 23477},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 839, col: 19, offset: 24100},
+								pos:  position{line: 818, col: 19, offset: 23483},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 839, col: 27, offset: 24108},
+							pos:  position{line: 818, col: 27, offset: 23491},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 839, col: 30, offset: 24111},
+							pos:        position{line: 818, col: 30, offset: 23494},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6388,31 +6243,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 843, col: 1, offset: 24202},
+			pos:  position{line: 822, col: 1, offset: 23585},
 			expr: &choiceExpr{
-				pos: position{line: 844, col: 5, offset: 24214},
+				pos: position{line: 823, col: 5, offset: 23597},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 844, col: 5, offset: 24214},
+						pos: position{line: 823, col: 5, offset: 23597},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 844, col: 5, offset: 24214},
+							pos: position{line: 823, col: 5, offset: 23597},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 844, col: 5, offset: 24214},
+									pos:   position{line: 823, col: 5, offset: 23597},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 844, col: 11, offset: 24220},
+										pos:  position{line: 823, col: 11, offset: 23603},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 844, col: 17, offset: 24226},
+									pos:   position{line: 823, col: 17, offset: 23609},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 844, col: 22, offset: 24231},
+										pos: position{line: 823, col: 22, offset: 23614},
 										expr: &ruleRefExpr{
-											pos:  position{line: 844, col: 22, offset: 24231},
+											pos:  position{line: 823, col: 22, offset: 23614},
 											name: "EntryTail",
 										},
 									},
@@ -6421,10 +6276,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 847, col: 5, offset: 24325},
+						pos: position{line: 826, col: 5, offset: 23708},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 847, col: 5, offset: 24325},
+							pos:  position{line: 826, col: 5, offset: 23708},
 							name: "__",
 						},
 					},
@@ -6433,31 +6288,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 850, col: 1, offset: 24362},
+			pos:  position{line: 829, col: 1, offset: 23745},
 			expr: &actionExpr{
-				pos: position{line: 850, col: 13, offset: 24374},
+				pos: position{line: 829, col: 13, offset: 23757},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 850, col: 13, offset: 24374},
+					pos: position{line: 829, col: 13, offset: 23757},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 850, col: 13, offset: 24374},
+							pos:  position{line: 829, col: 13, offset: 23757},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 850, col: 16, offset: 24377},
+							pos:        position{line: 829, col: 16, offset: 23760},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 850, col: 20, offset: 24381},
+							pos:  position{line: 829, col: 20, offset: 23764},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 850, col: 23, offset: 24384},
+							pos:   position{line: 829, col: 23, offset: 23767},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 850, col: 25, offset: 24386},
+								pos:  position{line: 829, col: 25, offset: 23769},
 								name: "Entry",
 							},
 						},
@@ -6467,39 +6322,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 852, col: 1, offset: 24411},
+			pos:  position{line: 831, col: 1, offset: 23794},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 5, offset: 24421},
+				pos: position{line: 832, col: 5, offset: 23804},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 853, col: 5, offset: 24421},
+					pos: position{line: 832, col: 5, offset: 23804},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 853, col: 5, offset: 24421},
+							pos:   position{line: 832, col: 5, offset: 23804},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 9, offset: 24425},
+								pos:  position{line: 832, col: 9, offset: 23808},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 853, col: 14, offset: 24430},
+							pos:  position{line: 832, col: 14, offset: 23813},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 853, col: 17, offset: 24433},
+							pos:        position{line: 832, col: 17, offset: 23816},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 853, col: 21, offset: 24437},
+							pos:  position{line: 832, col: 21, offset: 23820},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 24, offset: 24440},
+							pos:   position{line: 832, col: 24, offset: 23823},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 30, offset: 24446},
+								pos:  position{line: 832, col: 30, offset: 23829},
 								name: "Expr",
 							},
 						},
@@ -6509,74 +6364,74 @@ var g = &grammar{
 		},
 		{
 			name: "SQLProc",
-			pos:  position{line: 859, col: 1, offset: 24553},
+			pos:  position{line: 838, col: 1, offset: 23936},
 			expr: &actionExpr{
-				pos: position{line: 860, col: 5, offset: 24565},
+				pos: position{line: 839, col: 5, offset: 23948},
 				run: (*parser).callonSQLProc1,
 				expr: &seqExpr{
-					pos: position{line: 860, col: 5, offset: 24565},
+					pos: position{line: 839, col: 5, offset: 23948},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 860, col: 5, offset: 24565},
+							pos:   position{line: 839, col: 5, offset: 23948},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 860, col: 15, offset: 24575},
+								pos:  position{line: 839, col: 15, offset: 23958},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 5, offset: 24589},
+							pos:   position{line: 840, col: 5, offset: 23972},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 861, col: 10, offset: 24594},
+								pos:  position{line: 840, col: 10, offset: 23977},
 								name: "SQLFrom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 862, col: 5, offset: 24606},
+							pos:   position{line: 841, col: 5, offset: 23989},
 							label: "joins",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 11, offset: 24612},
+								pos:  position{line: 841, col: 11, offset: 23995},
 								name: "SQLJoins",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 863, col: 5, offset: 24625},
+							pos:   position{line: 842, col: 5, offset: 24008},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 863, col: 11, offset: 24631},
+								pos:  position{line: 842, col: 11, offset: 24014},
 								name: "SQLWhere",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 864, col: 5, offset: 24644},
+							pos:   position{line: 843, col: 5, offset: 24027},
 							label: "groupby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 864, col: 13, offset: 24652},
+								pos:  position{line: 843, col: 13, offset: 24035},
 								name: "SQLGroupBy",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 865, col: 5, offset: 24667},
+							pos:   position{line: 844, col: 5, offset: 24050},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 12, offset: 24674},
+								pos:  position{line: 844, col: 12, offset: 24057},
 								name: "SQLHaving",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 866, col: 5, offset: 24688},
+							pos:   position{line: 845, col: 5, offset: 24071},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 866, col: 13, offset: 24696},
+								pos:  position{line: 845, col: 13, offset: 24079},
 								name: "SQLOrderBy",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 867, col: 5, offset: 24711},
+							pos:   position{line: 846, col: 5, offset: 24094},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 867, col: 11, offset: 24717},
+								pos:  position{line: 846, col: 11, offset: 24100},
 								name: "SQLLimit",
 							},
 						},
@@ -6586,26 +6441,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 891, col: 1, offset: 25084},
+			pos:  position{line: 870, col: 1, offset: 24467},
 			expr: &choiceExpr{
-				pos: position{line: 892, col: 5, offset: 25098},
+				pos: position{line: 871, col: 5, offset: 24481},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 892, col: 5, offset: 25098},
+						pos: position{line: 871, col: 5, offset: 24481},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 892, col: 5, offset: 25098},
+							pos: position{line: 871, col: 5, offset: 24481},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 892, col: 5, offset: 25098},
+									pos:  position{line: 871, col: 5, offset: 24481},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 892, col: 12, offset: 25105},
+									pos:  position{line: 871, col: 12, offset: 24488},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 892, col: 14, offset: 25107},
+									pos:        position{line: 871, col: 14, offset: 24490},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6613,24 +6468,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 893, col: 5, offset: 25135},
+						pos: position{line: 872, col: 5, offset: 24518},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 893, col: 5, offset: 25135},
+							pos: position{line: 872, col: 5, offset: 24518},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 893, col: 5, offset: 25135},
+									pos:  position{line: 872, col: 5, offset: 24518},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 893, col: 12, offset: 25142},
+									pos:  position{line: 872, col: 12, offset: 24525},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 893, col: 14, offset: 25144},
+									pos:   position{line: 872, col: 14, offset: 24527},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 893, col: 26, offset: 25156},
+										pos:  position{line: 872, col: 26, offset: 24539},
 										name: "SQLAssignments",
 									},
 								},
@@ -6642,41 +6497,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 895, col: 1, offset: 25200},
+			pos:  position{line: 874, col: 1, offset: 24583},
 			expr: &choiceExpr{
-				pos: position{line: 896, col: 5, offset: 25218},
+				pos: position{line: 875, col: 5, offset: 24601},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 896, col: 5, offset: 25218},
+						pos: position{line: 875, col: 5, offset: 24601},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 896, col: 5, offset: 25218},
+							pos: position{line: 875, col: 5, offset: 24601},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 896, col: 5, offset: 25218},
+									pos:   position{line: 875, col: 5, offset: 24601},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 896, col: 9, offset: 25222},
+										pos:  position{line: 875, col: 9, offset: 24605},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 896, col: 14, offset: 25227},
+									pos:  position{line: 875, col: 14, offset: 24610},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 896, col: 16, offset: 25229},
+									pos:  position{line: 875, col: 16, offset: 24612},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 896, col: 19, offset: 25232},
+									pos:  position{line: 875, col: 19, offset: 24615},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 896, col: 21, offset: 25234},
+									pos:   position{line: 875, col: 21, offset: 24617},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 896, col: 25, offset: 25238},
+										pos:  position{line: 875, col: 25, offset: 24621},
 										name: "Lval",
 									},
 								},
@@ -6684,13 +6539,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 897, col: 5, offset: 25332},
+						pos: position{line: 876, col: 5, offset: 24715},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 897, col: 5, offset: 25332},
+							pos:   position{line: 876, col: 5, offset: 24715},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 897, col: 10, offset: 25337},
+								pos:  position{line: 876, col: 10, offset: 24720},
 								name: "Expr",
 							},
 						},
@@ -6700,50 +6555,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 899, col: 1, offset: 25429},
+			pos:  position{line: 878, col: 1, offset: 24812},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 25448},
+				pos: position{line: 879, col: 5, offset: 24831},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 25448},
+					pos: position{line: 879, col: 5, offset: 24831},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 25448},
+							pos:   position{line: 879, col: 5, offset: 24831},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 11, offset: 25454},
+								pos:  position{line: 879, col: 11, offset: 24837},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 900, col: 25, offset: 25468},
+							pos:   position{line: 879, col: 25, offset: 24851},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 900, col: 30, offset: 25473},
+								pos: position{line: 879, col: 30, offset: 24856},
 								expr: &actionExpr{
-									pos: position{line: 900, col: 31, offset: 25474},
+									pos: position{line: 879, col: 31, offset: 24857},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 900, col: 31, offset: 25474},
+										pos: position{line: 879, col: 31, offset: 24857},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 900, col: 31, offset: 25474},
+												pos:  position{line: 879, col: 31, offset: 24857},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 900, col: 34, offset: 25477},
+												pos:        position{line: 879, col: 34, offset: 24860},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 900, col: 38, offset: 25481},
+												pos:  position{line: 879, col: 38, offset: 24864},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 900, col: 41, offset: 25484},
+												pos:   position{line: 879, col: 41, offset: 24867},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 900, col: 46, offset: 25489},
+													pos:  position{line: 879, col: 46, offset: 24872},
 													name: "SQLAssignment",
 												},
 											},
@@ -6758,41 +6613,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 904, col: 1, offset: 25610},
+			pos:  position{line: 883, col: 1, offset: 24993},
 			expr: &choiceExpr{
-				pos: position{line: 905, col: 5, offset: 25622},
+				pos: position{line: 884, col: 5, offset: 25005},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 905, col: 5, offset: 25622},
+						pos: position{line: 884, col: 5, offset: 25005},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 905, col: 5, offset: 25622},
+							pos: position{line: 884, col: 5, offset: 25005},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 5, offset: 25622},
+									pos:  position{line: 884, col: 5, offset: 25005},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 7, offset: 25624},
+									pos:  position{line: 884, col: 7, offset: 25007},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 12, offset: 25629},
+									pos:  position{line: 884, col: 12, offset: 25012},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 14, offset: 25631},
+									pos:   position{line: 884, col: 14, offset: 25014},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 20, offset: 25637},
+										pos:  position{line: 884, col: 20, offset: 25020},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 29, offset: 25646},
+									pos:   position{line: 884, col: 29, offset: 25029},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 35, offset: 25652},
+										pos:  position{line: 884, col: 35, offset: 25035},
 										name: "SQLAlias",
 									},
 								},
@@ -6800,25 +6655,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 908, col: 5, offset: 25746},
+						pos: position{line: 887, col: 5, offset: 25129},
 						run: (*parser).callonSQLFrom11,
 						expr: &seqExpr{
-							pos: position{line: 908, col: 5, offset: 25746},
+							pos: position{line: 887, col: 5, offset: 25129},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 908, col: 5, offset: 25746},
+									pos:  position{line: 887, col: 5, offset: 25129},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 908, col: 7, offset: 25748},
+									pos:  position{line: 887, col: 7, offset: 25131},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 908, col: 12, offset: 25753},
+									pos:  position{line: 887, col: 12, offset: 25136},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 908, col: 14, offset: 25755},
+									pos:        position{line: 887, col: 14, offset: 25138},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6826,10 +6681,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 909, col: 5, offset: 25783},
+						pos: position{line: 888, col: 5, offset: 25166},
 						run: (*parser).callonSQLFrom17,
 						expr: &litMatcher{
-							pos:        position{line: 909, col: 5, offset: 25783},
+							pos:        position{line: 888, col: 5, offset: 25166},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -6839,33 +6694,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 911, col: 1, offset: 25807},
+			pos:  position{line: 890, col: 1, offset: 25190},
 			expr: &choiceExpr{
-				pos: position{line: 912, col: 5, offset: 25820},
+				pos: position{line: 891, col: 5, offset: 25203},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 912, col: 5, offset: 25820},
+						pos: position{line: 891, col: 5, offset: 25203},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 912, col: 5, offset: 25820},
+							pos: position{line: 891, col: 5, offset: 25203},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 912, col: 5, offset: 25820},
+									pos:  position{line: 891, col: 5, offset: 25203},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 912, col: 7, offset: 25822},
+									pos:  position{line: 891, col: 7, offset: 25205},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 912, col: 10, offset: 25825},
+									pos:  position{line: 891, col: 10, offset: 25208},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 912, col: 12, offset: 25827},
+									pos:   position{line: 891, col: 12, offset: 25210},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 912, col: 15, offset: 25830},
+										pos:  position{line: 891, col: 15, offset: 25213},
 										name: "Lval",
 									},
 								},
@@ -6873,20 +6728,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 913, col: 5, offset: 25858},
+						pos: position{line: 892, col: 5, offset: 25241},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 913, col: 5, offset: 25858},
+							pos: position{line: 892, col: 5, offset: 25241},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 913, col: 5, offset: 25858},
+									pos:  position{line: 892, col: 5, offset: 25241},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 913, col: 7, offset: 25860},
+									pos:   position{line: 892, col: 7, offset: 25243},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 913, col: 10, offset: 25863},
+										pos:  position{line: 892, col: 10, offset: 25246},
 										name: "Lval",
 									},
 								},
@@ -6894,10 +6749,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 914, col: 5, offset: 25891},
+						pos: position{line: 893, col: 5, offset: 25274},
 						run: (*parser).callonSQLAlias14,
 						expr: &litMatcher{
-							pos:        position{line: 914, col: 5, offset: 25891},
+							pos:        position{line: 893, col: 5, offset: 25274},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -6907,45 +6762,45 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 916, col: 1, offset: 25915},
+			pos:  position{line: 895, col: 1, offset: 25298},
 			expr: &ruleRefExpr{
-				pos:  position{line: 917, col: 5, offset: 25928},
+				pos:  position{line: 896, col: 5, offset: 25311},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 919, col: 1, offset: 25934},
+			pos:  position{line: 898, col: 1, offset: 25317},
 			expr: &choiceExpr{
-				pos: position{line: 920, col: 5, offset: 25947},
+				pos: position{line: 899, col: 5, offset: 25330},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 920, col: 5, offset: 25947},
+						pos: position{line: 899, col: 5, offset: 25330},
 						run: (*parser).callonSQLJoins2,
 						expr: &seqExpr{
-							pos: position{line: 920, col: 5, offset: 25947},
+							pos: position{line: 899, col: 5, offset: 25330},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 920, col: 5, offset: 25947},
+									pos:   position{line: 899, col: 5, offset: 25330},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 920, col: 11, offset: 25953},
+										pos:  position{line: 899, col: 11, offset: 25336},
 										name: "SQLJoin",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 920, col: 19, offset: 25961},
+									pos:   position{line: 899, col: 19, offset: 25344},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 920, col: 24, offset: 25966},
+										pos: position{line: 899, col: 24, offset: 25349},
 										expr: &actionExpr{
-											pos: position{line: 920, col: 25, offset: 25967},
+											pos: position{line: 899, col: 25, offset: 25350},
 											run: (*parser).callonSQLJoins8,
 											expr: &labeledExpr{
-												pos:   position{line: 920, col: 25, offset: 25967},
+												pos:   position{line: 899, col: 25, offset: 25350},
 												label: "join",
 												expr: &ruleRefExpr{
-													pos:  position{line: 920, col: 30, offset: 25972},
+													pos:  position{line: 899, col: 30, offset: 25355},
 													name: "SQLJoin",
 												},
 											},
@@ -6956,10 +6811,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 923, col: 5, offset: 26090},
+						pos: position{line: 902, col: 5, offset: 25473},
 						run: (*parser).callonSQLJoins11,
 						expr: &litMatcher{
-							pos:        position{line: 923, col: 5, offset: 26090},
+							pos:        position{line: 902, col: 5, offset: 25473},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -6969,87 +6824,87 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 925, col: 1, offset: 26114},
+			pos:  position{line: 904, col: 1, offset: 25497},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 5, offset: 26126},
+				pos: position{line: 905, col: 5, offset: 25509},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 926, col: 5, offset: 26126},
+					pos: position{line: 905, col: 5, offset: 25509},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 926, col: 5, offset: 26126},
+							pos:   position{line: 905, col: 5, offset: 25509},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 11, offset: 26132},
+								pos:  position{line: 905, col: 11, offset: 25515},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 24, offset: 26145},
+							pos:  position{line: 905, col: 24, offset: 25528},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 26, offset: 26147},
+							pos:  position{line: 905, col: 26, offset: 25530},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 31, offset: 26152},
+							pos:  position{line: 905, col: 31, offset: 25535},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 926, col: 33, offset: 26154},
+							pos:   position{line: 905, col: 33, offset: 25537},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 39, offset: 26160},
+								pos:  position{line: 905, col: 39, offset: 25543},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 926, col: 48, offset: 26169},
+							pos:   position{line: 905, col: 48, offset: 25552},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 54, offset: 26175},
+								pos:  position{line: 905, col: 54, offset: 25558},
 								name: "SQLAlias",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 63, offset: 26184},
+							pos:  position{line: 905, col: 63, offset: 25567},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 65, offset: 26186},
+							pos:  position{line: 905, col: 65, offset: 25569},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 68, offset: 26189},
+							pos:  position{line: 905, col: 68, offset: 25572},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 926, col: 70, offset: 26191},
+							pos:   position{line: 905, col: 70, offset: 25574},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 78, offset: 26199},
+								pos:  position{line: 905, col: 78, offset: 25582},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 86, offset: 26207},
+							pos:  position{line: 905, col: 86, offset: 25590},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 926, col: 89, offset: 26210},
+							pos:        position{line: 905, col: 89, offset: 25593},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 93, offset: 26214},
+							pos:  position{line: 905, col: 93, offset: 25597},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 926, col: 96, offset: 26217},
+							pos:   position{line: 905, col: 96, offset: 25600},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 105, offset: 26226},
+								pos:  position{line: 905, col: 105, offset: 25609},
 								name: "JoinKey",
 							},
 						},
@@ -7059,36 +6914,36 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 945, col: 1, offset: 26461},
+			pos:  position{line: 924, col: 1, offset: 25844},
 			expr: &choiceExpr{
-				pos: position{line: 946, col: 5, offset: 26478},
+				pos: position{line: 925, col: 5, offset: 25861},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 946, col: 5, offset: 26478},
+						pos: position{line: 925, col: 5, offset: 25861},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 946, col: 5, offset: 26478},
+							pos: position{line: 925, col: 5, offset: 25861},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 946, col: 5, offset: 26478},
+									pos:  position{line: 925, col: 5, offset: 25861},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 946, col: 7, offset: 26480},
+									pos:   position{line: 925, col: 7, offset: 25863},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 946, col: 14, offset: 26487},
+										pos: position{line: 925, col: 14, offset: 25870},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 946, col: 14, offset: 26487},
+												pos:  position{line: 925, col: 14, offset: 25870},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 946, col: 21, offset: 26494},
+												pos:  position{line: 925, col: 21, offset: 25877},
 												name: "RIGHT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 946, col: 29, offset: 26502},
+												pos:  position{line: 925, col: 29, offset: 25885},
 												name: "INNER",
 											},
 										},
@@ -7098,10 +6953,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 947, col: 5, offset: 26535},
+						pos: position{line: 926, col: 5, offset: 25918},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &litMatcher{
-							pos:        position{line: 947, col: 5, offset: 26535},
+							pos:        position{line: 926, col: 5, offset: 25918},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7111,33 +6966,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 949, col: 1, offset: 26571},
+			pos:  position{line: 928, col: 1, offset: 25954},
 			expr: &choiceExpr{
-				pos: position{line: 950, col: 5, offset: 26584},
+				pos: position{line: 929, col: 5, offset: 25967},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 950, col: 5, offset: 26584},
+						pos: position{line: 929, col: 5, offset: 25967},
 						run: (*parser).callonSQLWhere2,
 						expr: &seqExpr{
-							pos: position{line: 950, col: 5, offset: 26584},
+							pos: position{line: 929, col: 5, offset: 25967},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 5, offset: 26584},
+									pos:  position{line: 929, col: 5, offset: 25967},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 7, offset: 26586},
+									pos:  position{line: 929, col: 7, offset: 25969},
 									name: "WHERE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 13, offset: 26592},
+									pos:  position{line: 929, col: 13, offset: 25975},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 950, col: 15, offset: 26594},
+									pos:   position{line: 929, col: 15, offset: 25977},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 20, offset: 26599},
+										pos:  position{line: 929, col: 20, offset: 25982},
 										name: "SearchBoolean",
 									},
 								},
@@ -7145,10 +7000,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 951, col: 5, offset: 26638},
+						pos: position{line: 930, col: 5, offset: 26021},
 						run: (*parser).callonSQLWhere9,
 						expr: &litMatcher{
-							pos:        position{line: 951, col: 5, offset: 26638},
+							pos:        position{line: 930, col: 5, offset: 26021},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7158,41 +7013,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 953, col: 1, offset: 26662},
+			pos:  position{line: 932, col: 1, offset: 26045},
 			expr: &choiceExpr{
-				pos: position{line: 954, col: 5, offset: 26677},
+				pos: position{line: 933, col: 5, offset: 26060},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 954, col: 5, offset: 26677},
+						pos: position{line: 933, col: 5, offset: 26060},
 						run: (*parser).callonSQLGroupBy2,
 						expr: &seqExpr{
-							pos: position{line: 954, col: 5, offset: 26677},
+							pos: position{line: 933, col: 5, offset: 26060},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 5, offset: 26677},
+									pos:  position{line: 933, col: 5, offset: 26060},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 7, offset: 26679},
+									pos:  position{line: 933, col: 7, offset: 26062},
 									name: "GROUP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 13, offset: 26685},
+									pos:  position{line: 933, col: 13, offset: 26068},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 15, offset: 26687},
+									pos:  position{line: 933, col: 15, offset: 26070},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 18, offset: 26690},
+									pos:  position{line: 933, col: 18, offset: 26073},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 954, col: 20, offset: 26692},
+									pos:   position{line: 933, col: 20, offset: 26075},
 									label: "columns",
 									expr: &ruleRefExpr{
-										pos:  position{line: 954, col: 28, offset: 26700},
+										pos:  position{line: 933, col: 28, offset: 26083},
 										name: "FieldExprs",
 									},
 								},
@@ -7200,10 +7055,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 955, col: 5, offset: 26739},
+						pos: position{line: 934, col: 5, offset: 26122},
 						run: (*parser).callonSQLGroupBy11,
 						expr: &litMatcher{
-							pos:        position{line: 955, col: 5, offset: 26739},
+							pos:        position{line: 934, col: 5, offset: 26122},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7213,33 +7068,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 957, col: 1, offset: 26763},
+			pos:  position{line: 936, col: 1, offset: 26146},
 			expr: &choiceExpr{
-				pos: position{line: 958, col: 5, offset: 26777},
+				pos: position{line: 937, col: 5, offset: 26160},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 958, col: 5, offset: 26777},
+						pos: position{line: 937, col: 5, offset: 26160},
 						run: (*parser).callonSQLHaving2,
 						expr: &seqExpr{
-							pos: position{line: 958, col: 5, offset: 26777},
+							pos: position{line: 937, col: 5, offset: 26160},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 958, col: 5, offset: 26777},
+									pos:  position{line: 937, col: 5, offset: 26160},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 958, col: 7, offset: 26779},
+									pos:  position{line: 937, col: 7, offset: 26162},
 									name: "HAVING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 958, col: 14, offset: 26786},
+									pos:  position{line: 937, col: 14, offset: 26169},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 958, col: 16, offset: 26788},
+									pos:   position{line: 937, col: 16, offset: 26171},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 21, offset: 26793},
+										pos:  position{line: 937, col: 21, offset: 26176},
 										name: "SearchBoolean",
 									},
 								},
@@ -7247,10 +7102,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 959, col: 5, offset: 26832},
+						pos: position{line: 938, col: 5, offset: 26215},
 						run: (*parser).callonSQLHaving9,
 						expr: &litMatcher{
-							pos:        position{line: 959, col: 5, offset: 26832},
+							pos:        position{line: 938, col: 5, offset: 26215},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7260,49 +7115,49 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 961, col: 1, offset: 26856},
+			pos:  position{line: 940, col: 1, offset: 26239},
 			expr: &choiceExpr{
-				pos: position{line: 962, col: 5, offset: 26871},
+				pos: position{line: 941, col: 5, offset: 26254},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 962, col: 5, offset: 26871},
+						pos: position{line: 941, col: 5, offset: 26254},
 						run: (*parser).callonSQLOrderBy2,
 						expr: &seqExpr{
-							pos: position{line: 962, col: 5, offset: 26871},
+							pos: position{line: 941, col: 5, offset: 26254},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 5, offset: 26871},
+									pos:  position{line: 941, col: 5, offset: 26254},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 7, offset: 26873},
+									pos:  position{line: 941, col: 7, offset: 26256},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 13, offset: 26879},
+									pos:  position{line: 941, col: 13, offset: 26262},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 15, offset: 26881},
+									pos:  position{line: 941, col: 15, offset: 26264},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 18, offset: 26884},
+									pos:  position{line: 941, col: 18, offset: 26267},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 962, col: 20, offset: 26886},
+									pos:   position{line: 941, col: 20, offset: 26269},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 962, col: 25, offset: 26891},
+										pos:  position{line: 941, col: 25, offset: 26274},
 										name: "Exprs",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 962, col: 31, offset: 26897},
+									pos:   position{line: 941, col: 31, offset: 26280},
 									label: "order",
 									expr: &ruleRefExpr{
-										pos:  position{line: 962, col: 37, offset: 26903},
+										pos:  position{line: 941, col: 37, offset: 26286},
 										name: "SQLOrder",
 									},
 								},
@@ -7310,10 +7165,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 965, col: 5, offset: 27016},
+						pos: position{line: 944, col: 5, offset: 26399},
 						run: (*parser).callonSQLOrderBy13,
 						expr: &litMatcher{
-							pos:        position{line: 965, col: 5, offset: 27016},
+							pos:        position{line: 944, col: 5, offset: 26399},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7323,32 +7178,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 967, col: 1, offset: 27040},
+			pos:  position{line: 946, col: 1, offset: 26423},
 			expr: &choiceExpr{
-				pos: position{line: 968, col: 5, offset: 27053},
+				pos: position{line: 947, col: 5, offset: 26436},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 968, col: 5, offset: 27053},
+						pos: position{line: 947, col: 5, offset: 26436},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 968, col: 5, offset: 27053},
+							pos: position{line: 947, col: 5, offset: 26436},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 968, col: 5, offset: 27053},
+									pos:  position{line: 947, col: 5, offset: 26436},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 968, col: 7, offset: 27055},
+									pos:   position{line: 947, col: 7, offset: 26438},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 968, col: 12, offset: 27060},
+										pos: position{line: 947, col: 12, offset: 26443},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 968, col: 12, offset: 27060},
+												pos:  position{line: 947, col: 12, offset: 26443},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 968, col: 18, offset: 27066},
+												pos:  position{line: 947, col: 18, offset: 26449},
 												name: "DESC",
 											},
 										},
@@ -7358,10 +7213,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 969, col: 5, offset: 27096},
+						pos: position{line: 948, col: 5, offset: 26479},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 969, col: 5, offset: 27096},
+							pos:        position{line: 948, col: 5, offset: 26479},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7371,33 +7226,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 971, col: 1, offset: 27122},
+			pos:  position{line: 950, col: 1, offset: 26505},
 			expr: &choiceExpr{
-				pos: position{line: 972, col: 5, offset: 27135},
+				pos: position{line: 951, col: 5, offset: 26518},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 972, col: 5, offset: 27135},
+						pos: position{line: 951, col: 5, offset: 26518},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 972, col: 5, offset: 27135},
+							pos: position{line: 951, col: 5, offset: 26518},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 972, col: 5, offset: 27135},
+									pos:  position{line: 951, col: 5, offset: 26518},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 972, col: 7, offset: 27137},
+									pos:  position{line: 951, col: 7, offset: 26520},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 972, col: 13, offset: 27143},
+									pos:  position{line: 951, col: 13, offset: 26526},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 972, col: 15, offset: 27145},
+									pos:   position{line: 951, col: 15, offset: 26528},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 972, col: 21, offset: 27151},
+										pos:  position{line: 951, col: 21, offset: 26534},
 										name: "UInt",
 									},
 								},
@@ -7405,10 +7260,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 973, col: 5, offset: 27182},
+						pos: position{line: 952, col: 5, offset: 26565},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 973, col: 5, offset: 27182},
+							pos:        position{line: 952, col: 5, offset: 26565},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7418,12 +7273,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 975, col: 1, offset: 27204},
+			pos:  position{line: 954, col: 1, offset: 26587},
 			expr: &actionExpr{
-				pos: position{line: 975, col: 10, offset: 27213},
+				pos: position{line: 954, col: 10, offset: 26596},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 975, col: 10, offset: 27213},
+					pos:        position{line: 954, col: 10, offset: 26596},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7431,12 +7286,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 976, col: 1, offset: 27248},
+			pos:  position{line: 955, col: 1, offset: 26631},
 			expr: &actionExpr{
-				pos: position{line: 976, col: 6, offset: 27253},
+				pos: position{line: 955, col: 6, offset: 26636},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 976, col: 6, offset: 27253},
+					pos:        position{line: 955, col: 6, offset: 26636},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7444,12 +7299,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 977, col: 1, offset: 27280},
+			pos:  position{line: 956, col: 1, offset: 26663},
 			expr: &actionExpr{
-				pos: position{line: 977, col: 8, offset: 27287},
+				pos: position{line: 956, col: 8, offset: 26670},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 977, col: 8, offset: 27287},
+					pos:        position{line: 956, col: 8, offset: 26670},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7457,12 +7312,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 978, col: 1, offset: 27318},
+			pos:  position{line: 957, col: 1, offset: 26701},
 			expr: &actionExpr{
-				pos: position{line: 978, col: 8, offset: 27325},
+				pos: position{line: 957, col: 8, offset: 26708},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 978, col: 8, offset: 27325},
+					pos:        position{line: 957, col: 8, offset: 26708},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7470,12 +7325,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 979, col: 1, offset: 27356},
+			pos:  position{line: 958, col: 1, offset: 26739},
 			expr: &actionExpr{
-				pos: position{line: 979, col: 9, offset: 27364},
+				pos: position{line: 958, col: 9, offset: 26747},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 979, col: 9, offset: 27364},
+					pos:        position{line: 958, col: 9, offset: 26747},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7483,12 +7338,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 980, col: 1, offset: 27397},
+			pos:  position{line: 959, col: 1, offset: 26780},
 			expr: &actionExpr{
-				pos: position{line: 980, col: 9, offset: 27405},
+				pos: position{line: 959, col: 9, offset: 26788},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 980, col: 9, offset: 27405},
+					pos:        position{line: 959, col: 9, offset: 26788},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7496,20 +7351,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 981, col: 1, offset: 27438},
+			pos:  position{line: 960, col: 1, offset: 26821},
 			expr: &ruleRefExpr{
-				pos:  position{line: 981, col: 6, offset: 27443},
+				pos:  position{line: 960, col: 6, offset: 26826},
 				name: "ByToken",
 			},
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 982, col: 1, offset: 27451},
+			pos:  position{line: 961, col: 1, offset: 26834},
 			expr: &actionExpr{
-				pos: position{line: 982, col: 10, offset: 27460},
+				pos: position{line: 961, col: 10, offset: 26843},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 982, col: 10, offset: 27460},
+					pos:        position{line: 961, col: 10, offset: 26843},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7517,12 +7372,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 983, col: 1, offset: 27495},
+			pos:  position{line: 962, col: 1, offset: 26878},
 			expr: &actionExpr{
-				pos: position{line: 983, col: 9, offset: 27503},
+				pos: position{line: 962, col: 9, offset: 26886},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 983, col: 9, offset: 27503},
+					pos:        position{line: 962, col: 9, offset: 26886},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7530,12 +7385,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 984, col: 1, offset: 27536},
+			pos:  position{line: 963, col: 1, offset: 26919},
 			expr: &actionExpr{
-				pos: position{line: 984, col: 6, offset: 27541},
+				pos: position{line: 963, col: 6, offset: 26924},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 984, col: 6, offset: 27541},
+					pos:        position{line: 963, col: 6, offset: 26924},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7543,12 +7398,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 985, col: 1, offset: 27568},
+			pos:  position{line: 964, col: 1, offset: 26951},
 			expr: &actionExpr{
-				pos: position{line: 985, col: 9, offset: 27576},
+				pos: position{line: 964, col: 9, offset: 26959},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 985, col: 9, offset: 27576},
+					pos:        position{line: 964, col: 9, offset: 26959},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7556,12 +7411,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 986, col: 1, offset: 27609},
+			pos:  position{line: 965, col: 1, offset: 26992},
 			expr: &actionExpr{
-				pos: position{line: 986, col: 7, offset: 27615},
+				pos: position{line: 965, col: 7, offset: 26998},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 986, col: 7, offset: 27615},
+					pos:        position{line: 965, col: 7, offset: 26998},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7569,12 +7424,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 987, col: 1, offset: 27644},
+			pos:  position{line: 966, col: 1, offset: 27027},
 			expr: &actionExpr{
-				pos: position{line: 987, col: 8, offset: 27651},
+				pos: position{line: 966, col: 8, offset: 27034},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 987, col: 8, offset: 27651},
+					pos:        position{line: 966, col: 8, offset: 27034},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7582,12 +7437,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 988, col: 1, offset: 27682},
+			pos:  position{line: 967, col: 1, offset: 27065},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 8, offset: 27689},
+				pos: position{line: 967, col: 8, offset: 27072},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 988, col: 8, offset: 27689},
+					pos:        position{line: 967, col: 8, offset: 27072},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7595,12 +7450,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 989, col: 1, offset: 27720},
+			pos:  position{line: 968, col: 1, offset: 27103},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 9, offset: 27728},
+				pos: position{line: 968, col: 9, offset: 27111},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 989, col: 9, offset: 27728},
+					pos:        position{line: 968, col: 9, offset: 27111},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7608,12 +7463,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 990, col: 1, offset: 27761},
+			pos:  position{line: 969, col: 1, offset: 27144},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 9, offset: 27769},
+				pos: position{line: 969, col: 9, offset: 27152},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 990, col: 9, offset: 27769},
+					pos:        position{line: 969, col: 9, offset: 27152},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7621,48 +7476,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 992, col: 1, offset: 27803},
+			pos:  position{line: 971, col: 1, offset: 27186},
 			expr: &choiceExpr{
-				pos: position{line: 993, col: 5, offset: 27825},
+				pos: position{line: 972, col: 5, offset: 27208},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 5, offset: 27825},
+						pos:  position{line: 972, col: 5, offset: 27208},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 14, offset: 27834},
+						pos:  position{line: 972, col: 14, offset: 27217},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 19, offset: 27839},
+						pos:  position{line: 972, col: 19, offset: 27222},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 27, offset: 27847},
+						pos:  position{line: 972, col: 27, offset: 27230},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 34, offset: 27854},
+						pos:  position{line: 972, col: 34, offset: 27237},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 42, offset: 27862},
+						pos:  position{line: 972, col: 42, offset: 27245},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 50, offset: 27870},
+						pos:  position{line: 972, col: 50, offset: 27253},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 59, offset: 27879},
+						pos:  position{line: 972, col: 59, offset: 27262},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 67, offset: 27887},
+						pos:  position{line: 972, col: 67, offset: 27270},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 75, offset: 27895},
+						pos:  position{line: 972, col: 75, offset: 27278},
 						name: "ON",
 					},
 				},
@@ -7670,48 +7525,48 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 997, col: 1, offset: 27921},
+			pos:  position{line: 976, col: 1, offset: 27304},
 			expr: &choiceExpr{
-				pos: position{line: 998, col: 5, offset: 27933},
+				pos: position{line: 977, col: 5, offset: 27316},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 998, col: 5, offset: 27933},
+						pos:  position{line: 977, col: 5, offset: 27316},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 999, col: 5, offset: 27949},
+						pos:  position{line: 978, col: 5, offset: 27332},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 5, offset: 27967},
+						pos:  position{line: 979, col: 5, offset: 27350},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1001, col: 5, offset: 27985},
+						pos:  position{line: 980, col: 5, offset: 27368},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 5, offset: 28004},
+						pos:  position{line: 981, col: 5, offset: 27387},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1003, col: 5, offset: 28017},
+						pos:  position{line: 982, col: 5, offset: 27400},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1004, col: 5, offset: 28026},
+						pos:  position{line: 983, col: 5, offset: 27409},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 5, offset: 28043},
+						pos:  position{line: 984, col: 5, offset: 27426},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 5, offset: 28062},
+						pos:  position{line: 985, col: 5, offset: 27445},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 28081},
+						pos:  position{line: 986, col: 5, offset: 27464},
 						name: "NullLiteral",
 					},
 				},
@@ -7719,15 +7574,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1009, col: 1, offset: 28094},
+			pos:  position{line: 988, col: 1, offset: 27477},
 			expr: &actionExpr{
-				pos: position{line: 1010, col: 5, offset: 28112},
+				pos: position{line: 989, col: 5, offset: 27495},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1010, col: 5, offset: 28112},
+					pos:   position{line: 989, col: 5, offset: 27495},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1010, col: 7, offset: 28114},
+						pos:  position{line: 989, col: 7, offset: 27497},
 						name: "QuotedString",
 					},
 				},
@@ -7735,28 +7590,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1014, col: 1, offset: 28227},
+			pos:  position{line: 993, col: 1, offset: 27610},
 			expr: &choiceExpr{
-				pos: position{line: 1015, col: 5, offset: 28245},
+				pos: position{line: 994, col: 5, offset: 27628},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1015, col: 5, offset: 28245},
+						pos: position{line: 994, col: 5, offset: 27628},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1015, col: 5, offset: 28245},
+							pos: position{line: 994, col: 5, offset: 27628},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1015, col: 5, offset: 28245},
+									pos:   position{line: 994, col: 5, offset: 27628},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1015, col: 7, offset: 28247},
+										pos:  position{line: 994, col: 7, offset: 27630},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1015, col: 14, offset: 28254},
+									pos: position{line: 994, col: 14, offset: 27637},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1015, col: 15, offset: 28255},
+										pos:  position{line: 994, col: 15, offset: 27638},
 										name: "IdentifierRest",
 									},
 								},
@@ -7764,13 +7619,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1018, col: 5, offset: 28370},
+						pos: position{line: 997, col: 5, offset: 27753},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1018, col: 5, offset: 28370},
+							pos:   position{line: 997, col: 5, offset: 27753},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1018, col: 7, offset: 28372},
+								pos:  position{line: 997, col: 7, offset: 27755},
 								name: "IP4Net",
 							},
 						},
@@ -7780,28 +7635,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1022, col: 1, offset: 28476},
+			pos:  position{line: 1001, col: 1, offset: 27859},
 			expr: &choiceExpr{
-				pos: position{line: 1023, col: 5, offset: 28495},
+				pos: position{line: 1002, col: 5, offset: 27878},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 28495},
+						pos: position{line: 1002, col: 5, offset: 27878},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 28495},
+							pos: position{line: 1002, col: 5, offset: 27878},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1023, col: 5, offset: 28495},
+									pos:   position{line: 1002, col: 5, offset: 27878},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 7, offset: 28497},
+										pos:  position{line: 1002, col: 7, offset: 27880},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1023, col: 11, offset: 28501},
+									pos: position{line: 1002, col: 11, offset: 27884},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 12, offset: 28502},
+										pos:  position{line: 1002, col: 12, offset: 27885},
 										name: "IdentifierRest",
 									},
 								},
@@ -7809,13 +7664,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1026, col: 5, offset: 28616},
+						pos: position{line: 1005, col: 5, offset: 27999},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1026, col: 5, offset: 28616},
+							pos:   position{line: 1005, col: 5, offset: 27999},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1026, col: 7, offset: 28618},
+								pos:  position{line: 1005, col: 7, offset: 28001},
 								name: "IP",
 							},
 						},
@@ -7825,15 +7680,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1030, col: 1, offset: 28717},
+			pos:  position{line: 1009, col: 1, offset: 28100},
 			expr: &actionExpr{
-				pos: position{line: 1031, col: 5, offset: 28734},
+				pos: position{line: 1010, col: 5, offset: 28117},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1031, col: 5, offset: 28734},
+					pos:   position{line: 1010, col: 5, offset: 28117},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1031, col: 7, offset: 28736},
+						pos:  position{line: 1010, col: 7, offset: 28119},
 						name: "FloatString",
 					},
 				},
@@ -7841,15 +7696,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1035, col: 1, offset: 28849},
+			pos:  position{line: 1014, col: 1, offset: 28232},
 			expr: &actionExpr{
-				pos: position{line: 1036, col: 5, offset: 28868},
+				pos: position{line: 1015, col: 5, offset: 28251},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1036, col: 5, offset: 28868},
+					pos:   position{line: 1015, col: 5, offset: 28251},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1036, col: 7, offset: 28870},
+						pos:  position{line: 1015, col: 7, offset: 28253},
 						name: "IntString",
 					},
 				},
@@ -7857,24 +7712,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1040, col: 1, offset: 28979},
+			pos:  position{line: 1019, col: 1, offset: 28362},
 			expr: &choiceExpr{
-				pos: position{line: 1041, col: 5, offset: 28998},
+				pos: position{line: 1020, col: 5, offset: 28381},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1041, col: 5, offset: 28998},
+						pos: position{line: 1020, col: 5, offset: 28381},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 1041, col: 5, offset: 28998},
+							pos:        position{line: 1020, col: 5, offset: 28381},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1042, col: 5, offset: 29111},
+						pos: position{line: 1021, col: 5, offset: 28494},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 1042, col: 5, offset: 29111},
+							pos:        position{line: 1021, col: 5, offset: 28494},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7884,12 +7739,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1044, col: 1, offset: 29222},
+			pos:  position{line: 1023, col: 1, offset: 28605},
 			expr: &actionExpr{
-				pos: position{line: 1045, col: 5, offset: 29238},
+				pos: position{line: 1024, col: 5, offset: 28621},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 1045, col: 5, offset: 29238},
+					pos:        position{line: 1024, col: 5, offset: 28621},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7897,34 +7752,34 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1047, col: 1, offset: 29344},
+			pos:  position{line: 1026, col: 1, offset: 28727},
 			expr: &actionExpr{
-				pos: position{line: 1048, col: 5, offset: 29360},
+				pos: position{line: 1027, col: 5, offset: 28743},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1048, col: 5, offset: 29360},
+					pos: position{line: 1027, col: 5, offset: 28743},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1048, col: 5, offset: 29360},
+							pos: position{line: 1027, col: 5, offset: 28743},
 							expr: &seqExpr{
-								pos: position{line: 1048, col: 7, offset: 29362},
+								pos: position{line: 1027, col: 7, offset: 28745},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1048, col: 7, offset: 29362},
+										pos:  position{line: 1027, col: 7, offset: 28745},
 										name: "SQLTokenSentinels",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1048, col: 25, offset: 29380},
+										pos:  position{line: 1027, col: 25, offset: 28763},
 										name: "EOT",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1048, col: 30, offset: 29385},
+							pos:   position{line: 1027, col: 30, offset: 28768},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1048, col: 34, offset: 29389},
+								pos:  position{line: 1027, col: 34, offset: 28772},
 								name: "TypeExternal",
 							},
 						},
@@ -7934,16 +7789,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1052, col: 1, offset: 29487},
+			pos:  position{line: 1031, col: 1, offset: 28870},
 			expr: &choiceExpr{
-				pos: position{line: 1053, col: 5, offset: 29500},
+				pos: position{line: 1032, col: 5, offset: 28883},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1053, col: 5, offset: 29500},
+						pos:  position{line: 1032, col: 5, offset: 28883},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1054, col: 5, offset: 29517},
+						pos:  position{line: 1033, col: 5, offset: 28900},
 						name: "PrimitiveType",
 					},
 				},
@@ -7951,36 +7806,36 @@ var g = &grammar{
 		},
 		{
 			name: "TypeExternal",
-			pos:  position{line: 1056, col: 1, offset: 29532},
+			pos:  position{line: 1035, col: 1, offset: 28915},
 			expr: &choiceExpr{
-				pos: position{line: 1057, col: 5, offset: 29549},
+				pos: position{line: 1036, col: 5, offset: 28932},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1057, col: 5, offset: 29549},
+						pos:  position{line: 1036, col: 5, offset: 28932},
 						name: "ExplicitType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1058, col: 5, offset: 29566},
+						pos:  position{line: 1037, col: 5, offset: 28949},
 						name: "ComplexTypeExternal",
 					},
 					&actionExpr{
-						pos: position{line: 1059, col: 5, offset: 29590},
+						pos: position{line: 1038, col: 5, offset: 28973},
 						run: (*parser).callonTypeExternal4,
 						expr: &seqExpr{
-							pos: position{line: 1059, col: 5, offset: 29590},
+							pos: position{line: 1038, col: 5, offset: 28973},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1059, col: 5, offset: 29590},
+									pos:   position{line: 1038, col: 5, offset: 28973},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1059, col: 9, offset: 29594},
+										pos:  position{line: 1038, col: 9, offset: 28977},
 										name: "PrimitiveTypeExternal",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1059, col: 31, offset: 29616},
+									pos: position{line: 1038, col: 31, offset: 28999},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1059, col: 32, offset: 29617},
+										pos:  position{line: 1038, col: 32, offset: 29000},
 										name: "IdentifierRest",
 									},
 								},
@@ -7992,20 +7847,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1061, col: 1, offset: 29653},
+			pos:  position{line: 1040, col: 1, offset: 29036},
 			expr: &choiceExpr{
-				pos: position{line: 1062, col: 5, offset: 29662},
+				pos: position{line: 1041, col: 5, offset: 29045},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1062, col: 5, offset: 29662},
+						pos:  position{line: 1041, col: 5, offset: 29045},
 						name: "ExplicitType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1063, col: 5, offset: 29679},
+						pos:  position{line: 1042, col: 5, offset: 29062},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1064, col: 5, offset: 29697},
+						pos:  position{line: 1043, col: 5, offset: 29080},
 						name: "ComplexType",
 					},
 				},
@@ -8013,48 +7868,48 @@ var g = &grammar{
 		},
 		{
 			name: "ExplicitType",
-			pos:  position{line: 1066, col: 1, offset: 29710},
+			pos:  position{line: 1045, col: 1, offset: 29093},
 			expr: &choiceExpr{
-				pos: position{line: 1067, col: 5, offset: 29727},
+				pos: position{line: 1046, col: 5, offset: 29110},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 29727},
+						pos: position{line: 1046, col: 5, offset: 29110},
 						run: (*parser).callonExplicitType2,
 						expr: &seqExpr{
-							pos: position{line: 1067, col: 5, offset: 29727},
+							pos: position{line: 1046, col: 5, offset: 29110},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1067, col: 5, offset: 29727},
+									pos:        position{line: 1046, col: 5, offset: 29110},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1067, col: 12, offset: 29734},
+									pos:  position{line: 1046, col: 12, offset: 29117},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1067, col: 15, offset: 29737},
+									pos:        position{line: 1046, col: 15, offset: 29120},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1067, col: 19, offset: 29741},
+									pos:  position{line: 1046, col: 19, offset: 29124},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1067, col: 22, offset: 29744},
+									pos:   position{line: 1046, col: 22, offset: 29127},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1067, col: 26, offset: 29748},
+										pos:  position{line: 1046, col: 26, offset: 29131},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1067, col: 31, offset: 29753},
+									pos:  position{line: 1046, col: 31, offset: 29136},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1067, col: 34, offset: 29756},
+									pos:        position{line: 1046, col: 34, offset: 29139},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8062,43 +7917,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1068, col: 5, offset: 29783},
+						pos: position{line: 1047, col: 5, offset: 29166},
 						run: (*parser).callonExplicitType12,
 						expr: &seqExpr{
-							pos: position{line: 1068, col: 5, offset: 29783},
+							pos: position{line: 1047, col: 5, offset: 29166},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1068, col: 5, offset: 29783},
+									pos:        position{line: 1047, col: 5, offset: 29166},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 12, offset: 29790},
+									pos:  position{line: 1047, col: 12, offset: 29173},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1068, col: 15, offset: 29793},
+									pos:        position{line: 1047, col: 15, offset: 29176},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 19, offset: 29797},
+									pos:  position{line: 1047, col: 19, offset: 29180},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1068, col: 22, offset: 29800},
+									pos:   position{line: 1047, col: 22, offset: 29183},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1068, col: 26, offset: 29804},
+										pos:  position{line: 1047, col: 26, offset: 29187},
 										name: "TypeUnion",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 36, offset: 29814},
+									pos:  position{line: 1047, col: 36, offset: 29197},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1068, col: 39, offset: 29817},
+									pos:        position{line: 1047, col: 39, offset: 29200},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8110,28 +7965,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1070, col: 1, offset: 29842},
+			pos:  position{line: 1049, col: 1, offset: 29225},
 			expr: &choiceExpr{
-				pos: position{line: 1071, col: 5, offset: 29860},
+				pos: position{line: 1050, col: 5, offset: 29243},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 29860},
+						pos: position{line: 1050, col: 5, offset: 29243},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1071, col: 5, offset: 29860},
+							pos: position{line: 1050, col: 5, offset: 29243},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1071, col: 5, offset: 29860},
+									pos:   position{line: 1050, col: 5, offset: 29243},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1071, col: 10, offset: 29865},
+										pos:  position{line: 1050, col: 10, offset: 29248},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1071, col: 24, offset: 29879},
+									pos: position{line: 1050, col: 24, offset: 29262},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1071, col: 25, offset: 29880},
+										pos:  position{line: 1050, col: 25, offset: 29263},
 										name: "IdentifierRest",
 									},
 								},
@@ -8139,55 +7994,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1072, col: 5, offset: 29920},
+						pos: position{line: 1051, col: 5, offset: 29303},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1072, col: 5, offset: 29920},
+							pos: position{line: 1051, col: 5, offset: 29303},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1072, col: 5, offset: 29920},
+									pos:   position{line: 1051, col: 5, offset: 29303},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 10, offset: 29925},
+										pos:  position{line: 1051, col: 10, offset: 29308},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 25, offset: 29940},
+									pos:  position{line: 1051, col: 25, offset: 29323},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1072, col: 28, offset: 29943},
+									pos:        position{line: 1051, col: 28, offset: 29326},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 32, offset: 29947},
+									pos:  position{line: 1051, col: 32, offset: 29330},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1072, col: 35, offset: 29950},
+									pos:        position{line: 1051, col: 35, offset: 29333},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 39, offset: 29954},
+									pos:  position{line: 1051, col: 39, offset: 29337},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1072, col: 42, offset: 29957},
+									pos:   position{line: 1051, col: 42, offset: 29340},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 46, offset: 29961},
+										pos:  position{line: 1051, col: 46, offset: 29344},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 51, offset: 29966},
+									pos:  position{line: 1051, col: 51, offset: 29349},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1072, col: 54, offset: 29969},
+									pos:        position{line: 1051, col: 54, offset: 29352},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8195,42 +8050,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1075, col: 5, offset: 30070},
+						pos: position{line: 1054, col: 5, offset: 29453},
 						run: (*parser).callonAmbiguousType21,
 						expr: &labeledExpr{
-							pos:   position{line: 1075, col: 5, offset: 30070},
+							pos:   position{line: 1054, col: 5, offset: 29453},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1075, col: 10, offset: 30075},
+								pos:  position{line: 1054, col: 10, offset: 29458},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1078, col: 5, offset: 30177},
+						pos: position{line: 1057, col: 5, offset: 29560},
 						run: (*parser).callonAmbiguousType24,
 						expr: &seqExpr{
-							pos: position{line: 1078, col: 5, offset: 30177},
+							pos: position{line: 1057, col: 5, offset: 29560},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1078, col: 5, offset: 30177},
+									pos:        position{line: 1057, col: 5, offset: 29560},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1078, col: 9, offset: 30181},
+									pos:  position{line: 1057, col: 9, offset: 29564},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 12, offset: 30184},
+									pos:   position{line: 1057, col: 12, offset: 29567},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1078, col: 14, offset: 30186},
+										pos:  position{line: 1057, col: 14, offset: 29569},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1078, col: 25, offset: 30197},
+									pos:        position{line: 1057, col: 25, offset: 29580},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8242,15 +8097,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1080, col: 1, offset: 30220},
+			pos:  position{line: 1059, col: 1, offset: 29603},
 			expr: &actionExpr{
-				pos: position{line: 1081, col: 5, offset: 30234},
+				pos: position{line: 1060, col: 5, offset: 29617},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1081, col: 5, offset: 30234},
+					pos:   position{line: 1060, col: 5, offset: 29617},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1081, col: 11, offset: 30240},
+						pos:  position{line: 1060, col: 11, offset: 29623},
 						name: "TypeList",
 					},
 				},
@@ -8258,28 +8113,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1085, col: 1, offset: 30336},
+			pos:  position{line: 1064, col: 1, offset: 29719},
 			expr: &actionExpr{
-				pos: position{line: 1086, col: 5, offset: 30349},
+				pos: position{line: 1065, col: 5, offset: 29732},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1086, col: 5, offset: 30349},
+					pos: position{line: 1065, col: 5, offset: 29732},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1086, col: 5, offset: 30349},
+							pos:   position{line: 1065, col: 5, offset: 29732},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1086, col: 11, offset: 30355},
+								pos:  position{line: 1065, col: 11, offset: 29738},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1086, col: 16, offset: 30360},
+							pos:   position{line: 1065, col: 16, offset: 29743},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1086, col: 21, offset: 30365},
+								pos: position{line: 1065, col: 21, offset: 29748},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1086, col: 21, offset: 30365},
+									pos:  position{line: 1065, col: 21, offset: 29748},
 									name: "TypeListTail",
 								},
 							},
@@ -8290,31 +8145,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1090, col: 1, offset: 30459},
+			pos:  position{line: 1069, col: 1, offset: 29842},
 			expr: &actionExpr{
-				pos: position{line: 1090, col: 16, offset: 30474},
+				pos: position{line: 1069, col: 16, offset: 29857},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1090, col: 16, offset: 30474},
+					pos: position{line: 1069, col: 16, offset: 29857},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1090, col: 16, offset: 30474},
+							pos:  position{line: 1069, col: 16, offset: 29857},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1090, col: 19, offset: 30477},
+							pos:        position{line: 1069, col: 19, offset: 29860},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1090, col: 23, offset: 30481},
+							pos:  position{line: 1069, col: 23, offset: 29864},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1090, col: 26, offset: 30484},
+							pos:   position{line: 1069, col: 26, offset: 29867},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 30, offset: 30488},
+								pos:  position{line: 1069, col: 30, offset: 29871},
 								name: "Type",
 							},
 						},
@@ -8324,39 +8179,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1092, col: 1, offset: 30514},
+			pos:  position{line: 1071, col: 1, offset: 29897},
 			expr: &choiceExpr{
-				pos: position{line: 1093, col: 5, offset: 30530},
+				pos: position{line: 1072, col: 5, offset: 29913},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1093, col: 5, offset: 30530},
+						pos: position{line: 1072, col: 5, offset: 29913},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1093, col: 5, offset: 30530},
+							pos: position{line: 1072, col: 5, offset: 29913},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1093, col: 5, offset: 30530},
+									pos:        position{line: 1072, col: 5, offset: 29913},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1093, col: 9, offset: 30534},
+									pos:  position{line: 1072, col: 9, offset: 29917},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1093, col: 12, offset: 30537},
+									pos:   position{line: 1072, col: 12, offset: 29920},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1093, col: 19, offset: 30544},
+										pos:  position{line: 1072, col: 19, offset: 29927},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1093, col: 33, offset: 30558},
+									pos:  position{line: 1072, col: 33, offset: 29941},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1093, col: 36, offset: 30561},
+									pos:        position{line: 1072, col: 36, offset: 29944},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8364,34 +8219,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1096, col: 5, offset: 30656},
+						pos: position{line: 1075, col: 5, offset: 30039},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1096, col: 5, offset: 30656},
+							pos: position{line: 1075, col: 5, offset: 30039},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1096, col: 5, offset: 30656},
+									pos:        position{line: 1075, col: 5, offset: 30039},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1096, col: 9, offset: 30660},
+									pos:  position{line: 1075, col: 9, offset: 30043},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1096, col: 12, offset: 30663},
+									pos:   position{line: 1075, col: 12, offset: 30046},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1096, col: 16, offset: 30667},
+										pos:  position{line: 1075, col: 16, offset: 30050},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1096, col: 21, offset: 30672},
+									pos:  position{line: 1075, col: 21, offset: 30055},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1096, col: 24, offset: 30675},
+									pos:        position{line: 1075, col: 24, offset: 30058},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8399,34 +8254,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1099, col: 5, offset: 30764},
+						pos: position{line: 1078, col: 5, offset: 30147},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1099, col: 5, offset: 30764},
+							pos: position{line: 1078, col: 5, offset: 30147},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1099, col: 5, offset: 30764},
+									pos:        position{line: 1078, col: 5, offset: 30147},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 10, offset: 30769},
+									pos:  position{line: 1078, col: 10, offset: 30152},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1099, col: 14, offset: 30773},
+									pos:   position{line: 1078, col: 14, offset: 30156},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1099, col: 18, offset: 30777},
+										pos:  position{line: 1078, col: 18, offset: 30160},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 23, offset: 30782},
+									pos:  position{line: 1078, col: 23, offset: 30165},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1099, col: 26, offset: 30785},
+									pos:        position{line: 1078, col: 26, offset: 30168},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8434,55 +8289,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1102, col: 5, offset: 30873},
+						pos: position{line: 1081, col: 5, offset: 30256},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1102, col: 5, offset: 30873},
+							pos: position{line: 1081, col: 5, offset: 30256},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1102, col: 5, offset: 30873},
+									pos:        position{line: 1081, col: 5, offset: 30256},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 10, offset: 30878},
+									pos:  position{line: 1081, col: 10, offset: 30261},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 13, offset: 30881},
+									pos:   position{line: 1081, col: 13, offset: 30264},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1102, col: 21, offset: 30889},
+										pos:  position{line: 1081, col: 21, offset: 30272},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 26, offset: 30894},
+									pos:  position{line: 1081, col: 26, offset: 30277},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1102, col: 29, offset: 30897},
+									pos:        position{line: 1081, col: 29, offset: 30280},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 33, offset: 30901},
+									pos:  position{line: 1081, col: 33, offset: 30284},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 36, offset: 30904},
+									pos:   position{line: 1081, col: 36, offset: 30287},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1102, col: 44, offset: 30912},
+										pos:  position{line: 1081, col: 44, offset: 30295},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 49, offset: 30917},
+									pos:  position{line: 1081, col: 49, offset: 30300},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1102, col: 52, offset: 30920},
+									pos:        position{line: 1081, col: 52, offset: 30303},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8494,39 +8349,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexTypeExternal",
-			pos:  position{line: 1106, col: 1, offset: 31034},
+			pos:  position{line: 1085, col: 1, offset: 30417},
 			expr: &choiceExpr{
-				pos: position{line: 1107, col: 5, offset: 31058},
+				pos: position{line: 1086, col: 5, offset: 30441},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1107, col: 5, offset: 31058},
+						pos: position{line: 1086, col: 5, offset: 30441},
 						run: (*parser).callonComplexTypeExternal2,
 						expr: &seqExpr{
-							pos: position{line: 1107, col: 5, offset: 31058},
+							pos: position{line: 1086, col: 5, offset: 30441},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1107, col: 5, offset: 31058},
+									pos:        position{line: 1086, col: 5, offset: 30441},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1107, col: 9, offset: 31062},
+									pos:  position{line: 1086, col: 9, offset: 30445},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1107, col: 12, offset: 31065},
+									pos:   position{line: 1086, col: 12, offset: 30448},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1107, col: 19, offset: 31072},
+										pos:  position{line: 1086, col: 19, offset: 30455},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1107, col: 33, offset: 31086},
+									pos:  position{line: 1086, col: 33, offset: 30469},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1107, col: 36, offset: 31089},
+									pos:        position{line: 1086, col: 36, offset: 30472},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8534,34 +8389,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1110, col: 5, offset: 31184},
+						pos: position{line: 1089, col: 5, offset: 30567},
 						run: (*parser).callonComplexTypeExternal10,
 						expr: &seqExpr{
-							pos: position{line: 1110, col: 5, offset: 31184},
+							pos: position{line: 1089, col: 5, offset: 30567},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1110, col: 5, offset: 31184},
+									pos:        position{line: 1089, col: 5, offset: 30567},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 9, offset: 31188},
+									pos:  position{line: 1089, col: 9, offset: 30571},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 12, offset: 31191},
+									pos:   position{line: 1089, col: 12, offset: 30574},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 16, offset: 31195},
+										pos:  position{line: 1089, col: 16, offset: 30578},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 29, offset: 31208},
+									pos:  position{line: 1089, col: 29, offset: 30591},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 32, offset: 31211},
+									pos:        position{line: 1089, col: 32, offset: 30594},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8569,34 +8424,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1113, col: 5, offset: 31300},
+						pos: position{line: 1092, col: 5, offset: 30683},
 						run: (*parser).callonComplexTypeExternal18,
 						expr: &seqExpr{
-							pos: position{line: 1113, col: 5, offset: 31300},
+							pos: position{line: 1092, col: 5, offset: 30683},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1113, col: 5, offset: 31300},
+									pos:        position{line: 1092, col: 5, offset: 30683},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1113, col: 10, offset: 31305},
+									pos:  position{line: 1092, col: 10, offset: 30688},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1113, col: 13, offset: 31308},
+									pos:   position{line: 1092, col: 13, offset: 30691},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1113, col: 17, offset: 31312},
+										pos:  position{line: 1092, col: 17, offset: 30695},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1113, col: 30, offset: 31325},
+									pos:  position{line: 1092, col: 30, offset: 30708},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1113, col: 33, offset: 31328},
+									pos:        position{line: 1092, col: 33, offset: 30711},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8604,55 +8459,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1116, col: 5, offset: 31416},
+						pos: position{line: 1095, col: 5, offset: 30799},
 						run: (*parser).callonComplexTypeExternal26,
 						expr: &seqExpr{
-							pos: position{line: 1116, col: 5, offset: 31416},
+							pos: position{line: 1095, col: 5, offset: 30799},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1116, col: 5, offset: 31416},
+									pos:        position{line: 1095, col: 5, offset: 30799},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 10, offset: 31421},
+									pos:  position{line: 1095, col: 10, offset: 30804},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1116, col: 13, offset: 31424},
+									pos:   position{line: 1095, col: 13, offset: 30807},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1116, col: 21, offset: 31432},
+										pos:  position{line: 1095, col: 21, offset: 30815},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 34, offset: 31445},
+									pos:  position{line: 1095, col: 34, offset: 30828},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1116, col: 37, offset: 31448},
+									pos:        position{line: 1095, col: 37, offset: 30831},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 41, offset: 31452},
+									pos:  position{line: 1095, col: 41, offset: 30835},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1116, col: 44, offset: 31455},
+									pos:   position{line: 1095, col: 44, offset: 30838},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1116, col: 52, offset: 31463},
+										pos:  position{line: 1095, col: 52, offset: 30846},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 65, offset: 31476},
+									pos:  position{line: 1095, col: 65, offset: 30859},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1116, col: 68, offset: 31479},
+									pos:        position{line: 1095, col: 68, offset: 30862},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8664,16 +8519,16 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1120, col: 1, offset: 31593},
+			pos:  position{line: 1099, col: 1, offset: 30976},
 			expr: &choiceExpr{
-				pos: position{line: 1121, col: 5, offset: 31611},
+				pos: position{line: 1100, col: 5, offset: 30994},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1121, col: 5, offset: 31611},
+						pos:  position{line: 1100, col: 5, offset: 30994},
 						name: "PrimitiveTypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1122, col: 5, offset: 31637},
+						pos:  position{line: 1101, col: 5, offset: 31020},
 						name: "PrimitiveTypeInternal",
 					},
 				},
@@ -8681,65 +8536,65 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeExternal",
-			pos:  position{line: 1128, col: 1, offset: 31896},
+			pos:  position{line: 1107, col: 1, offset: 31279},
 			expr: &actionExpr{
-				pos: position{line: 1129, col: 5, offset: 31922},
+				pos: position{line: 1108, col: 5, offset: 31305},
 				run: (*parser).callonPrimitiveTypeExternal1,
 				expr: &choiceExpr{
-					pos: position{line: 1129, col: 9, offset: 31926},
+					pos: position{line: 1108, col: 9, offset: 31309},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1129, col: 9, offset: 31926},
+							pos:        position{line: 1108, col: 9, offset: 31309},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1129, col: 19, offset: 31936},
+							pos:        position{line: 1108, col: 19, offset: 31319},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1129, col: 30, offset: 31947},
+							pos:        position{line: 1108, col: 30, offset: 31330},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1129, col: 41, offset: 31958},
+							pos:        position{line: 1108, col: 41, offset: 31341},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1130, col: 9, offset: 31975},
+							pos:        position{line: 1109, col: 9, offset: 31358},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1130, col: 18, offset: 31984},
+							pos:        position{line: 1109, col: 18, offset: 31367},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1130, col: 28, offset: 31994},
+							pos:        position{line: 1109, col: 28, offset: 31377},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1130, col: 38, offset: 32004},
+							pos:        position{line: 1109, col: 38, offset: 31387},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1131, col: 9, offset: 32020},
+							pos:        position{line: 1110, col: 9, offset: 31403},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1132, col: 9, offset: 32038},
+							pos:        position{line: 1111, col: 9, offset: 31421},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1132, col: 18, offset: 32047},
+							pos:        position{line: 1111, col: 18, offset: 31430},
 							val:        "string",
 							ignoreCase: false,
 						},
@@ -8749,55 +8604,55 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeInternal",
-			pos:  position{line: 1143, col: 1, offset: 32688},
+			pos:  position{line: 1122, col: 1, offset: 32071},
 			expr: &actionExpr{
-				pos: position{line: 1144, col: 5, offset: 32714},
+				pos: position{line: 1123, col: 5, offset: 32097},
 				run: (*parser).callonPrimitiveTypeInternal1,
 				expr: &choiceExpr{
-					pos: position{line: 1144, col: 9, offset: 32718},
+					pos: position{line: 1123, col: 9, offset: 32101},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1144, col: 9, offset: 32718},
+							pos:        position{line: 1123, col: 9, offset: 32101},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1144, col: 22, offset: 32731},
+							pos:        position{line: 1123, col: 22, offset: 32114},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1145, col: 9, offset: 32746},
+							pos:        position{line: 1124, col: 9, offset: 32129},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1146, col: 9, offset: 32762},
+							pos:        position{line: 1125, col: 9, offset: 32145},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1147, col: 9, offset: 32780},
+							pos:        position{line: 1126, col: 9, offset: 32163},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1147, col: 16, offset: 32787},
+							pos:        position{line: 1126, col: 16, offset: 32170},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1148, col: 9, offset: 32801},
+							pos:        position{line: 1127, col: 9, offset: 32184},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1148, col: 18, offset: 32810},
+							pos:        position{line: 1127, col: 18, offset: 32193},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1148, col: 28, offset: 32820},
+							pos:        position{line: 1127, col: 28, offset: 32203},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8807,28 +8662,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1152, col: 1, offset: 32936},
+			pos:  position{line: 1131, col: 1, offset: 32319},
 			expr: &actionExpr{
-				pos: position{line: 1153, col: 5, offset: 32954},
+				pos: position{line: 1132, col: 5, offset: 32337},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1153, col: 5, offset: 32954},
+					pos: position{line: 1132, col: 5, offset: 32337},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1153, col: 5, offset: 32954},
+							pos:   position{line: 1132, col: 5, offset: 32337},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1153, col: 11, offset: 32960},
+								pos:  position{line: 1132, col: 11, offset: 32343},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1153, col: 21, offset: 32970},
+							pos:   position{line: 1132, col: 21, offset: 32353},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1153, col: 26, offset: 32975},
+								pos: position{line: 1132, col: 26, offset: 32358},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1153, col: 26, offset: 32975},
+									pos:  position{line: 1132, col: 26, offset: 32358},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -8839,31 +8694,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1157, col: 1, offset: 33074},
+			pos:  position{line: 1136, col: 1, offset: 32457},
 			expr: &actionExpr{
-				pos: position{line: 1157, col: 21, offset: 33094},
+				pos: position{line: 1136, col: 21, offset: 32477},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1157, col: 21, offset: 33094},
+					pos: position{line: 1136, col: 21, offset: 32477},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1157, col: 21, offset: 33094},
+							pos:  position{line: 1136, col: 21, offset: 32477},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1157, col: 24, offset: 33097},
+							pos:        position{line: 1136, col: 24, offset: 32480},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1157, col: 28, offset: 33101},
+							pos:  position{line: 1136, col: 28, offset: 32484},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1157, col: 31, offset: 33104},
+							pos:   position{line: 1136, col: 31, offset: 32487},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1157, col: 35, offset: 33108},
+								pos:  position{line: 1136, col: 35, offset: 32491},
 								name: "TypeField",
 							},
 						},
@@ -8873,39 +8728,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1159, col: 1, offset: 33139},
+			pos:  position{line: 1138, col: 1, offset: 32522},
 			expr: &actionExpr{
-				pos: position{line: 1160, col: 5, offset: 33153},
+				pos: position{line: 1139, col: 5, offset: 32536},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1160, col: 5, offset: 33153},
+					pos: position{line: 1139, col: 5, offset: 32536},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1160, col: 5, offset: 33153},
+							pos:   position{line: 1139, col: 5, offset: 32536},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1160, col: 10, offset: 33158},
+								pos:  position{line: 1139, col: 10, offset: 32541},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1160, col: 20, offset: 33168},
+							pos:  position{line: 1139, col: 20, offset: 32551},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 23, offset: 33171},
+							pos:        position{line: 1139, col: 23, offset: 32554},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1160, col: 27, offset: 33175},
+							pos:  position{line: 1139, col: 27, offset: 32558},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1160, col: 30, offset: 33178},
+							pos:   position{line: 1139, col: 30, offset: 32561},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1160, col: 34, offset: 33182},
+								pos:  position{line: 1139, col: 34, offset: 32565},
 								name: "Type",
 							},
 						},
@@ -8915,28 +8770,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListExternal",
-			pos:  position{line: 1164, col: 1, offset: 33264},
+			pos:  position{line: 1143, col: 1, offset: 32647},
 			expr: &actionExpr{
-				pos: position{line: 1165, col: 5, offset: 33290},
+				pos: position{line: 1144, col: 5, offset: 32673},
 				run: (*parser).callonTypeFieldListExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1165, col: 5, offset: 33290},
+					pos: position{line: 1144, col: 5, offset: 32673},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1165, col: 5, offset: 33290},
+							pos:   position{line: 1144, col: 5, offset: 32673},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1165, col: 11, offset: 33296},
+								pos:  position{line: 1144, col: 11, offset: 32679},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1165, col: 21, offset: 33306},
+							pos:   position{line: 1144, col: 21, offset: 32689},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1165, col: 26, offset: 33311},
+								pos: position{line: 1144, col: 26, offset: 32694},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1165, col: 26, offset: 33311},
+									pos:  position{line: 1144, col: 26, offset: 32694},
 									name: "TypeFieldListTailExternal",
 								},
 							},
@@ -8947,31 +8802,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTailExternal",
-			pos:  position{line: 1169, col: 1, offset: 33418},
+			pos:  position{line: 1148, col: 1, offset: 32801},
 			expr: &actionExpr{
-				pos: position{line: 1169, col: 29, offset: 33446},
+				pos: position{line: 1148, col: 29, offset: 32829},
 				run: (*parser).callonTypeFieldListTailExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1169, col: 29, offset: 33446},
+					pos: position{line: 1148, col: 29, offset: 32829},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1169, col: 29, offset: 33446},
+							pos:  position{line: 1148, col: 29, offset: 32829},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1169, col: 32, offset: 33449},
+							pos:        position{line: 1148, col: 32, offset: 32832},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1169, col: 36, offset: 33453},
+							pos:  position{line: 1148, col: 36, offset: 32836},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1169, col: 39, offset: 33456},
+							pos:   position{line: 1148, col: 39, offset: 32839},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1169, col: 43, offset: 33460},
+								pos:  position{line: 1148, col: 43, offset: 32843},
 								name: "TypeFieldExternal",
 							},
 						},
@@ -8981,39 +8836,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldExternal",
-			pos:  position{line: 1171, col: 1, offset: 33499},
+			pos:  position{line: 1150, col: 1, offset: 32882},
 			expr: &actionExpr{
-				pos: position{line: 1172, col: 5, offset: 33521},
+				pos: position{line: 1151, col: 5, offset: 32904},
 				run: (*parser).callonTypeFieldExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1172, col: 5, offset: 33521},
+					pos: position{line: 1151, col: 5, offset: 32904},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1172, col: 5, offset: 33521},
+							pos:   position{line: 1151, col: 5, offset: 32904},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 10, offset: 33526},
+								pos:  position{line: 1151, col: 10, offset: 32909},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1172, col: 20, offset: 33536},
+							pos:  position{line: 1151, col: 20, offset: 32919},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1172, col: 23, offset: 33539},
+							pos:        position{line: 1151, col: 23, offset: 32922},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1172, col: 27, offset: 33543},
+							pos:  position{line: 1151, col: 27, offset: 32926},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 30, offset: 33546},
+							pos:   position{line: 1151, col: 30, offset: 32929},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 34, offset: 33550},
+								pos:  position{line: 1151, col: 34, offset: 32933},
 								name: "TypeExternal",
 							},
 						},
@@ -9023,16 +8878,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1176, col: 1, offset: 33640},
+			pos:  position{line: 1155, col: 1, offset: 33023},
 			expr: &choiceExpr{
-				pos: position{line: 1177, col: 5, offset: 33654},
+				pos: position{line: 1156, col: 5, offset: 33037},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1177, col: 5, offset: 33654},
+						pos:  position{line: 1156, col: 5, offset: 33037},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1178, col: 5, offset: 33673},
+						pos:  position{line: 1157, col: 5, offset: 33056},
 						name: "QuotedString",
 					},
 				},
@@ -9040,16 +8895,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 1180, col: 1, offset: 33687},
+			pos:  position{line: 1159, col: 1, offset: 33070},
 			expr: &choiceExpr{
-				pos: position{line: 1181, col: 5, offset: 33705},
+				pos: position{line: 1160, col: 5, offset: 33088},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1181, col: 5, offset: 33705},
+						pos:  position{line: 1160, col: 5, offset: 33088},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1181, col: 24, offset: 33724},
+						pos:  position{line: 1160, col: 24, offset: 33107},
 						name: "RelativeOperator",
 					},
 				},
@@ -9057,22 +8912,22 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1183, col: 1, offset: 33742},
+			pos:  position{line: 1162, col: 1, offset: 33125},
 			expr: &actionExpr{
-				pos: position{line: 1183, col: 12, offset: 33753},
+				pos: position{line: 1162, col: 12, offset: 33136},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1183, col: 12, offset: 33753},
+					pos: position{line: 1162, col: 12, offset: 33136},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1183, col: 12, offset: 33753},
+							pos:        position{line: 1162, col: 12, offset: 33136},
 							val:        "and",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1183, col: 19, offset: 33760},
+							pos: position{line: 1162, col: 19, offset: 33143},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1183, col: 20, offset: 33761},
+								pos:  position{line: 1162, col: 20, offset: 33144},
 								name: "IdentifierRest",
 							},
 						},
@@ -9082,22 +8937,22 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1184, col: 1, offset: 33798},
+			pos:  position{line: 1163, col: 1, offset: 33181},
 			expr: &actionExpr{
-				pos: position{line: 1184, col: 11, offset: 33808},
+				pos: position{line: 1163, col: 11, offset: 33191},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1184, col: 11, offset: 33808},
+					pos: position{line: 1163, col: 11, offset: 33191},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1184, col: 11, offset: 33808},
+							pos:        position{line: 1163, col: 11, offset: 33191},
 							val:        "or",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1184, col: 17, offset: 33814},
+							pos: position{line: 1163, col: 17, offset: 33197},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1184, col: 18, offset: 33815},
+								pos:  position{line: 1163, col: 18, offset: 33198},
 								name: "IdentifierRest",
 							},
 						},
@@ -9107,22 +8962,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1185, col: 1, offset: 33851},
+			pos:  position{line: 1164, col: 1, offset: 33234},
 			expr: &actionExpr{
-				pos: position{line: 1185, col: 11, offset: 33861},
+				pos: position{line: 1164, col: 11, offset: 33244},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1185, col: 11, offset: 33861},
+					pos: position{line: 1164, col: 11, offset: 33244},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1185, col: 11, offset: 33861},
+							pos:        position{line: 1164, col: 11, offset: 33244},
 							val:        "in",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1185, col: 17, offset: 33867},
+							pos: position{line: 1164, col: 17, offset: 33250},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1185, col: 18, offset: 33868},
+								pos:  position{line: 1164, col: 18, offset: 33251},
 								name: "IdentifierRest",
 							},
 						},
@@ -9132,22 +8987,22 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1186, col: 1, offset: 33904},
+			pos:  position{line: 1165, col: 1, offset: 33287},
 			expr: &actionExpr{
-				pos: position{line: 1186, col: 12, offset: 33915},
+				pos: position{line: 1165, col: 12, offset: 33298},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1186, col: 12, offset: 33915},
+					pos: position{line: 1165, col: 12, offset: 33298},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1186, col: 12, offset: 33915},
+							pos:        position{line: 1165, col: 12, offset: 33298},
 							val:        "not",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1186, col: 19, offset: 33922},
+							pos: position{line: 1165, col: 19, offset: 33305},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1186, col: 20, offset: 33923},
+								pos:  position{line: 1165, col: 20, offset: 33306},
 								name: "IdentifierRest",
 							},
 						},
@@ -9157,22 +9012,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1187, col: 1, offset: 33960},
+			pos:  position{line: 1166, col: 1, offset: 33343},
 			expr: &actionExpr{
-				pos: position{line: 1187, col: 11, offset: 33970},
+				pos: position{line: 1166, col: 11, offset: 33353},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1187, col: 11, offset: 33970},
+					pos: position{line: 1166, col: 11, offset: 33353},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1187, col: 11, offset: 33970},
+							pos:        position{line: 1166, col: 11, offset: 33353},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1187, col: 17, offset: 33976},
+							pos: position{line: 1166, col: 17, offset: 33359},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1187, col: 18, offset: 33977},
+								pos:  position{line: 1166, col: 18, offset: 33360},
 								name: "IdentifierRest",
 							},
 						},
@@ -9182,9 +9037,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1189, col: 1, offset: 34014},
+			pos:  position{line: 1168, col: 1, offset: 33397},
 			expr: &charClassMatcher{
-				pos:        position{line: 1189, col: 19, offset: 34032},
+				pos:        position{line: 1168, col: 19, offset: 33415},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9194,16 +9049,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1191, col: 1, offset: 34044},
+			pos:  position{line: 1170, col: 1, offset: 33427},
 			expr: &choiceExpr{
-				pos: position{line: 1191, col: 18, offset: 34061},
+				pos: position{line: 1170, col: 18, offset: 33444},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1191, col: 18, offset: 34061},
+						pos:  position{line: 1170, col: 18, offset: 33444},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1191, col: 36, offset: 34079},
+						pos:        position{line: 1170, col: 36, offset: 33462},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9214,15 +9069,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1193, col: 1, offset: 34086},
+			pos:  position{line: 1172, col: 1, offset: 33469},
 			expr: &actionExpr{
-				pos: position{line: 1194, col: 5, offset: 34101},
+				pos: position{line: 1173, col: 5, offset: 33484},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1194, col: 5, offset: 34101},
+					pos:   position{line: 1173, col: 5, offset: 33484},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1194, col: 8, offset: 34104},
+						pos:  position{line: 1173, col: 8, offset: 33487},
 						name: "IdentifierName",
 					},
 				},
@@ -9230,29 +9085,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1196, col: 1, offset: 34185},
+			pos:  position{line: 1175, col: 1, offset: 33568},
 			expr: &choiceExpr{
-				pos: position{line: 1197, col: 5, offset: 34204},
+				pos: position{line: 1176, col: 5, offset: 33587},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1197, col: 5, offset: 34204},
+						pos: position{line: 1176, col: 5, offset: 33587},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1197, col: 5, offset: 34204},
+							pos: position{line: 1176, col: 5, offset: 33587},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1197, col: 5, offset: 34204},
+									pos: position{line: 1176, col: 5, offset: 33587},
 									expr: &seqExpr{
-										pos: position{line: 1197, col: 7, offset: 34206},
+										pos: position{line: 1176, col: 7, offset: 33589},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1197, col: 7, offset: 34206},
+												pos:  position{line: 1176, col: 7, offset: 33589},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1197, col: 15, offset: 34214},
+												pos: position{line: 1176, col: 15, offset: 33597},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1197, col: 16, offset: 34215},
+													pos:  position{line: 1176, col: 16, offset: 33598},
 													name: "IdentifierRest",
 												},
 											},
@@ -9260,13 +9115,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1197, col: 32, offset: 34231},
+									pos:  position{line: 1176, col: 32, offset: 33614},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1197, col: 48, offset: 34247},
+									pos: position{line: 1176, col: 48, offset: 33630},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1197, col: 48, offset: 34247},
+										pos:  position{line: 1176, col: 48, offset: 33630},
 										name: "IdentifierRest",
 									},
 								},
@@ -9274,30 +9129,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1198, col: 5, offset: 34299},
+						pos: position{line: 1177, col: 5, offset: 33682},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1198, col: 5, offset: 34299},
+							pos:        position{line: 1177, col: 5, offset: 33682},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1199, col: 5, offset: 34338},
+						pos: position{line: 1178, col: 5, offset: 33721},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1199, col: 5, offset: 34338},
+							pos: position{line: 1178, col: 5, offset: 33721},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1199, col: 5, offset: 34338},
+									pos:        position{line: 1178, col: 5, offset: 33721},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1199, col: 10, offset: 34343},
+									pos:   position{line: 1178, col: 10, offset: 33726},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1199, col: 13, offset: 34346},
+										pos:  position{line: 1178, col: 13, offset: 33729},
 										name: "IDGuard",
 									},
 								},
@@ -9305,39 +9160,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1201, col: 5, offset: 34437},
+						pos: position{line: 1180, col: 5, offset: 33820},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1201, col: 5, offset: 34437},
+							pos:        position{line: 1180, col: 5, offset: 33820},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1202, col: 5, offset: 34479},
+						pos: position{line: 1181, col: 5, offset: 33862},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1202, col: 5, offset: 34479},
+							pos: position{line: 1181, col: 5, offset: 33862},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1202, col: 5, offset: 34479},
+									pos:   position{line: 1181, col: 5, offset: 33862},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1202, col: 8, offset: 34482},
+										pos:  position{line: 1181, col: 8, offset: 33865},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1202, col: 26, offset: 34500},
+									pos: position{line: 1181, col: 26, offset: 33883},
 									expr: &seqExpr{
-										pos: position{line: 1202, col: 28, offset: 34502},
+										pos: position{line: 1181, col: 28, offset: 33885},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1202, col: 28, offset: 34502},
+												pos:  position{line: 1181, col: 28, offset: 33885},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1202, col: 31, offset: 34505},
+												pos:        position{line: 1181, col: 31, offset: 33888},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9352,24 +9207,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1204, col: 1, offset: 34530},
+			pos:  position{line: 1183, col: 1, offset: 33913},
 			expr: &choiceExpr{
-				pos: position{line: 1205, col: 5, offset: 34542},
+				pos: position{line: 1184, col: 5, offset: 33925},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1205, col: 5, offset: 34542},
+						pos:  position{line: 1184, col: 5, offset: 33925},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1206, col: 5, offset: 34561},
+						pos:  position{line: 1185, col: 5, offset: 33944},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1207, col: 5, offset: 34577},
+						pos:  position{line: 1186, col: 5, offset: 33960},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1208, col: 5, offset: 34594},
+						pos:  position{line: 1187, col: 5, offset: 33977},
 						name: "SearchGuard",
 					},
 				},
@@ -9377,24 +9232,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1210, col: 1, offset: 34607},
+			pos:  position{line: 1189, col: 1, offset: 33990},
 			expr: &actionExpr{
-				pos: position{line: 1211, col: 5, offset: 34616},
+				pos: position{line: 1190, col: 5, offset: 33999},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1211, col: 5, offset: 34616},
+					pos: position{line: 1190, col: 5, offset: 33999},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1211, col: 5, offset: 34616},
+							pos:  position{line: 1190, col: 5, offset: 33999},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1211, col: 14, offset: 34625},
+							pos:        position{line: 1190, col: 14, offset: 34008},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1211, col: 18, offset: 34629},
+							pos:  position{line: 1190, col: 18, offset: 34012},
 							name: "FullTime",
 						},
 					},
@@ -9403,30 +9258,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1215, col: 1, offset: 34749},
+			pos:  position{line: 1194, col: 1, offset: 34132},
 			expr: &seqExpr{
-				pos: position{line: 1215, col: 12, offset: 34760},
+				pos: position{line: 1194, col: 12, offset: 34143},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 12, offset: 34760},
+						pos:  position{line: 1194, col: 12, offset: 34143},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1215, col: 15, offset: 34763},
+						pos:        position{line: 1194, col: 15, offset: 34146},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 19, offset: 34767},
+						pos:  position{line: 1194, col: 19, offset: 34150},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1215, col: 22, offset: 34770},
+						pos:        position{line: 1194, col: 22, offset: 34153},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 26, offset: 34774},
+						pos:  position{line: 1194, col: 26, offset: 34157},
 						name: "D2",
 					},
 				},
@@ -9434,33 +9289,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1217, col: 1, offset: 34778},
+			pos:  position{line: 1196, col: 1, offset: 34161},
 			expr: &seqExpr{
-				pos: position{line: 1217, col: 6, offset: 34783},
+				pos: position{line: 1196, col: 6, offset: 34166},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1217, col: 6, offset: 34783},
+						pos:        position{line: 1196, col: 6, offset: 34166},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1217, col: 11, offset: 34788},
+						pos:        position{line: 1196, col: 11, offset: 34171},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1217, col: 16, offset: 34793},
+						pos:        position{line: 1196, col: 16, offset: 34176},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1217, col: 21, offset: 34798},
+						pos:        position{line: 1196, col: 21, offset: 34181},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9471,19 +9326,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1218, col: 1, offset: 34804},
+			pos:  position{line: 1197, col: 1, offset: 34187},
 			expr: &seqExpr{
-				pos: position{line: 1218, col: 6, offset: 34809},
+				pos: position{line: 1197, col: 6, offset: 34192},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1218, col: 6, offset: 34809},
+						pos:        position{line: 1197, col: 6, offset: 34192},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1218, col: 11, offset: 34814},
+						pos:        position{line: 1197, col: 11, offset: 34197},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9494,16 +9349,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1220, col: 1, offset: 34821},
+			pos:  position{line: 1199, col: 1, offset: 34204},
 			expr: &seqExpr{
-				pos: position{line: 1220, col: 12, offset: 34832},
+				pos: position{line: 1199, col: 12, offset: 34215},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 12, offset: 34832},
+						pos:  position{line: 1199, col: 12, offset: 34215},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 24, offset: 34844},
+						pos:  position{line: 1199, col: 24, offset: 34227},
 						name: "TimeOffset",
 					},
 				},
@@ -9511,46 +9366,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1222, col: 1, offset: 34856},
+			pos:  position{line: 1201, col: 1, offset: 34239},
 			expr: &seqExpr{
-				pos: position{line: 1222, col: 15, offset: 34870},
+				pos: position{line: 1201, col: 15, offset: 34253},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1222, col: 15, offset: 34870},
+						pos:  position{line: 1201, col: 15, offset: 34253},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1222, col: 18, offset: 34873},
+						pos:        position{line: 1201, col: 18, offset: 34256},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1222, col: 22, offset: 34877},
+						pos:  position{line: 1201, col: 22, offset: 34260},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1222, col: 25, offset: 34880},
+						pos:        position{line: 1201, col: 25, offset: 34263},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1222, col: 29, offset: 34884},
+						pos:  position{line: 1201, col: 29, offset: 34267},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1222, col: 32, offset: 34887},
+						pos: position{line: 1201, col: 32, offset: 34270},
 						expr: &seqExpr{
-							pos: position{line: 1222, col: 33, offset: 34888},
+							pos: position{line: 1201, col: 33, offset: 34271},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1222, col: 33, offset: 34888},
+									pos:        position{line: 1201, col: 33, offset: 34271},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1222, col: 37, offset: 34892},
+									pos: position{line: 1201, col: 37, offset: 34275},
 									expr: &charClassMatcher{
-										pos:        position{line: 1222, col: 37, offset: 34892},
+										pos:        position{line: 1201, col: 37, offset: 34275},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9565,60 +9420,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1224, col: 1, offset: 34902},
+			pos:  position{line: 1203, col: 1, offset: 34285},
 			expr: &choiceExpr{
-				pos: position{line: 1225, col: 5, offset: 34917},
+				pos: position{line: 1204, col: 5, offset: 34300},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1225, col: 5, offset: 34917},
+						pos:        position{line: 1204, col: 5, offset: 34300},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1226, col: 5, offset: 34925},
+						pos: position{line: 1205, col: 5, offset: 34308},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1226, col: 6, offset: 34926},
+								pos: position{line: 1205, col: 6, offset: 34309},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1226, col: 6, offset: 34926},
+										pos:        position{line: 1205, col: 6, offset: 34309},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1226, col: 12, offset: 34932},
+										pos:        position{line: 1205, col: 12, offset: 34315},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1226, col: 17, offset: 34937},
+								pos:  position{line: 1205, col: 17, offset: 34320},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1226, col: 20, offset: 34940},
+								pos:        position{line: 1205, col: 20, offset: 34323},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1226, col: 24, offset: 34944},
+								pos:  position{line: 1205, col: 24, offset: 34327},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1226, col: 27, offset: 34947},
+								pos: position{line: 1205, col: 27, offset: 34330},
 								expr: &seqExpr{
-									pos: position{line: 1226, col: 28, offset: 34948},
+									pos: position{line: 1205, col: 28, offset: 34331},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1226, col: 28, offset: 34948},
+											pos:        position{line: 1205, col: 28, offset: 34331},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1226, col: 32, offset: 34952},
+											pos: position{line: 1205, col: 32, offset: 34335},
 											expr: &charClassMatcher{
-												pos:        position{line: 1226, col: 32, offset: 34952},
+												pos:        position{line: 1205, col: 32, offset: 34335},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9635,32 +9490,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1228, col: 1, offset: 34962},
+			pos:  position{line: 1207, col: 1, offset: 34345},
 			expr: &actionExpr{
-				pos: position{line: 1229, col: 5, offset: 34975},
+				pos: position{line: 1208, col: 5, offset: 34358},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1229, col: 5, offset: 34975},
+					pos: position{line: 1208, col: 5, offset: 34358},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1229, col: 5, offset: 34975},
+							pos: position{line: 1208, col: 5, offset: 34358},
 							expr: &litMatcher{
-								pos:        position{line: 1229, col: 5, offset: 34975},
+								pos:        position{line: 1208, col: 5, offset: 34358},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1229, col: 10, offset: 34980},
+							pos: position{line: 1208, col: 10, offset: 34363},
 							expr: &seqExpr{
-								pos: position{line: 1229, col: 11, offset: 34981},
+								pos: position{line: 1208, col: 11, offset: 34364},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1229, col: 11, offset: 34981},
+										pos:  position{line: 1208, col: 11, offset: 34364},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1229, col: 19, offset: 34989},
+										pos:  position{line: 1208, col: 19, offset: 34372},
 										name: "TimeUnit",
 									},
 								},
@@ -9672,26 +9527,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1233, col: 1, offset: 35115},
+			pos:  position{line: 1212, col: 1, offset: 34498},
 			expr: &seqExpr{
-				pos: position{line: 1233, col: 11, offset: 35125},
+				pos: position{line: 1212, col: 11, offset: 34508},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1233, col: 11, offset: 35125},
+						pos:  position{line: 1212, col: 11, offset: 34508},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1233, col: 16, offset: 35130},
+						pos: position{line: 1212, col: 16, offset: 34513},
 						expr: &seqExpr{
-							pos: position{line: 1233, col: 17, offset: 35131},
+							pos: position{line: 1212, col: 17, offset: 34514},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1233, col: 17, offset: 35131},
+									pos:        position{line: 1212, col: 17, offset: 34514},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1233, col: 21, offset: 35135},
+									pos:  position{line: 1212, col: 21, offset: 34518},
 									name: "UInt",
 								},
 							},
@@ -9702,52 +9557,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1235, col: 1, offset: 35143},
+			pos:  position{line: 1214, col: 1, offset: 34526},
 			expr: &choiceExpr{
-				pos: position{line: 1236, col: 5, offset: 35156},
+				pos: position{line: 1215, col: 5, offset: 34539},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1236, col: 5, offset: 35156},
+						pos:        position{line: 1215, col: 5, offset: 34539},
 						val:        "ns",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1237, col: 5, offset: 35166},
+						pos:        position{line: 1216, col: 5, offset: 34549},
 						val:        "us",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1238, col: 5, offset: 35176},
+						pos:        position{line: 1217, col: 5, offset: 34559},
 						val:        "ms",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1239, col: 5, offset: 35186},
+						pos:        position{line: 1218, col: 5, offset: 34569},
 						val:        "s",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1240, col: 5, offset: 35195},
+						pos:        position{line: 1219, col: 5, offset: 34578},
 						val:        "m",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1241, col: 5, offset: 35204},
+						pos:        position{line: 1220, col: 5, offset: 34587},
 						val:        "h",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1242, col: 5, offset: 35213},
+						pos:        position{line: 1221, col: 5, offset: 34596},
 						val:        "d",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1243, col: 5, offset: 35222},
+						pos:        position{line: 1222, col: 5, offset: 34605},
 						val:        "w",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1244, col: 5, offset: 35231},
+						pos:        position{line: 1223, col: 5, offset: 34614},
 						val:        "y",
 						ignoreCase: true,
 					},
@@ -9756,42 +9611,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1246, col: 1, offset: 35237},
+			pos:  position{line: 1225, col: 1, offset: 34620},
 			expr: &actionExpr{
-				pos: position{line: 1247, col: 5, offset: 35244},
+				pos: position{line: 1226, col: 5, offset: 34627},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1247, col: 5, offset: 35244},
+					pos: position{line: 1226, col: 5, offset: 34627},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 5, offset: 35244},
+							pos:  position{line: 1226, col: 5, offset: 34627},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1247, col: 10, offset: 35249},
+							pos:        position{line: 1226, col: 10, offset: 34632},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 14, offset: 35253},
+							pos:  position{line: 1226, col: 14, offset: 34636},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1247, col: 19, offset: 35258},
+							pos:        position{line: 1226, col: 19, offset: 34641},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 23, offset: 35262},
+							pos:  position{line: 1226, col: 23, offset: 34645},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1247, col: 28, offset: 35267},
+							pos:        position{line: 1226, col: 28, offset: 34650},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 32, offset: 35271},
+							pos:  position{line: 1226, col: 32, offset: 34654},
 							name: "UInt",
 						},
 					},
@@ -9800,42 +9655,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1249, col: 1, offset: 35308},
+			pos:  position{line: 1228, col: 1, offset: 34691},
 			expr: &actionExpr{
-				pos: position{line: 1250, col: 5, offset: 35316},
+				pos: position{line: 1229, col: 5, offset: 34699},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1250, col: 5, offset: 35316},
+					pos: position{line: 1229, col: 5, offset: 34699},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1250, col: 5, offset: 35316},
+							pos: position{line: 1229, col: 5, offset: 34699},
 							expr: &seqExpr{
-								pos: position{line: 1250, col: 8, offset: 35319},
+								pos: position{line: 1229, col: 8, offset: 34702},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1250, col: 8, offset: 35319},
+										pos:  position{line: 1229, col: 8, offset: 34702},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1250, col: 12, offset: 35323},
+										pos:        position{line: 1229, col: 12, offset: 34706},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1250, col: 16, offset: 35327},
+										pos:  position{line: 1229, col: 16, offset: 34710},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1250, col: 20, offset: 35331},
+										pos: position{line: 1229, col: 20, offset: 34714},
 										expr: &choiceExpr{
-											pos: position{line: 1250, col: 22, offset: 35333},
+											pos: position{line: 1229, col: 22, offset: 34716},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1250, col: 22, offset: 35333},
+													pos:  position{line: 1229, col: 22, offset: 34716},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1250, col: 33, offset: 35344},
+													pos:        position{line: 1229, col: 33, offset: 34727},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9846,10 +9701,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1250, col: 39, offset: 35350},
+							pos:   position{line: 1229, col: 39, offset: 34733},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1250, col: 41, offset: 35352},
+								pos:  position{line: 1229, col: 41, offset: 34735},
 								name: "IP6Variations",
 							},
 						},
@@ -9859,32 +9714,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1254, col: 1, offset: 35516},
+			pos:  position{line: 1233, col: 1, offset: 34899},
 			expr: &choiceExpr{
-				pos: position{line: 1255, col: 5, offset: 35534},
+				pos: position{line: 1234, col: 5, offset: 34917},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1255, col: 5, offset: 35534},
+						pos: position{line: 1234, col: 5, offset: 34917},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1255, col: 5, offset: 35534},
+							pos: position{line: 1234, col: 5, offset: 34917},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1255, col: 5, offset: 35534},
+									pos:   position{line: 1234, col: 5, offset: 34917},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1255, col: 7, offset: 35536},
+										pos: position{line: 1234, col: 7, offset: 34919},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1255, col: 7, offset: 35536},
+											pos:  position{line: 1234, col: 7, offset: 34919},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1255, col: 17, offset: 35546},
+									pos:   position{line: 1234, col: 17, offset: 34929},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1255, col: 19, offset: 35548},
+										pos:  position{line: 1234, col: 19, offset: 34931},
 										name: "IP6Tail",
 									},
 								},
@@ -9892,51 +9747,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1258, col: 5, offset: 35612},
+						pos: position{line: 1237, col: 5, offset: 34995},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1258, col: 5, offset: 35612},
+							pos: position{line: 1237, col: 5, offset: 34995},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1258, col: 5, offset: 35612},
+									pos:   position{line: 1237, col: 5, offset: 34995},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1258, col: 7, offset: 35614},
+										pos:  position{line: 1237, col: 7, offset: 34997},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1258, col: 11, offset: 35618},
+									pos:   position{line: 1237, col: 11, offset: 35001},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1258, col: 13, offset: 35620},
+										pos: position{line: 1237, col: 13, offset: 35003},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1258, col: 13, offset: 35620},
+											pos:  position{line: 1237, col: 13, offset: 35003},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1258, col: 23, offset: 35630},
+									pos:        position{line: 1237, col: 23, offset: 35013},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1258, col: 28, offset: 35635},
+									pos:   position{line: 1237, col: 28, offset: 35018},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1258, col: 30, offset: 35637},
+										pos: position{line: 1237, col: 30, offset: 35020},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1258, col: 30, offset: 35637},
+											pos:  position{line: 1237, col: 30, offset: 35020},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1258, col: 40, offset: 35647},
+									pos:   position{line: 1237, col: 40, offset: 35030},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1258, col: 42, offset: 35649},
+										pos:  position{line: 1237, col: 42, offset: 35032},
 										name: "IP6Tail",
 									},
 								},
@@ -9944,32 +9799,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1261, col: 5, offset: 35748},
+						pos: position{line: 1240, col: 5, offset: 35131},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1261, col: 5, offset: 35748},
+							pos: position{line: 1240, col: 5, offset: 35131},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1261, col: 5, offset: 35748},
+									pos:        position{line: 1240, col: 5, offset: 35131},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1261, col: 10, offset: 35753},
+									pos:   position{line: 1240, col: 10, offset: 35136},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1261, col: 12, offset: 35755},
+										pos: position{line: 1240, col: 12, offset: 35138},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1261, col: 12, offset: 35755},
+											pos:  position{line: 1240, col: 12, offset: 35138},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1261, col: 22, offset: 35765},
+									pos:   position{line: 1240, col: 22, offset: 35148},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1261, col: 24, offset: 35767},
+										pos:  position{line: 1240, col: 24, offset: 35150},
 										name: "IP6Tail",
 									},
 								},
@@ -9977,32 +9832,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1264, col: 5, offset: 35838},
+						pos: position{line: 1243, col: 5, offset: 35221},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 5, offset: 35838},
+							pos: position{line: 1243, col: 5, offset: 35221},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1264, col: 5, offset: 35838},
+									pos:   position{line: 1243, col: 5, offset: 35221},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1264, col: 7, offset: 35840},
+										pos:  position{line: 1243, col: 7, offset: 35223},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1264, col: 11, offset: 35844},
+									pos:   position{line: 1243, col: 11, offset: 35227},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1264, col: 13, offset: 35846},
+										pos: position{line: 1243, col: 13, offset: 35229},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1264, col: 13, offset: 35846},
+											pos:  position{line: 1243, col: 13, offset: 35229},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1264, col: 23, offset: 35856},
+									pos:        position{line: 1243, col: 23, offset: 35239},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -10010,10 +9865,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 35924},
+						pos: position{line: 1246, col: 5, offset: 35307},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1267, col: 5, offset: 35924},
+							pos:        position{line: 1246, col: 5, offset: 35307},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -10023,16 +9878,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1271, col: 1, offset: 35961},
+			pos:  position{line: 1250, col: 1, offset: 35344},
 			expr: &choiceExpr{
-				pos: position{line: 1272, col: 5, offset: 35973},
+				pos: position{line: 1251, col: 5, offset: 35356},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1272, col: 5, offset: 35973},
+						pos:  position{line: 1251, col: 5, offset: 35356},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 35980},
+						pos:  position{line: 1252, col: 5, offset: 35363},
 						name: "Hex",
 					},
 				},
@@ -10040,23 +9895,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1275, col: 1, offset: 35985},
+			pos:  position{line: 1254, col: 1, offset: 35368},
 			expr: &actionExpr{
-				pos: position{line: 1275, col: 12, offset: 35996},
+				pos: position{line: 1254, col: 12, offset: 35379},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1275, col: 12, offset: 35996},
+					pos: position{line: 1254, col: 12, offset: 35379},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1275, col: 12, offset: 35996},
+							pos:        position{line: 1254, col: 12, offset: 35379},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1275, col: 16, offset: 36000},
+							pos:   position{line: 1254, col: 16, offset: 35383},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1275, col: 18, offset: 36002},
+								pos:  position{line: 1254, col: 18, offset: 35385},
 								name: "Hex",
 							},
 						},
@@ -10066,23 +9921,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1277, col: 1, offset: 36040},
+			pos:  position{line: 1256, col: 1, offset: 35423},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 12, offset: 36051},
+				pos: position{line: 1256, col: 12, offset: 35434},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1277, col: 12, offset: 36051},
+					pos: position{line: 1256, col: 12, offset: 35434},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1277, col: 12, offset: 36051},
+							pos:   position{line: 1256, col: 12, offset: 35434},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1277, col: 14, offset: 36053},
+								pos:  position{line: 1256, col: 14, offset: 35436},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1277, col: 18, offset: 36057},
+							pos:        position{line: 1256, col: 18, offset: 35440},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -10092,31 +9947,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1279, col: 1, offset: 36095},
+			pos:  position{line: 1258, col: 1, offset: 35478},
 			expr: &actionExpr{
-				pos: position{line: 1280, col: 5, offset: 36106},
+				pos: position{line: 1259, col: 5, offset: 35489},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1280, col: 5, offset: 36106},
+					pos: position{line: 1259, col: 5, offset: 35489},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1280, col: 5, offset: 36106},
+							pos:   position{line: 1259, col: 5, offset: 35489},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1280, col: 7, offset: 36108},
+								pos:  position{line: 1259, col: 7, offset: 35491},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1280, col: 10, offset: 36111},
+							pos:        position{line: 1259, col: 10, offset: 35494},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1280, col: 14, offset: 36115},
+							pos:   position{line: 1259, col: 14, offset: 35498},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1280, col: 16, offset: 36117},
+								pos:  position{line: 1259, col: 16, offset: 35500},
 								name: "UInt",
 							},
 						},
@@ -10126,31 +9981,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1284, col: 1, offset: 36190},
+			pos:  position{line: 1263, col: 1, offset: 35573},
 			expr: &actionExpr{
-				pos: position{line: 1285, col: 5, offset: 36201},
+				pos: position{line: 1264, col: 5, offset: 35584},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1285, col: 5, offset: 36201},
+					pos: position{line: 1264, col: 5, offset: 35584},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1285, col: 5, offset: 36201},
+							pos:   position{line: 1264, col: 5, offset: 35584},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1285, col: 7, offset: 36203},
+								pos:  position{line: 1264, col: 7, offset: 35586},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1285, col: 11, offset: 36207},
+							pos:        position{line: 1264, col: 11, offset: 35590},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1285, col: 15, offset: 36211},
+							pos:   position{line: 1264, col: 15, offset: 35594},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1285, col: 17, offset: 36213},
+								pos:  position{line: 1264, col: 17, offset: 35596},
 								name: "UInt",
 							},
 						},
@@ -10160,15 +10015,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1289, col: 1, offset: 36276},
+			pos:  position{line: 1268, col: 1, offset: 35659},
 			expr: &actionExpr{
-				pos: position{line: 1290, col: 4, offset: 36284},
+				pos: position{line: 1269, col: 4, offset: 35667},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1290, col: 4, offset: 36284},
+					pos:   position{line: 1269, col: 4, offset: 35667},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1290, col: 6, offset: 36286},
+						pos:  position{line: 1269, col: 6, offset: 35669},
 						name: "UIntString",
 					},
 				},
@@ -10176,16 +10031,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1292, col: 1, offset: 36326},
+			pos:  position{line: 1271, col: 1, offset: 35709},
 			expr: &choiceExpr{
-				pos: position{line: 1293, col: 5, offset: 36340},
+				pos: position{line: 1272, col: 5, offset: 35723},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1293, col: 5, offset: 36340},
+						pos:  position{line: 1272, col: 5, offset: 35723},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1294, col: 5, offset: 36355},
+						pos:  position{line: 1273, col: 5, offset: 35738},
 						name: "MinusIntString",
 					},
 				},
@@ -10193,14 +10048,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1296, col: 1, offset: 36371},
+			pos:  position{line: 1275, col: 1, offset: 35754},
 			expr: &actionExpr{
-				pos: position{line: 1296, col: 14, offset: 36384},
+				pos: position{line: 1275, col: 14, offset: 35767},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1296, col: 14, offset: 36384},
+					pos: position{line: 1275, col: 14, offset: 35767},
 					expr: &charClassMatcher{
-						pos:        position{line: 1296, col: 14, offset: 36384},
+						pos:        position{line: 1275, col: 14, offset: 35767},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10211,20 +10066,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1298, col: 1, offset: 36423},
+			pos:  position{line: 1277, col: 1, offset: 35806},
 			expr: &actionExpr{
-				pos: position{line: 1299, col: 5, offset: 36442},
+				pos: position{line: 1278, col: 5, offset: 35825},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1299, col: 5, offset: 36442},
+					pos: position{line: 1278, col: 5, offset: 35825},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1299, col: 5, offset: 36442},
+							pos:        position{line: 1278, col: 5, offset: 35825},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1299, col: 9, offset: 36446},
+							pos:  position{line: 1278, col: 9, offset: 35829},
 							name: "UIntString",
 						},
 					},
@@ -10233,28 +10088,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1301, col: 1, offset: 36489},
+			pos:  position{line: 1280, col: 1, offset: 35872},
 			expr: &choiceExpr{
-				pos: position{line: 1302, col: 5, offset: 36505},
+				pos: position{line: 1281, col: 5, offset: 35888},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1302, col: 5, offset: 36505},
+						pos: position{line: 1281, col: 5, offset: 35888},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1302, col: 5, offset: 36505},
+							pos: position{line: 1281, col: 5, offset: 35888},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1302, col: 5, offset: 36505},
+									pos: position{line: 1281, col: 5, offset: 35888},
 									expr: &litMatcher{
-										pos:        position{line: 1302, col: 5, offset: 36505},
+										pos:        position{line: 1281, col: 5, offset: 35888},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1302, col: 10, offset: 36510},
+									pos: position{line: 1281, col: 10, offset: 35893},
 									expr: &charClassMatcher{
-										pos:        position{line: 1302, col: 10, offset: 36510},
+										pos:        position{line: 1281, col: 10, offset: 35893},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10262,14 +10117,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1302, col: 17, offset: 36517},
+									pos:        position{line: 1281, col: 17, offset: 35900},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1302, col: 21, offset: 36521},
+									pos: position{line: 1281, col: 21, offset: 35904},
 									expr: &charClassMatcher{
-										pos:        position{line: 1302, col: 21, offset: 36521},
+										pos:        position{line: 1281, col: 21, offset: 35904},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10277,9 +10132,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1302, col: 28, offset: 36528},
+									pos: position{line: 1281, col: 28, offset: 35911},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1302, col: 28, offset: 36528},
+										pos:  position{line: 1281, col: 28, offset: 35911},
 										name: "ExponentPart",
 									},
 								},
@@ -10287,28 +10142,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1305, col: 5, offset: 36587},
+						pos: position{line: 1284, col: 5, offset: 35970},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1305, col: 5, offset: 36587},
+							pos: position{line: 1284, col: 5, offset: 35970},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1305, col: 5, offset: 36587},
+									pos: position{line: 1284, col: 5, offset: 35970},
 									expr: &litMatcher{
-										pos:        position{line: 1305, col: 5, offset: 36587},
+										pos:        position{line: 1284, col: 5, offset: 35970},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1305, col: 10, offset: 36592},
+									pos:        position{line: 1284, col: 10, offset: 35975},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1305, col: 14, offset: 36596},
+									pos: position{line: 1284, col: 14, offset: 35979},
 									expr: &charClassMatcher{
-										pos:        position{line: 1305, col: 14, offset: 36596},
+										pos:        position{line: 1284, col: 14, offset: 35979},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10316,9 +10171,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1305, col: 21, offset: 36603},
+									pos: position{line: 1284, col: 21, offset: 35986},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1305, col: 21, offset: 36603},
+										pos:  position{line: 1284, col: 21, offset: 35986},
 										name: "ExponentPart",
 									},
 								},
@@ -10330,19 +10185,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1309, col: 1, offset: 36659},
+			pos:  position{line: 1288, col: 1, offset: 36042},
 			expr: &seqExpr{
-				pos: position{line: 1309, col: 16, offset: 36674},
+				pos: position{line: 1288, col: 16, offset: 36057},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1309, col: 16, offset: 36674},
+						pos:        position{line: 1288, col: 16, offset: 36057},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1309, col: 21, offset: 36679},
+						pos: position{line: 1288, col: 21, offset: 36062},
 						expr: &charClassMatcher{
-							pos:        position{line: 1309, col: 21, offset: 36679},
+							pos:        position{line: 1288, col: 21, offset: 36062},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10350,7 +10205,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1309, col: 27, offset: 36685},
+						pos:  position{line: 1288, col: 27, offset: 36068},
 						name: "UIntString",
 					},
 				},
@@ -10358,14 +10213,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1311, col: 1, offset: 36697},
+			pos:  position{line: 1290, col: 1, offset: 36080},
 			expr: &actionExpr{
-				pos: position{line: 1311, col: 7, offset: 36703},
+				pos: position{line: 1290, col: 7, offset: 36086},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1311, col: 7, offset: 36703},
+					pos: position{line: 1290, col: 7, offset: 36086},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1311, col: 7, offset: 36703},
+						pos:  position{line: 1290, col: 7, offset: 36086},
 						name: "HexDigit",
 					},
 				},
@@ -10373,9 +10228,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1313, col: 1, offset: 36745},
+			pos:  position{line: 1292, col: 1, offset: 36128},
 			expr: &charClassMatcher{
-				pos:        position{line: 1313, col: 12, offset: 36756},
+				pos:        position{line: 1292, col: 12, offset: 36139},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10384,34 +10239,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1316, col: 1, offset: 36770},
+			pos:  position{line: 1295, col: 1, offset: 36153},
 			expr: &choiceExpr{
-				pos: position{line: 1317, col: 5, offset: 36787},
+				pos: position{line: 1296, col: 5, offset: 36170},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 36787},
+						pos: position{line: 1296, col: 5, offset: 36170},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1317, col: 5, offset: 36787},
+							pos: position{line: 1296, col: 5, offset: 36170},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1317, col: 5, offset: 36787},
+									pos:        position{line: 1296, col: 5, offset: 36170},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1317, col: 9, offset: 36791},
+									pos:   position{line: 1296, col: 9, offset: 36174},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1317, col: 11, offset: 36793},
+										pos: position{line: 1296, col: 11, offset: 36176},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1317, col: 11, offset: 36793},
+											pos:  position{line: 1296, col: 11, offset: 36176},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1317, col: 29, offset: 36811},
+									pos:        position{line: 1296, col: 29, offset: 36194},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10419,29 +10274,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1318, col: 5, offset: 36848},
+						pos: position{line: 1297, col: 5, offset: 36231},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1318, col: 5, offset: 36848},
+							pos: position{line: 1297, col: 5, offset: 36231},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1318, col: 5, offset: 36848},
+									pos:        position{line: 1297, col: 5, offset: 36231},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1318, col: 9, offset: 36852},
+									pos:   position{line: 1297, col: 9, offset: 36235},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1318, col: 11, offset: 36854},
+										pos: position{line: 1297, col: 11, offset: 36237},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1318, col: 11, offset: 36854},
+											pos:  position{line: 1297, col: 11, offset: 36237},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1318, col: 29, offset: 36872},
+									pos:        position{line: 1297, col: 29, offset: 36255},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10453,55 +10308,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1320, col: 1, offset: 36906},
+			pos:  position{line: 1299, col: 1, offset: 36289},
 			expr: &choiceExpr{
-				pos: position{line: 1321, col: 5, offset: 36927},
+				pos: position{line: 1300, col: 5, offset: 36310},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1321, col: 5, offset: 36927},
+						pos: position{line: 1300, col: 5, offset: 36310},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1321, col: 5, offset: 36927},
+							pos: position{line: 1300, col: 5, offset: 36310},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1321, col: 5, offset: 36927},
+									pos: position{line: 1300, col: 5, offset: 36310},
 									expr: &choiceExpr{
-										pos: position{line: 1321, col: 7, offset: 36929},
+										pos: position{line: 1300, col: 7, offset: 36312},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1321, col: 7, offset: 36929},
+												pos:        position{line: 1300, col: 7, offset: 36312},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1321, col: 13, offset: 36935},
+												pos:  position{line: 1300, col: 13, offset: 36318},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1321, col: 26, offset: 36948,
+									line: 1300, col: 26, offset: 36331,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1322, col: 5, offset: 36985},
+						pos: position{line: 1301, col: 5, offset: 36368},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1322, col: 5, offset: 36985},
+							pos: position{line: 1301, col: 5, offset: 36368},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1322, col: 5, offset: 36985},
+									pos:        position{line: 1301, col: 5, offset: 36368},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1322, col: 10, offset: 36990},
+									pos:   position{line: 1301, col: 10, offset: 36373},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1322, col: 12, offset: 36992},
+										pos:  position{line: 1301, col: 12, offset: 36375},
 										name: "EscapeSequence",
 									},
 								},
@@ -10513,28 +10368,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1324, col: 1, offset: 37026},
+			pos:  position{line: 1303, col: 1, offset: 36409},
 			expr: &actionExpr{
-				pos: position{line: 1325, col: 5, offset: 37038},
+				pos: position{line: 1304, col: 5, offset: 36421},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1325, col: 5, offset: 37038},
+					pos: position{line: 1304, col: 5, offset: 36421},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1325, col: 5, offset: 37038},
+							pos:   position{line: 1304, col: 5, offset: 36421},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1325, col: 10, offset: 37043},
+								pos:  position{line: 1304, col: 10, offset: 36426},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1325, col: 23, offset: 37056},
+							pos:   position{line: 1304, col: 23, offset: 36439},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1325, col: 28, offset: 37061},
+								pos: position{line: 1304, col: 28, offset: 36444},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1325, col: 28, offset: 37061},
+									pos:  position{line: 1304, col: 28, offset: 36444},
 									name: "KeyWordRest",
 								},
 							},
@@ -10545,16 +10400,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1327, col: 1, offset: 37123},
+			pos:  position{line: 1306, col: 1, offset: 36506},
 			expr: &choiceExpr{
-				pos: position{line: 1328, col: 5, offset: 37140},
+				pos: position{line: 1307, col: 5, offset: 36523},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1328, col: 5, offset: 37140},
+						pos:  position{line: 1307, col: 5, offset: 36523},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1329, col: 5, offset: 37157},
+						pos:  position{line: 1308, col: 5, offset: 36540},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10562,12 +10417,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1331, col: 1, offset: 37169},
+			pos:  position{line: 1310, col: 1, offset: 36552},
 			expr: &actionExpr{
-				pos: position{line: 1331, col: 16, offset: 37184},
+				pos: position{line: 1310, col: 16, offset: 36567},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1331, col: 16, offset: 37184},
+					pos:        position{line: 1310, col: 16, offset: 36567},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10578,16 +10433,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1333, col: 1, offset: 37233},
+			pos:  position{line: 1312, col: 1, offset: 36616},
 			expr: &choiceExpr{
-				pos: position{line: 1334, col: 5, offset: 37249},
+				pos: position{line: 1313, col: 5, offset: 36632},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1334, col: 5, offset: 37249},
+						pos:  position{line: 1313, col: 5, offset: 36632},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1335, col: 5, offset: 37266},
+						pos:        position{line: 1314, col: 5, offset: 36649},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10598,30 +10453,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1337, col: 1, offset: 37273},
+			pos:  position{line: 1316, col: 1, offset: 36656},
 			expr: &actionExpr{
-				pos: position{line: 1337, col: 14, offset: 37286},
+				pos: position{line: 1316, col: 14, offset: 36669},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1337, col: 14, offset: 37286},
+					pos: position{line: 1316, col: 14, offset: 36669},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1337, col: 14, offset: 37286},
+							pos:        position{line: 1316, col: 14, offset: 36669},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1337, col: 19, offset: 37291},
+							pos:   position{line: 1316, col: 19, offset: 36674},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1337, col: 22, offset: 37294},
+								pos: position{line: 1316, col: 22, offset: 36677},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1337, col: 22, offset: 37294},
+										pos:  position{line: 1316, col: 22, offset: 36677},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1337, col: 38, offset: 37310},
+										pos:  position{line: 1316, col: 38, offset: 36693},
 										name: "EscapeSequence",
 									},
 								},
@@ -10633,42 +10488,42 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 1339, col: 1, offset: 37346},
+			pos:  position{line: 1318, col: 1, offset: 36729},
 			expr: &actionExpr{
-				pos: position{line: 1340, col: 5, offset: 37355},
+				pos: position{line: 1319, col: 5, offset: 36738},
 				run: (*parser).callonGlob1,
 				expr: &seqExpr{
-					pos: position{line: 1340, col: 5, offset: 37355},
+					pos: position{line: 1319, col: 5, offset: 36738},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1340, col: 5, offset: 37355},
+							pos: position{line: 1319, col: 5, offset: 36738},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1340, col: 6, offset: 37356},
+								pos:  position{line: 1319, col: 6, offset: 36739},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1340, col: 22, offset: 37372},
+							pos: position{line: 1319, col: 22, offset: 36755},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1340, col: 23, offset: 37373},
+								pos:  position{line: 1319, col: 23, offset: 36756},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1340, col: 35, offset: 37385},
+							pos:   position{line: 1319, col: 35, offset: 36768},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1340, col: 40, offset: 37390},
+								pos:  position{line: 1319, col: 40, offset: 36773},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1340, col: 50, offset: 37400},
+							pos:   position{line: 1319, col: 50, offset: 36783},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1340, col: 55, offset: 37405},
+								pos: position{line: 1319, col: 55, offset: 36788},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1340, col: 55, offset: 37405},
+									pos:  position{line: 1319, col: 55, offset: 36788},
 									name: "GlobRest",
 								},
 							},
@@ -10679,20 +10534,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1344, col: 1, offset: 37489},
+			pos:  position{line: 1323, col: 1, offset: 36872},
 			expr: &seqExpr{
-				pos: position{line: 1344, col: 19, offset: 37507},
+				pos: position{line: 1323, col: 19, offset: 36890},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1344, col: 19, offset: 37507},
+						pos: position{line: 1323, col: 19, offset: 36890},
 						expr: &litMatcher{
-							pos:        position{line: 1344, col: 19, offset: 37507},
+							pos:        position{line: 1323, col: 19, offset: 36890},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1344, col: 24, offset: 37512},
+						pos:  position{line: 1323, col: 24, offset: 36895},
 						name: "KeyWordStart",
 					},
 				},
@@ -10700,19 +10555,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1345, col: 1, offset: 37525},
+			pos:  position{line: 1324, col: 1, offset: 36908},
 			expr: &seqExpr{
-				pos: position{line: 1345, col: 15, offset: 37539},
+				pos: position{line: 1324, col: 15, offset: 36922},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1345, col: 15, offset: 37539},
+						pos: position{line: 1324, col: 15, offset: 36922},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1345, col: 15, offset: 37539},
+							pos:  position{line: 1324, col: 15, offset: 36922},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1345, col: 28, offset: 37552},
+						pos:        position{line: 1324, col: 28, offset: 36935},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10721,23 +10576,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1347, col: 1, offset: 37557},
+			pos:  position{line: 1326, col: 1, offset: 36940},
 			expr: &choiceExpr{
-				pos: position{line: 1348, col: 5, offset: 37571},
+				pos: position{line: 1327, col: 5, offset: 36954},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1348, col: 5, offset: 37571},
+						pos:  position{line: 1327, col: 5, offset: 36954},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1349, col: 5, offset: 37588},
+						pos:  position{line: 1328, col: 5, offset: 36971},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1350, col: 5, offset: 37600},
+						pos: position{line: 1329, col: 5, offset: 36983},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1350, col: 5, offset: 37600},
+							pos:        position{line: 1329, col: 5, offset: 36983},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10747,16 +10602,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1352, col: 1, offset: 37624},
+			pos:  position{line: 1331, col: 1, offset: 37007},
 			expr: &choiceExpr{
-				pos: position{line: 1353, col: 5, offset: 37637},
+				pos: position{line: 1332, col: 5, offset: 37020},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1353, col: 5, offset: 37637},
+						pos:  position{line: 1332, col: 5, offset: 37020},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1354, col: 5, offset: 37651},
+						pos:        position{line: 1333, col: 5, offset: 37034},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10767,30 +10622,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1356, col: 1, offset: 37658},
+			pos:  position{line: 1335, col: 1, offset: 37041},
 			expr: &actionExpr{
-				pos: position{line: 1356, col: 11, offset: 37668},
+				pos: position{line: 1335, col: 11, offset: 37051},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1356, col: 11, offset: 37668},
+					pos: position{line: 1335, col: 11, offset: 37051},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1356, col: 11, offset: 37668},
+							pos:        position{line: 1335, col: 11, offset: 37051},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1356, col: 16, offset: 37673},
+							pos:   position{line: 1335, col: 16, offset: 37056},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1356, col: 19, offset: 37676},
+								pos: position{line: 1335, col: 19, offset: 37059},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1356, col: 19, offset: 37676},
+										pos:  position{line: 1335, col: 19, offset: 37059},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1356, col: 32, offset: 37689},
+										pos:  position{line: 1335, col: 32, offset: 37072},
 										name: "EscapeSequence",
 									},
 								},
@@ -10802,30 +10657,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1358, col: 1, offset: 37725},
+			pos:  position{line: 1337, col: 1, offset: 37108},
 			expr: &choiceExpr{
-				pos: position{line: 1359, col: 5, offset: 37740},
+				pos: position{line: 1338, col: 5, offset: 37123},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1359, col: 5, offset: 37740},
+						pos: position{line: 1338, col: 5, offset: 37123},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1359, col: 5, offset: 37740},
+							pos:        position{line: 1338, col: 5, offset: 37123},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1360, col: 5, offset: 37768},
+						pos: position{line: 1339, col: 5, offset: 37151},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1360, col: 5, offset: 37768},
+							pos:        position{line: 1339, col: 5, offset: 37151},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1361, col: 5, offset: 37798},
+						pos:        position{line: 1340, col: 5, offset: 37181},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10836,55 +10691,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1364, col: 1, offset: 37805},
+			pos:  position{line: 1343, col: 1, offset: 37188},
 			expr: &choiceExpr{
-				pos: position{line: 1365, col: 5, offset: 37826},
+				pos: position{line: 1344, col: 5, offset: 37209},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1365, col: 5, offset: 37826},
+						pos: position{line: 1344, col: 5, offset: 37209},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1365, col: 5, offset: 37826},
+							pos: position{line: 1344, col: 5, offset: 37209},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1365, col: 5, offset: 37826},
+									pos: position{line: 1344, col: 5, offset: 37209},
 									expr: &choiceExpr{
-										pos: position{line: 1365, col: 7, offset: 37828},
+										pos: position{line: 1344, col: 7, offset: 37211},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1365, col: 7, offset: 37828},
+												pos:        position{line: 1344, col: 7, offset: 37211},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1365, col: 13, offset: 37834},
+												pos:  position{line: 1344, col: 13, offset: 37217},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1365, col: 26, offset: 37847,
+									line: 1344, col: 26, offset: 37230,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1366, col: 5, offset: 37884},
+						pos: position{line: 1345, col: 5, offset: 37267},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1366, col: 5, offset: 37884},
+							pos: position{line: 1345, col: 5, offset: 37267},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1366, col: 5, offset: 37884},
+									pos:        position{line: 1345, col: 5, offset: 37267},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1366, col: 10, offset: 37889},
+									pos:   position{line: 1345, col: 10, offset: 37272},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 12, offset: 37891},
+										pos:  position{line: 1345, col: 12, offset: 37274},
 										name: "EscapeSequence",
 									},
 								},
@@ -10896,38 +10751,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1368, col: 1, offset: 37925},
+			pos:  position{line: 1347, col: 1, offset: 37308},
 			expr: &choiceExpr{
-				pos: position{line: 1369, col: 5, offset: 37944},
+				pos: position{line: 1348, col: 5, offset: 37327},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 37944},
+						pos: position{line: 1348, col: 5, offset: 37327},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 1369, col: 5, offset: 37944},
+							pos: position{line: 1348, col: 5, offset: 37327},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1369, col: 5, offset: 37944},
+									pos:        position{line: 1348, col: 5, offset: 37327},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1369, col: 9, offset: 37948},
+									pos:  position{line: 1348, col: 9, offset: 37331},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1369, col: 18, offset: 37957},
+									pos:  position{line: 1348, col: 18, offset: 37340},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1370, col: 5, offset: 38008},
+						pos:  position{line: 1349, col: 5, offset: 37391},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1371, col: 5, offset: 38029},
+						pos:  position{line: 1350, col: 5, offset: 37412},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10935,79 +10790,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1373, col: 1, offset: 38044},
+			pos:  position{line: 1352, col: 1, offset: 37427},
 			expr: &choiceExpr{
-				pos: position{line: 1374, col: 5, offset: 38065},
+				pos: position{line: 1353, col: 5, offset: 37448},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1374, col: 5, offset: 38065},
+						pos:        position{line: 1353, col: 5, offset: 37448},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1375, col: 5, offset: 38073},
+						pos: position{line: 1354, col: 5, offset: 37456},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1375, col: 5, offset: 38073},
+							pos:        position{line: 1354, col: 5, offset: 37456},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1376, col: 5, offset: 38113},
+						pos:        position{line: 1355, col: 5, offset: 37496},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1377, col: 5, offset: 38122},
+						pos: position{line: 1356, col: 5, offset: 37505},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1377, col: 5, offset: 38122},
+							pos:        position{line: 1356, col: 5, offset: 37505},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1378, col: 5, offset: 38151},
+						pos: position{line: 1357, col: 5, offset: 37534},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1378, col: 5, offset: 38151},
+							pos:        position{line: 1357, col: 5, offset: 37534},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1379, col: 5, offset: 38180},
+						pos: position{line: 1358, col: 5, offset: 37563},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1379, col: 5, offset: 38180},
+							pos:        position{line: 1358, col: 5, offset: 37563},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1380, col: 5, offset: 38209},
+						pos: position{line: 1359, col: 5, offset: 37592},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1380, col: 5, offset: 38209},
+							pos:        position{line: 1359, col: 5, offset: 37592},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1381, col: 5, offset: 38238},
+						pos: position{line: 1360, col: 5, offset: 37621},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1381, col: 5, offset: 38238},
+							pos:        position{line: 1360, col: 5, offset: 37621},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1382, col: 5, offset: 38267},
+						pos: position{line: 1361, col: 5, offset: 37650},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1382, col: 5, offset: 38267},
+							pos:        position{line: 1361, col: 5, offset: 37650},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -11017,30 +10872,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1384, col: 1, offset: 38293},
+			pos:  position{line: 1363, col: 1, offset: 37676},
 			expr: &choiceExpr{
-				pos: position{line: 1385, col: 5, offset: 38311},
+				pos: position{line: 1364, col: 5, offset: 37694},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1385, col: 5, offset: 38311},
+						pos: position{line: 1364, col: 5, offset: 37694},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1385, col: 5, offset: 38311},
+							pos:        position{line: 1364, col: 5, offset: 37694},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1386, col: 5, offset: 38339},
+						pos: position{line: 1365, col: 5, offset: 37722},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1386, col: 5, offset: 38339},
+							pos:        position{line: 1365, col: 5, offset: 37722},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1387, col: 5, offset: 38367},
+						pos:        position{line: 1366, col: 5, offset: 37750},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11051,41 +10906,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1389, col: 1, offset: 38373},
+			pos:  position{line: 1368, col: 1, offset: 37756},
 			expr: &choiceExpr{
-				pos: position{line: 1390, col: 5, offset: 38391},
+				pos: position{line: 1369, col: 5, offset: 37774},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1390, col: 5, offset: 38391},
+						pos: position{line: 1369, col: 5, offset: 37774},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1390, col: 5, offset: 38391},
+							pos: position{line: 1369, col: 5, offset: 37774},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1390, col: 5, offset: 38391},
+									pos:        position{line: 1369, col: 5, offset: 37774},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1390, col: 9, offset: 38395},
+									pos:   position{line: 1369, col: 9, offset: 37778},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1390, col: 16, offset: 38402},
+										pos: position{line: 1369, col: 16, offset: 37785},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1390, col: 16, offset: 38402},
+												pos:  position{line: 1369, col: 16, offset: 37785},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1390, col: 25, offset: 38411},
+												pos:  position{line: 1369, col: 25, offset: 37794},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1390, col: 34, offset: 38420},
+												pos:  position{line: 1369, col: 34, offset: 37803},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1390, col: 43, offset: 38429},
+												pos:  position{line: 1369, col: 43, offset: 37812},
 												name: "HexDigit",
 											},
 										},
@@ -11095,63 +10950,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1393, col: 5, offset: 38492},
+						pos: position{line: 1372, col: 5, offset: 37875},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1393, col: 5, offset: 38492},
+							pos: position{line: 1372, col: 5, offset: 37875},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1393, col: 5, offset: 38492},
+									pos:        position{line: 1372, col: 5, offset: 37875},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1393, col: 9, offset: 38496},
+									pos:        position{line: 1372, col: 9, offset: 37879},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1393, col: 13, offset: 38500},
+									pos:   position{line: 1372, col: 13, offset: 37883},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1393, col: 20, offset: 38507},
+										pos: position{line: 1372, col: 20, offset: 37890},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1393, col: 20, offset: 38507},
+												pos:  position{line: 1372, col: 20, offset: 37890},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1393, col: 29, offset: 38516},
+												pos: position{line: 1372, col: 29, offset: 37899},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1393, col: 29, offset: 38516},
+													pos:  position{line: 1372, col: 29, offset: 37899},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1393, col: 39, offset: 38526},
+												pos: position{line: 1372, col: 39, offset: 37909},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1393, col: 39, offset: 38526},
+													pos:  position{line: 1372, col: 39, offset: 37909},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1393, col: 49, offset: 38536},
+												pos: position{line: 1372, col: 49, offset: 37919},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1393, col: 49, offset: 38536},
+													pos:  position{line: 1372, col: 49, offset: 37919},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1393, col: 59, offset: 38546},
+												pos: position{line: 1372, col: 59, offset: 37929},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1393, col: 59, offset: 38546},
+													pos:  position{line: 1372, col: 59, offset: 37929},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1393, col: 69, offset: 38556},
+												pos: position{line: 1372, col: 69, offset: 37939},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1393, col: 69, offset: 38556},
+													pos:  position{line: 1372, col: 69, offset: 37939},
 													name: "HexDigit",
 												},
 											},
@@ -11159,7 +11014,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1393, col: 80, offset: 38567},
+									pos:        position{line: 1372, col: 80, offset: 37950},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11171,35 +11026,35 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1397, col: 1, offset: 38621},
+			pos:  position{line: 1376, col: 1, offset: 38004},
 			expr: &actionExpr{
-				pos: position{line: 1398, col: 5, offset: 38632},
+				pos: position{line: 1377, col: 5, offset: 38015},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1398, col: 5, offset: 38632},
+					pos: position{line: 1377, col: 5, offset: 38015},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1398, col: 5, offset: 38632},
+							pos:        position{line: 1377, col: 5, offset: 38015},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1398, col: 9, offset: 38636},
+							pos:   position{line: 1377, col: 9, offset: 38019},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1398, col: 14, offset: 38641},
+								pos:  position{line: 1377, col: 14, offset: 38024},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1398, col: 25, offset: 38652},
+							pos:        position{line: 1377, col: 25, offset: 38035},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1398, col: 29, offset: 38656},
+							pos: position{line: 1377, col: 29, offset: 38039},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1398, col: 30, offset: 38657},
+								pos:  position{line: 1377, col: 30, offset: 38040},
 								name: "KeyWordStart",
 							},
 						},
@@ -11209,24 +11064,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1400, col: 1, offset: 38692},
+			pos:  position{line: 1379, col: 1, offset: 38075},
 			expr: &actionExpr{
-				pos: position{line: 1401, col: 5, offset: 38707},
+				pos: position{line: 1380, col: 5, offset: 38090},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1401, col: 5, offset: 38707},
+					pos: position{line: 1380, col: 5, offset: 38090},
 					expr: &choiceExpr{
-						pos: position{line: 1401, col: 6, offset: 38708},
+						pos: position{line: 1380, col: 6, offset: 38091},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1401, col: 6, offset: 38708},
+								pos:        position{line: 1380, col: 6, offset: 38091},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 1401, col: 13, offset: 38715},
+								pos:        position{line: 1380, col: 13, offset: 38098},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -11237,9 +11092,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1403, col: 1, offset: 38755},
+			pos:  position{line: 1382, col: 1, offset: 38138},
 			expr: &charClassMatcher{
-				pos:        position{line: 1404, col: 5, offset: 38771},
+				pos:        position{line: 1383, col: 5, offset: 38154},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11249,42 +11104,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1406, col: 1, offset: 38786},
+			pos:  position{line: 1385, col: 1, offset: 38169},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1406, col: 6, offset: 38791},
+				pos: position{line: 1385, col: 6, offset: 38174},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1406, col: 6, offset: 38791},
+					pos:  position{line: 1385, col: 6, offset: 38174},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1408, col: 1, offset: 38802},
+			pos:  position{line: 1387, col: 1, offset: 38185},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1408, col: 6, offset: 38807},
+				pos: position{line: 1387, col: 6, offset: 38190},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1408, col: 6, offset: 38807},
+					pos:  position{line: 1387, col: 6, offset: 38190},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1410, col: 1, offset: 38818},
+			pos:  position{line: 1389, col: 1, offset: 38201},
 			expr: &choiceExpr{
-				pos: position{line: 1411, col: 5, offset: 38831},
+				pos: position{line: 1390, col: 5, offset: 38214},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 5, offset: 38831},
+						pos:  position{line: 1390, col: 5, offset: 38214},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1412, col: 5, offset: 38846},
+						pos:  position{line: 1391, col: 5, offset: 38229},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1413, col: 5, offset: 38865},
+						pos:  position{line: 1392, col: 5, offset: 38248},
 						name: "Comment",
 					},
 				},
@@ -11292,45 +11147,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1415, col: 1, offset: 38874},
+			pos:  position{line: 1394, col: 1, offset: 38257},
 			expr: &anyMatcher{
-				line: 1416, col: 5, offset: 38894,
+				line: 1395, col: 5, offset: 38277,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1418, col: 1, offset: 38897},
+			pos:         position{line: 1397, col: 1, offset: 38280},
 			expr: &choiceExpr{
-				pos: position{line: 1419, col: 5, offset: 38925},
+				pos: position{line: 1398, col: 5, offset: 38308},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1419, col: 5, offset: 38925},
+						pos:        position{line: 1398, col: 5, offset: 38308},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1420, col: 5, offset: 38934},
+						pos:        position{line: 1399, col: 5, offset: 38317},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1421, col: 5, offset: 38943},
+						pos:        position{line: 1400, col: 5, offset: 38326},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1422, col: 5, offset: 38952},
+						pos:        position{line: 1401, col: 5, offset: 38335},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1423, col: 5, offset: 38960},
+						pos:        position{line: 1402, col: 5, offset: 38343},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1424, col: 5, offset: 38973},
+						pos:        position{line: 1403, col: 5, offset: 38356},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11339,9 +11194,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1426, col: 1, offset: 38983},
+			pos:  position{line: 1405, col: 1, offset: 38366},
 			expr: &charClassMatcher{
-				pos:        position{line: 1427, col: 5, offset: 39002},
+				pos:        position{line: 1406, col: 5, offset: 38385},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11351,45 +11206,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1433, col: 1, offset: 39332},
+			pos:         position{line: 1412, col: 1, offset: 38715},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1436, col: 5, offset: 39403},
+				pos:  position{line: 1415, col: 5, offset: 38786},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1438, col: 1, offset: 39422},
+			pos:  position{line: 1417, col: 1, offset: 38805},
 			expr: &seqExpr{
-				pos: position{line: 1439, col: 5, offset: 39443},
+				pos: position{line: 1418, col: 5, offset: 38826},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1439, col: 5, offset: 39443},
+						pos:        position{line: 1418, col: 5, offset: 38826},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1439, col: 10, offset: 39448},
+						pos: position{line: 1418, col: 10, offset: 38831},
 						expr: &seqExpr{
-							pos: position{line: 1439, col: 11, offset: 39449},
+							pos: position{line: 1418, col: 11, offset: 38832},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1439, col: 11, offset: 39449},
+									pos: position{line: 1418, col: 11, offset: 38832},
 									expr: &litMatcher{
-										pos:        position{line: 1439, col: 12, offset: 39450},
+										pos:        position{line: 1418, col: 12, offset: 38833},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1439, col: 17, offset: 39455},
+									pos:  position{line: 1418, col: 17, offset: 38838},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1439, col: 35, offset: 39473},
+						pos:        position{line: 1418, col: 35, offset: 38856},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11398,29 +11253,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1441, col: 1, offset: 39479},
+			pos:  position{line: 1420, col: 1, offset: 38862},
 			expr: &seqExpr{
-				pos: position{line: 1442, col: 5, offset: 39501},
+				pos: position{line: 1421, col: 5, offset: 38884},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1442, col: 5, offset: 39501},
+						pos:        position{line: 1421, col: 5, offset: 38884},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1442, col: 10, offset: 39506},
+						pos: position{line: 1421, col: 10, offset: 38889},
 						expr: &seqExpr{
-							pos: position{line: 1442, col: 11, offset: 39507},
+							pos: position{line: 1421, col: 11, offset: 38890},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1442, col: 11, offset: 39507},
+									pos: position{line: 1421, col: 11, offset: 38890},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1442, col: 12, offset: 39508},
+										pos:  position{line: 1421, col: 12, offset: 38891},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1442, col: 27, offset: 39523},
+									pos:  position{line: 1421, col: 27, offset: 38906},
 									name: "SourceCharacter",
 								},
 							},
@@ -11431,19 +11286,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1444, col: 1, offset: 39542},
+			pos:  position{line: 1423, col: 1, offset: 38925},
 			expr: &seqExpr{
-				pos: position{line: 1444, col: 7, offset: 39548},
+				pos: position{line: 1423, col: 7, offset: 38931},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1444, col: 7, offset: 39548},
+						pos: position{line: 1423, col: 7, offset: 38931},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1444, col: 7, offset: 39548},
+							pos:  position{line: 1423, col: 7, offset: 38931},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1444, col: 19, offset: 39560},
+						pos:  position{line: 1423, col: 19, offset: 38943},
 						name: "LineTerminator",
 					},
 				},
@@ -11451,16 +11306,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1446, col: 1, offset: 39576},
+			pos:  position{line: 1425, col: 1, offset: 38959},
 			expr: &choiceExpr{
-				pos: position{line: 1446, col: 7, offset: 39582},
+				pos: position{line: 1425, col: 7, offset: 38965},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1446, col: 7, offset: 39582},
+						pos:  position{line: 1425, col: 7, offset: 38965},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1446, col: 11, offset: 39586},
+						pos:  position{line: 1425, col: 11, offset: 38969},
 						name: "EOF",
 					},
 				},
@@ -11468,11 +11323,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1448, col: 1, offset: 39591},
+			pos:  position{line: 1427, col: 1, offset: 38974},
 			expr: &notExpr{
-				pos: position{line: 1448, col: 7, offset: 39597},
+				pos: position{line: 1427, col: 7, offset: 38980},
 				expr: &anyMatcher{
-					line: 1448, col: 8, offset: 39598,
+					line: 1427, col: 8, offset: 38981,
 				},
 			},
 		},
@@ -11569,92 +11424,36 @@ func (p *parser) callonSequentialTail1() (interface{}, error) {
 	return p.cur.onSequentialTail1(stack["p"])
 }
 
-func (c *current) onParallel2(first, rest interface{}) (interface{}, error) {
-	return append([]interface{}{first}, (rest.([]interface{})[0].([]interface{}))...), nil
-
+func (c *current) onParallel1(s interface{}) (interface{}, error) {
+	return s, nil
 }
 
-func (p *parser) callonParallel2() (interface{}, error) {
+func (p *parser) callonParallel1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onParallel2(stack["first"], stack["rest"])
+	return p.cur.onParallel1(stack["s"])
 }
 
-func (c *current) onParallel14(first interface{}) (interface{}, error) {
-	return []interface{}{first}, nil
-
-}
-
-func (p *parser) callonParallel14() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onParallel14(stack["first"])
-}
-
-func (c *current) onSwitchBranch2(proc interface{}) (interface{}, error) {
-	return map[string]interface{}{"expr": map[string]interface{}{"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}, nil
+func (c *current) onSwitchBranch2(e, proc interface{}) (interface{}, error) {
+	return map[string]interface{}{"expr": e, "proc": proc}, nil
 
 }
 
 func (p *parser) callonSwitchBranch2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSwitchBranch2(stack["proc"])
+	return p.cur.onSwitchBranch2(stack["e"], stack["proc"])
 }
 
-func (c *current) onSwitchBranch12(e, proc interface{}) (interface{}, error) {
-	return map[string]interface{}{"expr": e, "proc": proc}, nil
+func (c *current) onSwitchBranch14(proc interface{}) (interface{}, error) {
+	return map[string]interface{}{"expr": map[string]interface{}{"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}, nil
 
 }
 
-func (p *parser) callonSwitchBranch12() (interface{}, error) {
+func (p *parser) callonSwitchBranch14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSwitchBranch12(stack["e"], stack["proc"])
-}
-
-func (c *current) onSwitch2(first, rest interface{}) (interface{}, error) {
-	return append([]interface{}{first}, (rest.([]interface{})[0].([]interface{}))...), nil
-
-}
-
-func (p *parser) callonSwitch2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSwitch2(stack["first"], stack["rest"])
-}
-
-func (c *current) onSwitch10(first interface{}) (interface{}, error) {
-	return []interface{}{first}, nil
-
-}
-
-func (p *parser) callonSwitch10() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSwitch10(stack["first"])
-}
-
-func (c *current) onFromTrunks2(first, rest interface{}) (interface{}, error) {
-	return append([]interface{}{first}, (rest.([]interface{})[0].([]interface{}))...), nil
-
-}
-
-func (p *parser) callonFromTrunks2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFromTrunks2(stack["first"], stack["rest"])
-}
-
-func (c *current) onFromTrunks10(first interface{}) (interface{}, error) {
-	return []interface{}{first}, nil
-
-}
-
-func (p *parser) callonFromTrunks10() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFromTrunks10(stack["first"])
+	return p.cur.onSwitchBranch14(stack["proc"])
 }
 
 func (c *current) onFromTrunk1(source, seq interface{}) (interface{}, error) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -56,46 +56,46 @@ var g = &grammar{
 		},
 		{
 			name: "Z",
-			pos:  position{line: 13, col: 1, offset: 353},
+			pos:  position{line: 13, col: 1, offset: 355},
 			expr: &choiceExpr{
-				pos: position{line: 14, col: 5, offset: 433},
+				pos: position{line: 14, col: 5, offset: 435},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 14, col: 5, offset: 433},
+						pos: position{line: 14, col: 5, offset: 435},
 						run: (*parser).callonZ2,
 						expr: &seqExpr{
-							pos: position{line: 14, col: 5, offset: 433},
+							pos: position{line: 14, col: 5, offset: 435},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 14, col: 5, offset: 433},
+									pos:   position{line: 14, col: 5, offset: 435},
 									label: "decls",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 14, col: 11, offset: 439},
+										pos: position{line: 14, col: 11, offset: 441},
 										expr: &ruleRefExpr{
-											pos:  position{line: 14, col: 11, offset: 439},
+											pos:  position{line: 14, col: 11, offset: 441},
 											name: "Decl",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 14, col: 17, offset: 445},
+									pos:  position{line: 14, col: 17, offset: 447},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 14, col: 20, offset: 448},
+									pos:   position{line: 14, col: 20, offset: 450},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 14, col: 26, offset: 454},
+										pos:  position{line: 14, col: 26, offset: 456},
 										name: "Operation",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 14, col: 36, offset: 464},
+									pos:   position{line: 14, col: 36, offset: 466},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 14, col: 41, offset: 469},
+										pos: position{line: 14, col: 41, offset: 471},
 										expr: &ruleRefExpr{
-											pos:  position{line: 14, col: 41, offset: 469},
+											pos:  position{line: 14, col: 41, offset: 471},
 											name: "SequentialTail",
 										},
 									},
@@ -104,7 +104,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 22, col: 5, offset: 742},
+						pos:  position{line: 22, col: 5, offset: 744},
 						name: "Sequential",
 					},
 				},
@@ -112,22 +112,22 @@ var g = &grammar{
 		},
 		{
 			name: "Decl",
-			pos:  position{line: 24, col: 1, offset: 754},
+			pos:  position{line: 24, col: 1, offset: 756},
 			expr: &actionExpr{
-				pos: position{line: 24, col: 8, offset: 761},
+				pos: position{line: 24, col: 8, offset: 763},
 				run: (*parser).callonDecl1,
 				expr: &seqExpr{
-					pos: position{line: 24, col: 8, offset: 761},
+					pos: position{line: 24, col: 8, offset: 763},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 24, col: 8, offset: 761},
+							pos:  position{line: 24, col: 8, offset: 763},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 24, col: 11, offset: 764},
+							pos:   position{line: 24, col: 11, offset: 766},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 24, col: 13, offset: 766},
+								pos:  position{line: 24, col: 13, offset: 768},
 								name: "AnyDecl",
 							},
 						},
@@ -137,73 +137,73 @@ var g = &grammar{
 		},
 		{
 			name: "AnyDecl",
-			pos:  position{line: 26, col: 1, offset: 793},
+			pos:  position{line: 26, col: 1, offset: 795},
 			expr: &choiceExpr{
-				pos: position{line: 27, col: 5, offset: 805},
+				pos: position{line: 27, col: 5, offset: 807},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 27, col: 5, offset: 805},
+						pos: position{line: 27, col: 5, offset: 807},
 						run: (*parser).callonAnyDecl2,
 						expr: &seqExpr{
-							pos: position{line: 27, col: 5, offset: 805},
+							pos: position{line: 27, col: 5, offset: 807},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 27, col: 5, offset: 805},
+									pos:        position{line: 27, col: 5, offset: 807},
 									val:        "const",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 13, offset: 813},
+									pos:  position{line: 27, col: 13, offset: 815},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 27, col: 15, offset: 815},
+									pos:   position{line: 27, col: 15, offset: 817},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 27, col: 18, offset: 818},
+										pos:  position{line: 27, col: 18, offset: 820},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 33, offset: 833},
+									pos:  position{line: 27, col: 33, offset: 835},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 27, col: 36, offset: 836},
+									pos:        position{line: 27, col: 36, offset: 838},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 40, offset: 840},
+									pos:  position{line: 27, col: 40, offset: 842},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 27, col: 43, offset: 843},
+									pos:   position{line: 27, col: 43, offset: 845},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 27, col: 48, offset: 848},
+										pos:  position{line: 27, col: 48, offset: 850},
 										name: "Expr",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 27, col: 55, offset: 855},
+									pos: position{line: 27, col: 55, offset: 857},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 27, col: 55, offset: 855},
+											pos: position{line: 27, col: 55, offset: 857},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 27, col: 55, offset: 855},
+													pos:  position{line: 27, col: 55, offset: 857},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 27, col: 58, offset: 858},
+													pos:        position{line: 27, col: 58, offset: 860},
 													val:        ";",
 													ignoreCase: false,
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 27, col: 64, offset: 864},
+											pos:  position{line: 27, col: 64, offset: 866},
 											name: "EOL",
 										},
 									},
@@ -212,68 +212,68 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 30, col: 5, offset: 962},
+						pos: position{line: 30, col: 5, offset: 964},
 						run: (*parser).callonAnyDecl18,
 						expr: &seqExpr{
-							pos: position{line: 30, col: 5, offset: 962},
+							pos: position{line: 30, col: 5, offset: 964},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 30, col: 5, offset: 962},
+									pos:        position{line: 30, col: 5, offset: 964},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 12, offset: 969},
+									pos:  position{line: 30, col: 12, offset: 971},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 30, col: 14, offset: 971},
+									pos:   position{line: 30, col: 14, offset: 973},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 30, col: 17, offset: 974},
+										pos:  position{line: 30, col: 17, offset: 976},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 32, offset: 989},
+									pos:  position{line: 30, col: 32, offset: 991},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 30, col: 35, offset: 992},
+									pos:        position{line: 30, col: 35, offset: 994},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 39, offset: 996},
+									pos:  position{line: 30, col: 39, offset: 998},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 30, col: 42, offset: 999},
+									pos:   position{line: 30, col: 42, offset: 1001},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 30, col: 46, offset: 1003},
+										pos:  position{line: 30, col: 46, offset: 1005},
 										name: "Type",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 30, col: 53, offset: 1010},
+									pos: position{line: 30, col: 53, offset: 1012},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 30, col: 53, offset: 1010},
+											pos: position{line: 30, col: 53, offset: 1012},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 30, col: 53, offset: 1010},
+													pos:  position{line: 30, col: 53, offset: 1012},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 30, col: 56, offset: 1013},
+													pos:        position{line: 30, col: 56, offset: 1015},
 													val:        ";",
 													ignoreCase: false,
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 30, col: 62, offset: 1019},
+											pos:  position{line: 30, col: 62, offset: 1021},
 											name: "EOL",
 										},
 									},
@@ -286,31 +286,31 @@ var g = &grammar{
 		},
 		{
 			name: "Sequential",
-			pos:  position{line: 34, col: 1, offset: 1116},
+			pos:  position{line: 34, col: 1, offset: 1118},
 			expr: &choiceExpr{
-				pos: position{line: 35, col: 5, offset: 1131},
+				pos: position{line: 35, col: 5, offset: 1133},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 35, col: 5, offset: 1131},
+						pos: position{line: 35, col: 5, offset: 1133},
 						run: (*parser).callonSequential2,
 						expr: &seqExpr{
-							pos: position{line: 35, col: 5, offset: 1131},
+							pos: position{line: 35, col: 5, offset: 1133},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 35, col: 5, offset: 1131},
+									pos:   position{line: 35, col: 5, offset: 1133},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 35, col: 11, offset: 1137},
+										pos:  position{line: 35, col: 11, offset: 1139},
 										name: "Operation",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 35, col: 21, offset: 1147},
+									pos:   position{line: 35, col: 21, offset: 1149},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 35, col: 26, offset: 1152},
+										pos: position{line: 35, col: 26, offset: 1154},
 										expr: &ruleRefExpr{
-											pos:  position{line: 35, col: 26, offset: 1152},
+											pos:  position{line: 35, col: 26, offset: 1154},
 											name: "SequentialTail",
 										},
 									},
@@ -319,13 +319,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 38, col: 5, offset: 1310},
+						pos: position{line: 38, col: 5, offset: 1312},
 						run: (*parser).callonSequential9,
 						expr: &labeledExpr{
-							pos:   position{line: 38, col: 5, offset: 1310},
+							pos:   position{line: 38, col: 5, offset: 1312},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 38, col: 8, offset: 1313},
+								pos:  position{line: 38, col: 8, offset: 1315},
 								name: "Operation",
 							},
 						},
@@ -335,30 +335,30 @@ var g = &grammar{
 		},
 		{
 			name: "SequentialTail",
-			pos:  position{line: 42, col: 1, offset: 1423},
+			pos:  position{line: 42, col: 1, offset: 1425},
 			expr: &actionExpr{
-				pos: position{line: 42, col: 18, offset: 1440},
+				pos: position{line: 42, col: 18, offset: 1442},
 				run: (*parser).callonSequentialTail1,
 				expr: &seqExpr{
-					pos: position{line: 42, col: 18, offset: 1440},
+					pos: position{line: 42, col: 18, offset: 1442},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 42, col: 18, offset: 1440},
+							pos:  position{line: 42, col: 18, offset: 1442},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 42, col: 21, offset: 1443},
+							pos:  position{line: 42, col: 21, offset: 1445},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 42, col: 26, offset: 1448},
+							pos:  position{line: 42, col: 26, offset: 1450},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 42, col: 29, offset: 1451},
+							pos:   position{line: 42, col: 29, offset: 1453},
 							label: "p",
 							expr: &ruleRefExpr{
-								pos:  position{line: 42, col: 31, offset: 1453},
+								pos:  position{line: 42, col: 31, offset: 1455},
 								name: "Operation",
 							},
 						},
@@ -368,32 +368,54 @@ var g = &grammar{
 		},
 		{
 			name: "Parallel",
-			pos:  position{line: 44, col: 1, offset: 1482},
+			pos:  position{line: 44, col: 1, offset: 1484},
 			expr: &choiceExpr{
-				pos: position{line: 45, col: 5, offset: 1495},
+				pos: position{line: 45, col: 5, offset: 1497},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 45, col: 5, offset: 1495},
+						pos: position{line: 45, col: 5, offset: 1497},
 						run: (*parser).callonParallel2,
 						expr: &seqExpr{
-							pos: position{line: 45, col: 5, offset: 1495},
+							pos: position{line: 45, col: 5, offset: 1497},
 							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 45, col: 5, offset: 1497},
+									val:        "=>",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 45, col: 10, offset: 1502},
+									name: "__",
+								},
 								&labeledExpr{
-									pos:   position{line: 45, col: 5, offset: 1495},
+									pos:   position{line: 45, col: 13, offset: 1505},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 45, col: 11, offset: 1501},
+										pos:  position{line: 45, col: 19, offset: 1511},
 										name: "Sequential",
 									},
 								},
+								&ruleRefExpr{
+									pos:  position{line: 45, col: 30, offset: 1522},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 45, col: 33, offset: 1525},
+									val:        ";",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 45, col: 37, offset: 1529},
+									name: "__",
+								},
 								&labeledExpr{
-									pos:   position{line: 45, col: 22, offset: 1512},
+									pos:   position{line: 45, col: 40, offset: 1532},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 45, col: 27, offset: 1517},
+										pos: position{line: 45, col: 45, offset: 1537},
 										expr: &ruleRefExpr{
-											pos:  position{line: 45, col: 27, offset: 1517},
-											name: "ParallelTail",
+											pos:  position{line: 45, col: 45, offset: 1537},
+											name: "Parallel",
 										},
 									},
 								},
@@ -401,48 +423,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 48, col: 5, offset: 1618},
-						run: (*parser).callonParallel9,
-						expr: &labeledExpr{
-							pos:   position{line: 48, col: 5, offset: 1618},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 48, col: 11, offset: 1624},
-								name: "Sequential",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ParallelTail",
-			pos:  position{line: 52, col: 1, offset: 1683},
-			expr: &actionExpr{
-				pos: position{line: 53, col: 5, offset: 1700},
-				run: (*parser).callonParallelTail1,
-				expr: &seqExpr{
-					pos: position{line: 53, col: 5, offset: 1700},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 53, col: 5, offset: 1700},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 53, col: 8, offset: 1703},
-							val:        "=>",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 53, col: 13, offset: 1708},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 53, col: 16, offset: 1711},
-							label: "ch",
-							expr: &ruleRefExpr{
-								pos:  position{line: 53, col: 19, offset: 1714},
-								name: "Sequential",
+						pos: position{line: 48, col: 5, offset: 1653},
+						run: (*parser).callonParallel14,
+						expr: &seqExpr{
+							pos: position{line: 48, col: 5, offset: 1653},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 48, col: 5, offset: 1653},
+									val:        "=>",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 48, col: 10, offset: 1658},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 48, col: 13, offset: 1661},
+									label: "first",
+									expr: &ruleRefExpr{
+										pos:  position{line: 48, col: 19, offset: 1667},
+										name: "Sequential",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 48, col: 30, offset: 1678},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 48, col: 33, offset: 1681},
+									val:        ";",
+									ignoreCase: false,
+								},
 							},
 						},
 					},
@@ -451,94 +462,96 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchBranch",
-			pos:  position{line: 55, col: 1, offset: 1745},
+			pos:  position{line: 52, col: 1, offset: 1733},
 			expr: &choiceExpr{
-				pos: position{line: 56, col: 5, offset: 1762},
+				pos: position{line: 53, col: 6, offset: 1751},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 56, col: 5, offset: 1762},
+						pos: position{line: 53, col: 6, offset: 1751},
 						run: (*parser).callonSwitchBranch2,
 						expr: &seqExpr{
-							pos: position{line: 56, col: 5, offset: 1762},
+							pos: position{line: 53, col: 6, offset: 1751},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 5, offset: 1762},
-									name: "__",
+									pos:  position{line: 53, col: 6, offset: 1751},
+									name: "DefaultToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 8, offset: 1765},
-									name: "CaseToken",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 56, col: 18, offset: 1775},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 56, col: 20, offset: 1777},
-									label: "e",
-									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 22, offset: 1779},
-										name: "SearchBoolean",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 56, col: 36, offset: 1793},
+									pos:  position{line: 53, col: 19, offset: 1764},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 56, col: 39, offset: 1796},
+									pos:        position{line: 53, col: 22, offset: 1767},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 44, offset: 1801},
+									pos:  position{line: 53, col: 27, offset: 1772},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 56, col: 47, offset: 1804},
+									pos:   position{line: 53, col: 30, offset: 1775},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 52, offset: 1809},
+										pos:  position{line: 53, col: 35, offset: 1780},
 										name: "Sequential",
 									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 53, col: 46, offset: 1791},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 53, col: 49, offset: 1794},
+									val:        ";",
+									ignoreCase: false,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 59, col: 5, offset: 1898},
-						run: (*parser).callonSwitchBranch14,
+						pos: position{line: 56, col: 5, offset: 1950},
+						run: (*parser).callonSwitchBranch12,
 						expr: &seqExpr{
-							pos: position{line: 59, col: 5, offset: 1898},
+							pos: position{line: 56, col: 5, offset: 1950},
 							exprs: []interface{}{
-								&ruleRefExpr{
-									pos:  position{line: 59, col: 5, offset: 1898},
-									name: "__",
+								&labeledExpr{
+									pos:   position{line: 56, col: 5, offset: 1950},
+									label: "e",
+									expr: &ruleRefExpr{
+										pos:  position{line: 56, col: 7, offset: 1952},
+										name: "SearchBoolean",
+									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 8, offset: 1901},
-									name: "DefaultToken",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 59, col: 21, offset: 1914},
+									pos:  position{line: 56, col: 21, offset: 1966},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 59, col: 24, offset: 1917},
+									pos:        position{line: 56, col: 24, offset: 1969},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 29, offset: 1922},
+									pos:  position{line: 56, col: 29, offset: 1974},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 59, col: 32, offset: 1925},
+									pos:   position{line: 56, col: 32, offset: 1977},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 59, col: 37, offset: 1930},
+										pos:  position{line: 56, col: 37, offset: 1982},
 										name: "Sequential",
 									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 56, col: 48, offset: 1993},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 56, col: 51, offset: 1996},
+									val:        ";",
+									ignoreCase: false,
 								},
 							},
 						},
@@ -548,32 +561,36 @@ var g = &grammar{
 		},
 		{
 			name: "Switch",
-			pos:  position{line: 63, col: 1, offset: 2090},
+			pos:  position{line: 60, col: 1, offset: 2075},
 			expr: &choiceExpr{
-				pos: position{line: 64, col: 5, offset: 2101},
+				pos: position{line: 61, col: 5, offset: 2086},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 64, col: 5, offset: 2101},
+						pos: position{line: 61, col: 5, offset: 2086},
 						run: (*parser).callonSwitch2,
 						expr: &seqExpr{
-							pos: position{line: 64, col: 5, offset: 2101},
+							pos: position{line: 61, col: 5, offset: 2086},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 64, col: 5, offset: 2101},
+									pos:   position{line: 61, col: 5, offset: 2086},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 64, col: 11, offset: 2107},
+										pos:  position{line: 61, col: 11, offset: 2092},
 										name: "SwitchBranch",
 									},
 								},
+								&ruleRefExpr{
+									pos:  position{line: 61, col: 24, offset: 2105},
+									name: "__",
+								},
 								&labeledExpr{
-									pos:   position{line: 64, col: 24, offset: 2120},
+									pos:   position{line: 61, col: 27, offset: 2108},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 64, col: 29, offset: 2125},
+										pos: position{line: 61, col: 32, offset: 2113},
 										expr: &ruleRefExpr{
-											pos:  position{line: 64, col: 29, offset: 2125},
-											name: "SwitchBranch",
+											pos:  position{line: 61, col: 32, offset: 2113},
+											name: "Switch",
 										},
 									},
 								},
@@ -581,13 +598,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 67, col: 5, offset: 2226},
-						run: (*parser).callonSwitch9,
+						pos: position{line: 64, col: 5, offset: 2227},
+						run: (*parser).callonSwitch10,
 						expr: &labeledExpr{
-							pos:   position{line: 67, col: 5, offset: 2226},
+							pos:   position{line: 64, col: 5, offset: 2227},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 67, col: 11, offset: 2232},
+								pos:  position{line: 64, col: 11, offset: 2233},
 								name: "SwitchBranch",
 							},
 						},
@@ -596,51 +613,46 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "CaseToken",
-			pos:  position{line: 71, col: 1, offset: 2293},
-			expr: &litMatcher{
-				pos:        position{line: 71, col: 13, offset: 2305},
-				val:        "case",
-				ignoreCase: true,
-			},
-		},
-		{
 			name: "DefaultToken",
-			pos:  position{line: 72, col: 1, offset: 2313},
+			pos:  position{line: 68, col: 1, offset: 2294},
 			expr: &litMatcher{
-				pos:        position{line: 72, col: 16, offset: 2328},
+				pos:        position{line: 68, col: 16, offset: 2309},
 				val:        "default",
 				ignoreCase: true,
 			},
 		},
 		{
 			name: "FromTrunks",
-			pos:  position{line: 74, col: 1, offset: 2340},
+			pos:  position{line: 70, col: 1, offset: 2321},
 			expr: &choiceExpr{
-				pos: position{line: 75, col: 5, offset: 2355},
+				pos: position{line: 71, col: 5, offset: 2336},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 75, col: 5, offset: 2355},
+						pos: position{line: 71, col: 5, offset: 2336},
 						run: (*parser).callonFromTrunks2,
 						expr: &seqExpr{
-							pos: position{line: 75, col: 5, offset: 2355},
+							pos: position{line: 71, col: 5, offset: 2336},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 75, col: 5, offset: 2355},
+									pos:   position{line: 71, col: 5, offset: 2336},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 75, col: 11, offset: 2361},
+										pos:  position{line: 71, col: 11, offset: 2342},
 										name: "FromTrunk",
 									},
 								},
+								&ruleRefExpr{
+									pos:  position{line: 71, col: 21, offset: 2352},
+									name: "__",
+								},
 								&labeledExpr{
-									pos:   position{line: 75, col: 21, offset: 2371},
+									pos:   position{line: 71, col: 24, offset: 2355},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 75, col: 26, offset: 2376},
+										pos: position{line: 71, col: 29, offset: 2360},
 										expr: &ruleRefExpr{
-											pos:  position{line: 75, col: 26, offset: 2376},
-											name: "FromTrunkTail",
+											pos:  position{line: 71, col: 29, offset: 2360},
+											name: "FromTrunks",
 										},
 									},
 								},
@@ -648,13 +660,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 78, col: 5, offset: 2478},
-						run: (*parser).callonFromTrunks9,
+						pos: position{line: 74, col: 5, offset: 2478},
+						run: (*parser).callonFromTrunks10,
 						expr: &labeledExpr{
-							pos:   position{line: 78, col: 5, offset: 2478},
+							pos:   position{line: 74, col: 5, offset: 2478},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 78, col: 11, offset: 2484},
+								pos:  position{line: 74, col: 11, offset: 2484},
 								name: "FromTrunk",
 							},
 						},
@@ -664,28 +676,37 @@ var g = &grammar{
 		},
 		{
 			name: "FromTrunk",
-			pos:  position{line: 82, col: 1, offset: 2542},
+			pos:  position{line: 78, col: 1, offset: 2542},
 			expr: &actionExpr{
-				pos: position{line: 83, col: 5, offset: 2556},
+				pos: position{line: 79, col: 5, offset: 2556},
 				run: (*parser).callonFromTrunk1,
 				expr: &seqExpr{
-					pos: position{line: 83, col: 5, offset: 2556},
+					pos: position{line: 79, col: 5, offset: 2556},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 83, col: 5, offset: 2556},
+							pos:   position{line: 79, col: 5, offset: 2556},
 							label: "source",
 							expr: &ruleRefExpr{
-								pos:  position{line: 83, col: 12, offset: 2563},
+								pos:  position{line: 79, col: 12, offset: 2563},
 								name: "FromSource",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 83, col: 23, offset: 2574},
+							pos:   position{line: 79, col: 23, offset: 2574},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 83, col: 27, offset: 2578},
+								pos:  position{line: 79, col: 27, offset: 2578},
 								name: "FromTrunkSeq",
 							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 79, col: 40, offset: 2591},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 79, col: 43, offset: 2594},
+							val:        ";",
+							ignoreCase: false,
 						},
 					},
 				},
@@ -693,34 +714,34 @@ var g = &grammar{
 		},
 		{
 			name: "FromTrunkSeq",
-			pos:  position{line: 87, col: 1, offset: 2688},
+			pos:  position{line: 83, col: 1, offset: 2695},
 			expr: &choiceExpr{
-				pos: position{line: 88, col: 5, offset: 2705},
+				pos: position{line: 84, col: 5, offset: 2712},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 88, col: 5, offset: 2705},
+						pos: position{line: 84, col: 5, offset: 2712},
 						run: (*parser).callonFromTrunkSeq2,
 						expr: &seqExpr{
-							pos: position{line: 88, col: 5, offset: 2705},
+							pos: position{line: 84, col: 5, offset: 2712},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 88, col: 5, offset: 2705},
+									pos:  position{line: 84, col: 5, offset: 2712},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 88, col: 8, offset: 2708},
+									pos:        position{line: 84, col: 8, offset: 2715},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 88, col: 13, offset: 2713},
+									pos:  position{line: 84, col: 13, offset: 2720},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 88, col: 16, offset: 2716},
+									pos:   position{line: 84, col: 16, offset: 2723},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 88, col: 20, offset: 2720},
+										pos:  position{line: 84, col: 20, offset: 2727},
 										name: "Sequential",
 									},
 								},
@@ -728,10 +749,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 89, col: 5, offset: 2755},
+						pos: position{line: 85, col: 5, offset: 2762},
 						run: (*parser).callonFromTrunkSeq9,
 						expr: &litMatcher{
-							pos:        position{line: 89, col: 5, offset: 2755},
+							pos:        position{line: 85, col: 5, offset: 2762},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -740,64 +761,25 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "FromTrunkTail",
-			pos:  position{line: 91, col: 1, offset: 2778},
-			expr: &actionExpr{
-				pos: position{line: 92, col: 5, offset: 2796},
-				run: (*parser).callonFromTrunkTail1,
-				expr: &seqExpr{
-					pos: position{line: 92, col: 5, offset: 2796},
-					exprs: []interface{}{
-						&seqExpr{
-							pos: position{line: 92, col: 6, offset: 2797},
-							exprs: []interface{}{
-								&ruleRefExpr{
-									pos:  position{line: 92, col: 6, offset: 2797},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 92, col: 9, offset: 2800},
-									val:        ";",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 92, col: 13, offset: 2804},
-									name: "__",
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 92, col: 18, offset: 2809},
-							label: "trunk",
-							expr: &ruleRefExpr{
-								pos:  position{line: 92, col: 24, offset: 2815},
-								name: "FromTrunk",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "FromSource",
-			pos:  position{line: 94, col: 1, offset: 2848},
+			pos:  position{line: 87, col: 1, offset: 2785},
 			expr: &choiceExpr{
-				pos: position{line: 95, col: 5, offset: 2863},
+				pos: position{line: 88, col: 5, offset: 2800},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 95, col: 5, offset: 2863},
+						pos:  position{line: 88, col: 5, offset: 2800},
 						name: "FileProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 96, col: 5, offset: 2876},
+						pos:  position{line: 89, col: 5, offset: 2813},
 						name: "HTTPProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 97, col: 5, offset: 2889},
+						pos:  position{line: 90, col: 5, offset: 2826},
 						name: "PassProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 98, col: 5, offset: 2902},
+						pos:  position{line: 91, col: 5, offset: 2839},
 						name: "PoolBody",
 					},
 				},
@@ -805,57 +787,48 @@ var g = &grammar{
 		},
 		{
 			name: "Operation",
-			pos:  position{line: 100, col: 1, offset: 2912},
+			pos:  position{line: 93, col: 1, offset: 2849},
 			expr: &choiceExpr{
-				pos: position{line: 101, col: 5, offset: 2926},
+				pos: position{line: 94, col: 5, offset: 2863},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 101, col: 5, offset: 2926},
+						pos: position{line: 94, col: 5, offset: 2863},
 						run: (*parser).callonOperation2,
 						expr: &seqExpr{
-							pos: position{line: 101, col: 5, offset: 2926},
+							pos: position{line: 94, col: 5, offset: 2863},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 101, col: 5, offset: 2926},
+									pos:        position{line: 94, col: 5, offset: 2863},
 									val:        "split",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 101, col: 13, offset: 2934},
+									pos:  position{line: 94, col: 13, offset: 2871},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 101, col: 16, offset: 2937},
+									pos:        position{line: 94, col: 16, offset: 2874},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 101, col: 20, offset: 2941},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 101, col: 23, offset: 2944},
-									val:        "=>",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 101, col: 28, offset: 2949},
+									pos:  position{line: 94, col: 20, offset: 2878},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 101, col: 31, offset: 2952},
+									pos:   position{line: 94, col: 23, offset: 2881},
 									label: "procArray",
 									expr: &ruleRefExpr{
-										pos:  position{line: 101, col: 41, offset: 2962},
+										pos:  position{line: 94, col: 33, offset: 2891},
 										name: "Parallel",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 101, col: 50, offset: 2971},
+									pos:  position{line: 94, col: 42, offset: 2900},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 101, col: 53, offset: 2974},
+									pos:        position{line: 94, col: 45, offset: 2903},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -863,43 +836,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 104, col: 5, offset: 3071},
-						run: (*parser).callonOperation14,
+						pos: position{line: 97, col: 5, offset: 3000},
+						run: (*parser).callonOperation12,
 						expr: &seqExpr{
-							pos: position{line: 104, col: 5, offset: 3071},
+							pos: position{line: 97, col: 5, offset: 3000},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 104, col: 5, offset: 3071},
+									pos:        position{line: 97, col: 5, offset: 3000},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 104, col: 14, offset: 3080},
+									pos:  position{line: 97, col: 14, offset: 3009},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 104, col: 17, offset: 3083},
+									pos:        position{line: 97, col: 17, offset: 3012},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 104, col: 21, offset: 3087},
+									pos:  position{line: 97, col: 21, offset: 3016},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 104, col: 24, offset: 3090},
+									pos:   position{line: 97, col: 24, offset: 3019},
 									label: "caseArray",
 									expr: &ruleRefExpr{
-										pos:  position{line: 104, col: 34, offset: 3100},
+										pos:  position{line: 97, col: 34, offset: 3029},
 										name: "Switch",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 104, col: 41, offset: 3107},
+									pos:  position{line: 97, col: 41, offset: 3036},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 104, col: 44, offset: 3110},
+									pos:        position{line: 97, col: 44, offset: 3039},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -907,55 +880,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 107, col: 5, offset: 3205},
-						run: (*parser).callonOperation24,
+						pos: position{line: 100, col: 5, offset: 3134},
+						run: (*parser).callonOperation22,
 						expr: &seqExpr{
-							pos: position{line: 107, col: 5, offset: 3205},
+							pos: position{line: 100, col: 5, offset: 3134},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 107, col: 5, offset: 3205},
+									pos:        position{line: 100, col: 5, offset: 3134},
 									val:        "from",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 107, col: 12, offset: 3212},
+									pos:  position{line: 100, col: 12, offset: 3141},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 107, col: 15, offset: 3215},
+									pos:        position{line: 100, col: 15, offset: 3144},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 107, col: 19, offset: 3219},
+									pos:  position{line: 100, col: 19, offset: 3148},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 107, col: 22, offset: 3222},
+									pos:   position{line: 100, col: 22, offset: 3151},
 									label: "trunks",
 									expr: &ruleRefExpr{
-										pos:  position{line: 107, col: 29, offset: 3229},
+										pos:  position{line: 100, col: 29, offset: 3158},
 										name: "FromTrunks",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 107, col: 40, offset: 3240},
-									name: "__",
-								},
-								&zeroOrOneExpr{
-									pos: position{line: 107, col: 43, offset: 3243},
-									expr: &litMatcher{
-										pos:        position{line: 107, col: 43, offset: 3243},
-										val:        ";",
-										ignoreCase: false,
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 107, col: 48, offset: 3248},
+									pos:  position{line: 100, col: 40, offset: 3169},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 107, col: 51, offset: 3251},
+									pos:        position{line: 100, col: 43, offset: 3172},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -963,27 +924,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 110, col: 5, offset: 3342},
+						pos:  position{line: 103, col: 5, offset: 3263},
 						name: "Operator",
 					},
 					&actionExpr{
-						pos: position{line: 111, col: 5, offset: 3355},
-						run: (*parser).callonOperation38,
+						pos: position{line: 104, col: 5, offset: 3276},
+						run: (*parser).callonOperation33,
 						expr: &seqExpr{
-							pos: position{line: 111, col: 5, offset: 3355},
+							pos: position{line: 104, col: 5, offset: 3276},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 111, col: 5, offset: 3355},
+									pos:   position{line: 104, col: 5, offset: 3276},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 111, col: 7, offset: 3357},
+										pos:  position{line: 104, col: 7, offset: 3278},
 										name: "Function",
 									},
 								},
 								&andExpr{
-									pos: position{line: 111, col: 16, offset: 3366},
+									pos: position{line: 104, col: 16, offset: 3287},
 									expr: &ruleRefExpr{
-										pos:  position{line: 111, col: 17, offset: 3367},
+										pos:  position{line: 104, col: 17, offset: 3288},
 										name: "EndOfOp",
 									},
 								},
@@ -991,23 +952,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 112, col: 5, offset: 3397},
-						run: (*parser).callonOperation44,
+						pos: position{line: 105, col: 5, offset: 3318},
+						run: (*parser).callonOperation39,
 						expr: &seqExpr{
-							pos: position{line: 112, col: 5, offset: 3397},
+							pos: position{line: 105, col: 5, offset: 3318},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 112, col: 5, offset: 3397},
+									pos:   position{line: 105, col: 5, offset: 3318},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 112, col: 7, offset: 3399},
+										pos:  position{line: 105, col: 7, offset: 3320},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 112, col: 19, offset: 3411},
+									pos: position{line: 105, col: 19, offset: 3332},
 									expr: &ruleRefExpr{
-										pos:  position{line: 112, col: 20, offset: 3412},
+										pos:  position{line: 105, col: 20, offset: 3333},
 										name: "EndOfOp",
 									},
 								},
@@ -1015,23 +976,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 113, col: 5, offset: 3443},
-						run: (*parser).callonOperation50,
+						pos: position{line: 106, col: 5, offset: 3364},
+						run: (*parser).callonOperation45,
 						expr: &seqExpr{
-							pos: position{line: 113, col: 5, offset: 3443},
+							pos: position{line: 106, col: 5, offset: 3364},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 113, col: 5, offset: 3443},
+									pos:   position{line: 106, col: 5, offset: 3364},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 113, col: 10, offset: 3448},
+										pos:  position{line: 106, col: 10, offset: 3369},
 										name: "SearchBoolean",
 									},
 								},
 								&notExpr{
-									pos: position{line: 113, col: 24, offset: 3462},
+									pos: position{line: 106, col: 24, offset: 3383},
 									expr: &ruleRefExpr{
-										pos:  position{line: 113, col: 25, offset: 3463},
+										pos:  position{line: 106, col: 25, offset: 3384},
 										name: "AggGuard",
 									},
 								},
@@ -1043,33 +1004,35 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 117, col: 1, offset: 3554},
+			pos:  position{line: 110, col: 1, offset: 3475},
 			expr: &seqExpr{
-				pos: position{line: 117, col: 11, offset: 3564},
+				pos: position{line: 110, col: 11, offset: 3485},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 117, col: 11, offset: 3564},
+						pos:  position{line: 110, col: 11, offset: 3485},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 117, col: 15, offset: 3568},
+						pos: position{line: 110, col: 15, offset: 3489},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 117, col: 15, offset: 3568},
+								pos:  position{line: 110, col: 15, offset: 3489},
 								name: "Pipe",
 							},
 							&litMatcher{
-								pos:        position{line: 117, col: 22, offset: 3575},
+								pos:        position{line: 110, col: 22, offset: 3496},
 								val:        "=>",
 								ignoreCase: false,
 							},
-							&litMatcher{
-								pos:        position{line: 117, col: 29, offset: 3582},
-								val:        ")",
+							&charClassMatcher{
+								pos:        position{line: 110, col: 29, offset: 3503},
+								val:        "[);]",
+								chars:      []rune{')', ';'},
 								ignoreCase: false,
+								inverted:   false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 117, col: 35, offset: 3588},
+								pos:  position{line: 110, col: 36, offset: 3510},
 								name: "EOF",
 							},
 						},
@@ -1079,27 +1042,27 @@ var g = &grammar{
 		},
 		{
 			name: "Pipe",
-			pos:  position{line: 118, col: 1, offset: 3593},
+			pos:  position{line: 111, col: 1, offset: 3515},
 			expr: &seqExpr{
-				pos: position{line: 118, col: 8, offset: 3600},
+				pos: position{line: 111, col: 8, offset: 3522},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 118, col: 8, offset: 3600},
+						pos:        position{line: 111, col: 8, offset: 3522},
 						val:        "|",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 118, col: 12, offset: 3604},
+						pos: position{line: 111, col: 12, offset: 3526},
 						expr: &choiceExpr{
-							pos: position{line: 118, col: 14, offset: 3606},
+							pos: position{line: 111, col: 14, offset: 3528},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 118, col: 14, offset: 3606},
+									pos:        position{line: 111, col: 14, offset: 3528},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 118, col: 20, offset: 3612},
+									pos:        position{line: 111, col: 20, offset: 3534},
 									val:        "[",
 									ignoreCase: false,
 								},
@@ -1111,59 +1074,59 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 120, col: 1, offset: 3618},
+			pos:  position{line: 113, col: 1, offset: 3540},
 			expr: &seqExpr{
-				pos: position{line: 120, col: 13, offset: 3630},
+				pos: position{line: 113, col: 13, offset: 3552},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 120, col: 13, offset: 3630},
+						pos:  position{line: 113, col: 13, offset: 3552},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 120, col: 17, offset: 3634},
+						pos: position{line: 113, col: 17, offset: 3556},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 120, col: 18, offset: 3635},
+								pos: position{line: 113, col: 18, offset: 3557},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 120, col: 18, offset: 3635},
+										pos: position{line: 113, col: 18, offset: 3557},
 										expr: &litMatcher{
-											pos:        position{line: 120, col: 19, offset: 3636},
+											pos:        position{line: 113, col: 19, offset: 3558},
 											val:        "=>",
 											ignoreCase: false,
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 120, col: 24, offset: 3641},
+										pos:  position{line: 113, col: 24, offset: 3563},
 										name: "Comparator",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 120, col: 38, offset: 3655},
+								pos:  position{line: 113, col: 38, offset: 3577},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 120, col: 57, offset: 3674},
+								pos:  position{line: 113, col: 57, offset: 3596},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 120, col: 82, offset: 3699},
+								pos:        position{line: 113, col: 82, offset: 3621},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 120, col: 88, offset: 3705},
+								pos:        position{line: 113, col: 88, offset: 3627},
 								val:        "(",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 120, col: 94, offset: 3711},
+								pos:        position{line: 113, col: 94, offset: 3633},
 								val:        "[",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 120, col: 100, offset: 3717},
+								pos:        position{line: 113, col: 100, offset: 3639},
 								val:        "matches",
 								ignoreCase: false,
 							},
@@ -1174,45 +1137,45 @@ var g = &grammar{
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 122, col: 1, offset: 3729},
+			pos:  position{line: 115, col: 1, offset: 3651},
 			expr: &actionExpr{
-				pos: position{line: 122, col: 14, offset: 3742},
+				pos: position{line: 115, col: 14, offset: 3664},
 				run: (*parser).callonComparator1,
 				expr: &choiceExpr{
-					pos: position{line: 122, col: 15, offset: 3743},
+					pos: position{line: 115, col: 15, offset: 3665},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 122, col: 15, offset: 3743},
+							pos:        position{line: 115, col: 15, offset: 3665},
 							val:        "==",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 122, col: 22, offset: 3750},
+							pos:        position{line: 115, col: 22, offset: 3672},
 							val:        "!=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 122, col: 29, offset: 3757},
+							pos:        position{line: 115, col: 29, offset: 3679},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 122, col: 36, offset: 3764},
+							pos:        position{line: 115, col: 36, offset: 3686},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 122, col: 43, offset: 3771},
+							pos:        position{line: 115, col: 43, offset: 3693},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 122, col: 49, offset: 3777},
+							pos:        position{line: 115, col: 49, offset: 3699},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 122, col: 56, offset: 3784},
+							pos:        position{line: 115, col: 56, offset: 3706},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1222,46 +1185,46 @@ var g = &grammar{
 		},
 		{
 			name: "AggGuard",
-			pos:  position{line: 124, col: 1, offset: 3821},
+			pos:  position{line: 117, col: 1, offset: 3743},
 			expr: &choiceExpr{
-				pos: position{line: 124, col: 12, offset: 3832},
+				pos: position{line: 117, col: 12, offset: 3754},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 124, col: 13, offset: 3833},
+						pos: position{line: 117, col: 13, offset: 3755},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 124, col: 13, offset: 3833},
+								pos:  position{line: 117, col: 13, offset: 3755},
 								name: "_",
 							},
 							&choiceExpr{
-								pos: position{line: 124, col: 16, offset: 3836},
+								pos: position{line: 117, col: 16, offset: 3758},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 124, col: 16, offset: 3836},
+										pos:  position{line: 117, col: 16, offset: 3758},
 										name: "ByToken",
 									},
 									&litMatcher{
-										pos:        position{line: 124, col: 26, offset: 3846},
+										pos:        position{line: 117, col: 26, offset: 3768},
 										val:        "-with",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 124, col: 35, offset: 3855},
+								pos:  position{line: 117, col: 35, offset: 3777},
 								name: "EOT",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 124, col: 43, offset: 3863},
+						pos: position{line: 117, col: 43, offset: 3785},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 124, col: 43, offset: 3863},
+								pos:  position{line: 117, col: 43, offset: 3785},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 46, offset: 3866},
+								pos:        position{line: 117, col: 46, offset: 3788},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -1272,28 +1235,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 126, col: 1, offset: 3872},
+			pos:  position{line: 119, col: 1, offset: 3794},
 			expr: &actionExpr{
-				pos: position{line: 127, col: 5, offset: 3890},
+				pos: position{line: 120, col: 5, offset: 3812},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 127, col: 5, offset: 3890},
+					pos: position{line: 120, col: 5, offset: 3812},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 127, col: 5, offset: 3890},
+							pos:   position{line: 120, col: 5, offset: 3812},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 127, col: 11, offset: 3896},
+								pos:  position{line: 120, col: 11, offset: 3818},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 127, col: 21, offset: 3906},
+							pos:   position{line: 120, col: 21, offset: 3828},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 127, col: 26, offset: 3911},
+								pos: position{line: 120, col: 26, offset: 3833},
 								expr: &ruleRefExpr{
-									pos:  position{line: 127, col: 26, offset: 3911},
+									pos:  position{line: 120, col: 26, offset: 3833},
 									name: "SearchOrTerm",
 								},
 							},
@@ -1304,30 +1267,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 131, col: 1, offset: 3985},
+			pos:  position{line: 124, col: 1, offset: 3907},
 			expr: &actionExpr{
-				pos: position{line: 131, col: 16, offset: 4000},
+				pos: position{line: 124, col: 16, offset: 3922},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 131, col: 16, offset: 4000},
+					pos: position{line: 124, col: 16, offset: 3922},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 131, col: 16, offset: 4000},
+							pos:  position{line: 124, col: 16, offset: 3922},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 131, col: 18, offset: 4002},
+							pos:  position{line: 124, col: 18, offset: 3924},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 131, col: 26, offset: 4010},
+							pos:  position{line: 124, col: 26, offset: 3932},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 131, col: 28, offset: 4012},
+							pos:   position{line: 124, col: 28, offset: 3934},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 131, col: 30, offset: 4014},
+								pos:  position{line: 124, col: 30, offset: 3936},
 								name: "SearchAnd",
 							},
 						},
@@ -1337,57 +1300,57 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 133, col: 1, offset: 4064},
+			pos:  position{line: 126, col: 1, offset: 3986},
 			expr: &actionExpr{
-				pos: position{line: 134, col: 5, offset: 4078},
+				pos: position{line: 127, col: 5, offset: 4000},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 134, col: 5, offset: 4078},
+					pos: position{line: 127, col: 5, offset: 4000},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 134, col: 5, offset: 4078},
+							pos:   position{line: 127, col: 5, offset: 4000},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 134, col: 11, offset: 4084},
+								pos:  position{line: 127, col: 11, offset: 4006},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 135, col: 5, offset: 4101},
+							pos:   position{line: 128, col: 5, offset: 4023},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 135, col: 10, offset: 4106},
+								pos: position{line: 128, col: 10, offset: 4028},
 								expr: &actionExpr{
-									pos: position{line: 135, col: 11, offset: 4107},
+									pos: position{line: 128, col: 11, offset: 4029},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 135, col: 11, offset: 4107},
+										pos: position{line: 128, col: 11, offset: 4029},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 135, col: 11, offset: 4107},
+												pos: position{line: 128, col: 11, offset: 4029},
 												expr: &seqExpr{
-													pos: position{line: 135, col: 12, offset: 4108},
+													pos: position{line: 128, col: 12, offset: 4030},
 													exprs: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 135, col: 12, offset: 4108},
+															pos:  position{line: 128, col: 12, offset: 4030},
 															name: "_",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 135, col: 14, offset: 4110},
+															pos:  position{line: 128, col: 14, offset: 4032},
 															name: "AndToken",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 135, col: 25, offset: 4121},
+												pos:  position{line: 128, col: 25, offset: 4043},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 135, col: 27, offset: 4123},
+												pos:   position{line: 128, col: 27, offset: 4045},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 135, col: 32, offset: 4128},
+													pos:  position{line: 128, col: 32, offset: 4050},
 													name: "SearchFactor",
 												},
 											},
@@ -1402,42 +1365,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 139, col: 1, offset: 4244},
+			pos:  position{line: 132, col: 1, offset: 4166},
 			expr: &choiceExpr{
-				pos: position{line: 140, col: 5, offset: 4261},
+				pos: position{line: 133, col: 5, offset: 4183},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 140, col: 5, offset: 4261},
+						pos: position{line: 133, col: 5, offset: 4183},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 140, col: 5, offset: 4261},
+							pos: position{line: 133, col: 5, offset: 4183},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 140, col: 6, offset: 4262},
+									pos: position{line: 133, col: 6, offset: 4184},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 140, col: 6, offset: 4262},
+											pos: position{line: 133, col: 6, offset: 4184},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 140, col: 6, offset: 4262},
+													pos:  position{line: 133, col: 6, offset: 4184},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 140, col: 15, offset: 4271},
+													pos:  position{line: 133, col: 15, offset: 4193},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 140, col: 19, offset: 4275},
+											pos: position{line: 133, col: 19, offset: 4197},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 140, col: 19, offset: 4275},
+													pos:        position{line: 133, col: 19, offset: 4197},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 140, col: 23, offset: 4279},
+													pos:  position{line: 133, col: 23, offset: 4201},
 													name: "__",
 												},
 											},
@@ -1445,10 +1408,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 140, col: 27, offset: 4283},
+									pos:   position{line: 133, col: 27, offset: 4205},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 140, col: 29, offset: 4285},
+										pos:  position{line: 133, col: 29, offset: 4207},
 										name: "SearchFactor",
 									},
 								},
@@ -1456,38 +1419,38 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 143, col: 5, offset: 4397},
+						pos:  position{line: 136, col: 5, offset: 4319},
 						name: "SearchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 144, col: 5, offset: 4412},
+						pos: position{line: 137, col: 5, offset: 4334},
 						run: (*parser).callonSearchFactor14,
 						expr: &seqExpr{
-							pos: position{line: 144, col: 5, offset: 4412},
+							pos: position{line: 137, col: 5, offset: 4334},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 144, col: 5, offset: 4412},
+									pos:        position{line: 137, col: 5, offset: 4334},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 144, col: 9, offset: 4416},
+									pos:  position{line: 137, col: 9, offset: 4338},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 144, col: 12, offset: 4419},
+									pos:   position{line: 137, col: 12, offset: 4341},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 144, col: 17, offset: 4424},
+										pos:  position{line: 137, col: 17, offset: 4346},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 144, col: 31, offset: 4438},
+									pos:  position{line: 137, col: 31, offset: 4360},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 144, col: 34, offset: 4441},
+									pos:        position{line: 137, col: 34, offset: 4363},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1499,42 +1462,42 @@ var g = &grammar{
 		},
 		{
 			name: "TBD",
-			pos:  position{line: 147, col: 1, offset: 4468},
+			pos:  position{line: 140, col: 1, offset: 4390},
 			expr: &choiceExpr{
-				pos: position{line: 148, col: 5, offset: 4476},
+				pos: position{line: 141, col: 5, offset: 4398},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 148, col: 5, offset: 4476},
+						pos: position{line: 141, col: 5, offset: 4398},
 						run: (*parser).callonTBD2,
 						expr: &seqExpr{
-							pos: position{line: 148, col: 5, offset: 4476},
+							pos: position{line: 141, col: 5, offset: 4398},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 148, col: 5, offset: 4476},
+									pos:        position{line: 141, col: 5, offset: 4398},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 148, col: 9, offset: 4480},
+									pos:  position{line: 141, col: 9, offset: 4402},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 148, col: 12, offset: 4483},
+									pos:   position{line: 141, col: 12, offset: 4405},
 									label: "compareOp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 148, col: 22, offset: 4493},
+										pos:  position{line: 141, col: 22, offset: 4415},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 148, col: 36, offset: 4507},
+									pos:  position{line: 141, col: 36, offset: 4429},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 148, col: 39, offset: 4510},
+									pos:   position{line: 141, col: 39, offset: 4432},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 148, col: 41, offset: 4512},
+										pos:  position{line: 141, col: 41, offset: 4434},
 										name: "Expr",
 									},
 								},
@@ -1542,23 +1505,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 175, col: 5, offset: 5194},
+						pos: position{line: 168, col: 5, offset: 5116},
 						run: (*parser).callonTBD11,
 						expr: &seqExpr{
-							pos: position{line: 175, col: 5, offset: 5194},
+							pos: position{line: 168, col: 5, offset: 5116},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 175, col: 5, offset: 5194},
+									pos:   position{line: 168, col: 5, offset: 5116},
 									label: "match",
 									expr: &ruleRefExpr{
-										pos:  position{line: 175, col: 11, offset: 5200},
+										pos:  position{line: 168, col: 11, offset: 5122},
 										name: "PatternMatch",
 									},
 								},
 								&notExpr{
-									pos: position{line: 175, col: 24, offset: 5213},
+									pos: position{line: 168, col: 24, offset: 5135},
 									expr: &ruleRefExpr{
-										pos:  position{line: 175, col: 25, offset: 5214},
+										pos:  position{line: 168, col: 25, offset: 5136},
 										name: "ExprGuard",
 									},
 								},
@@ -1566,33 +1529,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 176, col: 5, offset: 5250},
+						pos: position{line: 169, col: 5, offset: 5172},
 						run: (*parser).callonTBD17,
 						expr: &seqExpr{
-							pos: position{line: 176, col: 5, offset: 5250},
+							pos: position{line: 169, col: 5, offset: 5172},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 176, col: 5, offset: 5250},
+									pos:   position{line: 169, col: 5, offset: 5172},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 7, offset: 5252},
+										pos:  position{line: 169, col: 7, offset: 5174},
 										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 176, col: 19, offset: 5264},
+									pos:  position{line: 169, col: 19, offset: 5186},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 176, col: 21, offset: 5266},
+									pos:  position{line: 169, col: 21, offset: 5188},
 									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 176, col: 29, offset: 5274},
+									pos:  position{line: 169, col: 29, offset: 5196},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 176, col: 31, offset: 5276},
+									pos:        position{line: 169, col: 31, offset: 5198},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -1604,37 +1567,37 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 205, col: 1, offset: 5956},
+			pos:  position{line: 197, col: 1, offset: 5877},
 			expr: &choiceExpr{
-				pos: position{line: 206, col: 5, offset: 5971},
+				pos: position{line: 198, col: 5, offset: 5892},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 206, col: 5, offset: 5971},
+						pos: position{line: 198, col: 5, offset: 5892},
 						run: (*parser).callonSearchExpr2,
 						expr: &seqExpr{
-							pos: position{line: 206, col: 5, offset: 5971},
+							pos: position{line: 198, col: 5, offset: 5892},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 206, col: 5, offset: 5971},
+									pos: position{line: 198, col: 5, offset: 5892},
 									expr: &seqExpr{
-										pos: position{line: 206, col: 7, offset: 5973},
+										pos: position{line: 198, col: 7, offset: 5894},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 206, col: 7, offset: 5973},
+												pos:  position{line: 198, col: 7, offset: 5894},
 												name: "SearchGuard",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 206, col: 19, offset: 5985},
+												pos:  position{line: 198, col: 19, offset: 5906},
 												name: "EOT",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 206, col: 24, offset: 5990},
+									pos:   position{line: 198, col: 24, offset: 5911},
 									label: "search",
 									expr: &ruleRefExpr{
-										pos:  position{line: 206, col: 31, offset: 5997},
+										pos:  position{line: 198, col: 31, offset: 5918},
 										name: "PatternSearch",
 									},
 								},
@@ -1642,39 +1605,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 207, col: 5, offset: 6038},
+						pos: position{line: 199, col: 5, offset: 5959},
 						run: (*parser).callonSearchExpr10,
 						expr: &seqExpr{
-							pos: position{line: 207, col: 5, offset: 6038},
+							pos: position{line: 199, col: 5, offset: 5959},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 207, col: 5, offset: 6038},
+									pos: position{line: 199, col: 5, offset: 5959},
 									expr: &seqExpr{
-										pos: position{line: 207, col: 7, offset: 6040},
+										pos: position{line: 199, col: 7, offset: 5961},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 207, col: 7, offset: 6040},
+												pos:  position{line: 199, col: 7, offset: 5961},
 												name: "SearchGuard",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 207, col: 19, offset: 6052},
+												pos:  position{line: 199, col: 19, offset: 5973},
 												name: "EOT",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 207, col: 24, offset: 6057},
+									pos:   position{line: 199, col: 24, offset: 5978},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 207, col: 26, offset: 6059},
+										pos:  position{line: 199, col: 26, offset: 5980},
 										name: "SearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 207, col: 38, offset: 6071},
+									pos: position{line: 199, col: 38, offset: 5992},
 									expr: &ruleRefExpr{
-										pos:  position{line: 207, col: 39, offset: 6072},
+										pos:  position{line: 199, col: 39, offset: 5993},
 										name: "ExprGuard",
 									},
 								},
@@ -1682,20 +1645,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 210, col: 5, offset: 6189},
+						pos: position{line: 202, col: 5, offset: 6110},
 						run: (*parser).callonSearchExpr20,
 						expr: &seqExpr{
-							pos: position{line: 210, col: 5, offset: 6189},
+							pos: position{line: 202, col: 5, offset: 6110},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 210, col: 5, offset: 6189},
+									pos:        position{line: 202, col: 5, offset: 6110},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 210, col: 9, offset: 6193},
+									pos: position{line: 202, col: 9, offset: 6114},
 									expr: &ruleRefExpr{
-										pos:  position{line: 210, col: 10, offset: 6194},
+										pos:  position{line: 202, col: 10, offset: 6115},
 										name: "ExprGuard",
 									},
 								},
@@ -1703,7 +1666,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 213, col: 5, offset: 6310},
+						pos:  position{line: 205, col: 5, offset: 6231},
 						name: "EqualityCompareExpr",
 					},
 				},
@@ -1711,32 +1674,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 215, col: 1, offset: 6331},
+			pos:  position{line: 207, col: 1, offset: 6252},
 			expr: &choiceExpr{
-				pos: position{line: 216, col: 5, offset: 6347},
+				pos: position{line: 208, col: 5, offset: 6268},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 216, col: 5, offset: 6347},
+						pos:  position{line: 208, col: 5, offset: 6268},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 217, col: 5, offset: 6359},
+						pos: position{line: 209, col: 5, offset: 6280},
 						run: (*parser).callonSearchValue3,
 						expr: &seqExpr{
-							pos: position{line: 217, col: 5, offset: 6359},
+							pos: position{line: 209, col: 5, offset: 6280},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 217, col: 5, offset: 6359},
+									pos: position{line: 209, col: 5, offset: 6280},
 									expr: &ruleRefExpr{
-										pos:  position{line: 217, col: 6, offset: 6360},
+										pos:  position{line: 209, col: 6, offset: 6281},
 										name: "Regexp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 217, col: 13, offset: 6367},
+									pos:   position{line: 209, col: 13, offset: 6288},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 217, col: 15, offset: 6369},
+										pos:  position{line: 209, col: 15, offset: 6290},
 										name: "KeyWord",
 									},
 								},
@@ -1748,15 +1711,15 @@ var g = &grammar{
 		},
 		{
 			name: "PatternSearch",
-			pos:  position{line: 221, col: 1, offset: 6477},
+			pos:  position{line: 213, col: 1, offset: 6398},
 			expr: &actionExpr{
-				pos: position{line: 222, col: 5, offset: 6495},
+				pos: position{line: 214, col: 5, offset: 6416},
 				run: (*parser).callonPatternSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 222, col: 5, offset: 6495},
+					pos:   position{line: 214, col: 5, offset: 6416},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 222, col: 13, offset: 6503},
+						pos:  position{line: 214, col: 13, offset: 6424},
 						name: "Pattern",
 					},
 				},
@@ -1764,39 +1727,39 @@ var g = &grammar{
 		},
 		{
 			name: "PatternMatch",
-			pos:  position{line: 226, col: 1, offset: 6605},
+			pos:  position{line: 218, col: 1, offset: 6526},
 			expr: &actionExpr{
-				pos: position{line: 227, col: 5, offset: 6622},
+				pos: position{line: 219, col: 5, offset: 6543},
 				run: (*parser).callonPatternMatch1,
 				expr: &seqExpr{
-					pos: position{line: 227, col: 5, offset: 6622},
+					pos: position{line: 219, col: 5, offset: 6543},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 227, col: 5, offset: 6622},
+							pos:   position{line: 219, col: 5, offset: 6543},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 227, col: 7, offset: 6624},
+								pos:  position{line: 219, col: 7, offset: 6545},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 227, col: 12, offset: 6629},
+							pos:  position{line: 219, col: 12, offset: 6550},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 227, col: 14, offset: 6631},
+							pos:        position{line: 219, col: 14, offset: 6552},
 							val:        "matches",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 227, col: 25, offset: 6642},
+							pos:  position{line: 219, col: 25, offset: 6563},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 227, col: 28, offset: 6645},
+							pos:   position{line: 219, col: 28, offset: 6566},
 							label: "pattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 227, col: 36, offset: 6653},
+								pos:  position{line: 219, col: 36, offset: 6574},
 								name: "Pattern",
 							},
 						},
@@ -1806,16 +1769,16 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 231, col: 1, offset: 6765},
+			pos:  position{line: 223, col: 1, offset: 6686},
 			expr: &choiceExpr{
-				pos: position{line: 231, col: 11, offset: 6775},
+				pos: position{line: 223, col: 11, offset: 6696},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 231, col: 11, offset: 6775},
+						pos:  position{line: 223, col: 11, offset: 6696},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 231, col: 20, offset: 6784},
+						pos:  position{line: 223, col: 20, offset: 6705},
 						name: "Glob",
 					},
 				},
@@ -1823,49 +1786,45 @@ var g = &grammar{
 		},
 		{
 			name: "SearchGuard",
-			pos:  position{line: 233, col: 1, offset: 6790},
+			pos:  position{line: 225, col: 1, offset: 6711},
 			expr: &choiceExpr{
-				pos: position{line: 234, col: 5, offset: 6806},
+				pos: position{line: 226, col: 5, offset: 6727},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 234, col: 5, offset: 6806},
+						pos:  position{line: 226, col: 5, offset: 6727},
 						name: "SQLTokenSentinels",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 235, col: 5, offset: 6828},
+						pos:  position{line: 227, col: 5, offset: 6749},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 236, col: 5, offset: 6841},
+						pos:  position{line: 228, col: 5, offset: 6762},
 						name: "OrToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 237, col: 5, offset: 6853},
+						pos:  position{line: 229, col: 5, offset: 6774},
 						name: "NotToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 238, col: 5, offset: 6866},
+						pos:  position{line: 230, col: 5, offset: 6787},
 						name: "InToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 239, col: 5, offset: 6878},
+						pos:  position{line: 231, col: 5, offset: 6799},
 						name: "ByToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 240, col: 5, offset: 6890},
-						name: "CaseToken",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 241, col: 5, offset: 6904},
+						pos:  position{line: 232, col: 5, offset: 6811},
 						name: "DefaultToken",
 					},
 					&litMatcher{
-						pos:        position{line: 242, col: 5, offset: 6921},
+						pos:        position{line: 233, col: 5, offset: 6828},
 						val:        "type(",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 243, col: 5, offset: 6933},
+						pos:        position{line: 234, col: 5, offset: 6840},
 						val:        "matches",
 						ignoreCase: true,
 					},
@@ -1874,41 +1833,41 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 247, col: 1, offset: 6971},
+			pos:  position{line: 238, col: 1, offset: 6878},
 			expr: &choiceExpr{
-				pos: position{line: 248, col: 5, offset: 6987},
+				pos: position{line: 239, col: 5, offset: 6894},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 248, col: 5, offset: 6987},
+						pos: position{line: 239, col: 5, offset: 6894},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 248, col: 5, offset: 6987},
+							pos: position{line: 239, col: 5, offset: 6894},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 248, col: 5, offset: 6987},
+									pos:  position{line: 239, col: 5, offset: 6894},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 248, col: 15, offset: 6997},
+									pos:   position{line: 239, col: 15, offset: 6904},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 248, col: 21, offset: 7003},
+										pos:  position{line: 239, col: 21, offset: 6910},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 248, col: 30, offset: 7012},
+									pos:   position{line: 239, col: 30, offset: 6919},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 248, col: 35, offset: 7017},
+										pos:  position{line: 239, col: 35, offset: 6924},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 248, col: 47, offset: 7029},
+									pos:   position{line: 239, col: 47, offset: 6936},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 248, col: 53, offset: 7035},
+										pos:  position{line: 239, col: 53, offset: 6942},
 										name: "LimitArg",
 									},
 								},
@@ -1916,45 +1875,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 251, col: 5, offset: 7180},
+						pos: position{line: 242, col: 5, offset: 7087},
 						run: (*parser).callonAggregation11,
 						expr: &seqExpr{
-							pos: position{line: 251, col: 5, offset: 7180},
+							pos: position{line: 242, col: 5, offset: 7087},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 251, col: 5, offset: 7180},
+									pos:  position{line: 242, col: 5, offset: 7087},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 251, col: 15, offset: 7190},
+									pos:   position{line: 242, col: 15, offset: 7097},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 251, col: 21, offset: 7196},
+										pos:  position{line: 242, col: 21, offset: 7103},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 251, col: 30, offset: 7205},
+									pos:   position{line: 242, col: 30, offset: 7112},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 251, col: 35, offset: 7210},
+										pos:  position{line: 242, col: 35, offset: 7117},
 										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 251, col: 50, offset: 7225},
+									pos:   position{line: 242, col: 50, offset: 7132},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 251, col: 55, offset: 7230},
+										pos: position{line: 242, col: 55, offset: 7137},
 										expr: &seqExpr{
-											pos: position{line: 251, col: 56, offset: 7231},
+											pos: position{line: 242, col: 56, offset: 7138},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 251, col: 56, offset: 7231},
+													pos:  position{line: 242, col: 56, offset: 7138},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 251, col: 58, offset: 7233},
+													pos:  position{line: 242, col: 58, offset: 7140},
 													name: "GroupByKeys",
 												},
 											},
@@ -1962,10 +1921,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 251, col: 72, offset: 7247},
+									pos:   position{line: 242, col: 72, offset: 7154},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 251, col: 78, offset: 7253},
+										pos:  position{line: 242, col: 78, offset: 7160},
 										name: "LimitArg",
 									},
 								},
@@ -1977,26 +1936,26 @@ var g = &grammar{
 		},
 		{
 			name: "Summarize",
-			pos:  position{line: 259, col: 1, offset: 7486},
+			pos:  position{line: 250, col: 1, offset: 7393},
 			expr: &choiceExpr{
-				pos: position{line: 259, col: 13, offset: 7498},
+				pos: position{line: 250, col: 13, offset: 7405},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 259, col: 13, offset: 7498},
+						pos: position{line: 250, col: 13, offset: 7405},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 259, col: 13, offset: 7498},
+								pos:        position{line: 250, col: 13, offset: 7405},
 								val:        "summarize",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 259, col: 25, offset: 7510},
+								pos:  position{line: 250, col: 25, offset: 7417},
 								name: "_",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 259, col: 29, offset: 7514},
+						pos:        position{line: 250, col: 29, offset: 7421},
 						val:        "",
 						ignoreCase: false,
 					},
@@ -2005,45 +1964,45 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 261, col: 1, offset: 7518},
+			pos:  position{line: 252, col: 1, offset: 7425},
 			expr: &choiceExpr{
-				pos: position{line: 262, col: 5, offset: 7531},
+				pos: position{line: 253, col: 5, offset: 7438},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 262, col: 5, offset: 7531},
+						pos: position{line: 253, col: 5, offset: 7438},
 						run: (*parser).callonEveryDur2,
 						expr: &seqExpr{
-							pos: position{line: 262, col: 5, offset: 7531},
+							pos: position{line: 253, col: 5, offset: 7438},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 262, col: 5, offset: 7531},
+									pos:        position{line: 253, col: 5, offset: 7438},
 									val:        "every",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 262, col: 14, offset: 7540},
+									pos:  position{line: 253, col: 14, offset: 7447},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 262, col: 16, offset: 7542},
+									pos:   position{line: 253, col: 16, offset: 7449},
 									label: "dur",
 									expr: &ruleRefExpr{
-										pos:  position{line: 262, col: 20, offset: 7546},
+										pos:  position{line: 253, col: 20, offset: 7453},
 										name: "Duration",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 262, col: 29, offset: 7555},
+									pos:  position{line: 253, col: 29, offset: 7462},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 263, col: 5, offset: 7581},
+						pos: position{line: 254, col: 5, offset: 7488},
 						run: (*parser).callonEveryDur9,
 						expr: &litMatcher{
-							pos:        position{line: 263, col: 5, offset: 7581},
+							pos:        position{line: 254, col: 5, offset: 7488},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2053,26 +2012,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 265, col: 1, offset: 7606},
+			pos:  position{line: 256, col: 1, offset: 7513},
 			expr: &actionExpr{
-				pos: position{line: 266, col: 5, offset: 7622},
+				pos: position{line: 257, col: 5, offset: 7529},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 266, col: 5, offset: 7622},
+					pos: position{line: 257, col: 5, offset: 7529},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 266, col: 5, offset: 7622},
+							pos:  position{line: 257, col: 5, offset: 7529},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 266, col: 13, offset: 7630},
+							pos:  position{line: 257, col: 13, offset: 7537},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 266, col: 15, offset: 7632},
+							pos:   position{line: 257, col: 15, offset: 7539},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 266, col: 23, offset: 7640},
+								pos:  position{line: 257, col: 23, offset: 7547},
 								name: "FlexAssignments",
 							},
 						},
@@ -2082,43 +2041,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 268, col: 1, offset: 7681},
+			pos:  position{line: 259, col: 1, offset: 7588},
 			expr: &choiceExpr{
-				pos: position{line: 269, col: 5, offset: 7694},
+				pos: position{line: 260, col: 5, offset: 7601},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 269, col: 5, offset: 7694},
+						pos: position{line: 260, col: 5, offset: 7601},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 269, col: 5, offset: 7694},
+							pos: position{line: 260, col: 5, offset: 7601},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 269, col: 5, offset: 7694},
+									pos:  position{line: 260, col: 5, offset: 7601},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 269, col: 7, offset: 7696},
+									pos:        position{line: 260, col: 7, offset: 7603},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 269, col: 14, offset: 7703},
+									pos:  position{line: 260, col: 14, offset: 7610},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 269, col: 16, offset: 7705},
+									pos:        position{line: 260, col: 16, offset: 7612},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 269, col: 25, offset: 7714},
+									pos:  position{line: 260, col: 25, offset: 7621},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 269, col: 27, offset: 7716},
+									pos:   position{line: 260, col: 27, offset: 7623},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 269, col: 33, offset: 7722},
+										pos:  position{line: 260, col: 33, offset: 7629},
 										name: "UInt",
 									},
 								},
@@ -2126,10 +2085,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 270, col: 5, offset: 7753},
+						pos: position{line: 261, col: 5, offset: 7660},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 270, col: 5, offset: 7753},
+							pos:        position{line: 261, col: 5, offset: 7660},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2139,22 +2098,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 275, col: 1, offset: 8013},
+			pos:  position{line: 266, col: 1, offset: 7920},
 			expr: &choiceExpr{
-				pos: position{line: 276, col: 5, offset: 8032},
+				pos: position{line: 267, col: 5, offset: 7939},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 276, col: 5, offset: 8032},
+						pos:  position{line: 267, col: 5, offset: 7939},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 277, col: 5, offset: 8047},
+						pos: position{line: 268, col: 5, offset: 7954},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 277, col: 5, offset: 8047},
+							pos:   position{line: 268, col: 5, offset: 7954},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 10, offset: 8052},
+								pos:  position{line: 268, col: 10, offset: 7959},
 								name: "Expr",
 							},
 						},
@@ -2164,50 +2123,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 279, col: 1, offset: 8144},
+			pos:  position{line: 270, col: 1, offset: 8051},
 			expr: &actionExpr{
-				pos: position{line: 280, col: 5, offset: 8164},
+				pos: position{line: 271, col: 5, offset: 8071},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 280, col: 5, offset: 8164},
+					pos: position{line: 271, col: 5, offset: 8071},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 280, col: 5, offset: 8164},
+							pos:   position{line: 271, col: 5, offset: 8071},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 280, col: 11, offset: 8170},
+								pos:  position{line: 271, col: 11, offset: 8077},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 280, col: 26, offset: 8185},
+							pos:   position{line: 271, col: 26, offset: 8092},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 280, col: 31, offset: 8190},
+								pos: position{line: 271, col: 31, offset: 8097},
 								expr: &actionExpr{
-									pos: position{line: 280, col: 32, offset: 8191},
+									pos: position{line: 271, col: 32, offset: 8098},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 280, col: 32, offset: 8191},
+										pos: position{line: 271, col: 32, offset: 8098},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 280, col: 32, offset: 8191},
+												pos:  position{line: 271, col: 32, offset: 8098},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 280, col: 35, offset: 8194},
+												pos:        position{line: 271, col: 35, offset: 8101},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 280, col: 39, offset: 8198},
+												pos:  position{line: 271, col: 39, offset: 8105},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 280, col: 42, offset: 8201},
+												pos:   position{line: 271, col: 42, offset: 8108},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 280, col: 47, offset: 8206},
+													pos:  position{line: 271, col: 47, offset: 8113},
 													name: "FlexAssignment",
 												},
 											},
@@ -2222,42 +2181,42 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignment",
-			pos:  position{line: 284, col: 1, offset: 8328},
+			pos:  position{line: 275, col: 1, offset: 8235},
 			expr: &choiceExpr{
-				pos: position{line: 285, col: 5, offset: 8346},
+				pos: position{line: 276, col: 5, offset: 8253},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 285, col: 5, offset: 8346},
+						pos: position{line: 276, col: 5, offset: 8253},
 						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 285, col: 5, offset: 8346},
+							pos: position{line: 276, col: 5, offset: 8253},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 285, col: 5, offset: 8346},
+									pos:   position{line: 276, col: 5, offset: 8253},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 285, col: 10, offset: 8351},
+										pos:  position{line: 276, col: 10, offset: 8258},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 285, col: 15, offset: 8356},
+									pos:  position{line: 276, col: 15, offset: 8263},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 285, col: 18, offset: 8359},
+									pos:        position{line: 276, col: 18, offset: 8266},
 									val:        ":=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 285, col: 23, offset: 8364},
+									pos:  position{line: 276, col: 23, offset: 8271},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 285, col: 26, offset: 8367},
+									pos:   position{line: 276, col: 26, offset: 8274},
 									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 285, col: 30, offset: 8371},
+										pos:  position{line: 276, col: 30, offset: 8278},
 										name: "Agg",
 									},
 								},
@@ -2265,13 +2224,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 288, col: 5, offset: 8475},
+						pos: position{line: 279, col: 5, offset: 8382},
 						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 288, col: 5, offset: 8475},
+							pos:   position{line: 279, col: 5, offset: 8382},
 							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 288, col: 9, offset: 8479},
+								pos:  position{line: 279, col: 9, offset: 8386},
 								name: "Agg",
 							},
 						},
@@ -2281,72 +2240,72 @@ var g = &grammar{
 		},
 		{
 			name: "Agg",
-			pos:  position{line: 292, col: 1, offset: 8579},
+			pos:  position{line: 283, col: 1, offset: 8486},
 			expr: &actionExpr{
-				pos: position{line: 293, col: 5, offset: 8587},
+				pos: position{line: 284, col: 5, offset: 8494},
 				run: (*parser).callonAgg1,
 				expr: &seqExpr{
-					pos: position{line: 293, col: 5, offset: 8587},
+					pos: position{line: 284, col: 5, offset: 8494},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 293, col: 5, offset: 8587},
+							pos: position{line: 284, col: 5, offset: 8494},
 							expr: &ruleRefExpr{
-								pos:  position{line: 293, col: 6, offset: 8588},
+								pos:  position{line: 284, col: 6, offset: 8495},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 293, col: 16, offset: 8598},
+							pos:   position{line: 284, col: 16, offset: 8505},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 293, col: 19, offset: 8601},
+								pos:  position{line: 284, col: 19, offset: 8508},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 27, offset: 8609},
+							pos:  position{line: 284, col: 27, offset: 8516},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 293, col: 30, offset: 8612},
+							pos:        position{line: 284, col: 30, offset: 8519},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 34, offset: 8616},
+							pos:  position{line: 284, col: 34, offset: 8523},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 293, col: 37, offset: 8619},
+							pos:   position{line: 284, col: 37, offset: 8526},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 293, col: 42, offset: 8624},
+								pos: position{line: 284, col: 42, offset: 8531},
 								expr: &ruleRefExpr{
-									pos:  position{line: 293, col: 42, offset: 8624},
+									pos:  position{line: 284, col: 42, offset: 8531},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 49, offset: 8631},
+							pos:  position{line: 284, col: 49, offset: 8538},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 293, col: 52, offset: 8634},
+							pos:        position{line: 284, col: 52, offset: 8541},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 293, col: 56, offset: 8638},
+							pos: position{line: 284, col: 56, offset: 8545},
 							expr: &seqExpr{
-								pos: position{line: 293, col: 58, offset: 8640},
+								pos: position{line: 284, col: 58, offset: 8547},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 293, col: 58, offset: 8640},
+										pos:  position{line: 284, col: 58, offset: 8547},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 293, col: 61, offset: 8643},
+										pos:        position{line: 284, col: 61, offset: 8550},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -2354,12 +2313,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 293, col: 66, offset: 8648},
+							pos:   position{line: 284, col: 66, offset: 8555},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 293, col: 72, offset: 8654},
+								pos: position{line: 284, col: 72, offset: 8561},
 								expr: &ruleRefExpr{
-									pos:  position{line: 293, col: 72, offset: 8654},
+									pos:  position{line: 284, col: 72, offset: 8561},
 									name: "WhereClause",
 								},
 							},
@@ -2370,20 +2329,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 301, col: 1, offset: 8844},
+			pos:  position{line: 292, col: 1, offset: 8751},
 			expr: &choiceExpr{
-				pos: position{line: 302, col: 5, offset: 8856},
+				pos: position{line: 293, col: 5, offset: 8763},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 302, col: 5, offset: 8856},
+						pos:  position{line: 293, col: 5, offset: 8763},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 5, offset: 8875},
+						pos:  position{line: 294, col: 5, offset: 8782},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 304, col: 5, offset: 8888},
+						pos:  position{line: 295, col: 5, offset: 8795},
 						name: "OrToken",
 					},
 				},
@@ -2391,31 +2350,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 306, col: 1, offset: 8897},
+			pos:  position{line: 297, col: 1, offset: 8804},
 			expr: &actionExpr{
-				pos: position{line: 306, col: 15, offset: 8911},
+				pos: position{line: 297, col: 15, offset: 8818},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 306, col: 15, offset: 8911},
+					pos: position{line: 297, col: 15, offset: 8818},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 306, col: 15, offset: 8911},
+							pos:  position{line: 297, col: 15, offset: 8818},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 306, col: 17, offset: 8913},
+							pos:        position{line: 297, col: 17, offset: 8820},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 306, col: 25, offset: 8921},
+							pos:  position{line: 297, col: 25, offset: 8828},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 306, col: 27, offset: 8923},
+							pos:   position{line: 297, col: 27, offset: 8830},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 306, col: 32, offset: 8928},
+								pos:  position{line: 297, col: 32, offset: 8835},
 								name: "SearchBoolean",
 							},
 						},
@@ -2425,44 +2384,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 308, col: 1, offset: 8964},
+			pos:  position{line: 299, col: 1, offset: 8871},
 			expr: &actionExpr{
-				pos: position{line: 309, col: 5, offset: 8983},
+				pos: position{line: 300, col: 5, offset: 8890},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 309, col: 5, offset: 8983},
+					pos: position{line: 300, col: 5, offset: 8890},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 309, col: 5, offset: 8983},
+							pos:   position{line: 300, col: 5, offset: 8890},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 309, col: 11, offset: 8989},
+								pos:  position{line: 300, col: 11, offset: 8896},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 309, col: 25, offset: 9003},
+							pos:   position{line: 300, col: 25, offset: 8910},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 309, col: 30, offset: 9008},
+								pos: position{line: 300, col: 30, offset: 8915},
 								expr: &seqExpr{
-									pos: position{line: 309, col: 31, offset: 9009},
+									pos: position{line: 300, col: 31, offset: 8916},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 309, col: 31, offset: 9009},
+											pos:  position{line: 300, col: 31, offset: 8916},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 309, col: 34, offset: 9012},
+											pos:        position{line: 300, col: 34, offset: 8919},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 309, col: 38, offset: 9016},
+											pos:  position{line: 300, col: 38, offset: 8923},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 309, col: 41, offset: 9019},
+											pos:  position{line: 300, col: 41, offset: 8926},
 											name: "AggAssignment",
 										},
 									},
@@ -2475,84 +2434,84 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 319, col: 1, offset: 9255},
+			pos:  position{line: 310, col: 1, offset: 9162},
 			expr: &choiceExpr{
-				pos: position{line: 320, col: 5, offset: 9268},
+				pos: position{line: 311, col: 5, offset: 9175},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 5, offset: 9268},
+						pos:  position{line: 311, col: 5, offset: 9175},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 321, col: 5, offset: 9281},
+						pos:  position{line: 312, col: 5, offset: 9188},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 5, offset: 9293},
+						pos:  position{line: 313, col: 5, offset: 9200},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 5, offset: 9305},
+						pos:  position{line: 314, col: 5, offset: 9212},
 						name: "PickProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 324, col: 5, offset: 9318},
+						pos:  position{line: 315, col: 5, offset: 9225},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 325, col: 5, offset: 9331},
+						pos:  position{line: 316, col: 5, offset: 9238},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 326, col: 5, offset: 9344},
+						pos:  position{line: 317, col: 5, offset: 9251},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 327, col: 5, offset: 9357},
+						pos:  position{line: 318, col: 5, offset: 9264},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 328, col: 5, offset: 9372},
+						pos:  position{line: 319, col: 5, offset: 9279},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 329, col: 5, offset: 9385},
+						pos:  position{line: 320, col: 5, offset: 9292},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 330, col: 5, offset: 9397},
+						pos:  position{line: 321, col: 5, offset: 9304},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 331, col: 5, offset: 9412},
+						pos:  position{line: 322, col: 5, offset: 9319},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 332, col: 5, offset: 9425},
+						pos:  position{line: 323, col: 5, offset: 9332},
 						name: "ShapeProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 333, col: 5, offset: 9439},
+						pos:  position{line: 324, col: 5, offset: 9346},
 						name: "JoinProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 334, col: 5, offset: 9452},
+						pos:  position{line: 325, col: 5, offset: 9359},
 						name: "SampleProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 335, col: 5, offset: 9467},
+						pos:  position{line: 326, col: 5, offset: 9374},
 						name: "SQLProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 336, col: 5, offset: 9479},
+						pos:  position{line: 327, col: 5, offset: 9386},
 						name: "FromProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 337, col: 5, offset: 9492},
+						pos:  position{line: 328, col: 5, offset: 9399},
 						name: "PassProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 338, col: 5, offset: 9505},
+						pos:  position{line: 329, col: 5, offset: 9412},
 						name: "ExplodeProc",
 					},
 				},
@@ -2560,46 +2519,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 340, col: 1, offset: 9518},
+			pos:  position{line: 331, col: 1, offset: 9425},
 			expr: &actionExpr{
-				pos: position{line: 341, col: 5, offset: 9531},
+				pos: position{line: 332, col: 5, offset: 9438},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 341, col: 5, offset: 9531},
+					pos: position{line: 332, col: 5, offset: 9438},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 341, col: 5, offset: 9531},
+							pos:        position{line: 332, col: 5, offset: 9438},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 341, col: 13, offset: 9539},
+							pos:   position{line: 332, col: 13, offset: 9446},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 341, col: 18, offset: 9544},
+								pos:  position{line: 332, col: 18, offset: 9451},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 341, col: 27, offset: 9553},
+							pos:   position{line: 332, col: 27, offset: 9460},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 341, col: 32, offset: 9558},
+								pos: position{line: 332, col: 32, offset: 9465},
 								expr: &actionExpr{
-									pos: position{line: 341, col: 33, offset: 9559},
+									pos: position{line: 332, col: 33, offset: 9466},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 341, col: 33, offset: 9559},
+										pos: position{line: 332, col: 33, offset: 9466},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 341, col: 33, offset: 9559},
+												pos:  position{line: 332, col: 33, offset: 9466},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 341, col: 35, offset: 9561},
+												pos:   position{line: 332, col: 35, offset: 9468},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 341, col: 37, offset: 9563},
+													pos:  position{line: 332, col: 37, offset: 9470},
 													name: "Exprs",
 												},
 											},
@@ -2614,30 +2573,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 355, col: 1, offset: 9982},
+			pos:  position{line: 346, col: 1, offset: 9889},
 			expr: &actionExpr{
-				pos: position{line: 355, col: 12, offset: 9993},
+				pos: position{line: 346, col: 12, offset: 9900},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 355, col: 12, offset: 9993},
+					pos:   position{line: 346, col: 12, offset: 9900},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 355, col: 17, offset: 9998},
+						pos: position{line: 346, col: 17, offset: 9905},
 						expr: &actionExpr{
-							pos: position{line: 355, col: 18, offset: 9999},
+							pos: position{line: 346, col: 18, offset: 9906},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 355, col: 18, offset: 9999},
+								pos: position{line: 346, col: 18, offset: 9906},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 355, col: 18, offset: 9999},
+										pos:  position{line: 346, col: 18, offset: 9906},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 355, col: 20, offset: 10001},
+										pos:   position{line: 346, col: 20, offset: 9908},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 355, col: 22, offset: 10003},
+											pos:  position{line: 346, col: 22, offset: 9910},
 											name: "SortArg",
 										},
 									},
@@ -2650,50 +2609,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 357, col: 1, offset: 10059},
+			pos:  position{line: 348, col: 1, offset: 9966},
 			expr: &choiceExpr{
-				pos: position{line: 358, col: 5, offset: 10071},
+				pos: position{line: 349, col: 5, offset: 9978},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 358, col: 5, offset: 10071},
+						pos: position{line: 349, col: 5, offset: 9978},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 358, col: 5, offset: 10071},
+							pos:        position{line: 349, col: 5, offset: 9978},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 359, col: 5, offset: 10146},
+						pos: position{line: 350, col: 5, offset: 10053},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 359, col: 5, offset: 10146},
+							pos: position{line: 350, col: 5, offset: 10053},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 359, col: 5, offset: 10146},
+									pos:        position{line: 350, col: 5, offset: 10053},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 359, col: 14, offset: 10155},
+									pos:  position{line: 350, col: 14, offset: 10062},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 359, col: 16, offset: 10157},
+									pos:   position{line: 350, col: 16, offset: 10064},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 359, col: 23, offset: 10164},
+										pos: position{line: 350, col: 23, offset: 10071},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 359, col: 24, offset: 10165},
+											pos: position{line: 350, col: 24, offset: 10072},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 359, col: 24, offset: 10165},
+													pos:        position{line: 350, col: 24, offset: 10072},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 359, col: 34, offset: 10175},
+													pos:        position{line: 350, col: 34, offset: 10082},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2709,38 +2668,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 361, col: 1, offset: 10289},
+			pos:  position{line: 352, col: 1, offset: 10196},
 			expr: &actionExpr{
-				pos: position{line: 362, col: 5, offset: 10301},
+				pos: position{line: 353, col: 5, offset: 10208},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 362, col: 5, offset: 10301},
+					pos: position{line: 353, col: 5, offset: 10208},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 362, col: 5, offset: 10301},
+							pos:        position{line: 353, col: 5, offset: 10208},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 362, col: 12, offset: 10308},
+							pos:   position{line: 353, col: 12, offset: 10215},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 362, col: 18, offset: 10314},
+								pos: position{line: 353, col: 18, offset: 10221},
 								expr: &actionExpr{
-									pos: position{line: 362, col: 19, offset: 10315},
+									pos: position{line: 353, col: 19, offset: 10222},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 362, col: 19, offset: 10315},
+										pos: position{line: 353, col: 19, offset: 10222},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 362, col: 19, offset: 10315},
+												pos:  position{line: 353, col: 19, offset: 10222},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 362, col: 21, offset: 10317},
+												pos:   position{line: 353, col: 21, offset: 10224},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 362, col: 23, offset: 10319},
+													pos:  position{line: 353, col: 23, offset: 10226},
 													name: "UInt",
 												},
 											},
@@ -2750,19 +2709,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 362, col: 47, offset: 10343},
+							pos:   position{line: 353, col: 47, offset: 10250},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 362, col: 53, offset: 10349},
+								pos: position{line: 353, col: 53, offset: 10256},
 								expr: &seqExpr{
-									pos: position{line: 362, col: 54, offset: 10350},
+									pos: position{line: 353, col: 54, offset: 10257},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 362, col: 54, offset: 10350},
+											pos:  position{line: 353, col: 54, offset: 10257},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 362, col: 56, offset: 10352},
+											pos:        position{line: 353, col: 56, offset: 10259},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2771,25 +2730,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 362, col: 67, offset: 10363},
+							pos:   position{line: 353, col: 67, offset: 10270},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 362, col: 74, offset: 10370},
+								pos: position{line: 353, col: 74, offset: 10277},
 								expr: &actionExpr{
-									pos: position{line: 362, col: 75, offset: 10371},
+									pos: position{line: 353, col: 75, offset: 10278},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 362, col: 75, offset: 10371},
+										pos: position{line: 353, col: 75, offset: 10278},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 362, col: 75, offset: 10371},
+												pos:  position{line: 353, col: 75, offset: 10278},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 362, col: 77, offset: 10373},
+												pos:   position{line: 353, col: 77, offset: 10280},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 362, col: 79, offset: 10375},
+													pos:  position{line: 353, col: 79, offset: 10282},
 													name: "FieldExprs",
 												},
 											},
@@ -2804,27 +2763,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 376, col: 1, offset: 10720},
+			pos:  position{line: 367, col: 1, offset: 10627},
 			expr: &actionExpr{
-				pos: position{line: 377, col: 5, offset: 10732},
+				pos: position{line: 368, col: 5, offset: 10639},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 377, col: 5, offset: 10732},
+					pos: position{line: 368, col: 5, offset: 10639},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 377, col: 5, offset: 10732},
+							pos:        position{line: 368, col: 5, offset: 10639},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 377, col: 12, offset: 10739},
+							pos:  position{line: 368, col: 12, offset: 10646},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 377, col: 14, offset: 10741},
+							pos:   position{line: 368, col: 14, offset: 10648},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 377, col: 19, offset: 10746},
+								pos:  position{line: 368, col: 19, offset: 10653},
 								name: "FlexAssignments",
 							},
 						},
@@ -2834,27 +2793,27 @@ var g = &grammar{
 		},
 		{
 			name: "PickProc",
-			pos:  position{line: 381, col: 1, offset: 10841},
+			pos:  position{line: 372, col: 1, offset: 10748},
 			expr: &actionExpr{
-				pos: position{line: 382, col: 5, offset: 10854},
+				pos: position{line: 373, col: 5, offset: 10761},
 				run: (*parser).callonPickProc1,
 				expr: &seqExpr{
-					pos: position{line: 382, col: 5, offset: 10854},
+					pos: position{line: 373, col: 5, offset: 10761},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 382, col: 5, offset: 10854},
+							pos:        position{line: 373, col: 5, offset: 10761},
 							val:        "pick",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 382, col: 13, offset: 10862},
+							pos:  position{line: 373, col: 13, offset: 10769},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 382, col: 15, offset: 10864},
+							pos:   position{line: 373, col: 15, offset: 10771},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 382, col: 20, offset: 10869},
+								pos:  position{line: 373, col: 20, offset: 10776},
 								name: "FlexAssignments",
 							},
 						},
@@ -2864,27 +2823,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 386, col: 1, offset: 10965},
+			pos:  position{line: 377, col: 1, offset: 10872},
 			expr: &actionExpr{
-				pos: position{line: 387, col: 5, offset: 10978},
+				pos: position{line: 378, col: 5, offset: 10885},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 387, col: 5, offset: 10978},
+					pos: position{line: 378, col: 5, offset: 10885},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 387, col: 5, offset: 10978},
+							pos:        position{line: 378, col: 5, offset: 10885},
 							val:        "drop",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 387, col: 13, offset: 10986},
+							pos:  position{line: 378, col: 13, offset: 10893},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 387, col: 15, offset: 10988},
+							pos:   position{line: 378, col: 15, offset: 10895},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 387, col: 20, offset: 10993},
+								pos:  position{line: 378, col: 20, offset: 10900},
 								name: "FieldExprs",
 							},
 						},
@@ -2894,30 +2853,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 391, col: 1, offset: 11084},
+			pos:  position{line: 382, col: 1, offset: 10991},
 			expr: &choiceExpr{
-				pos: position{line: 392, col: 5, offset: 11097},
+				pos: position{line: 383, col: 5, offset: 11004},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 392, col: 5, offset: 11097},
+						pos: position{line: 383, col: 5, offset: 11004},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 392, col: 5, offset: 11097},
+							pos: position{line: 383, col: 5, offset: 11004},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 392, col: 5, offset: 11097},
+									pos:        position{line: 383, col: 5, offset: 11004},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 392, col: 13, offset: 11105},
+									pos:  position{line: 383, col: 13, offset: 11012},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 392, col: 15, offset: 11107},
+									pos:   position{line: 383, col: 15, offset: 11014},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 392, col: 21, offset: 11113},
+										pos:  position{line: 383, col: 21, offset: 11020},
 										name: "UInt",
 									},
 								},
@@ -2925,10 +2884,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 393, col: 5, offset: 11193},
+						pos: position{line: 384, col: 5, offset: 11100},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 393, col: 5, offset: 11193},
+							pos:        position{line: 384, col: 5, offset: 11100},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2938,30 +2897,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 395, col: 1, offset: 11269},
+			pos:  position{line: 386, col: 1, offset: 11176},
 			expr: &choiceExpr{
-				pos: position{line: 396, col: 5, offset: 11282},
+				pos: position{line: 387, col: 5, offset: 11189},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 396, col: 5, offset: 11282},
+						pos: position{line: 387, col: 5, offset: 11189},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 396, col: 5, offset: 11282},
+							pos: position{line: 387, col: 5, offset: 11189},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 396, col: 5, offset: 11282},
+									pos:        position{line: 387, col: 5, offset: 11189},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 396, col: 13, offset: 11290},
+									pos:  position{line: 387, col: 13, offset: 11197},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 396, col: 15, offset: 11292},
+									pos:   position{line: 387, col: 15, offset: 11199},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 396, col: 21, offset: 11298},
+										pos:  position{line: 387, col: 21, offset: 11205},
 										name: "UInt",
 									},
 								},
@@ -2969,10 +2928,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 397, col: 5, offset: 11378},
+						pos: position{line: 388, col: 5, offset: 11285},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 397, col: 5, offset: 11378},
+							pos:        position{line: 388, col: 5, offset: 11285},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2982,27 +2941,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 399, col: 1, offset: 11454},
+			pos:  position{line: 390, col: 1, offset: 11361},
 			expr: &actionExpr{
-				pos: position{line: 400, col: 5, offset: 11469},
+				pos: position{line: 391, col: 5, offset: 11376},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 400, col: 5, offset: 11469},
+					pos: position{line: 391, col: 5, offset: 11376},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 400, col: 5, offset: 11469},
+							pos:        position{line: 391, col: 5, offset: 11376},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 400, col: 15, offset: 11479},
+							pos:  position{line: 391, col: 15, offset: 11386},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 400, col: 17, offset: 11481},
+							pos:   position{line: 391, col: 17, offset: 11388},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 400, col: 20, offset: 11484},
+								pos:  position{line: 391, col: 20, offset: 11391},
 								name: "Filter",
 							},
 						},
@@ -3012,15 +2971,15 @@ var g = &grammar{
 		},
 		{
 			name: "Filter",
-			pos:  position{line: 404, col: 1, offset: 11521},
+			pos:  position{line: 395, col: 1, offset: 11428},
 			expr: &actionExpr{
-				pos: position{line: 405, col: 5, offset: 11532},
+				pos: position{line: 396, col: 5, offset: 11439},
 				run: (*parser).callonFilter1,
 				expr: &labeledExpr{
-					pos:   position{line: 405, col: 5, offset: 11532},
+					pos:   position{line: 396, col: 5, offset: 11439},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 405, col: 10, offset: 11537},
+						pos:  position{line: 396, col: 10, offset: 11444},
 						name: "SearchBoolean",
 					},
 				},
@@ -3028,27 +2987,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 409, col: 1, offset: 11633},
+			pos:  position{line: 400, col: 1, offset: 11540},
 			expr: &choiceExpr{
-				pos: position{line: 410, col: 5, offset: 11646},
+				pos: position{line: 401, col: 5, offset: 11553},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 410, col: 5, offset: 11646},
+						pos: position{line: 401, col: 5, offset: 11553},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 410, col: 5, offset: 11646},
+							pos: position{line: 401, col: 5, offset: 11553},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 410, col: 5, offset: 11646},
+									pos:        position{line: 401, col: 5, offset: 11553},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 410, col: 13, offset: 11654},
+									pos:  position{line: 401, col: 13, offset: 11561},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 410, col: 15, offset: 11656},
+									pos:        position{line: 401, col: 15, offset: 11563},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -3056,10 +3015,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 413, col: 5, offset: 11745},
+						pos: position{line: 404, col: 5, offset: 11652},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 413, col: 5, offset: 11745},
+							pos:        position{line: 404, col: 5, offset: 11652},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -3069,27 +3028,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 417, col: 1, offset: 11835},
+			pos:  position{line: 408, col: 1, offset: 11742},
 			expr: &actionExpr{
-				pos: position{line: 418, col: 5, offset: 11847},
+				pos: position{line: 409, col: 5, offset: 11754},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 418, col: 5, offset: 11847},
+					pos: position{line: 409, col: 5, offset: 11754},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 418, col: 5, offset: 11847},
+							pos:        position{line: 409, col: 5, offset: 11754},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 418, col: 12, offset: 11854},
+							pos:  position{line: 409, col: 12, offset: 11761},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 418, col: 14, offset: 11856},
+							pos:   position{line: 409, col: 14, offset: 11763},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 418, col: 19, offset: 11861},
+								pos:  position{line: 409, col: 19, offset: 11768},
 								name: "FlexAssignments",
 							},
 						},
@@ -3099,59 +3058,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 422, col: 1, offset: 11956},
+			pos:  position{line: 413, col: 1, offset: 11863},
 			expr: &actionExpr{
-				pos: position{line: 423, col: 5, offset: 11971},
+				pos: position{line: 414, col: 5, offset: 11878},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 423, col: 5, offset: 11971},
+					pos: position{line: 414, col: 5, offset: 11878},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 423, col: 5, offset: 11971},
+							pos:        position{line: 414, col: 5, offset: 11878},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 423, col: 15, offset: 11981},
+							pos:  position{line: 414, col: 15, offset: 11888},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 423, col: 17, offset: 11983},
+							pos:   position{line: 414, col: 17, offset: 11890},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 423, col: 23, offset: 11989},
+								pos:  position{line: 414, col: 23, offset: 11896},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 423, col: 34, offset: 12000},
+							pos:   position{line: 414, col: 34, offset: 11907},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 423, col: 39, offset: 12005},
+								pos: position{line: 414, col: 39, offset: 11912},
 								expr: &actionExpr{
-									pos: position{line: 423, col: 40, offset: 12006},
+									pos: position{line: 414, col: 40, offset: 11913},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 423, col: 40, offset: 12006},
+										pos: position{line: 414, col: 40, offset: 11913},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 423, col: 40, offset: 12006},
+												pos:  position{line: 414, col: 40, offset: 11913},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 423, col: 43, offset: 12009},
+												pos:        position{line: 414, col: 43, offset: 11916},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 423, col: 47, offset: 12013},
+												pos:  position{line: 414, col: 47, offset: 11920},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 423, col: 50, offset: 12016},
+												pos:   position{line: 414, col: 50, offset: 11923},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 423, col: 53, offset: 12019},
+													pos:  position{line: 414, col: 53, offset: 11926},
 													name: "Assignment",
 												},
 											},
@@ -3166,29 +3125,29 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 431, col: 1, offset: 12428},
+			pos:  position{line: 422, col: 1, offset: 12335},
 			expr: &actionExpr{
-				pos: position{line: 432, col: 5, offset: 12441},
+				pos: position{line: 423, col: 5, offset: 12348},
 				run: (*parser).callonFuseProc1,
 				expr: &seqExpr{
-					pos: position{line: 432, col: 5, offset: 12441},
+					pos: position{line: 423, col: 5, offset: 12348},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 432, col: 5, offset: 12441},
+							pos:        position{line: 423, col: 5, offset: 12348},
 							val:        "fuse",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 432, col: 13, offset: 12449},
+							pos: position{line: 423, col: 13, offset: 12356},
 							expr: &seqExpr{
-								pos: position{line: 432, col: 15, offset: 12451},
+								pos: position{line: 423, col: 15, offset: 12358},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 432, col: 15, offset: 12451},
+										pos:  position{line: 423, col: 15, offset: 12358},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 432, col: 18, offset: 12454},
+										pos:        position{line: 423, col: 18, offset: 12361},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -3201,12 +3160,12 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeProc",
-			pos:  position{line: 436, col: 1, offset: 12525},
+			pos:  position{line: 427, col: 1, offset: 12432},
 			expr: &actionExpr{
-				pos: position{line: 437, col: 5, offset: 12539},
+				pos: position{line: 428, col: 5, offset: 12446},
 				run: (*parser).callonShapeProc1,
 				expr: &litMatcher{
-					pos:        position{line: 437, col: 5, offset: 12539},
+					pos:        position{line: 428, col: 5, offset: 12446},
 					val:        "shape",
 					ignoreCase: true,
 				},
@@ -3214,84 +3173,84 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 441, col: 1, offset: 12615},
+			pos:  position{line: 432, col: 1, offset: 12522},
 			expr: &choiceExpr{
-				pos: position{line: 442, col: 5, offset: 12628},
+				pos: position{line: 433, col: 5, offset: 12535},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 442, col: 5, offset: 12628},
+						pos: position{line: 433, col: 5, offset: 12535},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 442, col: 5, offset: 12628},
+							pos: position{line: 433, col: 5, offset: 12535},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 442, col: 5, offset: 12628},
+									pos:   position{line: 433, col: 5, offset: 12535},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 442, col: 11, offset: 12634},
+										pos:  position{line: 433, col: 11, offset: 12541},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 442, col: 21, offset: 12644},
+									pos:        position{line: 433, col: 21, offset: 12551},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 442, col: 29, offset: 12652},
+									pos:  position{line: 433, col: 29, offset: 12559},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 442, col: 31, offset: 12654},
+									pos:  position{line: 433, col: 31, offset: 12561},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 442, col: 34, offset: 12657},
+									pos:  position{line: 433, col: 34, offset: 12564},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 442, col: 36, offset: 12659},
+									pos:   position{line: 433, col: 36, offset: 12566},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 442, col: 44, offset: 12667},
+										pos:  position{line: 433, col: 44, offset: 12574},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 442, col: 52, offset: 12675},
+									pos:  position{line: 433, col: 52, offset: 12582},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 442, col: 55, offset: 12678},
+									pos:        position{line: 433, col: 55, offset: 12585},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 442, col: 59, offset: 12682},
+									pos:  position{line: 433, col: 59, offset: 12589},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 442, col: 62, offset: 12685},
+									pos:   position{line: 433, col: 62, offset: 12592},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 442, col: 71, offset: 12694},
+										pos:  position{line: 433, col: 71, offset: 12601},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 442, col: 79, offset: 12702},
+									pos:   position{line: 433, col: 79, offset: 12609},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 442, col: 87, offset: 12710},
+										pos: position{line: 433, col: 87, offset: 12617},
 										expr: &seqExpr{
-											pos: position{line: 442, col: 88, offset: 12711},
+											pos: position{line: 433, col: 88, offset: 12618},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 442, col: 88, offset: 12711},
+													pos:  position{line: 433, col: 88, offset: 12618},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 442, col: 90, offset: 12713},
+													pos:  position{line: 433, col: 90, offset: 12620},
 													name: "FlexAssignments",
 												},
 											},
@@ -3302,58 +3261,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 449, col: 5, offset: 12979},
+						pos: position{line: 440, col: 5, offset: 12886},
 						run: (*parser).callonJoinProc22,
 						expr: &seqExpr{
-							pos: position{line: 449, col: 5, offset: 12979},
+							pos: position{line: 440, col: 5, offset: 12886},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 449, col: 5, offset: 12979},
+									pos:   position{line: 440, col: 5, offset: 12886},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 449, col: 11, offset: 12985},
+										pos:  position{line: 440, col: 11, offset: 12892},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 449, col: 22, offset: 12996},
+									pos:        position{line: 440, col: 22, offset: 12903},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 30, offset: 13004},
+									pos:  position{line: 440, col: 30, offset: 12911},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 32, offset: 13006},
+									pos:  position{line: 440, col: 32, offset: 12913},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 35, offset: 13009},
+									pos:  position{line: 440, col: 35, offset: 12916},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 449, col: 37, offset: 13011},
+									pos:   position{line: 440, col: 37, offset: 12918},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 449, col: 41, offset: 13015},
+										pos:  position{line: 440, col: 41, offset: 12922},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 449, col: 49, offset: 13023},
+									pos:   position{line: 440, col: 49, offset: 12930},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 449, col: 57, offset: 13031},
+										pos: position{line: 440, col: 57, offset: 12938},
 										expr: &seqExpr{
-											pos: position{line: 449, col: 58, offset: 13032},
+											pos: position{line: 440, col: 58, offset: 12939},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 449, col: 58, offset: 13032},
+													pos:  position{line: 440, col: 58, offset: 12939},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 449, col: 60, offset: 13034},
+													pos:  position{line: 440, col: 60, offset: 12941},
 													name: "FlexAssignments",
 												},
 											},
@@ -3368,69 +3327,69 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 457, col: 1, offset: 13288},
+			pos:  position{line: 448, col: 1, offset: 13195},
 			expr: &choiceExpr{
-				pos: position{line: 458, col: 5, offset: 13302},
+				pos: position{line: 449, col: 5, offset: 13209},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 458, col: 5, offset: 13302},
+						pos: position{line: 449, col: 5, offset: 13209},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 458, col: 5, offset: 13302},
+							pos: position{line: 449, col: 5, offset: 13209},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 458, col: 5, offset: 13302},
+									pos:        position{line: 449, col: 5, offset: 13209},
 									val:        "inner",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 458, col: 14, offset: 13311},
+									pos:  position{line: 449, col: 14, offset: 13218},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 459, col: 5, offset: 13341},
+						pos: position{line: 450, col: 5, offset: 13248},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 459, col: 5, offset: 13341},
+							pos: position{line: 450, col: 5, offset: 13248},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 459, col: 5, offset: 13341},
+									pos:        position{line: 450, col: 5, offset: 13248},
 									val:        "left",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 459, col: 14, offset: 13350},
+									pos:  position{line: 450, col: 14, offset: 13257},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 460, col: 5, offset: 13379},
+						pos: position{line: 451, col: 5, offset: 13286},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 460, col: 5, offset: 13379},
+							pos: position{line: 451, col: 5, offset: 13286},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 460, col: 5, offset: 13379},
+									pos:        position{line: 451, col: 5, offset: 13286},
 									val:        "right",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 460, col: 14, offset: 13388},
+									pos:  position{line: 451, col: 14, offset: 13295},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 461, col: 5, offset: 13418},
+						pos: position{line: 452, col: 5, offset: 13325},
 						run: (*parser).callonJoinStyle14,
 						expr: &litMatcher{
-							pos:        position{line: 461, col: 5, offset: 13418},
+							pos:        position{line: 452, col: 5, offset: 13325},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3440,35 +3399,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 463, col: 1, offset: 13454},
+			pos:  position{line: 454, col: 1, offset: 13361},
 			expr: &choiceExpr{
-				pos: position{line: 464, col: 5, offset: 13466},
+				pos: position{line: 455, col: 5, offset: 13373},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 464, col: 5, offset: 13466},
+						pos:  position{line: 455, col: 5, offset: 13373},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 465, col: 5, offset: 13475},
+						pos: position{line: 456, col: 5, offset: 13382},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 465, col: 5, offset: 13475},
+							pos: position{line: 456, col: 5, offset: 13382},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 465, col: 5, offset: 13475},
+									pos:        position{line: 456, col: 5, offset: 13382},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 465, col: 9, offset: 13479},
+									pos:   position{line: 456, col: 9, offset: 13386},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 465, col: 14, offset: 13484},
+										pos:  position{line: 456, col: 14, offset: 13391},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 465, col: 19, offset: 13489},
+									pos:        position{line: 456, col: 19, offset: 13396},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3480,23 +3439,23 @@ var g = &grammar{
 		},
 		{
 			name: "SampleProc",
-			pos:  position{line: 467, col: 1, offset: 13515},
+			pos:  position{line: 458, col: 1, offset: 13422},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 5, offset: 13530},
+				pos: position{line: 459, col: 5, offset: 13437},
 				run: (*parser).callonSampleProc1,
 				expr: &seqExpr{
-					pos: position{line: 468, col: 5, offset: 13530},
+					pos: position{line: 459, col: 5, offset: 13437},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 468, col: 5, offset: 13530},
+							pos:        position{line: 459, col: 5, offset: 13437},
 							val:        "sample",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 15, offset: 13540},
+							pos:   position{line: 459, col: 15, offset: 13447},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 17, offset: 13542},
+								pos:  position{line: 459, col: 17, offset: 13449},
 								name: "SampleExpr",
 							},
 						},
@@ -3506,25 +3465,25 @@ var g = &grammar{
 		},
 		{
 			name: "SampleExpr",
-			pos:  position{line: 505, col: 1, offset: 14837},
+			pos:  position{line: 496, col: 1, offset: 14744},
 			expr: &choiceExpr{
-				pos: position{line: 506, col: 5, offset: 14852},
+				pos: position{line: 497, col: 5, offset: 14759},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 506, col: 5, offset: 14852},
+						pos: position{line: 497, col: 5, offset: 14759},
 						run: (*parser).callonSampleExpr2,
 						expr: &seqExpr{
-							pos: position{line: 506, col: 5, offset: 14852},
+							pos: position{line: 497, col: 5, offset: 14759},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 506, col: 5, offset: 14852},
+									pos:  position{line: 497, col: 5, offset: 14759},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 506, col: 7, offset: 14854},
+									pos:   position{line: 497, col: 7, offset: 14761},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 506, col: 12, offset: 14859},
+										pos:  position{line: 497, col: 12, offset: 14766},
 										name: "Lval",
 									},
 								},
@@ -3532,10 +3491,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 507, col: 5, offset: 14888},
+						pos: position{line: 498, col: 5, offset: 14795},
 						run: (*parser).callonSampleExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 507, col: 5, offset: 14888},
+							pos:        position{line: 498, col: 5, offset: 14795},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3545,15 +3504,15 @@ var g = &grammar{
 		},
 		{
 			name: "FromProc",
-			pos:  position{line: 509, col: 1, offset: 14946},
+			pos:  position{line: 500, col: 1, offset: 14853},
 			expr: &actionExpr{
-				pos: position{line: 510, col: 5, offset: 14959},
+				pos: position{line: 501, col: 5, offset: 14866},
 				run: (*parser).callonFromProc1,
 				expr: &labeledExpr{
-					pos:   position{line: 510, col: 5, offset: 14959},
+					pos:   position{line: 501, col: 5, offset: 14866},
 					label: "source",
 					expr: &ruleRefExpr{
-						pos:  position{line: 510, col: 12, offset: 14966},
+						pos:  position{line: 501, col: 12, offset: 14873},
 						name: "FromAny",
 					},
 				},
@@ -3561,20 +3520,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromAny",
-			pos:  position{line: 514, col: 1, offset: 15122},
+			pos:  position{line: 505, col: 1, offset: 15029},
 			expr: &choiceExpr{
-				pos: position{line: 515, col: 5, offset: 15134},
+				pos: position{line: 506, col: 5, offset: 15041},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 515, col: 5, offset: 15134},
+						pos:  position{line: 506, col: 5, offset: 15041},
 						name: "FileProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 516, col: 5, offset: 15147},
+						pos:  position{line: 507, col: 5, offset: 15054},
 						name: "HTTPProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 517, col: 5, offset: 15160},
+						pos:  position{line: 508, col: 5, offset: 15067},
 						name: "PoolProc",
 					},
 				},
@@ -3582,43 +3541,43 @@ var g = &grammar{
 		},
 		{
 			name: "FileProc",
-			pos:  position{line: 519, col: 1, offset: 15170},
+			pos:  position{line: 510, col: 1, offset: 15077},
 			expr: &actionExpr{
-				pos: position{line: 520, col: 5, offset: 15183},
+				pos: position{line: 511, col: 5, offset: 15090},
 				run: (*parser).callonFileProc1,
 				expr: &seqExpr{
-					pos: position{line: 520, col: 5, offset: 15183},
+					pos: position{line: 511, col: 5, offset: 15090},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 520, col: 5, offset: 15183},
+							pos:        position{line: 511, col: 5, offset: 15090},
 							val:        "file",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 520, col: 13, offset: 15191},
+							pos:  position{line: 511, col: 13, offset: 15098},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 520, col: 15, offset: 15193},
+							pos:   position{line: 511, col: 15, offset: 15100},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 20, offset: 15198},
+								pos:  position{line: 511, col: 20, offset: 15105},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 520, col: 25, offset: 15203},
+							pos:   position{line: 511, col: 25, offset: 15110},
 							label: "format",
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 32, offset: 15210},
+								pos:  position{line: 511, col: 32, offset: 15117},
 								name: "FormatArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 520, col: 42, offset: 15220},
+							pos:   position{line: 511, col: 42, offset: 15127},
 							label: "layout",
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 49, offset: 15227},
+								pos:  position{line: 511, col: 49, offset: 15134},
 								name: "LayoutArg",
 							},
 						},
@@ -3628,27 +3587,27 @@ var g = &grammar{
 		},
 		{
 			name: "PoolProc",
-			pos:  position{line: 524, col: 1, offset: 15355},
+			pos:  position{line: 515, col: 1, offset: 15262},
 			expr: &actionExpr{
-				pos: position{line: 525, col: 5, offset: 15368},
+				pos: position{line: 516, col: 5, offset: 15275},
 				run: (*parser).callonPoolProc1,
 				expr: &seqExpr{
-					pos: position{line: 525, col: 5, offset: 15368},
+					pos: position{line: 516, col: 5, offset: 15275},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 525, col: 5, offset: 15368},
+							pos:        position{line: 516, col: 5, offset: 15275},
 							val:        "from",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 525, col: 13, offset: 15376},
+							pos:  position{line: 516, col: 13, offset: 15283},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 15, offset: 15378},
+							pos:   position{line: 516, col: 15, offset: 15285},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 20, offset: 15383},
+								pos:  position{line: 516, col: 20, offset: 15290},
 								name: "PoolBody",
 							},
 						},
@@ -3658,42 +3617,42 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBody",
-			pos:  position{line: 527, col: 1, offset: 15414},
+			pos:  position{line: 518, col: 1, offset: 15321},
 			expr: &actionExpr{
-				pos: position{line: 528, col: 5, offset: 15427},
+				pos: position{line: 519, col: 5, offset: 15334},
 				run: (*parser).callonPoolBody1,
 				expr: &seqExpr{
-					pos: position{line: 528, col: 5, offset: 15427},
+					pos: position{line: 519, col: 5, offset: 15334},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 528, col: 5, offset: 15427},
+							pos:   position{line: 519, col: 5, offset: 15334},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 10, offset: 15432},
+								pos:  position{line: 519, col: 10, offset: 15339},
 								name: "PoolName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 19, offset: 15441},
+							pos:   position{line: 519, col: 19, offset: 15348},
 							label: "at",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 22, offset: 15444},
+								pos:  position{line: 519, col: 22, offset: 15351},
 								name: "PoolAt",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 29, offset: 15451},
+							pos:   position{line: 519, col: 29, offset: 15358},
 							label: "over",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 34, offset: 15456},
+								pos:  position{line: 519, col: 34, offset: 15363},
 								name: "PoolRange",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 44, offset: 15466},
+							pos:   position{line: 519, col: 44, offset: 15373},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 50, offset: 15472},
+								pos:  position{line: 519, col: 50, offset: 15379},
 								name: "OrderArg",
 							},
 						},
@@ -3703,43 +3662,43 @@ var g = &grammar{
 		},
 		{
 			name: "HTTPProc",
-			pos:  position{line: 532, col: 1, offset: 15607},
+			pos:  position{line: 523, col: 1, offset: 15514},
 			expr: &actionExpr{
-				pos: position{line: 533, col: 5, offset: 15620},
+				pos: position{line: 524, col: 5, offset: 15527},
 				run: (*parser).callonHTTPProc1,
 				expr: &seqExpr{
-					pos: position{line: 533, col: 5, offset: 15620},
+					pos: position{line: 524, col: 5, offset: 15527},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 533, col: 5, offset: 15620},
+							pos:        position{line: 524, col: 5, offset: 15527},
 							val:        "get",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 533, col: 12, offset: 15627},
+							pos:  position{line: 524, col: 12, offset: 15534},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 533, col: 14, offset: 15629},
+							pos:   position{line: 524, col: 14, offset: 15536},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 533, col: 18, offset: 15633},
+								pos:  position{line: 524, col: 18, offset: 15540},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 533, col: 22, offset: 15637},
+							pos:   position{line: 524, col: 22, offset: 15544},
 							label: "format",
 							expr: &ruleRefExpr{
-								pos:  position{line: 533, col: 29, offset: 15644},
+								pos:  position{line: 524, col: 29, offset: 15551},
 								name: "FormatArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 533, col: 39, offset: 15654},
+							pos:   position{line: 524, col: 39, offset: 15561},
 							label: "layout",
 							expr: &ruleRefExpr{
-								pos:  position{line: 533, col: 46, offset: 15661},
+								pos:  position{line: 524, col: 46, offset: 15568},
 								name: "LayoutArg",
 							},
 						},
@@ -3749,30 +3708,30 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 537, col: 1, offset: 15786},
+			pos:  position{line: 528, col: 1, offset: 15693},
 			expr: &actionExpr{
-				pos: position{line: 537, col: 7, offset: 15792},
+				pos: position{line: 528, col: 7, offset: 15699},
 				run: (*parser).callonURL1,
 				expr: &seqExpr{
-					pos: position{line: 537, col: 7, offset: 15792},
+					pos: position{line: 528, col: 7, offset: 15699},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 537, col: 8, offset: 15793},
+							pos: position{line: 528, col: 8, offset: 15700},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 537, col: 8, offset: 15793},
+									pos:        position{line: 528, col: 8, offset: 15700},
 									val:        "http:",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 537, col: 18, offset: 15803},
+									pos:        position{line: 528, col: 18, offset: 15710},
 									val:        "https:",
 									ignoreCase: false,
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 537, col: 28, offset: 15813},
+							pos:  position{line: 528, col: 28, offset: 15720},
 							name: "Path",
 						},
 					},
@@ -3781,46 +3740,34 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 539, col: 1, offset: 15850},
+			pos:  position{line: 530, col: 1, offset: 15757},
 			expr: &choiceExpr{
-				pos: position{line: 540, col: 5, offset: 15859},
+				pos: position{line: 531, col: 5, offset: 15766},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 540, col: 5, offset: 15859},
+						pos: position{line: 531, col: 5, offset: 15766},
 						run: (*parser).callonPath2,
 						expr: &labeledExpr{
-							pos:   position{line: 540, col: 5, offset: 15859},
+							pos:   position{line: 531, col: 5, offset: 15766},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 540, col: 7, offset: 15861},
+								pos:  position{line: 531, col: 7, offset: 15768},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 15896},
+						pos: position{line: 532, col: 5, offset: 15803},
 						run: (*parser).callonPath5,
-						expr: &seqExpr{
-							pos: position{line: 541, col: 5, offset: 15896},
-							exprs: []interface{}{
-								&oneOrMoreExpr{
-									pos: position{line: 541, col: 5, offset: 15896},
-									expr: &charClassMatcher{
-										pos:        position{line: 541, col: 5, offset: 15896},
-										val:        "[0-9a-zA-Z!@$%^&*()_=<>,./?;:[\\]{}~|+-]",
-										chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '(', ')', '_', '=', '<', '>', ',', '.', '/', '?', ';', ':', '[', ']', '{', '}', '~', '|', '+', '-'},
-										ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
-										ignoreCase: false,
-										inverted:   false,
-									},
-								},
-								&andExpr{
-									pos: position{line: 541, col: 46, offset: 15937},
-									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 47, offset: 15938},
-										name: "EOT",
-									},
-								},
+						expr: &oneOrMoreExpr{
+							pos: position{line: 532, col: 5, offset: 15803},
+							expr: &charClassMatcher{
+								pos:        position{line: 532, col: 5, offset: 15803},
+								val:        "[0-9a-zA-Z!@$%^&*()_=<>,./?:[\\]{}~|+-]",
+								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '(', ')', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '|', '+', '-'},
+								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
+								ignoreCase: false,
+								inverted:   false,
 							},
 						},
 					},
@@ -3829,34 +3776,34 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 543, col: 1, offset: 15974},
+			pos:  position{line: 534, col: 1, offset: 15875},
 			expr: &choiceExpr{
-				pos: position{line: 544, col: 5, offset: 15985},
+				pos: position{line: 535, col: 5, offset: 15886},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 544, col: 5, offset: 15985},
+						pos: position{line: 535, col: 5, offset: 15886},
 						run: (*parser).callonPoolAt2,
 						expr: &seqExpr{
-							pos: position{line: 544, col: 5, offset: 15985},
+							pos: position{line: 535, col: 5, offset: 15886},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 544, col: 5, offset: 15985},
+									pos:  position{line: 535, col: 5, offset: 15886},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 544, col: 7, offset: 15987},
+									pos:        position{line: 535, col: 7, offset: 15888},
 									val:        "at",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 544, col: 13, offset: 15993},
+									pos:  position{line: 535, col: 13, offset: 15894},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 544, col: 15, offset: 15995},
+									pos:   position{line: 535, col: 15, offset: 15896},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 544, col: 18, offset: 15998},
+										pos:  position{line: 535, col: 18, offset: 15899},
 										name: "KSUID",
 									},
 								},
@@ -3864,10 +3811,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 545, col: 5, offset: 16027},
+						pos: position{line: 536, col: 5, offset: 15928},
 						run: (*parser).callonPoolAt9,
 						expr: &litMatcher{
-							pos:        position{line: 545, col: 5, offset: 16027},
+							pos:        position{line: 536, col: 5, offset: 15928},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3877,14 +3824,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 547, col: 1, offset: 16051},
+			pos:  position{line: 538, col: 1, offset: 15952},
 			expr: &actionExpr{
-				pos: position{line: 547, col: 9, offset: 16059},
+				pos: position{line: 538, col: 9, offset: 15960},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 547, col: 9, offset: 16059},
+					pos: position{line: 538, col: 9, offset: 15960},
 					expr: &charClassMatcher{
-						pos:        position{line: 547, col: 10, offset: 16060},
+						pos:        position{line: 538, col: 10, offset: 15961},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -3895,55 +3842,55 @@ var g = &grammar{
 		},
 		{
 			name: "PoolRange",
-			pos:  position{line: 549, col: 1, offset: 16106},
+			pos:  position{line: 540, col: 1, offset: 16007},
 			expr: &choiceExpr{
-				pos: position{line: 550, col: 5, offset: 16120},
+				pos: position{line: 541, col: 5, offset: 16021},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 550, col: 5, offset: 16120},
+						pos: position{line: 541, col: 5, offset: 16021},
 						run: (*parser).callonPoolRange2,
 						expr: &seqExpr{
-							pos: position{line: 550, col: 5, offset: 16120},
+							pos: position{line: 541, col: 5, offset: 16021},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 5, offset: 16120},
+									pos:  position{line: 541, col: 5, offset: 16021},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 550, col: 7, offset: 16122},
+									pos:        position{line: 541, col: 7, offset: 16023},
 									val:        "over",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 15, offset: 16130},
+									pos:  position{line: 541, col: 15, offset: 16031},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 17, offset: 16132},
+									pos:   position{line: 541, col: 17, offset: 16033},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 23, offset: 16138},
+										pos:  position{line: 541, col: 23, offset: 16039},
 										name: "Literal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 31, offset: 16146},
+									pos:  position{line: 541, col: 31, offset: 16047},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 550, col: 33, offset: 16148},
+									pos:        position{line: 541, col: 33, offset: 16049},
 									val:        "to",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 39, offset: 16154},
+									pos:  position{line: 541, col: 39, offset: 16055},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 41, offset: 16156},
+									pos:   position{line: 541, col: 41, offset: 16057},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 47, offset: 16162},
+										pos:  position{line: 541, col: 47, offset: 16063},
 										name: "Literal",
 									},
 								},
@@ -3951,10 +3898,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 553, col: 5, offset: 16270},
+						pos: position{line: 544, col: 5, offset: 16171},
 						run: (*parser).callonPoolRange14,
 						expr: &litMatcher{
-							pos:        position{line: 553, col: 5, offset: 16270},
+							pos:        position{line: 544, col: 5, offset: 16171},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3964,34 +3911,34 @@ var g = &grammar{
 		},
 		{
 			name: "PoolTo",
-			pos:  position{line: 555, col: 1, offset: 16294},
+			pos:  position{line: 546, col: 1, offset: 16195},
 			expr: &choiceExpr{
-				pos: position{line: 556, col: 5, offset: 16305},
+				pos: position{line: 547, col: 5, offset: 16206},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 556, col: 5, offset: 16305},
+						pos: position{line: 547, col: 5, offset: 16206},
 						run: (*parser).callonPoolTo2,
 						expr: &seqExpr{
-							pos: position{line: 556, col: 5, offset: 16305},
+							pos: position{line: 547, col: 5, offset: 16206},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 556, col: 5, offset: 16305},
+									pos:  position{line: 547, col: 5, offset: 16206},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 556, col: 7, offset: 16307},
+									pos:        position{line: 547, col: 7, offset: 16208},
 									val:        "to",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 556, col: 13, offset: 16313},
+									pos:  position{line: 547, col: 13, offset: 16214},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 556, col: 15, offset: 16315},
+									pos:   position{line: 547, col: 15, offset: 16216},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 556, col: 19, offset: 16319},
+										pos:  position{line: 547, col: 19, offset: 16220},
 										name: "Literal",
 									},
 								},
@@ -3999,10 +3946,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 557, col: 5, offset: 16351},
+						pos: position{line: 548, col: 5, offset: 16252},
 						run: (*parser).callonPoolTo9,
 						expr: &litMatcher{
-							pos:        position{line: 557, col: 5, offset: 16351},
+							pos:        position{line: 548, col: 5, offset: 16252},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4012,42 +3959,42 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 559, col: 1, offset: 16375},
+			pos:  position{line: 550, col: 1, offset: 16276},
 			expr: &choiceExpr{
-				pos: position{line: 560, col: 5, offset: 16388},
+				pos: position{line: 551, col: 5, offset: 16289},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 560, col: 5, offset: 16388},
+						pos: position{line: 551, col: 5, offset: 16289},
 						run: (*parser).callonPoolName2,
 						expr: &labeledExpr{
-							pos:   position{line: 560, col: 5, offset: 16388},
+							pos:   position{line: 551, col: 5, offset: 16289},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 560, col: 10, offset: 16393},
+								pos:  position{line: 551, col: 10, offset: 16294},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 561, col: 5, offset: 16433},
+						pos: position{line: 552, col: 5, offset: 16334},
 						run: (*parser).callonPoolName5,
 						expr: &labeledExpr{
-							pos:   position{line: 561, col: 5, offset: 16433},
+							pos:   position{line: 552, col: 5, offset: 16334},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 8, offset: 16436},
+								pos:  position{line: 552, col: 8, offset: 16337},
 								name: "KSUID",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 562, col: 5, offset: 16465},
+						pos: position{line: 553, col: 5, offset: 16366},
 						run: (*parser).callonPoolName8,
 						expr: &labeledExpr{
-							pos:   position{line: 562, col: 5, offset: 16465},
+							pos:   position{line: 553, col: 5, offset: 16366},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 7, offset: 16467},
+								pos:  position{line: 553, col: 7, offset: 16368},
 								name: "QuotedString",
 							},
 						},
@@ -4057,42 +4004,42 @@ var g = &grammar{
 		},
 		{
 			name: "LayoutArg",
-			pos:  position{line: 564, col: 1, offset: 16499},
+			pos:  position{line: 555, col: 1, offset: 16400},
 			expr: &choiceExpr{
-				pos: position{line: 565, col: 5, offset: 16513},
+				pos: position{line: 556, col: 5, offset: 16414},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 565, col: 5, offset: 16513},
+						pos: position{line: 556, col: 5, offset: 16414},
 						run: (*parser).callonLayoutArg2,
 						expr: &seqExpr{
-							pos: position{line: 565, col: 5, offset: 16513},
+							pos: position{line: 556, col: 5, offset: 16414},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 565, col: 5, offset: 16513},
+									pos:  position{line: 556, col: 5, offset: 16414},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 565, col: 7, offset: 16515},
+									pos:        position{line: 556, col: 7, offset: 16416},
 									val:        "order",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 565, col: 16, offset: 16524},
+									pos:  position{line: 556, col: 16, offset: 16425},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 565, col: 18, offset: 16526},
+									pos:   position{line: 556, col: 18, offset: 16427},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 565, col: 23, offset: 16531},
+										pos:  position{line: 556, col: 23, offset: 16432},
 										name: "FieldExprs",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 565, col: 34, offset: 16542},
+									pos:   position{line: 556, col: 34, offset: 16443},
 									label: "order",
 									expr: &ruleRefExpr{
-										pos:  position{line: 565, col: 40, offset: 16548},
+										pos:  position{line: 556, col: 40, offset: 16449},
 										name: "OrderSuffix",
 									},
 								},
@@ -4100,10 +4047,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 568, col: 5, offset: 16661},
+						pos: position{line: 559, col: 5, offset: 16562},
 						run: (*parser).callonLayoutArg11,
 						expr: &litMatcher{
-							pos:        position{line: 568, col: 5, offset: 16661},
+							pos:        position{line: 559, col: 5, offset: 16562},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4113,34 +4060,34 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 570, col: 1, offset: 16685},
+			pos:  position{line: 561, col: 1, offset: 16586},
 			expr: &choiceExpr{
-				pos: position{line: 571, col: 5, offset: 16699},
+				pos: position{line: 562, col: 5, offset: 16600},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 571, col: 5, offset: 16699},
+						pos: position{line: 562, col: 5, offset: 16600},
 						run: (*parser).callonFormatArg2,
 						expr: &seqExpr{
-							pos: position{line: 571, col: 5, offset: 16699},
+							pos: position{line: 562, col: 5, offset: 16600},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 571, col: 5, offset: 16699},
+									pos:  position{line: 562, col: 5, offset: 16600},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 571, col: 7, offset: 16701},
+									pos:        position{line: 562, col: 7, offset: 16602},
 									val:        "format",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 571, col: 17, offset: 16711},
+									pos:  position{line: 562, col: 17, offset: 16612},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 571, col: 19, offset: 16713},
+									pos:   position{line: 562, col: 19, offset: 16614},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 571, col: 23, offset: 16717},
+										pos:  position{line: 562, col: 23, offset: 16618},
 										name: "IdentifierName",
 									},
 								},
@@ -4148,10 +4095,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 572, col: 5, offset: 16756},
+						pos: position{line: 563, col: 5, offset: 16657},
 						run: (*parser).callonFormatArg9,
 						expr: &litMatcher{
-							pos:        position{line: 572, col: 5, offset: 16756},
+							pos:        position{line: 563, col: 5, offset: 16657},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4161,33 +4108,33 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 574, col: 1, offset: 16779},
+			pos:  position{line: 565, col: 1, offset: 16680},
 			expr: &choiceExpr{
-				pos: position{line: 575, col: 5, offset: 16795},
+				pos: position{line: 566, col: 5, offset: 16696},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 575, col: 5, offset: 16795},
+						pos: position{line: 566, col: 5, offset: 16696},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 575, col: 5, offset: 16795},
+							pos:        position{line: 566, col: 5, offset: 16696},
 							val:        ":asc",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 576, col: 5, offset: 16830},
+						pos: position{line: 567, col: 5, offset: 16731},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 576, col: 5, offset: 16830},
+							pos:        position{line: 567, col: 5, offset: 16731},
 							val:        ":desc",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 577, col: 5, offset: 16867},
+						pos: position{line: 568, col: 5, offset: 16768},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 577, col: 5, offset: 16867},
+							pos:        position{line: 568, col: 5, offset: 16768},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4197,31 +4144,31 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 579, col: 1, offset: 16893},
+			pos:  position{line: 570, col: 1, offset: 16794},
 			expr: &choiceExpr{
-				pos: position{line: 580, col: 5, offset: 16906},
+				pos: position{line: 571, col: 5, offset: 16807},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 580, col: 5, offset: 16906},
+						pos: position{line: 571, col: 5, offset: 16807},
 						run: (*parser).callonOrderArg2,
 						expr: &seqExpr{
-							pos: position{line: 580, col: 5, offset: 16906},
+							pos: position{line: 571, col: 5, offset: 16807},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 580, col: 5, offset: 16906},
+									pos:  position{line: 571, col: 5, offset: 16807},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 580, col: 7, offset: 16908},
+									pos:        position{line: 571, col: 7, offset: 16809},
 									val:        "order",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 580, col: 16, offset: 16917},
+									pos:  position{line: 571, col: 16, offset: 16818},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 580, col: 18, offset: 16919},
+									pos:        position{line: 571, col: 18, offset: 16820},
 									val:        "asc",
 									ignoreCase: true,
 								},
@@ -4229,26 +4176,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 581, col: 5, offset: 16953},
+						pos: position{line: 572, col: 5, offset: 16854},
 						run: (*parser).callonOrderArg8,
 						expr: &seqExpr{
-							pos: position{line: 581, col: 5, offset: 16953},
+							pos: position{line: 572, col: 5, offset: 16854},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 581, col: 5, offset: 16953},
+									pos:  position{line: 572, col: 5, offset: 16854},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 581, col: 7, offset: 16955},
+									pos:        position{line: 572, col: 7, offset: 16856},
 									val:        "order",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 581, col: 16, offset: 16964},
+									pos:  position{line: 572, col: 16, offset: 16865},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 581, col: 18, offset: 16966},
+									pos:        position{line: 572, col: 18, offset: 16867},
 									val:        "desc",
 									ignoreCase: true,
 								},
@@ -4256,10 +4203,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 582, col: 5, offset: 17002},
+						pos: position{line: 573, col: 5, offset: 16903},
 						run: (*parser).callonOrderArg14,
 						expr: &litMatcher{
-							pos:        position{line: 582, col: 5, offset: 17002},
+							pos:        position{line: 573, col: 5, offset: 16903},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4269,12 +4216,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassProc",
-			pos:  position{line: 584, col: 1, offset: 17025},
+			pos:  position{line: 575, col: 1, offset: 16926},
 			expr: &actionExpr{
-				pos: position{line: 585, col: 5, offset: 17038},
+				pos: position{line: 576, col: 5, offset: 16939},
 				run: (*parser).callonPassProc1,
 				expr: &litMatcher{
-					pos:        position{line: 585, col: 5, offset: 17038},
+					pos:        position{line: 576, col: 5, offset: 16939},
 					val:        "pass",
 					ignoreCase: true,
 				},
@@ -4282,43 +4229,43 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeProc",
-			pos:  position{line: 591, col: 1, offset: 17233},
+			pos:  position{line: 582, col: 1, offset: 17134},
 			expr: &actionExpr{
-				pos: position{line: 592, col: 5, offset: 17249},
+				pos: position{line: 583, col: 5, offset: 17150},
 				run: (*parser).callonExplodeProc1,
 				expr: &seqExpr{
-					pos: position{line: 592, col: 5, offset: 17249},
+					pos: position{line: 583, col: 5, offset: 17150},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 592, col: 5, offset: 17249},
+							pos:        position{line: 583, col: 5, offset: 17150},
 							val:        "explode",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 16, offset: 17260},
+							pos:  position{line: 583, col: 16, offset: 17161},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 592, col: 18, offset: 17262},
+							pos:   position{line: 583, col: 18, offset: 17163},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 592, col: 23, offset: 17267},
+								pos:  position{line: 583, col: 23, offset: 17168},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 592, col: 29, offset: 17273},
+							pos:   position{line: 583, col: 29, offset: 17174},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 592, col: 33, offset: 17277},
+								pos:  position{line: 583, col: 33, offset: 17178},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 592, col: 41, offset: 17285},
+							pos:   position{line: 583, col: 41, offset: 17186},
 							label: "as",
 							expr: &ruleRefExpr{
-								pos:  position{line: 592, col: 44, offset: 17288},
+								pos:  position{line: 583, col: 44, offset: 17189},
 								name: "AsArg",
 							},
 						},
@@ -4328,30 +4275,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 596, col: 1, offset: 17399},
+			pos:  position{line: 587, col: 1, offset: 17300},
 			expr: &actionExpr{
-				pos: position{line: 597, col: 5, offset: 17411},
+				pos: position{line: 588, col: 5, offset: 17312},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 597, col: 5, offset: 17411},
+					pos: position{line: 588, col: 5, offset: 17312},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 597, col: 5, offset: 17411},
+							pos:  position{line: 588, col: 5, offset: 17312},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 597, col: 7, offset: 17413},
+							pos:  position{line: 588, col: 7, offset: 17314},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 597, col: 10, offset: 17416},
+							pos:  position{line: 588, col: 10, offset: 17317},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 597, col: 12, offset: 17418},
+							pos:   position{line: 588, col: 12, offset: 17319},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 597, col: 16, offset: 17422},
+								pos:  position{line: 588, col: 16, offset: 17323},
 								name: "Type",
 							},
 						},
@@ -4361,33 +4308,33 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 599, col: 1, offset: 17447},
+			pos:  position{line: 590, col: 1, offset: 17348},
 			expr: &choiceExpr{
-				pos: position{line: 600, col: 5, offset: 17457},
+				pos: position{line: 591, col: 5, offset: 17358},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 600, col: 5, offset: 17457},
+						pos: position{line: 591, col: 5, offset: 17358},
 						run: (*parser).callonAsArg2,
 						expr: &seqExpr{
-							pos: position{line: 600, col: 5, offset: 17457},
+							pos: position{line: 591, col: 5, offset: 17358},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 600, col: 5, offset: 17457},
+									pos:  position{line: 591, col: 5, offset: 17358},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 600, col: 7, offset: 17459},
+									pos:  position{line: 591, col: 7, offset: 17360},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 600, col: 10, offset: 17462},
+									pos:  position{line: 591, col: 10, offset: 17363},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 600, col: 12, offset: 17464},
+									pos:   position{line: 591, col: 12, offset: 17365},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 600, col: 16, offset: 17468},
+										pos:  position{line: 591, col: 16, offset: 17369},
 										name: "Lval",
 									},
 								},
@@ -4395,10 +4342,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 601, col: 5, offset: 17497},
+						pos: position{line: 592, col: 5, offset: 17398},
 						run: (*parser).callonAsArg9,
 						expr: &litMatcher{
-							pos:        position{line: 601, col: 5, offset: 17497},
+							pos:        position{line: 592, col: 5, offset: 17398},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4408,58 +4355,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 605, col: 1, offset: 17545},
+			pos:  position{line: 596, col: 1, offset: 17446},
 			expr: &ruleRefExpr{
-				pos:  position{line: 605, col: 8, offset: 17552},
+				pos:  position{line: 596, col: 8, offset: 17453},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 607, col: 1, offset: 17563},
+			pos:  position{line: 598, col: 1, offset: 17464},
 			expr: &actionExpr{
-				pos: position{line: 608, col: 5, offset: 17573},
+				pos: position{line: 599, col: 5, offset: 17474},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 608, col: 5, offset: 17573},
+					pos: position{line: 599, col: 5, offset: 17474},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 608, col: 5, offset: 17573},
+							pos:   position{line: 599, col: 5, offset: 17474},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 608, col: 11, offset: 17579},
+								pos:  position{line: 599, col: 11, offset: 17480},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 608, col: 16, offset: 17584},
+							pos:   position{line: 599, col: 16, offset: 17485},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 608, col: 21, offset: 17589},
+								pos: position{line: 599, col: 21, offset: 17490},
 								expr: &actionExpr{
-									pos: position{line: 608, col: 22, offset: 17590},
+									pos: position{line: 599, col: 22, offset: 17491},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 608, col: 22, offset: 17590},
+										pos: position{line: 599, col: 22, offset: 17491},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 608, col: 22, offset: 17590},
+												pos:  position{line: 599, col: 22, offset: 17491},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 608, col: 25, offset: 17593},
+												pos:        position{line: 599, col: 25, offset: 17494},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 608, col: 29, offset: 17597},
+												pos:  position{line: 599, col: 29, offset: 17498},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 608, col: 32, offset: 17600},
+												pos:   position{line: 599, col: 32, offset: 17501},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 608, col: 37, offset: 17605},
+													pos:  position{line: 599, col: 37, offset: 17506},
 													name: "Lval",
 												},
 											},
@@ -4474,52 +4421,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 612, col: 1, offset: 17717},
+			pos:  position{line: 603, col: 1, offset: 17618},
 			expr: &ruleRefExpr{
-				pos:  position{line: 612, col: 13, offset: 17729},
+				pos:  position{line: 603, col: 13, offset: 17630},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 614, col: 1, offset: 17735},
+			pos:  position{line: 605, col: 1, offset: 17636},
 			expr: &actionExpr{
-				pos: position{line: 615, col: 5, offset: 17750},
+				pos: position{line: 606, col: 5, offset: 17651},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 615, col: 5, offset: 17750},
+					pos: position{line: 606, col: 5, offset: 17651},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 615, col: 5, offset: 17750},
+							pos:   position{line: 606, col: 5, offset: 17651},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 615, col: 11, offset: 17756},
+								pos:  position{line: 606, col: 11, offset: 17657},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 615, col: 21, offset: 17766},
+							pos:   position{line: 606, col: 21, offset: 17667},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 615, col: 26, offset: 17771},
+								pos: position{line: 606, col: 26, offset: 17672},
 								expr: &seqExpr{
-									pos: position{line: 615, col: 27, offset: 17772},
+									pos: position{line: 606, col: 27, offset: 17673},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 615, col: 27, offset: 17772},
+											pos:  position{line: 606, col: 27, offset: 17673},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 615, col: 30, offset: 17775},
+											pos:        position{line: 606, col: 30, offset: 17676},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 615, col: 34, offset: 17779},
+											pos:  position{line: 606, col: 34, offset: 17680},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 615, col: 37, offset: 17782},
+											pos:  position{line: 606, col: 37, offset: 17683},
 											name: "FieldExpr",
 										},
 									},
@@ -4532,39 +4479,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 625, col: 1, offset: 17981},
+			pos:  position{line: 616, col: 1, offset: 17882},
 			expr: &actionExpr{
-				pos: position{line: 626, col: 5, offset: 17996},
+				pos: position{line: 617, col: 5, offset: 17897},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 626, col: 5, offset: 17996},
+					pos: position{line: 617, col: 5, offset: 17897},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 626, col: 5, offset: 17996},
+							pos:   position{line: 617, col: 5, offset: 17897},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 626, col: 9, offset: 18000},
+								pos:  position{line: 617, col: 9, offset: 17901},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 14, offset: 18005},
+							pos:  position{line: 617, col: 14, offset: 17906},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 626, col: 17, offset: 18008},
+							pos:        position{line: 617, col: 17, offset: 17909},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 22, offset: 18013},
+							pos:  position{line: 617, col: 22, offset: 17914},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 25, offset: 18016},
+							pos:   position{line: 617, col: 25, offset: 17917},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 626, col: 29, offset: 18020},
+								pos:  position{line: 617, col: 29, offset: 17921},
 								name: "Expr",
 							},
 						},
@@ -4574,71 +4521,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 628, col: 1, offset: 18111},
+			pos:  position{line: 619, col: 1, offset: 18012},
 			expr: &ruleRefExpr{
-				pos:  position{line: 628, col: 8, offset: 18118},
+				pos:  position{line: 619, col: 8, offset: 18019},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 630, col: 1, offset: 18135},
+			pos:  position{line: 621, col: 1, offset: 18036},
 			expr: &choiceExpr{
-				pos: position{line: 631, col: 5, offset: 18155},
+				pos: position{line: 622, col: 5, offset: 18056},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 631, col: 5, offset: 18155},
+						pos: position{line: 622, col: 5, offset: 18056},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 631, col: 5, offset: 18155},
+							pos: position{line: 622, col: 5, offset: 18056},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 631, col: 5, offset: 18155},
+									pos:   position{line: 622, col: 5, offset: 18056},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 631, col: 15, offset: 18165},
+										pos:  position{line: 622, col: 15, offset: 18066},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 631, col: 29, offset: 18179},
+									pos:  position{line: 622, col: 29, offset: 18080},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 631, col: 32, offset: 18182},
+									pos:        position{line: 622, col: 32, offset: 18083},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 631, col: 36, offset: 18186},
+									pos:  position{line: 622, col: 36, offset: 18087},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 631, col: 39, offset: 18189},
+									pos:   position{line: 622, col: 39, offset: 18090},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 631, col: 50, offset: 18200},
+										pos:  position{line: 622, col: 50, offset: 18101},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 631, col: 55, offset: 18205},
+									pos:  position{line: 622, col: 55, offset: 18106},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 631, col: 58, offset: 18208},
+									pos:        position{line: 622, col: 58, offset: 18109},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 631, col: 62, offset: 18212},
+									pos:  position{line: 622, col: 62, offset: 18113},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 631, col: 65, offset: 18215},
+									pos:   position{line: 622, col: 65, offset: 18116},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 631, col: 76, offset: 18226},
+										pos:  position{line: 622, col: 76, offset: 18127},
 										name: "Expr",
 									},
 								},
@@ -4646,7 +4593,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 634, col: 5, offset: 18366},
+						pos:  position{line: 625, col: 5, offset: 18267},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4654,53 +4601,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 636, col: 1, offset: 18381},
+			pos:  position{line: 627, col: 1, offset: 18282},
 			expr: &actionExpr{
-				pos: position{line: 637, col: 5, offset: 18399},
+				pos: position{line: 628, col: 5, offset: 18300},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 637, col: 5, offset: 18399},
+					pos: position{line: 628, col: 5, offset: 18300},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 637, col: 5, offset: 18399},
+							pos:   position{line: 628, col: 5, offset: 18300},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 637, col: 11, offset: 18405},
+								pos:  position{line: 628, col: 11, offset: 18306},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 638, col: 5, offset: 18424},
+							pos:   position{line: 629, col: 5, offset: 18325},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 638, col: 10, offset: 18429},
+								pos: position{line: 629, col: 10, offset: 18330},
 								expr: &actionExpr{
-									pos: position{line: 638, col: 11, offset: 18430},
+									pos: position{line: 629, col: 11, offset: 18331},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 638, col: 11, offset: 18430},
+										pos: position{line: 629, col: 11, offset: 18331},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 638, col: 11, offset: 18430},
+												pos:  position{line: 629, col: 11, offset: 18331},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 638, col: 14, offset: 18433},
+												pos:   position{line: 629, col: 14, offset: 18334},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 638, col: 17, offset: 18436},
+													pos:  position{line: 629, col: 17, offset: 18337},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 638, col: 25, offset: 18444},
+												pos:  position{line: 629, col: 25, offset: 18345},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 638, col: 28, offset: 18447},
+												pos:   position{line: 629, col: 28, offset: 18348},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 638, col: 33, offset: 18452},
+													pos:  position{line: 629, col: 33, offset: 18353},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4715,53 +4662,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 642, col: 1, offset: 18570},
+			pos:  position{line: 633, col: 1, offset: 18471},
 			expr: &actionExpr{
-				pos: position{line: 643, col: 5, offset: 18589},
+				pos: position{line: 634, col: 5, offset: 18490},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 643, col: 5, offset: 18589},
+					pos: position{line: 634, col: 5, offset: 18490},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 643, col: 5, offset: 18589},
+							pos:   position{line: 634, col: 5, offset: 18490},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 643, col: 11, offset: 18595},
+								pos:  position{line: 634, col: 11, offset: 18496},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 644, col: 5, offset: 18619},
+							pos:   position{line: 635, col: 5, offset: 18520},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 644, col: 10, offset: 18624},
+								pos: position{line: 635, col: 10, offset: 18525},
 								expr: &actionExpr{
-									pos: position{line: 644, col: 11, offset: 18625},
+									pos: position{line: 635, col: 11, offset: 18526},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 644, col: 11, offset: 18625},
+										pos: position{line: 635, col: 11, offset: 18526},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 644, col: 11, offset: 18625},
+												pos:  position{line: 635, col: 11, offset: 18526},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 644, col: 14, offset: 18628},
+												pos:   position{line: 635, col: 14, offset: 18529},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 644, col: 17, offset: 18631},
+													pos:  position{line: 635, col: 17, offset: 18532},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 644, col: 26, offset: 18640},
+												pos:  position{line: 635, col: 26, offset: 18541},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 644, col: 29, offset: 18643},
+												pos:   position{line: 635, col: 29, offset: 18544},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 644, col: 34, offset: 18648},
+													pos:  position{line: 635, col: 34, offset: 18549},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -4776,60 +4723,60 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 648, col: 1, offset: 18771},
+			pos:  position{line: 639, col: 1, offset: 18672},
 			expr: &choiceExpr{
-				pos: position{line: 649, col: 5, offset: 18795},
+				pos: position{line: 640, col: 5, offset: 18696},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 649, col: 5, offset: 18795},
+						pos:  position{line: 640, col: 5, offset: 18696},
 						name: "PatternMatch",
 					},
 					&actionExpr{
-						pos: position{line: 650, col: 5, offset: 18812},
+						pos: position{line: 641, col: 5, offset: 18713},
 						run: (*parser).callonEqualityCompareExpr3,
 						expr: &seqExpr{
-							pos: position{line: 650, col: 5, offset: 18812},
+							pos: position{line: 641, col: 5, offset: 18713},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 650, col: 5, offset: 18812},
+									pos:   position{line: 641, col: 5, offset: 18713},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 650, col: 11, offset: 18818},
+										pos:  position{line: 641, col: 11, offset: 18719},
 										name: "RelativeExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 651, col: 5, offset: 18835},
+									pos:   position{line: 642, col: 5, offset: 18736},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 651, col: 10, offset: 18840},
+										pos: position{line: 642, col: 10, offset: 18741},
 										expr: &actionExpr{
-											pos: position{line: 651, col: 11, offset: 18841},
+											pos: position{line: 642, col: 11, offset: 18742},
 											run: (*parser).callonEqualityCompareExpr9,
 											expr: &seqExpr{
-												pos: position{line: 651, col: 11, offset: 18841},
+												pos: position{line: 642, col: 11, offset: 18742},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 651, col: 11, offset: 18841},
+														pos:  position{line: 642, col: 11, offset: 18742},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 651, col: 14, offset: 18844},
+														pos:   position{line: 642, col: 14, offset: 18745},
 														label: "comp",
 														expr: &ruleRefExpr{
-															pos:  position{line: 651, col: 19, offset: 18849},
+															pos:  position{line: 642, col: 19, offset: 18750},
 															name: "EqualityComparator",
 														},
 													},
 													&ruleRefExpr{
-														pos:  position{line: 651, col: 38, offset: 18868},
+														pos:  position{line: 642, col: 38, offset: 18769},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 651, col: 41, offset: 18871},
+														pos:   position{line: 642, col: 41, offset: 18772},
 														label: "expr",
 														expr: &ruleRefExpr{
-															pos:  position{line: 651, col: 46, offset: 18876},
+															pos:  position{line: 642, col: 46, offset: 18777},
 															name: "RelativeExpr",
 														},
 													},
@@ -4846,24 +4793,24 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 655, col: 1, offset: 18994},
+			pos:  position{line: 646, col: 1, offset: 18895},
 			expr: &choiceExpr{
-				pos: position{line: 656, col: 5, offset: 19015},
+				pos: position{line: 647, col: 5, offset: 18916},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 656, col: 5, offset: 19015},
+						pos: position{line: 647, col: 5, offset: 18916},
 						run: (*parser).callonEqualityOperator2,
 						expr: &litMatcher{
-							pos:        position{line: 656, col: 5, offset: 19015},
+							pos:        position{line: 647, col: 5, offset: 18916},
 							val:        "==",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 657, col: 5, offset: 19044},
+						pos: position{line: 648, col: 5, offset: 18945},
 						run: (*parser).callonEqualityOperator4,
 						expr: &litMatcher{
-							pos:        position{line: 657, col: 5, offset: 19044},
+							pos:        position{line: 648, col: 5, offset: 18945},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -4873,19 +4820,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 659, col: 1, offset: 19081},
+			pos:  position{line: 650, col: 1, offset: 18982},
 			expr: &choiceExpr{
-				pos: position{line: 660, col: 5, offset: 19104},
+				pos: position{line: 651, col: 5, offset: 19005},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 660, col: 5, offset: 19104},
+						pos:  position{line: 651, col: 5, offset: 19005},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 661, col: 5, offset: 19125},
+						pos: position{line: 652, col: 5, offset: 19026},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 661, col: 5, offset: 19125},
+							pos:        position{line: 652, col: 5, offset: 19026},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -4895,53 +4842,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 663, col: 1, offset: 19162},
+			pos:  position{line: 654, col: 1, offset: 19063},
 			expr: &actionExpr{
-				pos: position{line: 664, col: 5, offset: 19179},
+				pos: position{line: 655, col: 5, offset: 19080},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 664, col: 5, offset: 19179},
+					pos: position{line: 655, col: 5, offset: 19080},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 664, col: 5, offset: 19179},
+							pos:   position{line: 655, col: 5, offset: 19080},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 664, col: 11, offset: 19185},
+								pos:  position{line: 655, col: 11, offset: 19086},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 665, col: 5, offset: 19202},
+							pos:   position{line: 656, col: 5, offset: 19103},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 665, col: 10, offset: 19207},
+								pos: position{line: 656, col: 10, offset: 19108},
 								expr: &actionExpr{
-									pos: position{line: 665, col: 11, offset: 19208},
+									pos: position{line: 656, col: 11, offset: 19109},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 665, col: 11, offset: 19208},
+										pos: position{line: 656, col: 11, offset: 19109},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 665, col: 11, offset: 19208},
+												pos:  position{line: 656, col: 11, offset: 19109},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 665, col: 14, offset: 19211},
+												pos:   position{line: 656, col: 14, offset: 19112},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 665, col: 17, offset: 19214},
+													pos:  position{line: 656, col: 17, offset: 19115},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 665, col: 34, offset: 19231},
+												pos:  position{line: 656, col: 34, offset: 19132},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 665, col: 37, offset: 19234},
+												pos:   position{line: 656, col: 37, offset: 19135},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 665, col: 42, offset: 19239},
+													pos:  position{line: 656, col: 42, offset: 19140},
 													name: "AdditiveExpr",
 												},
 											},
@@ -4956,30 +4903,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 669, col: 1, offset: 19355},
+			pos:  position{line: 660, col: 1, offset: 19256},
 			expr: &actionExpr{
-				pos: position{line: 669, col: 20, offset: 19374},
+				pos: position{line: 660, col: 20, offset: 19275},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 669, col: 21, offset: 19375},
+					pos: position{line: 660, col: 21, offset: 19276},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 669, col: 21, offset: 19375},
+							pos:        position{line: 660, col: 21, offset: 19276},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 669, col: 28, offset: 19382},
+							pos:        position{line: 660, col: 28, offset: 19283},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 669, col: 34, offset: 19388},
+							pos:        position{line: 660, col: 34, offset: 19289},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 669, col: 41, offset: 19395},
+							pos:        position{line: 660, col: 41, offset: 19296},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -4989,53 +4936,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 671, col: 1, offset: 19432},
+			pos:  position{line: 662, col: 1, offset: 19333},
 			expr: &actionExpr{
-				pos: position{line: 672, col: 5, offset: 19449},
+				pos: position{line: 663, col: 5, offset: 19350},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 672, col: 5, offset: 19449},
+					pos: position{line: 663, col: 5, offset: 19350},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 672, col: 5, offset: 19449},
+							pos:   position{line: 663, col: 5, offset: 19350},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 672, col: 11, offset: 19455},
+								pos:  position{line: 663, col: 11, offset: 19356},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 673, col: 5, offset: 19478},
+							pos:   position{line: 664, col: 5, offset: 19379},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 673, col: 10, offset: 19483},
+								pos: position{line: 664, col: 10, offset: 19384},
 								expr: &actionExpr{
-									pos: position{line: 673, col: 11, offset: 19484},
+									pos: position{line: 664, col: 11, offset: 19385},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 673, col: 11, offset: 19484},
+										pos: position{line: 664, col: 11, offset: 19385},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 673, col: 11, offset: 19484},
+												pos:  position{line: 664, col: 11, offset: 19385},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 673, col: 14, offset: 19487},
+												pos:   position{line: 664, col: 14, offset: 19388},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 673, col: 17, offset: 19490},
+													pos:  position{line: 664, col: 17, offset: 19391},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 673, col: 34, offset: 19507},
+												pos:  position{line: 664, col: 34, offset: 19408},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 673, col: 37, offset: 19510},
+												pos:   position{line: 664, col: 37, offset: 19411},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 673, col: 42, offset: 19515},
+													pos:  position{line: 664, col: 42, offset: 19416},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5050,20 +4997,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 677, col: 1, offset: 19637},
+			pos:  position{line: 668, col: 1, offset: 19538},
 			expr: &actionExpr{
-				pos: position{line: 677, col: 20, offset: 19656},
+				pos: position{line: 668, col: 20, offset: 19557},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 677, col: 21, offset: 19657},
+					pos: position{line: 668, col: 21, offset: 19558},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 677, col: 21, offset: 19657},
+							pos:        position{line: 668, col: 21, offset: 19558},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 677, col: 27, offset: 19663},
+							pos:        position{line: 668, col: 27, offset: 19564},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5073,53 +5020,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 679, col: 1, offset: 19700},
+			pos:  position{line: 670, col: 1, offset: 19601},
 			expr: &actionExpr{
-				pos: position{line: 680, col: 5, offset: 19723},
+				pos: position{line: 671, col: 5, offset: 19624},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 680, col: 5, offset: 19723},
+					pos: position{line: 671, col: 5, offset: 19624},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 680, col: 5, offset: 19723},
+							pos:   position{line: 671, col: 5, offset: 19624},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 680, col: 11, offset: 19729},
+								pos:  position{line: 671, col: 11, offset: 19630},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 681, col: 5, offset: 19741},
+							pos:   position{line: 672, col: 5, offset: 19642},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 681, col: 10, offset: 19746},
+								pos: position{line: 672, col: 10, offset: 19647},
 								expr: &actionExpr{
-									pos: position{line: 681, col: 11, offset: 19747},
+									pos: position{line: 672, col: 11, offset: 19648},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 681, col: 11, offset: 19747},
+										pos: position{line: 672, col: 11, offset: 19648},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 11, offset: 19747},
+												pos:  position{line: 672, col: 11, offset: 19648},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 681, col: 14, offset: 19750},
+												pos:   position{line: 672, col: 14, offset: 19651},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 681, col: 17, offset: 19753},
+													pos:  position{line: 672, col: 17, offset: 19654},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 40, offset: 19776},
+												pos:  position{line: 672, col: 40, offset: 19677},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 681, col: 43, offset: 19779},
+												pos:   position{line: 672, col: 43, offset: 19680},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 681, col: 48, offset: 19784},
+													pos:  position{line: 672, col: 48, offset: 19685},
 													name: "NotExpr",
 												},
 											},
@@ -5134,20 +5081,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 685, col: 1, offset: 19895},
+			pos:  position{line: 676, col: 1, offset: 19796},
 			expr: &actionExpr{
-				pos: position{line: 685, col: 26, offset: 19920},
+				pos: position{line: 676, col: 26, offset: 19821},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 685, col: 27, offset: 19921},
+					pos: position{line: 676, col: 27, offset: 19822},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 685, col: 27, offset: 19921},
+							pos:        position{line: 676, col: 27, offset: 19822},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 685, col: 33, offset: 19927},
+							pos:        position{line: 676, col: 33, offset: 19828},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5157,30 +5104,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 687, col: 1, offset: 19964},
+			pos:  position{line: 678, col: 1, offset: 19865},
 			expr: &choiceExpr{
-				pos: position{line: 688, col: 5, offset: 19976},
+				pos: position{line: 679, col: 5, offset: 19877},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 19976},
+						pos: position{line: 679, col: 5, offset: 19877},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 688, col: 5, offset: 19976},
+							pos: position{line: 679, col: 5, offset: 19877},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 688, col: 5, offset: 19976},
+									pos:        position{line: 679, col: 5, offset: 19877},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 688, col: 9, offset: 19980},
+									pos:  position{line: 679, col: 9, offset: 19881},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 688, col: 12, offset: 19983},
+									pos:   position{line: 679, col: 12, offset: 19884},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 688, col: 14, offset: 19985},
+										pos:  position{line: 679, col: 14, offset: 19886},
 										name: "NotExpr",
 									},
 								},
@@ -5188,7 +5135,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 691, col: 5, offset: 20094},
+						pos:  position{line: 682, col: 5, offset: 19995},
 						name: "FuncExpr",
 					},
 				},
@@ -5196,43 +5143,43 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 693, col: 1, offset: 20104},
+			pos:  position{line: 684, col: 1, offset: 20005},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 20117},
+				pos: position{line: 685, col: 5, offset: 20018},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 694, col: 5, offset: 20117},
+						pos:  position{line: 685, col: 5, offset: 20018},
 						name: "SelectExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 695, col: 5, offset: 20132},
+						pos:  position{line: 686, col: 5, offset: 20033},
 						name: "MatchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 696, col: 5, offset: 20146},
+						pos: position{line: 687, col: 5, offset: 20047},
 						run: (*parser).callonFuncExpr4,
 						expr: &seqExpr{
-							pos: position{line: 696, col: 5, offset: 20146},
+							pos: position{line: 687, col: 5, offset: 20047},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 696, col: 5, offset: 20146},
+									pos:   position{line: 687, col: 5, offset: 20047},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 696, col: 9, offset: 20150},
+										pos:  position{line: 687, col: 9, offset: 20051},
 										name: "TypeLiteral",
 									},
 								},
 								&notExpr{
-									pos: position{line: 696, col: 21, offset: 20162},
+									pos: position{line: 687, col: 21, offset: 20063},
 									expr: &seqExpr{
-										pos: position{line: 696, col: 23, offset: 20164},
+										pos: position{line: 687, col: 23, offset: 20065},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 696, col: 23, offset: 20164},
+												pos:  position{line: 687, col: 23, offset: 20065},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 696, col: 26, offset: 20167},
+												pos:        position{line: 687, col: 26, offset: 20068},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -5243,26 +5190,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 697, col: 5, offset: 20196},
+						pos: position{line: 688, col: 5, offset: 20097},
 						run: (*parser).callonFuncExpr12,
 						expr: &seqExpr{
-							pos: position{line: 697, col: 5, offset: 20196},
+							pos: position{line: 688, col: 5, offset: 20097},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 697, col: 5, offset: 20196},
+									pos:   position{line: 688, col: 5, offset: 20097},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 697, col: 11, offset: 20202},
+										pos:  position{line: 688, col: 11, offset: 20103},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 697, col: 16, offset: 20207},
+									pos:   position{line: 688, col: 16, offset: 20108},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 697, col: 21, offset: 20212},
+										pos: position{line: 688, col: 21, offset: 20113},
 										expr: &ruleRefExpr{
-											pos:  position{line: 697, col: 22, offset: 20213},
+											pos:  position{line: 688, col: 22, offset: 20114},
 											name: "Deref",
 										},
 									},
@@ -5271,26 +5218,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20284},
+						pos: position{line: 691, col: 5, offset: 20185},
 						run: (*parser).callonFuncExpr19,
 						expr: &seqExpr{
-							pos: position{line: 700, col: 5, offset: 20284},
+							pos: position{line: 691, col: 5, offset: 20185},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 700, col: 5, offset: 20284},
+									pos:   position{line: 691, col: 5, offset: 20185},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 700, col: 11, offset: 20290},
+										pos:  position{line: 691, col: 11, offset: 20191},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 700, col: 20, offset: 20299},
+									pos:   position{line: 691, col: 20, offset: 20200},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 700, col: 25, offset: 20304},
+										pos: position{line: 691, col: 25, offset: 20205},
 										expr: &ruleRefExpr{
-											pos:  position{line: 700, col: 26, offset: 20305},
+											pos:  position{line: 691, col: 26, offset: 20206},
 											name: "Deref",
 										},
 									},
@@ -5299,11 +5246,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 703, col: 5, offset: 20376},
+						pos:  position{line: 694, col: 5, offset: 20277},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 704, col: 5, offset: 20390},
+						pos:  position{line: 695, col: 5, offset: 20291},
 						name: "Primary",
 					},
 				},
@@ -5311,20 +5258,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 706, col: 1, offset: 20399},
+			pos:  position{line: 697, col: 1, offset: 20300},
 			expr: &seqExpr{
-				pos: position{line: 706, col: 13, offset: 20411},
+				pos: position{line: 697, col: 13, offset: 20312},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 706, col: 13, offset: 20411},
+						pos:  position{line: 697, col: 13, offset: 20312},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 706, col: 22, offset: 20420},
+						pos:  position{line: 697, col: 22, offset: 20321},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 706, col: 25, offset: 20423},
+						pos:        position{line: 697, col: 25, offset: 20324},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5333,27 +5280,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 708, col: 1, offset: 20428},
+			pos:  position{line: 699, col: 1, offset: 20329},
 			expr: &choiceExpr{
-				pos: position{line: 709, col: 5, offset: 20441},
+				pos: position{line: 700, col: 5, offset: 20342},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 709, col: 5, offset: 20441},
+						pos:        position{line: 700, col: 5, offset: 20342},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 710, col: 5, offset: 20451},
+						pos:        position{line: 701, col: 5, offset: 20352},
 						val:        "match",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 711, col: 5, offset: 20463},
+						pos:        position{line: 702, col: 5, offset: 20364},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 712, col: 5, offset: 20476},
+						pos:        position{line: 703, col: 5, offset: 20377},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -5362,37 +5309,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 714, col: 1, offset: 20484},
+			pos:  position{line: 705, col: 1, offset: 20385},
 			expr: &actionExpr{
-				pos: position{line: 715, col: 5, offset: 20498},
+				pos: position{line: 706, col: 5, offset: 20399},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 715, col: 5, offset: 20498},
+					pos: position{line: 706, col: 5, offset: 20399},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 715, col: 5, offset: 20498},
+							pos:        position{line: 706, col: 5, offset: 20399},
 							val:        "match",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 715, col: 13, offset: 20506},
+							pos:  position{line: 706, col: 13, offset: 20407},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 715, col: 16, offset: 20509},
+							pos:        position{line: 706, col: 16, offset: 20410},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 715, col: 20, offset: 20513},
+							pos:   position{line: 706, col: 20, offset: 20414},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 715, col: 25, offset: 20518},
+								pos:  position{line: 706, col: 25, offset: 20419},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 715, col: 39, offset: 20532},
+							pos:        position{line: 706, col: 39, offset: 20433},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5402,53 +5349,53 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 717, col: 1, offset: 20558},
+			pos:  position{line: 708, col: 1, offset: 20459},
 			expr: &actionExpr{
-				pos: position{line: 718, col: 5, offset: 20573},
+				pos: position{line: 709, col: 5, offset: 20474},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 718, col: 5, offset: 20573},
+					pos: position{line: 709, col: 5, offset: 20474},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 718, col: 5, offset: 20573},
+							pos:        position{line: 709, col: 5, offset: 20474},
 							val:        "select",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 718, col: 14, offset: 20582},
+							pos:  position{line: 709, col: 14, offset: 20483},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 718, col: 17, offset: 20585},
+							pos:        position{line: 709, col: 17, offset: 20486},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 718, col: 21, offset: 20589},
+							pos:  position{line: 709, col: 21, offset: 20490},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 718, col: 24, offset: 20592},
+							pos:   position{line: 709, col: 24, offset: 20493},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 718, col: 29, offset: 20597},
+								pos:  position{line: 709, col: 29, offset: 20498},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 718, col: 35, offset: 20603},
+							pos:  position{line: 709, col: 35, offset: 20504},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 718, col: 38, offset: 20606},
+							pos:        position{line: 709, col: 38, offset: 20507},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 718, col: 42, offset: 20610},
+							pos:   position{line: 709, col: 42, offset: 20511},
 							label: "methods",
 							expr: &ruleRefExpr{
-								pos:  position{line: 718, col: 50, offset: 20618},
+								pos:  position{line: 709, col: 50, offset: 20519},
 								name: "Methods",
 							},
 						},
@@ -5458,30 +5405,30 @@ var g = &grammar{
 		},
 		{
 			name: "Methods",
-			pos:  position{line: 726, col: 1, offset: 21016},
+			pos:  position{line: 717, col: 1, offset: 20917},
 			expr: &choiceExpr{
-				pos: position{line: 727, col: 5, offset: 21028},
+				pos: position{line: 718, col: 5, offset: 20929},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 727, col: 5, offset: 21028},
+						pos: position{line: 718, col: 5, offset: 20929},
 						run: (*parser).callonMethods2,
 						expr: &labeledExpr{
-							pos:   position{line: 727, col: 5, offset: 21028},
+							pos:   position{line: 718, col: 5, offset: 20929},
 							label: "methods",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 727, col: 13, offset: 21036},
+								pos: position{line: 718, col: 13, offset: 20937},
 								expr: &ruleRefExpr{
-									pos:  position{line: 727, col: 13, offset: 21036},
+									pos:  position{line: 718, col: 13, offset: 20937},
 									name: "Method",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 728, col: 5, offset: 21072},
+						pos: position{line: 719, col: 5, offset: 20973},
 						run: (*parser).callonMethods6,
 						expr: &litMatcher{
-							pos:        position{line: 728, col: 5, offset: 21072},
+							pos:        position{line: 719, col: 5, offset: 20973},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -5491,31 +5438,31 @@ var g = &grammar{
 		},
 		{
 			name: "Method",
-			pos:  position{line: 730, col: 1, offset: 21096},
+			pos:  position{line: 721, col: 1, offset: 20997},
 			expr: &actionExpr{
-				pos: position{line: 731, col: 5, offset: 21107},
+				pos: position{line: 722, col: 5, offset: 21008},
 				run: (*parser).callonMethod1,
 				expr: &seqExpr{
-					pos: position{line: 731, col: 5, offset: 21107},
+					pos: position{line: 722, col: 5, offset: 21008},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 731, col: 5, offset: 21107},
+							pos:  position{line: 722, col: 5, offset: 21008},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 731, col: 8, offset: 21110},
+							pos:        position{line: 722, col: 8, offset: 21011},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 731, col: 12, offset: 21114},
+							pos:  position{line: 722, col: 12, offset: 21015},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 731, col: 15, offset: 21117},
+							pos:   position{line: 722, col: 15, offset: 21018},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 731, col: 17, offset: 21119},
+								pos:  position{line: 722, col: 17, offset: 21020},
 								name: "Function",
 							},
 						},
@@ -5525,48 +5472,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 733, col: 1, offset: 21147},
+			pos:  position{line: 724, col: 1, offset: 21048},
 			expr: &actionExpr{
-				pos: position{line: 734, col: 5, offset: 21156},
+				pos: position{line: 725, col: 5, offset: 21057},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 734, col: 5, offset: 21156},
+					pos: position{line: 725, col: 5, offset: 21057},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 734, col: 5, offset: 21156},
+							pos:   position{line: 725, col: 5, offset: 21057},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 734, col: 9, offset: 21160},
+								pos:  position{line: 725, col: 9, offset: 21061},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 734, col: 18, offset: 21169},
+							pos:  position{line: 725, col: 18, offset: 21070},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 734, col: 21, offset: 21172},
+							pos:        position{line: 725, col: 21, offset: 21073},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 734, col: 25, offset: 21176},
+							pos:  position{line: 725, col: 25, offset: 21077},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 734, col: 28, offset: 21179},
+							pos:   position{line: 725, col: 28, offset: 21080},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 734, col: 33, offset: 21184},
+								pos:  position{line: 725, col: 33, offset: 21085},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 734, col: 38, offset: 21189},
+							pos:  position{line: 725, col: 38, offset: 21090},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 734, col: 41, offset: 21192},
+							pos:        position{line: 725, col: 41, offset: 21093},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5576,55 +5523,55 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 738, col: 1, offset: 21289},
+			pos:  position{line: 729, col: 1, offset: 21190},
 			expr: &actionExpr{
-				pos: position{line: 739, col: 5, offset: 21302},
+				pos: position{line: 730, col: 5, offset: 21203},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 739, col: 5, offset: 21302},
+					pos: position{line: 730, col: 5, offset: 21203},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 739, col: 5, offset: 21302},
+							pos: position{line: 730, col: 5, offset: 21203},
 							expr: &ruleRefExpr{
-								pos:  position{line: 739, col: 6, offset: 21303},
+								pos:  position{line: 730, col: 6, offset: 21204},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 739, col: 16, offset: 21313},
+							pos:   position{line: 730, col: 16, offset: 21214},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 739, col: 19, offset: 21316},
+								pos:  position{line: 730, col: 19, offset: 21217},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 739, col: 34, offset: 21331},
+							pos:  position{line: 730, col: 34, offset: 21232},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 739, col: 37, offset: 21334},
+							pos:        position{line: 730, col: 37, offset: 21235},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 739, col: 41, offset: 21338},
+							pos:  position{line: 730, col: 41, offset: 21239},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 739, col: 44, offset: 21341},
+							pos:   position{line: 730, col: 44, offset: 21242},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 739, col: 49, offset: 21346},
+								pos:  position{line: 730, col: 49, offset: 21247},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 739, col: 63, offset: 21360},
+							pos:  position{line: 730, col: 63, offset: 21261},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 739, col: 66, offset: 21363},
+							pos:        position{line: 730, col: 66, offset: 21264},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5634,19 +5581,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 743, col: 1, offset: 21459},
+			pos:  position{line: 734, col: 1, offset: 21360},
 			expr: &choiceExpr{
-				pos: position{line: 744, col: 5, offset: 21477},
+				pos: position{line: 735, col: 5, offset: 21378},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 744, col: 5, offset: 21477},
+						pos:  position{line: 735, col: 5, offset: 21378},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 745, col: 5, offset: 21487},
+						pos: position{line: 736, col: 5, offset: 21388},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 745, col: 5, offset: 21487},
+							pos:  position{line: 736, col: 5, offset: 21388},
 							name: "__",
 						},
 					},
@@ -5655,50 +5602,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 747, col: 1, offset: 21523},
+			pos:  position{line: 738, col: 1, offset: 21424},
 			expr: &actionExpr{
-				pos: position{line: 748, col: 5, offset: 21533},
+				pos: position{line: 739, col: 5, offset: 21434},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 748, col: 5, offset: 21533},
+					pos: position{line: 739, col: 5, offset: 21434},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 748, col: 5, offset: 21533},
+							pos:   position{line: 739, col: 5, offset: 21434},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 748, col: 11, offset: 21539},
+								pos:  position{line: 739, col: 11, offset: 21440},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 748, col: 16, offset: 21544},
+							pos:   position{line: 739, col: 16, offset: 21445},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 748, col: 21, offset: 21549},
+								pos: position{line: 739, col: 21, offset: 21450},
 								expr: &actionExpr{
-									pos: position{line: 748, col: 22, offset: 21550},
+									pos: position{line: 739, col: 22, offset: 21451},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 748, col: 22, offset: 21550},
+										pos: position{line: 739, col: 22, offset: 21451},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 748, col: 22, offset: 21550},
+												pos:  position{line: 739, col: 22, offset: 21451},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 748, col: 25, offset: 21553},
+												pos:        position{line: 739, col: 25, offset: 21454},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 748, col: 29, offset: 21557},
+												pos:  position{line: 739, col: 29, offset: 21458},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 748, col: 32, offset: 21560},
+												pos:   position{line: 739, col: 32, offset: 21461},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 748, col: 34, offset: 21562},
+													pos:  position{line: 739, col: 34, offset: 21463},
 													name: "Expr",
 												},
 											},
@@ -5713,25 +5660,25 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 752, col: 1, offset: 21671},
+			pos:  position{line: 743, col: 1, offset: 21572},
 			expr: &actionExpr{
-				pos: position{line: 752, col: 13, offset: 21683},
+				pos: position{line: 743, col: 13, offset: 21584},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 752, col: 13, offset: 21683},
+					pos: position{line: 743, col: 13, offset: 21584},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 752, col: 13, offset: 21683},
+							pos: position{line: 743, col: 13, offset: 21584},
 							expr: &ruleRefExpr{
-								pos:  position{line: 752, col: 14, offset: 21684},
+								pos:  position{line: 743, col: 14, offset: 21585},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 752, col: 18, offset: 21688},
+							pos:   position{line: 743, col: 18, offset: 21589},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 752, col: 20, offset: 21690},
+								pos:  position{line: 743, col: 20, offset: 21591},
 								name: "DerefExprPattern",
 							},
 						},
@@ -5741,31 +5688,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExprPattern",
-			pos:  position{line: 754, col: 1, offset: 21726},
+			pos:  position{line: 745, col: 1, offset: 21627},
 			expr: &choiceExpr{
-				pos: position{line: 755, col: 5, offset: 21747},
+				pos: position{line: 746, col: 5, offset: 21648},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 755, col: 5, offset: 21747},
+						pos: position{line: 746, col: 5, offset: 21648},
 						run: (*parser).callonDerefExprPattern2,
 						expr: &seqExpr{
-							pos: position{line: 755, col: 5, offset: 21747},
+							pos: position{line: 746, col: 5, offset: 21648},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 755, col: 5, offset: 21747},
+									pos:   position{line: 746, col: 5, offset: 21648},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 755, col: 11, offset: 21753},
+										pos:  position{line: 746, col: 11, offset: 21654},
 										name: "DotID",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 755, col: 17, offset: 21759},
+									pos:   position{line: 746, col: 17, offset: 21660},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 755, col: 22, offset: 21764},
+										pos: position{line: 746, col: 22, offset: 21665},
 										expr: &ruleRefExpr{
-											pos:  position{line: 755, col: 23, offset: 21765},
+											pos:  position{line: 746, col: 23, offset: 21666},
 											name: "Deref",
 										},
 									},
@@ -5774,26 +5721,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 758, col: 5, offset: 21836},
+						pos: position{line: 749, col: 5, offset: 21737},
 						run: (*parser).callonDerefExprPattern9,
 						expr: &seqExpr{
-							pos: position{line: 758, col: 5, offset: 21836},
+							pos: position{line: 749, col: 5, offset: 21737},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 758, col: 5, offset: 21836},
+									pos:   position{line: 749, col: 5, offset: 21737},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 758, col: 11, offset: 21842},
+										pos:  position{line: 749, col: 11, offset: 21743},
 										name: "RootRecord",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 758, col: 22, offset: 21853},
+									pos:   position{line: 749, col: 22, offset: 21754},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 758, col: 27, offset: 21858},
+										pos: position{line: 749, col: 27, offset: 21759},
 										expr: &ruleRefExpr{
-											pos:  position{line: 758, col: 28, offset: 21859},
+											pos:  position{line: 749, col: 28, offset: 21760},
 											name: "Deref",
 										},
 									},
@@ -5802,26 +5749,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 761, col: 5, offset: 21930},
+						pos: position{line: 752, col: 5, offset: 21831},
 						run: (*parser).callonDerefExprPattern16,
 						expr: &seqExpr{
-							pos: position{line: 761, col: 5, offset: 21930},
+							pos: position{line: 752, col: 5, offset: 21831},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 761, col: 5, offset: 21930},
+									pos:   position{line: 752, col: 5, offset: 21831},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 761, col: 11, offset: 21936},
+										pos:  position{line: 752, col: 11, offset: 21837},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 761, col: 22, offset: 21947},
+									pos:   position{line: 752, col: 22, offset: 21848},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 761, col: 27, offset: 21952},
+										pos: position{line: 752, col: 27, offset: 21853},
 										expr: &ruleRefExpr{
-											pos:  position{line: 761, col: 28, offset: 21953},
+											pos:  position{line: 752, col: 28, offset: 21854},
 											name: "Deref",
 										},
 									},
@@ -5830,10 +5777,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 764, col: 5, offset: 22024},
+						pos: position{line: 755, col: 5, offset: 21925},
 						run: (*parser).callonDerefExprPattern23,
 						expr: &litMatcher{
-							pos:        position{line: 764, col: 5, offset: 22024},
+							pos:        position{line: 755, col: 5, offset: 21925},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -5843,12 +5790,12 @@ var g = &grammar{
 		},
 		{
 			name: "RootRecord",
-			pos:  position{line: 768, col: 1, offset: 22093},
+			pos:  position{line: 759, col: 1, offset: 21994},
 			expr: &actionExpr{
-				pos: position{line: 768, col: 14, offset: 22106},
+				pos: position{line: 759, col: 14, offset: 22007},
 				run: (*parser).callonRootRecord1,
 				expr: &litMatcher{
-					pos:        position{line: 768, col: 14, offset: 22106},
+					pos:        position{line: 759, col: 14, offset: 22007},
 					val:        "this",
 					ignoreCase: false,
 				},
@@ -5856,26 +5803,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotID",
-			pos:  position{line: 770, col: 1, offset: 22168},
+			pos:  position{line: 761, col: 1, offset: 22069},
 			expr: &choiceExpr{
-				pos: position{line: 771, col: 5, offset: 22178},
+				pos: position{line: 762, col: 5, offset: 22079},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 771, col: 5, offset: 22178},
+						pos: position{line: 762, col: 5, offset: 22079},
 						run: (*parser).callonDotID2,
 						expr: &seqExpr{
-							pos: position{line: 771, col: 5, offset: 22178},
+							pos: position{line: 762, col: 5, offset: 22079},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 771, col: 5, offset: 22178},
+									pos:        position{line: 762, col: 5, offset: 22079},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 771, col: 9, offset: 22182},
+									pos:   position{line: 762, col: 9, offset: 22083},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 771, col: 15, offset: 22188},
+										pos:  position{line: 762, col: 15, offset: 22089},
 										name: "Identifier",
 									},
 								},
@@ -5883,31 +5830,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 780, col: 5, offset: 22404},
+						pos: position{line: 771, col: 5, offset: 22305},
 						run: (*parser).callonDotID7,
 						expr: &seqExpr{
-							pos: position{line: 780, col: 5, offset: 22404},
+							pos: position{line: 771, col: 5, offset: 22305},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 780, col: 5, offset: 22404},
+									pos:        position{line: 771, col: 5, offset: 22305},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 780, col: 9, offset: 22408},
+									pos:        position{line: 771, col: 9, offset: 22309},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 780, col: 13, offset: 22412},
+									pos:   position{line: 771, col: 13, offset: 22313},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 780, col: 18, offset: 22417},
+										pos:  position{line: 771, col: 18, offset: 22318},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 780, col: 23, offset: 22422},
+									pos:        position{line: 771, col: 23, offset: 22323},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5919,52 +5866,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 790, col: 1, offset: 22627},
+			pos:  position{line: 781, col: 1, offset: 22528},
 			expr: &choiceExpr{
-				pos: position{line: 791, col: 5, offset: 22637},
+				pos: position{line: 782, col: 5, offset: 22538},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 791, col: 5, offset: 22637},
+						pos: position{line: 782, col: 5, offset: 22538},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 791, col: 5, offset: 22637},
+							pos: position{line: 782, col: 5, offset: 22538},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 791, col: 5, offset: 22637},
+									pos:        position{line: 782, col: 5, offset: 22538},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 791, col: 9, offset: 22641},
+									pos:   position{line: 782, col: 9, offset: 22542},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 791, col: 14, offset: 22646},
+										pos:  position{line: 782, col: 14, offset: 22547},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 791, col: 27, offset: 22659},
+									pos:  position{line: 782, col: 27, offset: 22560},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 791, col: 30, offset: 22662},
+									pos:        position{line: 782, col: 30, offset: 22563},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 791, col: 34, offset: 22666},
+									pos:  position{line: 782, col: 34, offset: 22567},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 791, col: 37, offset: 22669},
+									pos:   position{line: 782, col: 37, offset: 22570},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 791, col: 40, offset: 22672},
+										pos:  position{line: 782, col: 40, offset: 22573},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 791, col: 53, offset: 22685},
+									pos:        position{line: 782, col: 53, offset: 22586},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5972,39 +5919,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 797, col: 5, offset: 22856},
+						pos: position{line: 788, col: 5, offset: 22757},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 797, col: 5, offset: 22856},
+							pos: position{line: 788, col: 5, offset: 22757},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 797, col: 5, offset: 22856},
+									pos:        position{line: 788, col: 5, offset: 22757},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 9, offset: 22860},
+									pos:  position{line: 788, col: 9, offset: 22761},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 797, col: 12, offset: 22863},
+									pos:        position{line: 788, col: 12, offset: 22764},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 16, offset: 22867},
+									pos:  position{line: 788, col: 16, offset: 22768},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 797, col: 19, offset: 22870},
+									pos:   position{line: 788, col: 19, offset: 22771},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 797, col: 22, offset: 22873},
+										pos:  position{line: 788, col: 22, offset: 22774},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 797, col: 35, offset: 22886},
+									pos:        position{line: 788, col: 35, offset: 22787},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6012,39 +5959,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 803, col: 5, offset: 23057},
+						pos: position{line: 794, col: 5, offset: 22958},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 803, col: 5, offset: 23057},
+							pos: position{line: 794, col: 5, offset: 22958},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 803, col: 5, offset: 23057},
+									pos:        position{line: 794, col: 5, offset: 22958},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 803, col: 9, offset: 23061},
+									pos:   position{line: 794, col: 9, offset: 22962},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 803, col: 14, offset: 23066},
+										pos:  position{line: 794, col: 14, offset: 22967},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 803, col: 27, offset: 23079},
+									pos:  position{line: 794, col: 27, offset: 22980},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 803, col: 30, offset: 23082},
+									pos:        position{line: 794, col: 30, offset: 22983},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 803, col: 34, offset: 23086},
+									pos:  position{line: 794, col: 34, offset: 22987},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 803, col: 37, offset: 23089},
+									pos:        position{line: 794, col: 37, offset: 22990},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6052,26 +5999,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 809, col: 5, offset: 23262},
+						pos: position{line: 800, col: 5, offset: 23163},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 809, col: 5, offset: 23262},
+							pos: position{line: 800, col: 5, offset: 23163},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 809, col: 5, offset: 23262},
+									pos:        position{line: 800, col: 5, offset: 23163},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 809, col: 9, offset: 23266},
+									pos:   position{line: 800, col: 9, offset: 23167},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 809, col: 14, offset: 23271},
+										pos:  position{line: 800, col: 14, offset: 23172},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 809, col: 19, offset: 23276},
+									pos:        position{line: 800, col: 19, offset: 23177},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6079,29 +6026,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 810, col: 5, offset: 23325},
+						pos: position{line: 801, col: 5, offset: 23226},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 810, col: 5, offset: 23325},
+							pos: position{line: 801, col: 5, offset: 23226},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 810, col: 5, offset: 23325},
+									pos:        position{line: 801, col: 5, offset: 23226},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 810, col: 9, offset: 23329},
+									pos: position{line: 801, col: 9, offset: 23230},
 									expr: &litMatcher{
-										pos:        position{line: 810, col: 11, offset: 23331},
+										pos:        position{line: 801, col: 11, offset: 23232},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 810, col: 16, offset: 23336},
+									pos:   position{line: 801, col: 16, offset: 23237},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 810, col: 19, offset: 23339},
+										pos:  position{line: 801, col: 19, offset: 23240},
 										name: "Identifier",
 									},
 								},
@@ -6113,59 +6060,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 812, col: 1, offset: 23390},
+			pos:  position{line: 803, col: 1, offset: 23291},
 			expr: &choiceExpr{
-				pos: position{line: 813, col: 5, offset: 23402},
+				pos: position{line: 804, col: 5, offset: 23303},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 813, col: 5, offset: 23402},
+						pos:  position{line: 804, col: 5, offset: 23303},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 814, col: 5, offset: 23414},
+						pos:  position{line: 805, col: 5, offset: 23315},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 815, col: 5, offset: 23425},
+						pos:  position{line: 806, col: 5, offset: 23326},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 816, col: 5, offset: 23435},
+						pos:  position{line: 807, col: 5, offset: 23336},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 817, col: 5, offset: 23443},
+						pos:  position{line: 808, col: 5, offset: 23344},
 						name: "Map",
 					},
 					&actionExpr{
-						pos: position{line: 818, col: 5, offset: 23451},
+						pos: position{line: 809, col: 5, offset: 23352},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 818, col: 5, offset: 23451},
+							pos: position{line: 809, col: 5, offset: 23352},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 818, col: 5, offset: 23451},
+									pos:        position{line: 809, col: 5, offset: 23352},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 818, col: 9, offset: 23455},
+									pos:  position{line: 809, col: 9, offset: 23356},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 818, col: 12, offset: 23458},
+									pos:   position{line: 809, col: 12, offset: 23359},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 818, col: 17, offset: 23463},
+										pos:  position{line: 809, col: 17, offset: 23364},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 818, col: 22, offset: 23468},
+									pos:  position{line: 809, col: 22, offset: 23369},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 818, col: 25, offset: 23471},
+									pos:        position{line: 809, col: 25, offset: 23372},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6177,36 +6124,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 820, col: 1, offset: 23497},
+			pos:  position{line: 811, col: 1, offset: 23398},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 5, offset: 23508},
+				pos: position{line: 812, col: 5, offset: 23409},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 821, col: 5, offset: 23508},
+					pos: position{line: 812, col: 5, offset: 23409},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 821, col: 5, offset: 23508},
+							pos:        position{line: 812, col: 5, offset: 23409},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 9, offset: 23512},
+							pos:  position{line: 812, col: 9, offset: 23413},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 12, offset: 23515},
+							pos:   position{line: 812, col: 12, offset: 23416},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 821, col: 19, offset: 23522},
+								pos:  position{line: 812, col: 19, offset: 23423},
 								name: "Fields",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 26, offset: 23529},
+							pos:  position{line: 812, col: 26, offset: 23430},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 821, col: 29, offset: 23532},
+							pos:        position{line: 812, col: 29, offset: 23433},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6216,28 +6163,28 @@ var g = &grammar{
 		},
 		{
 			name: "Fields",
-			pos:  position{line: 825, col: 1, offset: 23625},
+			pos:  position{line: 816, col: 1, offset: 23526},
 			expr: &actionExpr{
-				pos: position{line: 826, col: 5, offset: 23636},
+				pos: position{line: 817, col: 5, offset: 23537},
 				run: (*parser).callonFields1,
 				expr: &seqExpr{
-					pos: position{line: 826, col: 5, offset: 23636},
+					pos: position{line: 817, col: 5, offset: 23537},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 826, col: 5, offset: 23636},
+							pos:   position{line: 817, col: 5, offset: 23537},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 826, col: 11, offset: 23642},
+								pos:  position{line: 817, col: 11, offset: 23543},
 								name: "Field",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 826, col: 17, offset: 23648},
+							pos:   position{line: 817, col: 17, offset: 23549},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 826, col: 22, offset: 23653},
+								pos: position{line: 817, col: 22, offset: 23554},
 								expr: &ruleRefExpr{
-									pos:  position{line: 826, col: 22, offset: 23653},
+									pos:  position{line: 817, col: 22, offset: 23554},
 									name: "FieldTail",
 								},
 							},
@@ -6248,31 +6195,31 @@ var g = &grammar{
 		},
 		{
 			name: "FieldTail",
-			pos:  position{line: 830, col: 1, offset: 23744},
+			pos:  position{line: 821, col: 1, offset: 23645},
 			expr: &actionExpr{
-				pos: position{line: 830, col: 13, offset: 23756},
+				pos: position{line: 821, col: 13, offset: 23657},
 				run: (*parser).callonFieldTail1,
 				expr: &seqExpr{
-					pos: position{line: 830, col: 13, offset: 23756},
+					pos: position{line: 821, col: 13, offset: 23657},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 830, col: 13, offset: 23756},
+							pos:  position{line: 821, col: 13, offset: 23657},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 830, col: 16, offset: 23759},
+							pos:        position{line: 821, col: 16, offset: 23660},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 830, col: 20, offset: 23763},
+							pos:  position{line: 821, col: 20, offset: 23664},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 830, col: 23, offset: 23766},
+							pos:   position{line: 821, col: 23, offset: 23667},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 830, col: 25, offset: 23768},
+								pos:  position{line: 821, col: 25, offset: 23669},
 								name: "Field",
 							},
 						},
@@ -6282,39 +6229,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 832, col: 1, offset: 23793},
+			pos:  position{line: 823, col: 1, offset: 23694},
 			expr: &actionExpr{
-				pos: position{line: 833, col: 5, offset: 23803},
+				pos: position{line: 824, col: 5, offset: 23704},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 833, col: 5, offset: 23803},
+					pos: position{line: 824, col: 5, offset: 23704},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 833, col: 5, offset: 23803},
+							pos:   position{line: 824, col: 5, offset: 23704},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 833, col: 10, offset: 23808},
+								pos:  position{line: 824, col: 10, offset: 23709},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 833, col: 20, offset: 23818},
+							pos:  position{line: 824, col: 20, offset: 23719},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 833, col: 23, offset: 23821},
+							pos:        position{line: 824, col: 23, offset: 23722},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 833, col: 27, offset: 23825},
+							pos:  position{line: 824, col: 27, offset: 23726},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 833, col: 30, offset: 23828},
+							pos:   position{line: 824, col: 30, offset: 23729},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 833, col: 36, offset: 23834},
+								pos:  position{line: 824, col: 36, offset: 23735},
 								name: "Expr",
 							},
 						},
@@ -6324,36 +6271,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 837, col: 1, offset: 23919},
+			pos:  position{line: 828, col: 1, offset: 23820},
 			expr: &actionExpr{
-				pos: position{line: 838, col: 5, offset: 23929},
+				pos: position{line: 829, col: 5, offset: 23830},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 838, col: 5, offset: 23929},
+					pos: position{line: 829, col: 5, offset: 23830},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 838, col: 5, offset: 23929},
+							pos:        position{line: 829, col: 5, offset: 23830},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 9, offset: 23933},
+							pos:  position{line: 829, col: 9, offset: 23834},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 838, col: 12, offset: 23936},
+							pos:   position{line: 829, col: 12, offset: 23837},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 838, col: 18, offset: 23942},
+								pos:  position{line: 829, col: 18, offset: 23843},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 32, offset: 23956},
+							pos:  position{line: 829, col: 32, offset: 23857},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 838, col: 35, offset: 23959},
+							pos:        position{line: 829, col: 35, offset: 23860},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6363,36 +6310,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 842, col: 1, offset: 24049},
+			pos:  position{line: 833, col: 1, offset: 23950},
 			expr: &actionExpr{
-				pos: position{line: 843, col: 5, offset: 24057},
+				pos: position{line: 834, col: 5, offset: 23958},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 843, col: 5, offset: 24057},
+					pos: position{line: 834, col: 5, offset: 23958},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 843, col: 5, offset: 24057},
+							pos:        position{line: 834, col: 5, offset: 23958},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 843, col: 10, offset: 24062},
+							pos:  position{line: 834, col: 10, offset: 23963},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 843, col: 13, offset: 24065},
+							pos:   position{line: 834, col: 13, offset: 23966},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 843, col: 19, offset: 24071},
+								pos:  position{line: 834, col: 19, offset: 23972},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 843, col: 33, offset: 24085},
+							pos:  position{line: 834, col: 33, offset: 23986},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 843, col: 36, offset: 24088},
+							pos:        position{line: 834, col: 36, offset: 23989},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6402,36 +6349,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 847, col: 1, offset: 24177},
+			pos:  position{line: 838, col: 1, offset: 24078},
 			expr: &actionExpr{
-				pos: position{line: 848, col: 5, offset: 24185},
+				pos: position{line: 839, col: 5, offset: 24086},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 848, col: 5, offset: 24185},
+					pos: position{line: 839, col: 5, offset: 24086},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 848, col: 5, offset: 24185},
+							pos:        position{line: 839, col: 5, offset: 24086},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 10, offset: 24190},
+							pos:  position{line: 839, col: 10, offset: 24091},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 848, col: 13, offset: 24193},
+							pos:   position{line: 839, col: 13, offset: 24094},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 19, offset: 24199},
+								pos:  position{line: 839, col: 19, offset: 24100},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 27, offset: 24207},
+							pos:  position{line: 839, col: 27, offset: 24108},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 848, col: 30, offset: 24210},
+							pos:        position{line: 839, col: 30, offset: 24111},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6441,31 +6388,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 852, col: 1, offset: 24301},
+			pos:  position{line: 843, col: 1, offset: 24202},
 			expr: &choiceExpr{
-				pos: position{line: 853, col: 5, offset: 24313},
+				pos: position{line: 844, col: 5, offset: 24214},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 853, col: 5, offset: 24313},
+						pos: position{line: 844, col: 5, offset: 24214},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 853, col: 5, offset: 24313},
+							pos: position{line: 844, col: 5, offset: 24214},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 853, col: 5, offset: 24313},
+									pos:   position{line: 844, col: 5, offset: 24214},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 853, col: 11, offset: 24319},
+										pos:  position{line: 844, col: 11, offset: 24220},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 853, col: 17, offset: 24325},
+									pos:   position{line: 844, col: 17, offset: 24226},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 853, col: 22, offset: 24330},
+										pos: position{line: 844, col: 22, offset: 24231},
 										expr: &ruleRefExpr{
-											pos:  position{line: 853, col: 22, offset: 24330},
+											pos:  position{line: 844, col: 22, offset: 24231},
 											name: "EntryTail",
 										},
 									},
@@ -6474,10 +6421,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 856, col: 5, offset: 24424},
+						pos: position{line: 847, col: 5, offset: 24325},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 856, col: 5, offset: 24424},
+							pos:  position{line: 847, col: 5, offset: 24325},
 							name: "__",
 						},
 					},
@@ -6486,31 +6433,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 859, col: 1, offset: 24461},
+			pos:  position{line: 850, col: 1, offset: 24362},
 			expr: &actionExpr{
-				pos: position{line: 859, col: 13, offset: 24473},
+				pos: position{line: 850, col: 13, offset: 24374},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 859, col: 13, offset: 24473},
+					pos: position{line: 850, col: 13, offset: 24374},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 13, offset: 24473},
+							pos:  position{line: 850, col: 13, offset: 24374},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 859, col: 16, offset: 24476},
+							pos:        position{line: 850, col: 16, offset: 24377},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 20, offset: 24480},
+							pos:  position{line: 850, col: 20, offset: 24381},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 859, col: 23, offset: 24483},
+							pos:   position{line: 850, col: 23, offset: 24384},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 859, col: 25, offset: 24485},
+								pos:  position{line: 850, col: 25, offset: 24386},
 								name: "Entry",
 							},
 						},
@@ -6520,39 +6467,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 861, col: 1, offset: 24510},
+			pos:  position{line: 852, col: 1, offset: 24411},
 			expr: &actionExpr{
-				pos: position{line: 862, col: 5, offset: 24520},
+				pos: position{line: 853, col: 5, offset: 24421},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 862, col: 5, offset: 24520},
+					pos: position{line: 853, col: 5, offset: 24421},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 862, col: 5, offset: 24520},
+							pos:   position{line: 853, col: 5, offset: 24421},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 9, offset: 24524},
+								pos:  position{line: 853, col: 9, offset: 24425},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 862, col: 14, offset: 24529},
+							pos:  position{line: 853, col: 14, offset: 24430},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 862, col: 17, offset: 24532},
+							pos:        position{line: 853, col: 17, offset: 24433},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 862, col: 21, offset: 24536},
+							pos:  position{line: 853, col: 21, offset: 24437},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 862, col: 24, offset: 24539},
+							pos:   position{line: 853, col: 24, offset: 24440},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 30, offset: 24545},
+								pos:  position{line: 853, col: 30, offset: 24446},
 								name: "Expr",
 							},
 						},
@@ -6562,74 +6509,74 @@ var g = &grammar{
 		},
 		{
 			name: "SQLProc",
-			pos:  position{line: 868, col: 1, offset: 24652},
+			pos:  position{line: 859, col: 1, offset: 24553},
 			expr: &actionExpr{
-				pos: position{line: 869, col: 5, offset: 24664},
+				pos: position{line: 860, col: 5, offset: 24565},
 				run: (*parser).callonSQLProc1,
 				expr: &seqExpr{
-					pos: position{line: 869, col: 5, offset: 24664},
+					pos: position{line: 860, col: 5, offset: 24565},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 869, col: 5, offset: 24664},
+							pos:   position{line: 860, col: 5, offset: 24565},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 869, col: 15, offset: 24674},
+								pos:  position{line: 860, col: 15, offset: 24575},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 870, col: 5, offset: 24688},
+							pos:   position{line: 861, col: 5, offset: 24589},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 870, col: 10, offset: 24693},
+								pos:  position{line: 861, col: 10, offset: 24594},
 								name: "SQLFrom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 871, col: 5, offset: 24705},
+							pos:   position{line: 862, col: 5, offset: 24606},
 							label: "joins",
 							expr: &ruleRefExpr{
-								pos:  position{line: 871, col: 11, offset: 24711},
+								pos:  position{line: 862, col: 11, offset: 24612},
 								name: "SQLJoins",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 872, col: 5, offset: 24724},
+							pos:   position{line: 863, col: 5, offset: 24625},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 872, col: 11, offset: 24730},
+								pos:  position{line: 863, col: 11, offset: 24631},
 								name: "SQLWhere",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 24743},
+							pos:   position{line: 864, col: 5, offset: 24644},
 							label: "groupby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 873, col: 13, offset: 24751},
+								pos:  position{line: 864, col: 13, offset: 24652},
 								name: "SQLGroupBy",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 874, col: 5, offset: 24766},
+							pos:   position{line: 865, col: 5, offset: 24667},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 874, col: 12, offset: 24773},
+								pos:  position{line: 865, col: 12, offset: 24674},
 								name: "SQLHaving",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 875, col: 5, offset: 24787},
+							pos:   position{line: 866, col: 5, offset: 24688},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 875, col: 13, offset: 24795},
+								pos:  position{line: 866, col: 13, offset: 24696},
 								name: "SQLOrderBy",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 5, offset: 24810},
+							pos:   position{line: 867, col: 5, offset: 24711},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 876, col: 11, offset: 24816},
+								pos:  position{line: 867, col: 11, offset: 24717},
 								name: "SQLLimit",
 							},
 						},
@@ -6639,26 +6586,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 900, col: 1, offset: 25183},
+			pos:  position{line: 891, col: 1, offset: 25084},
 			expr: &choiceExpr{
-				pos: position{line: 901, col: 5, offset: 25197},
+				pos: position{line: 892, col: 5, offset: 25098},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 901, col: 5, offset: 25197},
+						pos: position{line: 892, col: 5, offset: 25098},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 901, col: 5, offset: 25197},
+							pos: position{line: 892, col: 5, offset: 25098},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 901, col: 5, offset: 25197},
+									pos:  position{line: 892, col: 5, offset: 25098},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 901, col: 12, offset: 25204},
+									pos:  position{line: 892, col: 12, offset: 25105},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 901, col: 14, offset: 25206},
+									pos:        position{line: 892, col: 14, offset: 25107},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6666,24 +6613,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 902, col: 5, offset: 25234},
+						pos: position{line: 893, col: 5, offset: 25135},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 902, col: 5, offset: 25234},
+							pos: position{line: 893, col: 5, offset: 25135},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 902, col: 5, offset: 25234},
+									pos:  position{line: 893, col: 5, offset: 25135},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 902, col: 12, offset: 25241},
+									pos:  position{line: 893, col: 12, offset: 25142},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 902, col: 14, offset: 25243},
+									pos:   position{line: 893, col: 14, offset: 25144},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 902, col: 26, offset: 25255},
+										pos:  position{line: 893, col: 26, offset: 25156},
 										name: "SQLAssignments",
 									},
 								},
@@ -6695,41 +6642,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 904, col: 1, offset: 25299},
+			pos:  position{line: 895, col: 1, offset: 25200},
 			expr: &choiceExpr{
-				pos: position{line: 905, col: 5, offset: 25317},
+				pos: position{line: 896, col: 5, offset: 25218},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 905, col: 5, offset: 25317},
+						pos: position{line: 896, col: 5, offset: 25218},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 905, col: 5, offset: 25317},
+							pos: position{line: 896, col: 5, offset: 25218},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 905, col: 5, offset: 25317},
+									pos:   position{line: 896, col: 5, offset: 25218},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 9, offset: 25321},
+										pos:  position{line: 896, col: 9, offset: 25222},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 14, offset: 25326},
+									pos:  position{line: 896, col: 14, offset: 25227},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 16, offset: 25328},
+									pos:  position{line: 896, col: 16, offset: 25229},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 19, offset: 25331},
+									pos:  position{line: 896, col: 19, offset: 25232},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 21, offset: 25333},
+									pos:   position{line: 896, col: 21, offset: 25234},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 25, offset: 25337},
+										pos:  position{line: 896, col: 25, offset: 25238},
 										name: "Lval",
 									},
 								},
@@ -6737,13 +6684,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 906, col: 5, offset: 25431},
+						pos: position{line: 897, col: 5, offset: 25332},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 906, col: 5, offset: 25431},
+							pos:   position{line: 897, col: 5, offset: 25332},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 906, col: 10, offset: 25436},
+								pos:  position{line: 897, col: 10, offset: 25337},
 								name: "Expr",
 							},
 						},
@@ -6753,50 +6700,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 908, col: 1, offset: 25528},
+			pos:  position{line: 899, col: 1, offset: 25429},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 5, offset: 25547},
+				pos: position{line: 900, col: 5, offset: 25448},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 909, col: 5, offset: 25547},
+					pos: position{line: 900, col: 5, offset: 25448},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 909, col: 5, offset: 25547},
+							pos:   position{line: 900, col: 5, offset: 25448},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 909, col: 11, offset: 25553},
+								pos:  position{line: 900, col: 11, offset: 25454},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 25, offset: 25567},
+							pos:   position{line: 900, col: 25, offset: 25468},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 909, col: 30, offset: 25572},
+								pos: position{line: 900, col: 30, offset: 25473},
 								expr: &actionExpr{
-									pos: position{line: 909, col: 31, offset: 25573},
+									pos: position{line: 900, col: 31, offset: 25474},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 909, col: 31, offset: 25573},
+										pos: position{line: 900, col: 31, offset: 25474},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 909, col: 31, offset: 25573},
+												pos:  position{line: 900, col: 31, offset: 25474},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 909, col: 34, offset: 25576},
+												pos:        position{line: 900, col: 34, offset: 25477},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 909, col: 38, offset: 25580},
+												pos:  position{line: 900, col: 38, offset: 25481},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 909, col: 41, offset: 25583},
+												pos:   position{line: 900, col: 41, offset: 25484},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 909, col: 46, offset: 25588},
+													pos:  position{line: 900, col: 46, offset: 25489},
 													name: "SQLAssignment",
 												},
 											},
@@ -6811,41 +6758,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 913, col: 1, offset: 25709},
+			pos:  position{line: 904, col: 1, offset: 25610},
 			expr: &choiceExpr{
-				pos: position{line: 914, col: 5, offset: 25721},
+				pos: position{line: 905, col: 5, offset: 25622},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 914, col: 5, offset: 25721},
+						pos: position{line: 905, col: 5, offset: 25622},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 914, col: 5, offset: 25721},
+							pos: position{line: 905, col: 5, offset: 25622},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 914, col: 5, offset: 25721},
+									pos:  position{line: 905, col: 5, offset: 25622},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 914, col: 7, offset: 25723},
+									pos:  position{line: 905, col: 7, offset: 25624},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 914, col: 12, offset: 25728},
+									pos:  position{line: 905, col: 12, offset: 25629},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 914, col: 14, offset: 25730},
+									pos:   position{line: 905, col: 14, offset: 25631},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 914, col: 20, offset: 25736},
+										pos:  position{line: 905, col: 20, offset: 25637},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 914, col: 29, offset: 25745},
+									pos:   position{line: 905, col: 29, offset: 25646},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 914, col: 35, offset: 25751},
+										pos:  position{line: 905, col: 35, offset: 25652},
 										name: "SQLAlias",
 									},
 								},
@@ -6853,25 +6800,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 917, col: 5, offset: 25845},
+						pos: position{line: 908, col: 5, offset: 25746},
 						run: (*parser).callonSQLFrom11,
 						expr: &seqExpr{
-							pos: position{line: 917, col: 5, offset: 25845},
+							pos: position{line: 908, col: 5, offset: 25746},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 917, col: 5, offset: 25845},
+									pos:  position{line: 908, col: 5, offset: 25746},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 917, col: 7, offset: 25847},
+									pos:  position{line: 908, col: 7, offset: 25748},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 917, col: 12, offset: 25852},
+									pos:  position{line: 908, col: 12, offset: 25753},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 917, col: 14, offset: 25854},
+									pos:        position{line: 908, col: 14, offset: 25755},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6879,10 +6826,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 918, col: 5, offset: 25882},
+						pos: position{line: 909, col: 5, offset: 25783},
 						run: (*parser).callonSQLFrom17,
 						expr: &litMatcher{
-							pos:        position{line: 918, col: 5, offset: 25882},
+							pos:        position{line: 909, col: 5, offset: 25783},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -6892,33 +6839,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 920, col: 1, offset: 25906},
+			pos:  position{line: 911, col: 1, offset: 25807},
 			expr: &choiceExpr{
-				pos: position{line: 921, col: 5, offset: 25919},
+				pos: position{line: 912, col: 5, offset: 25820},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 921, col: 5, offset: 25919},
+						pos: position{line: 912, col: 5, offset: 25820},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 921, col: 5, offset: 25919},
+							pos: position{line: 912, col: 5, offset: 25820},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 921, col: 5, offset: 25919},
+									pos:  position{line: 912, col: 5, offset: 25820},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 921, col: 7, offset: 25921},
+									pos:  position{line: 912, col: 7, offset: 25822},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 921, col: 10, offset: 25924},
+									pos:  position{line: 912, col: 10, offset: 25825},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 921, col: 12, offset: 25926},
+									pos:   position{line: 912, col: 12, offset: 25827},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 921, col: 15, offset: 25929},
+										pos:  position{line: 912, col: 15, offset: 25830},
 										name: "Lval",
 									},
 								},
@@ -6926,20 +6873,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 922, col: 5, offset: 25957},
+						pos: position{line: 913, col: 5, offset: 25858},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 922, col: 5, offset: 25957},
+							pos: position{line: 913, col: 5, offset: 25858},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 5, offset: 25957},
+									pos:  position{line: 913, col: 5, offset: 25858},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 922, col: 7, offset: 25959},
+									pos:   position{line: 913, col: 7, offset: 25860},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 922, col: 10, offset: 25962},
+										pos:  position{line: 913, col: 10, offset: 25863},
 										name: "Lval",
 									},
 								},
@@ -6947,10 +6894,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 923, col: 5, offset: 25990},
+						pos: position{line: 914, col: 5, offset: 25891},
 						run: (*parser).callonSQLAlias14,
 						expr: &litMatcher{
-							pos:        position{line: 923, col: 5, offset: 25990},
+							pos:        position{line: 914, col: 5, offset: 25891},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -6960,45 +6907,45 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 925, col: 1, offset: 26014},
+			pos:  position{line: 916, col: 1, offset: 25915},
 			expr: &ruleRefExpr{
-				pos:  position{line: 926, col: 5, offset: 26027},
+				pos:  position{line: 917, col: 5, offset: 25928},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 928, col: 1, offset: 26033},
+			pos:  position{line: 919, col: 1, offset: 25934},
 			expr: &choiceExpr{
-				pos: position{line: 929, col: 5, offset: 26046},
+				pos: position{line: 920, col: 5, offset: 25947},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 929, col: 5, offset: 26046},
+						pos: position{line: 920, col: 5, offset: 25947},
 						run: (*parser).callonSQLJoins2,
 						expr: &seqExpr{
-							pos: position{line: 929, col: 5, offset: 26046},
+							pos: position{line: 920, col: 5, offset: 25947},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 929, col: 5, offset: 26046},
+									pos:   position{line: 920, col: 5, offset: 25947},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 929, col: 11, offset: 26052},
+										pos:  position{line: 920, col: 11, offset: 25953},
 										name: "SQLJoin",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 929, col: 19, offset: 26060},
+									pos:   position{line: 920, col: 19, offset: 25961},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 929, col: 24, offset: 26065},
+										pos: position{line: 920, col: 24, offset: 25966},
 										expr: &actionExpr{
-											pos: position{line: 929, col: 25, offset: 26066},
+											pos: position{line: 920, col: 25, offset: 25967},
 											run: (*parser).callonSQLJoins8,
 											expr: &labeledExpr{
-												pos:   position{line: 929, col: 25, offset: 26066},
+												pos:   position{line: 920, col: 25, offset: 25967},
 												label: "join",
 												expr: &ruleRefExpr{
-													pos:  position{line: 929, col: 30, offset: 26071},
+													pos:  position{line: 920, col: 30, offset: 25972},
 													name: "SQLJoin",
 												},
 											},
@@ -7009,10 +6956,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 932, col: 5, offset: 26189},
+						pos: position{line: 923, col: 5, offset: 26090},
 						run: (*parser).callonSQLJoins11,
 						expr: &litMatcher{
-							pos:        position{line: 932, col: 5, offset: 26189},
+							pos:        position{line: 923, col: 5, offset: 26090},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7022,87 +6969,87 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 934, col: 1, offset: 26213},
+			pos:  position{line: 925, col: 1, offset: 26114},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 5, offset: 26225},
+				pos: position{line: 926, col: 5, offset: 26126},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 935, col: 5, offset: 26225},
+					pos: position{line: 926, col: 5, offset: 26126},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 935, col: 5, offset: 26225},
+							pos:   position{line: 926, col: 5, offset: 26126},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 11, offset: 26231},
+								pos:  position{line: 926, col: 11, offset: 26132},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 24, offset: 26244},
+							pos:  position{line: 926, col: 24, offset: 26145},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 26, offset: 26246},
+							pos:  position{line: 926, col: 26, offset: 26147},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 31, offset: 26251},
+							pos:  position{line: 926, col: 31, offset: 26152},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 935, col: 33, offset: 26253},
+							pos:   position{line: 926, col: 33, offset: 26154},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 39, offset: 26259},
+								pos:  position{line: 926, col: 39, offset: 26160},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 935, col: 48, offset: 26268},
+							pos:   position{line: 926, col: 48, offset: 26169},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 54, offset: 26274},
+								pos:  position{line: 926, col: 54, offset: 26175},
 								name: "SQLAlias",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 63, offset: 26283},
+							pos:  position{line: 926, col: 63, offset: 26184},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 65, offset: 26285},
+							pos:  position{line: 926, col: 65, offset: 26186},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 68, offset: 26288},
+							pos:  position{line: 926, col: 68, offset: 26189},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 935, col: 70, offset: 26290},
+							pos:   position{line: 926, col: 70, offset: 26191},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 78, offset: 26298},
+								pos:  position{line: 926, col: 78, offset: 26199},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 86, offset: 26306},
+							pos:  position{line: 926, col: 86, offset: 26207},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 935, col: 89, offset: 26309},
+							pos:        position{line: 926, col: 89, offset: 26210},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 93, offset: 26313},
+							pos:  position{line: 926, col: 93, offset: 26214},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 935, col: 96, offset: 26316},
+							pos:   position{line: 926, col: 96, offset: 26217},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 105, offset: 26325},
+								pos:  position{line: 926, col: 105, offset: 26226},
 								name: "JoinKey",
 							},
 						},
@@ -7112,36 +7059,36 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 954, col: 1, offset: 26560},
+			pos:  position{line: 945, col: 1, offset: 26461},
 			expr: &choiceExpr{
-				pos: position{line: 955, col: 5, offset: 26577},
+				pos: position{line: 946, col: 5, offset: 26478},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 955, col: 5, offset: 26577},
+						pos: position{line: 946, col: 5, offset: 26478},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 955, col: 5, offset: 26577},
+							pos: position{line: 946, col: 5, offset: 26478},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 955, col: 5, offset: 26577},
+									pos:  position{line: 946, col: 5, offset: 26478},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 955, col: 7, offset: 26579},
+									pos:   position{line: 946, col: 7, offset: 26480},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 955, col: 14, offset: 26586},
+										pos: position{line: 946, col: 14, offset: 26487},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 955, col: 14, offset: 26586},
+												pos:  position{line: 946, col: 14, offset: 26487},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 955, col: 21, offset: 26593},
+												pos:  position{line: 946, col: 21, offset: 26494},
 												name: "RIGHT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 955, col: 29, offset: 26601},
+												pos:  position{line: 946, col: 29, offset: 26502},
 												name: "INNER",
 											},
 										},
@@ -7151,10 +7098,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 956, col: 5, offset: 26634},
+						pos: position{line: 947, col: 5, offset: 26535},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &litMatcher{
-							pos:        position{line: 956, col: 5, offset: 26634},
+							pos:        position{line: 947, col: 5, offset: 26535},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7164,33 +7111,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 958, col: 1, offset: 26670},
+			pos:  position{line: 949, col: 1, offset: 26571},
 			expr: &choiceExpr{
-				pos: position{line: 959, col: 5, offset: 26683},
+				pos: position{line: 950, col: 5, offset: 26584},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 959, col: 5, offset: 26683},
+						pos: position{line: 950, col: 5, offset: 26584},
 						run: (*parser).callonSQLWhere2,
 						expr: &seqExpr{
-							pos: position{line: 959, col: 5, offset: 26683},
+							pos: position{line: 950, col: 5, offset: 26584},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 959, col: 5, offset: 26683},
+									pos:  position{line: 950, col: 5, offset: 26584},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 959, col: 7, offset: 26685},
+									pos:  position{line: 950, col: 7, offset: 26586},
 									name: "WHERE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 959, col: 13, offset: 26691},
+									pos:  position{line: 950, col: 13, offset: 26592},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 959, col: 15, offset: 26693},
+									pos:   position{line: 950, col: 15, offset: 26594},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 959, col: 20, offset: 26698},
+										pos:  position{line: 950, col: 20, offset: 26599},
 										name: "SearchBoolean",
 									},
 								},
@@ -7198,10 +7145,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 960, col: 5, offset: 26737},
+						pos: position{line: 951, col: 5, offset: 26638},
 						run: (*parser).callonSQLWhere9,
 						expr: &litMatcher{
-							pos:        position{line: 960, col: 5, offset: 26737},
+							pos:        position{line: 951, col: 5, offset: 26638},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7211,41 +7158,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 962, col: 1, offset: 26761},
+			pos:  position{line: 953, col: 1, offset: 26662},
 			expr: &choiceExpr{
-				pos: position{line: 963, col: 5, offset: 26776},
+				pos: position{line: 954, col: 5, offset: 26677},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 963, col: 5, offset: 26776},
+						pos: position{line: 954, col: 5, offset: 26677},
 						run: (*parser).callonSQLGroupBy2,
 						expr: &seqExpr{
-							pos: position{line: 963, col: 5, offset: 26776},
+							pos: position{line: 954, col: 5, offset: 26677},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 963, col: 5, offset: 26776},
+									pos:  position{line: 954, col: 5, offset: 26677},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 963, col: 7, offset: 26778},
+									pos:  position{line: 954, col: 7, offset: 26679},
 									name: "GROUP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 963, col: 13, offset: 26784},
+									pos:  position{line: 954, col: 13, offset: 26685},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 963, col: 15, offset: 26786},
+									pos:  position{line: 954, col: 15, offset: 26687},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 963, col: 18, offset: 26789},
+									pos:  position{line: 954, col: 18, offset: 26690},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 963, col: 20, offset: 26791},
+									pos:   position{line: 954, col: 20, offset: 26692},
 									label: "columns",
 									expr: &ruleRefExpr{
-										pos:  position{line: 963, col: 28, offset: 26799},
+										pos:  position{line: 954, col: 28, offset: 26700},
 										name: "FieldExprs",
 									},
 								},
@@ -7253,10 +7200,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 964, col: 5, offset: 26838},
+						pos: position{line: 955, col: 5, offset: 26739},
 						run: (*parser).callonSQLGroupBy11,
 						expr: &litMatcher{
-							pos:        position{line: 964, col: 5, offset: 26838},
+							pos:        position{line: 955, col: 5, offset: 26739},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7266,33 +7213,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 966, col: 1, offset: 26862},
+			pos:  position{line: 957, col: 1, offset: 26763},
 			expr: &choiceExpr{
-				pos: position{line: 967, col: 5, offset: 26876},
+				pos: position{line: 958, col: 5, offset: 26777},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 967, col: 5, offset: 26876},
+						pos: position{line: 958, col: 5, offset: 26777},
 						run: (*parser).callonSQLHaving2,
 						expr: &seqExpr{
-							pos: position{line: 967, col: 5, offset: 26876},
+							pos: position{line: 958, col: 5, offset: 26777},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 967, col: 5, offset: 26876},
+									pos:  position{line: 958, col: 5, offset: 26777},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 967, col: 7, offset: 26878},
+									pos:  position{line: 958, col: 7, offset: 26779},
 									name: "HAVING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 967, col: 14, offset: 26885},
+									pos:  position{line: 958, col: 14, offset: 26786},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 967, col: 16, offset: 26887},
+									pos:   position{line: 958, col: 16, offset: 26788},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 967, col: 21, offset: 26892},
+										pos:  position{line: 958, col: 21, offset: 26793},
 										name: "SearchBoolean",
 									},
 								},
@@ -7300,10 +7247,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 968, col: 5, offset: 26931},
+						pos: position{line: 959, col: 5, offset: 26832},
 						run: (*parser).callonSQLHaving9,
 						expr: &litMatcher{
-							pos:        position{line: 968, col: 5, offset: 26931},
+							pos:        position{line: 959, col: 5, offset: 26832},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7313,49 +7260,49 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 970, col: 1, offset: 26955},
+			pos:  position{line: 961, col: 1, offset: 26856},
 			expr: &choiceExpr{
-				pos: position{line: 971, col: 5, offset: 26970},
+				pos: position{line: 962, col: 5, offset: 26871},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 971, col: 5, offset: 26970},
+						pos: position{line: 962, col: 5, offset: 26871},
 						run: (*parser).callonSQLOrderBy2,
 						expr: &seqExpr{
-							pos: position{line: 971, col: 5, offset: 26970},
+							pos: position{line: 962, col: 5, offset: 26871},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 971, col: 5, offset: 26970},
+									pos:  position{line: 962, col: 5, offset: 26871},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 971, col: 7, offset: 26972},
+									pos:  position{line: 962, col: 7, offset: 26873},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 971, col: 13, offset: 26978},
+									pos:  position{line: 962, col: 13, offset: 26879},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 971, col: 15, offset: 26980},
+									pos:  position{line: 962, col: 15, offset: 26881},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 971, col: 18, offset: 26983},
+									pos:  position{line: 962, col: 18, offset: 26884},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 971, col: 20, offset: 26985},
+									pos:   position{line: 962, col: 20, offset: 26886},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 971, col: 25, offset: 26990},
+										pos:  position{line: 962, col: 25, offset: 26891},
 										name: "Exprs",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 971, col: 31, offset: 26996},
+									pos:   position{line: 962, col: 31, offset: 26897},
 									label: "order",
 									expr: &ruleRefExpr{
-										pos:  position{line: 971, col: 37, offset: 27002},
+										pos:  position{line: 962, col: 37, offset: 26903},
 										name: "SQLOrder",
 									},
 								},
@@ -7363,10 +7310,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 974, col: 5, offset: 27115},
+						pos: position{line: 965, col: 5, offset: 27016},
 						run: (*parser).callonSQLOrderBy13,
 						expr: &litMatcher{
-							pos:        position{line: 974, col: 5, offset: 27115},
+							pos:        position{line: 965, col: 5, offset: 27016},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7376,32 +7323,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 976, col: 1, offset: 27139},
+			pos:  position{line: 967, col: 1, offset: 27040},
 			expr: &choiceExpr{
-				pos: position{line: 977, col: 5, offset: 27152},
+				pos: position{line: 968, col: 5, offset: 27053},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 977, col: 5, offset: 27152},
+						pos: position{line: 968, col: 5, offset: 27053},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 977, col: 5, offset: 27152},
+							pos: position{line: 968, col: 5, offset: 27053},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 977, col: 5, offset: 27152},
+									pos:  position{line: 968, col: 5, offset: 27053},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 977, col: 7, offset: 27154},
+									pos:   position{line: 968, col: 7, offset: 27055},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 977, col: 12, offset: 27159},
+										pos: position{line: 968, col: 12, offset: 27060},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 977, col: 12, offset: 27159},
+												pos:  position{line: 968, col: 12, offset: 27060},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 977, col: 18, offset: 27165},
+												pos:  position{line: 968, col: 18, offset: 27066},
 												name: "DESC",
 											},
 										},
@@ -7411,10 +7358,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 27195},
+						pos: position{line: 969, col: 5, offset: 27096},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 978, col: 5, offset: 27195},
+							pos:        position{line: 969, col: 5, offset: 27096},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7424,33 +7371,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 980, col: 1, offset: 27221},
+			pos:  position{line: 971, col: 1, offset: 27122},
 			expr: &choiceExpr{
-				pos: position{line: 981, col: 5, offset: 27234},
+				pos: position{line: 972, col: 5, offset: 27135},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 981, col: 5, offset: 27234},
+						pos: position{line: 972, col: 5, offset: 27135},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 981, col: 5, offset: 27234},
+							pos: position{line: 972, col: 5, offset: 27135},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 981, col: 5, offset: 27234},
+									pos:  position{line: 972, col: 5, offset: 27135},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 981, col: 7, offset: 27236},
+									pos:  position{line: 972, col: 7, offset: 27137},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 981, col: 13, offset: 27242},
+									pos:  position{line: 972, col: 13, offset: 27143},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 981, col: 15, offset: 27244},
+									pos:   position{line: 972, col: 15, offset: 27145},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 981, col: 21, offset: 27250},
+										pos:  position{line: 972, col: 21, offset: 27151},
 										name: "UInt",
 									},
 								},
@@ -7458,10 +7405,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 982, col: 5, offset: 27281},
+						pos: position{line: 973, col: 5, offset: 27182},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 982, col: 5, offset: 27281},
+							pos:        position{line: 973, col: 5, offset: 27182},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7471,12 +7418,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 984, col: 1, offset: 27303},
+			pos:  position{line: 975, col: 1, offset: 27204},
 			expr: &actionExpr{
-				pos: position{line: 984, col: 10, offset: 27312},
+				pos: position{line: 975, col: 10, offset: 27213},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 984, col: 10, offset: 27312},
+					pos:        position{line: 975, col: 10, offset: 27213},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7484,12 +7431,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 985, col: 1, offset: 27347},
+			pos:  position{line: 976, col: 1, offset: 27248},
 			expr: &actionExpr{
-				pos: position{line: 985, col: 6, offset: 27352},
+				pos: position{line: 976, col: 6, offset: 27253},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 985, col: 6, offset: 27352},
+					pos:        position{line: 976, col: 6, offset: 27253},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7497,12 +7444,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 986, col: 1, offset: 27379},
+			pos:  position{line: 977, col: 1, offset: 27280},
 			expr: &actionExpr{
-				pos: position{line: 986, col: 8, offset: 27386},
+				pos: position{line: 977, col: 8, offset: 27287},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 986, col: 8, offset: 27386},
+					pos:        position{line: 977, col: 8, offset: 27287},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7510,12 +7457,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 987, col: 1, offset: 27417},
+			pos:  position{line: 978, col: 1, offset: 27318},
 			expr: &actionExpr{
-				pos: position{line: 987, col: 8, offset: 27424},
+				pos: position{line: 978, col: 8, offset: 27325},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 987, col: 8, offset: 27424},
+					pos:        position{line: 978, col: 8, offset: 27325},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7523,12 +7470,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 988, col: 1, offset: 27455},
+			pos:  position{line: 979, col: 1, offset: 27356},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 9, offset: 27463},
+				pos: position{line: 979, col: 9, offset: 27364},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 988, col: 9, offset: 27463},
+					pos:        position{line: 979, col: 9, offset: 27364},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7536,12 +7483,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 989, col: 1, offset: 27496},
+			pos:  position{line: 980, col: 1, offset: 27397},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 9, offset: 27504},
+				pos: position{line: 980, col: 9, offset: 27405},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 989, col: 9, offset: 27504},
+					pos:        position{line: 980, col: 9, offset: 27405},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7549,20 +7496,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 990, col: 1, offset: 27537},
+			pos:  position{line: 981, col: 1, offset: 27438},
 			expr: &ruleRefExpr{
-				pos:  position{line: 990, col: 6, offset: 27542},
+				pos:  position{line: 981, col: 6, offset: 27443},
 				name: "ByToken",
 			},
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 991, col: 1, offset: 27550},
+			pos:  position{line: 982, col: 1, offset: 27451},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 10, offset: 27559},
+				pos: position{line: 982, col: 10, offset: 27460},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 991, col: 10, offset: 27559},
+					pos:        position{line: 982, col: 10, offset: 27460},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7570,12 +7517,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 992, col: 1, offset: 27594},
+			pos:  position{line: 983, col: 1, offset: 27495},
 			expr: &actionExpr{
-				pos: position{line: 992, col: 9, offset: 27602},
+				pos: position{line: 983, col: 9, offset: 27503},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 992, col: 9, offset: 27602},
+					pos:        position{line: 983, col: 9, offset: 27503},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7583,12 +7530,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 993, col: 1, offset: 27635},
+			pos:  position{line: 984, col: 1, offset: 27536},
 			expr: &actionExpr{
-				pos: position{line: 993, col: 6, offset: 27640},
+				pos: position{line: 984, col: 6, offset: 27541},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 993, col: 6, offset: 27640},
+					pos:        position{line: 984, col: 6, offset: 27541},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7596,12 +7543,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 994, col: 1, offset: 27667},
+			pos:  position{line: 985, col: 1, offset: 27568},
 			expr: &actionExpr{
-				pos: position{line: 994, col: 9, offset: 27675},
+				pos: position{line: 985, col: 9, offset: 27576},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 994, col: 9, offset: 27675},
+					pos:        position{line: 985, col: 9, offset: 27576},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7609,12 +7556,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 995, col: 1, offset: 27708},
+			pos:  position{line: 986, col: 1, offset: 27609},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 7, offset: 27714},
+				pos: position{line: 986, col: 7, offset: 27615},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 995, col: 7, offset: 27714},
+					pos:        position{line: 986, col: 7, offset: 27615},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7622,12 +7569,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 996, col: 1, offset: 27743},
+			pos:  position{line: 987, col: 1, offset: 27644},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 8, offset: 27750},
+				pos: position{line: 987, col: 8, offset: 27651},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 996, col: 8, offset: 27750},
+					pos:        position{line: 987, col: 8, offset: 27651},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7635,12 +7582,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 997, col: 1, offset: 27781},
+			pos:  position{line: 988, col: 1, offset: 27682},
 			expr: &actionExpr{
-				pos: position{line: 997, col: 8, offset: 27788},
+				pos: position{line: 988, col: 8, offset: 27689},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 997, col: 8, offset: 27788},
+					pos:        position{line: 988, col: 8, offset: 27689},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7648,12 +7595,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 998, col: 1, offset: 27819},
+			pos:  position{line: 989, col: 1, offset: 27720},
 			expr: &actionExpr{
-				pos: position{line: 998, col: 9, offset: 27827},
+				pos: position{line: 989, col: 9, offset: 27728},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 998, col: 9, offset: 27827},
+					pos:        position{line: 989, col: 9, offset: 27728},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7661,12 +7608,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 999, col: 1, offset: 27860},
+			pos:  position{line: 990, col: 1, offset: 27761},
 			expr: &actionExpr{
-				pos: position{line: 999, col: 9, offset: 27868},
+				pos: position{line: 990, col: 9, offset: 27769},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 999, col: 9, offset: 27868},
+					pos:        position{line: 990, col: 9, offset: 27769},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7674,48 +7621,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 1001, col: 1, offset: 27902},
+			pos:  position{line: 992, col: 1, offset: 27803},
 			expr: &choiceExpr{
-				pos: position{line: 1002, col: 5, offset: 27924},
+				pos: position{line: 993, col: 5, offset: 27825},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 5, offset: 27924},
+						pos:  position{line: 993, col: 5, offset: 27825},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 14, offset: 27933},
+						pos:  position{line: 993, col: 14, offset: 27834},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 19, offset: 27938},
+						pos:  position{line: 993, col: 19, offset: 27839},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 27, offset: 27946},
+						pos:  position{line: 993, col: 27, offset: 27847},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 34, offset: 27953},
+						pos:  position{line: 993, col: 34, offset: 27854},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 42, offset: 27961},
+						pos:  position{line: 993, col: 42, offset: 27862},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 50, offset: 27969},
+						pos:  position{line: 993, col: 50, offset: 27870},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 59, offset: 27978},
+						pos:  position{line: 993, col: 59, offset: 27879},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 67, offset: 27986},
+						pos:  position{line: 993, col: 67, offset: 27887},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 75, offset: 27994},
+						pos:  position{line: 993, col: 75, offset: 27895},
 						name: "ON",
 					},
 				},
@@ -7723,48 +7670,48 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1006, col: 1, offset: 28020},
+			pos:  position{line: 997, col: 1, offset: 27921},
 			expr: &choiceExpr{
-				pos: position{line: 1007, col: 5, offset: 28032},
+				pos: position{line: 998, col: 5, offset: 27933},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 28032},
+						pos:  position{line: 998, col: 5, offset: 27933},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 28048},
+						pos:  position{line: 999, col: 5, offset: 27949},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 28066},
+						pos:  position{line: 1000, col: 5, offset: 27967},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1010, col: 5, offset: 28084},
+						pos:  position{line: 1001, col: 5, offset: 27985},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1011, col: 5, offset: 28103},
+						pos:  position{line: 1002, col: 5, offset: 28004},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1012, col: 5, offset: 28116},
+						pos:  position{line: 1003, col: 5, offset: 28017},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 5, offset: 28125},
+						pos:  position{line: 1004, col: 5, offset: 28026},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1014, col: 5, offset: 28142},
+						pos:  position{line: 1005, col: 5, offset: 28043},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1015, col: 5, offset: 28161},
+						pos:  position{line: 1006, col: 5, offset: 28062},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1016, col: 5, offset: 28180},
+						pos:  position{line: 1007, col: 5, offset: 28081},
 						name: "NullLiteral",
 					},
 				},
@@ -7772,15 +7719,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1018, col: 1, offset: 28193},
+			pos:  position{line: 1009, col: 1, offset: 28094},
 			expr: &actionExpr{
-				pos: position{line: 1019, col: 5, offset: 28211},
+				pos: position{line: 1010, col: 5, offset: 28112},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1019, col: 5, offset: 28211},
+					pos:   position{line: 1010, col: 5, offset: 28112},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1019, col: 7, offset: 28213},
+						pos:  position{line: 1010, col: 7, offset: 28114},
 						name: "QuotedString",
 					},
 				},
@@ -7788,28 +7735,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1023, col: 1, offset: 28326},
+			pos:  position{line: 1014, col: 1, offset: 28227},
 			expr: &choiceExpr{
-				pos: position{line: 1024, col: 5, offset: 28344},
+				pos: position{line: 1015, col: 5, offset: 28245},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1024, col: 5, offset: 28344},
+						pos: position{line: 1015, col: 5, offset: 28245},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1024, col: 5, offset: 28344},
+							pos: position{line: 1015, col: 5, offset: 28245},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1024, col: 5, offset: 28344},
+									pos:   position{line: 1015, col: 5, offset: 28245},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1024, col: 7, offset: 28346},
+										pos:  position{line: 1015, col: 7, offset: 28247},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1024, col: 14, offset: 28353},
+									pos: position{line: 1015, col: 14, offset: 28254},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1024, col: 15, offset: 28354},
+										pos:  position{line: 1015, col: 15, offset: 28255},
 										name: "IdentifierRest",
 									},
 								},
@@ -7817,13 +7764,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1027, col: 5, offset: 28469},
+						pos: position{line: 1018, col: 5, offset: 28370},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1027, col: 5, offset: 28469},
+							pos:   position{line: 1018, col: 5, offset: 28370},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1027, col: 7, offset: 28471},
+								pos:  position{line: 1018, col: 7, offset: 28372},
 								name: "IP4Net",
 							},
 						},
@@ -7833,28 +7780,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1031, col: 1, offset: 28575},
+			pos:  position{line: 1022, col: 1, offset: 28476},
 			expr: &choiceExpr{
-				pos: position{line: 1032, col: 5, offset: 28594},
+				pos: position{line: 1023, col: 5, offset: 28495},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1032, col: 5, offset: 28594},
+						pos: position{line: 1023, col: 5, offset: 28495},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1032, col: 5, offset: 28594},
+							pos: position{line: 1023, col: 5, offset: 28495},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1032, col: 5, offset: 28594},
+									pos:   position{line: 1023, col: 5, offset: 28495},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1032, col: 7, offset: 28596},
+										pos:  position{line: 1023, col: 7, offset: 28497},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1032, col: 11, offset: 28600},
+									pos: position{line: 1023, col: 11, offset: 28501},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1032, col: 12, offset: 28601},
+										pos:  position{line: 1023, col: 12, offset: 28502},
 										name: "IdentifierRest",
 									},
 								},
@@ -7862,13 +7809,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1035, col: 5, offset: 28715},
+						pos: position{line: 1026, col: 5, offset: 28616},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1035, col: 5, offset: 28715},
+							pos:   position{line: 1026, col: 5, offset: 28616},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1035, col: 7, offset: 28717},
+								pos:  position{line: 1026, col: 7, offset: 28618},
 								name: "IP",
 							},
 						},
@@ -7878,15 +7825,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1039, col: 1, offset: 28816},
+			pos:  position{line: 1030, col: 1, offset: 28717},
 			expr: &actionExpr{
-				pos: position{line: 1040, col: 5, offset: 28833},
+				pos: position{line: 1031, col: 5, offset: 28734},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1040, col: 5, offset: 28833},
+					pos:   position{line: 1031, col: 5, offset: 28734},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1040, col: 7, offset: 28835},
+						pos:  position{line: 1031, col: 7, offset: 28736},
 						name: "FloatString",
 					},
 				},
@@ -7894,15 +7841,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1044, col: 1, offset: 28948},
+			pos:  position{line: 1035, col: 1, offset: 28849},
 			expr: &actionExpr{
-				pos: position{line: 1045, col: 5, offset: 28967},
+				pos: position{line: 1036, col: 5, offset: 28868},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1045, col: 5, offset: 28967},
+					pos:   position{line: 1036, col: 5, offset: 28868},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1045, col: 7, offset: 28969},
+						pos:  position{line: 1036, col: 7, offset: 28870},
 						name: "IntString",
 					},
 				},
@@ -7910,24 +7857,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1049, col: 1, offset: 29078},
+			pos:  position{line: 1040, col: 1, offset: 28979},
 			expr: &choiceExpr{
-				pos: position{line: 1050, col: 5, offset: 29097},
+				pos: position{line: 1041, col: 5, offset: 28998},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1050, col: 5, offset: 29097},
+						pos: position{line: 1041, col: 5, offset: 28998},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 1050, col: 5, offset: 29097},
+							pos:        position{line: 1041, col: 5, offset: 28998},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1051, col: 5, offset: 29210},
+						pos: position{line: 1042, col: 5, offset: 29111},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 1051, col: 5, offset: 29210},
+							pos:        position{line: 1042, col: 5, offset: 29111},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7937,12 +7884,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1053, col: 1, offset: 29321},
+			pos:  position{line: 1044, col: 1, offset: 29222},
 			expr: &actionExpr{
-				pos: position{line: 1054, col: 5, offset: 29337},
+				pos: position{line: 1045, col: 5, offset: 29238},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 1054, col: 5, offset: 29337},
+					pos:        position{line: 1045, col: 5, offset: 29238},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7950,34 +7897,34 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1056, col: 1, offset: 29443},
+			pos:  position{line: 1047, col: 1, offset: 29344},
 			expr: &actionExpr{
-				pos: position{line: 1057, col: 5, offset: 29459},
+				pos: position{line: 1048, col: 5, offset: 29360},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1057, col: 5, offset: 29459},
+					pos: position{line: 1048, col: 5, offset: 29360},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1057, col: 5, offset: 29459},
+							pos: position{line: 1048, col: 5, offset: 29360},
 							expr: &seqExpr{
-								pos: position{line: 1057, col: 7, offset: 29461},
+								pos: position{line: 1048, col: 7, offset: 29362},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1057, col: 7, offset: 29461},
+										pos:  position{line: 1048, col: 7, offset: 29362},
 										name: "SQLTokenSentinels",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1057, col: 25, offset: 29479},
+										pos:  position{line: 1048, col: 25, offset: 29380},
 										name: "EOT",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1057, col: 30, offset: 29484},
+							pos:   position{line: 1048, col: 30, offset: 29385},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1057, col: 34, offset: 29488},
+								pos:  position{line: 1048, col: 34, offset: 29389},
 								name: "TypeExternal",
 							},
 						},
@@ -7987,16 +7934,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1061, col: 1, offset: 29586},
+			pos:  position{line: 1052, col: 1, offset: 29487},
 			expr: &choiceExpr{
-				pos: position{line: 1062, col: 5, offset: 29599},
+				pos: position{line: 1053, col: 5, offset: 29500},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1062, col: 5, offset: 29599},
+						pos:  position{line: 1053, col: 5, offset: 29500},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1063, col: 5, offset: 29616},
+						pos:  position{line: 1054, col: 5, offset: 29517},
 						name: "PrimitiveType",
 					},
 				},
@@ -8004,36 +7951,36 @@ var g = &grammar{
 		},
 		{
 			name: "TypeExternal",
-			pos:  position{line: 1065, col: 1, offset: 29631},
+			pos:  position{line: 1056, col: 1, offset: 29532},
 			expr: &choiceExpr{
-				pos: position{line: 1066, col: 5, offset: 29648},
+				pos: position{line: 1057, col: 5, offset: 29549},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1066, col: 5, offset: 29648},
+						pos:  position{line: 1057, col: 5, offset: 29549},
 						name: "ExplicitType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 5, offset: 29665},
+						pos:  position{line: 1058, col: 5, offset: 29566},
 						name: "ComplexTypeExternal",
 					},
 					&actionExpr{
-						pos: position{line: 1068, col: 5, offset: 29689},
+						pos: position{line: 1059, col: 5, offset: 29590},
 						run: (*parser).callonTypeExternal4,
 						expr: &seqExpr{
-							pos: position{line: 1068, col: 5, offset: 29689},
+							pos: position{line: 1059, col: 5, offset: 29590},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1068, col: 5, offset: 29689},
+									pos:   position{line: 1059, col: 5, offset: 29590},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1068, col: 9, offset: 29693},
+										pos:  position{line: 1059, col: 9, offset: 29594},
 										name: "PrimitiveTypeExternal",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1068, col: 31, offset: 29715},
+									pos: position{line: 1059, col: 31, offset: 29616},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1068, col: 32, offset: 29716},
+										pos:  position{line: 1059, col: 32, offset: 29617},
 										name: "IdentifierRest",
 									},
 								},
@@ -8045,20 +7992,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1070, col: 1, offset: 29752},
+			pos:  position{line: 1061, col: 1, offset: 29653},
 			expr: &choiceExpr{
-				pos: position{line: 1071, col: 5, offset: 29761},
+				pos: position{line: 1062, col: 5, offset: 29662},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1071, col: 5, offset: 29761},
+						pos:  position{line: 1062, col: 5, offset: 29662},
 						name: "ExplicitType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1072, col: 5, offset: 29778},
+						pos:  position{line: 1063, col: 5, offset: 29679},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1073, col: 5, offset: 29796},
+						pos:  position{line: 1064, col: 5, offset: 29697},
 						name: "ComplexType",
 					},
 				},
@@ -8066,48 +8013,48 @@ var g = &grammar{
 		},
 		{
 			name: "ExplicitType",
-			pos:  position{line: 1075, col: 1, offset: 29809},
+			pos:  position{line: 1066, col: 1, offset: 29710},
 			expr: &choiceExpr{
-				pos: position{line: 1076, col: 5, offset: 29826},
+				pos: position{line: 1067, col: 5, offset: 29727},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1076, col: 5, offset: 29826},
+						pos: position{line: 1067, col: 5, offset: 29727},
 						run: (*parser).callonExplicitType2,
 						expr: &seqExpr{
-							pos: position{line: 1076, col: 5, offset: 29826},
+							pos: position{line: 1067, col: 5, offset: 29727},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1076, col: 5, offset: 29826},
+									pos:        position{line: 1067, col: 5, offset: 29727},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1076, col: 12, offset: 29833},
+									pos:  position{line: 1067, col: 12, offset: 29734},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1076, col: 15, offset: 29836},
+									pos:        position{line: 1067, col: 15, offset: 29737},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1076, col: 19, offset: 29840},
+									pos:  position{line: 1067, col: 19, offset: 29741},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1076, col: 22, offset: 29843},
+									pos:   position{line: 1067, col: 22, offset: 29744},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1076, col: 26, offset: 29847},
+										pos:  position{line: 1067, col: 26, offset: 29748},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1076, col: 31, offset: 29852},
+									pos:  position{line: 1067, col: 31, offset: 29753},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1076, col: 34, offset: 29855},
+									pos:        position{line: 1067, col: 34, offset: 29756},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8115,43 +8062,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 29882},
+						pos: position{line: 1068, col: 5, offset: 29783},
 						run: (*parser).callonExplicitType12,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 29882},
+							pos: position{line: 1068, col: 5, offset: 29783},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1077, col: 5, offset: 29882},
+									pos:        position{line: 1068, col: 5, offset: 29783},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1077, col: 12, offset: 29889},
+									pos:  position{line: 1068, col: 12, offset: 29790},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1077, col: 15, offset: 29892},
+									pos:        position{line: 1068, col: 15, offset: 29793},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1077, col: 19, offset: 29896},
+									pos:  position{line: 1068, col: 19, offset: 29797},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 22, offset: 29899},
+									pos:   position{line: 1068, col: 22, offset: 29800},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 26, offset: 29903},
+										pos:  position{line: 1068, col: 26, offset: 29804},
 										name: "TypeUnion",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1077, col: 36, offset: 29913},
+									pos:  position{line: 1068, col: 36, offset: 29814},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1077, col: 39, offset: 29916},
+									pos:        position{line: 1068, col: 39, offset: 29817},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8163,28 +8110,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1079, col: 1, offset: 29941},
+			pos:  position{line: 1070, col: 1, offset: 29842},
 			expr: &choiceExpr{
-				pos: position{line: 1080, col: 5, offset: 29959},
+				pos: position{line: 1071, col: 5, offset: 29860},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 29959},
+						pos: position{line: 1071, col: 5, offset: 29860},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1080, col: 5, offset: 29959},
+							pos: position{line: 1071, col: 5, offset: 29860},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1080, col: 5, offset: 29959},
+									pos:   position{line: 1071, col: 5, offset: 29860},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1080, col: 10, offset: 29964},
+										pos:  position{line: 1071, col: 10, offset: 29865},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1080, col: 24, offset: 29978},
+									pos: position{line: 1071, col: 24, offset: 29879},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1080, col: 25, offset: 29979},
+										pos:  position{line: 1071, col: 25, offset: 29880},
 										name: "IdentifierRest",
 									},
 								},
@@ -8192,55 +8139,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1081, col: 5, offset: 30019},
+						pos: position{line: 1072, col: 5, offset: 29920},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1081, col: 5, offset: 30019},
+							pos: position{line: 1072, col: 5, offset: 29920},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1081, col: 5, offset: 30019},
+									pos:   position{line: 1072, col: 5, offset: 29920},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1081, col: 10, offset: 30024},
+										pos:  position{line: 1072, col: 10, offset: 29925},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1081, col: 25, offset: 30039},
+									pos:  position{line: 1072, col: 25, offset: 29940},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1081, col: 28, offset: 30042},
+									pos:        position{line: 1072, col: 28, offset: 29943},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1081, col: 32, offset: 30046},
+									pos:  position{line: 1072, col: 32, offset: 29947},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1081, col: 35, offset: 30049},
+									pos:        position{line: 1072, col: 35, offset: 29950},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1081, col: 39, offset: 30053},
+									pos:  position{line: 1072, col: 39, offset: 29954},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1081, col: 42, offset: 30056},
+									pos:   position{line: 1072, col: 42, offset: 29957},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1081, col: 46, offset: 30060},
+										pos:  position{line: 1072, col: 46, offset: 29961},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1081, col: 51, offset: 30065},
+									pos:  position{line: 1072, col: 51, offset: 29966},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1081, col: 54, offset: 30068},
+									pos:        position{line: 1072, col: 54, offset: 29969},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8248,42 +8195,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1084, col: 5, offset: 30169},
+						pos: position{line: 1075, col: 5, offset: 30070},
 						run: (*parser).callonAmbiguousType21,
 						expr: &labeledExpr{
-							pos:   position{line: 1084, col: 5, offset: 30169},
+							pos:   position{line: 1075, col: 5, offset: 30070},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1084, col: 10, offset: 30174},
+								pos:  position{line: 1075, col: 10, offset: 30075},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1087, col: 5, offset: 30276},
+						pos: position{line: 1078, col: 5, offset: 30177},
 						run: (*parser).callonAmbiguousType24,
 						expr: &seqExpr{
-							pos: position{line: 1087, col: 5, offset: 30276},
+							pos: position{line: 1078, col: 5, offset: 30177},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1087, col: 5, offset: 30276},
+									pos:        position{line: 1078, col: 5, offset: 30177},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1087, col: 9, offset: 30280},
+									pos:  position{line: 1078, col: 9, offset: 30181},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1087, col: 12, offset: 30283},
+									pos:   position{line: 1078, col: 12, offset: 30184},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1087, col: 14, offset: 30285},
+										pos:  position{line: 1078, col: 14, offset: 30186},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1087, col: 25, offset: 30296},
+									pos:        position{line: 1078, col: 25, offset: 30197},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8295,15 +8242,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1089, col: 1, offset: 30319},
+			pos:  position{line: 1080, col: 1, offset: 30220},
 			expr: &actionExpr{
-				pos: position{line: 1090, col: 5, offset: 30333},
+				pos: position{line: 1081, col: 5, offset: 30234},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1090, col: 5, offset: 30333},
+					pos:   position{line: 1081, col: 5, offset: 30234},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1090, col: 11, offset: 30339},
+						pos:  position{line: 1081, col: 11, offset: 30240},
 						name: "TypeList",
 					},
 				},
@@ -8311,28 +8258,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1094, col: 1, offset: 30435},
+			pos:  position{line: 1085, col: 1, offset: 30336},
 			expr: &actionExpr{
-				pos: position{line: 1095, col: 5, offset: 30448},
+				pos: position{line: 1086, col: 5, offset: 30349},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1095, col: 5, offset: 30448},
+					pos: position{line: 1086, col: 5, offset: 30349},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1095, col: 5, offset: 30448},
+							pos:   position{line: 1086, col: 5, offset: 30349},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1095, col: 11, offset: 30454},
+								pos:  position{line: 1086, col: 11, offset: 30355},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1095, col: 16, offset: 30459},
+							pos:   position{line: 1086, col: 16, offset: 30360},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1095, col: 21, offset: 30464},
+								pos: position{line: 1086, col: 21, offset: 30365},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1095, col: 21, offset: 30464},
+									pos:  position{line: 1086, col: 21, offset: 30365},
 									name: "TypeListTail",
 								},
 							},
@@ -8343,31 +8290,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1099, col: 1, offset: 30558},
+			pos:  position{line: 1090, col: 1, offset: 30459},
 			expr: &actionExpr{
-				pos: position{line: 1099, col: 16, offset: 30573},
+				pos: position{line: 1090, col: 16, offset: 30474},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1099, col: 16, offset: 30573},
+					pos: position{line: 1090, col: 16, offset: 30474},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1099, col: 16, offset: 30573},
+							pos:  position{line: 1090, col: 16, offset: 30474},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1099, col: 19, offset: 30576},
+							pos:        position{line: 1090, col: 19, offset: 30477},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1099, col: 23, offset: 30580},
+							pos:  position{line: 1090, col: 23, offset: 30481},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1099, col: 26, offset: 30583},
+							pos:   position{line: 1090, col: 26, offset: 30484},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1099, col: 30, offset: 30587},
+								pos:  position{line: 1090, col: 30, offset: 30488},
 								name: "Type",
 							},
 						},
@@ -8377,39 +8324,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1101, col: 1, offset: 30613},
+			pos:  position{line: 1092, col: 1, offset: 30514},
 			expr: &choiceExpr{
-				pos: position{line: 1102, col: 5, offset: 30629},
+				pos: position{line: 1093, col: 5, offset: 30530},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1102, col: 5, offset: 30629},
+						pos: position{line: 1093, col: 5, offset: 30530},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1102, col: 5, offset: 30629},
+							pos: position{line: 1093, col: 5, offset: 30530},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1102, col: 5, offset: 30629},
+									pos:        position{line: 1093, col: 5, offset: 30530},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 9, offset: 30633},
+									pos:  position{line: 1093, col: 9, offset: 30534},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 12, offset: 30636},
+									pos:   position{line: 1093, col: 12, offset: 30537},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1102, col: 19, offset: 30643},
+										pos:  position{line: 1093, col: 19, offset: 30544},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 33, offset: 30657},
+									pos:  position{line: 1093, col: 33, offset: 30558},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1102, col: 36, offset: 30660},
+									pos:        position{line: 1093, col: 36, offset: 30561},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8417,34 +8364,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1105, col: 5, offset: 30755},
+						pos: position{line: 1096, col: 5, offset: 30656},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1105, col: 5, offset: 30755},
+							pos: position{line: 1096, col: 5, offset: 30656},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1105, col: 5, offset: 30755},
+									pos:        position{line: 1096, col: 5, offset: 30656},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1105, col: 9, offset: 30759},
+									pos:  position{line: 1096, col: 9, offset: 30660},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1105, col: 12, offset: 30762},
+									pos:   position{line: 1096, col: 12, offset: 30663},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 16, offset: 30766},
+										pos:  position{line: 1096, col: 16, offset: 30667},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1105, col: 21, offset: 30771},
+									pos:  position{line: 1096, col: 21, offset: 30672},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1105, col: 24, offset: 30774},
+									pos:        position{line: 1096, col: 24, offset: 30675},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8452,34 +8399,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1108, col: 5, offset: 30863},
+						pos: position{line: 1099, col: 5, offset: 30764},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1108, col: 5, offset: 30863},
+							pos: position{line: 1099, col: 5, offset: 30764},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1108, col: 5, offset: 30863},
+									pos:        position{line: 1099, col: 5, offset: 30764},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1108, col: 10, offset: 30868},
+									pos:  position{line: 1099, col: 10, offset: 30769},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1108, col: 14, offset: 30872},
+									pos:   position{line: 1099, col: 14, offset: 30773},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1108, col: 18, offset: 30876},
+										pos:  position{line: 1099, col: 18, offset: 30777},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1108, col: 23, offset: 30881},
+									pos:  position{line: 1099, col: 23, offset: 30782},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1108, col: 26, offset: 30884},
+									pos:        position{line: 1099, col: 26, offset: 30785},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8487,55 +8434,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1111, col: 5, offset: 30972},
+						pos: position{line: 1102, col: 5, offset: 30873},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1111, col: 5, offset: 30972},
+							pos: position{line: 1102, col: 5, offset: 30873},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1111, col: 5, offset: 30972},
+									pos:        position{line: 1102, col: 5, offset: 30873},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 10, offset: 30977},
+									pos:  position{line: 1102, col: 10, offset: 30878},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 13, offset: 30980},
+									pos:   position{line: 1102, col: 13, offset: 30881},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 21, offset: 30988},
+										pos:  position{line: 1102, col: 21, offset: 30889},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 26, offset: 30993},
+									pos:  position{line: 1102, col: 26, offset: 30894},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 29, offset: 30996},
+									pos:        position{line: 1102, col: 29, offset: 30897},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 33, offset: 31000},
+									pos:  position{line: 1102, col: 33, offset: 30901},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 36, offset: 31003},
+									pos:   position{line: 1102, col: 36, offset: 30904},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 44, offset: 31011},
+										pos:  position{line: 1102, col: 44, offset: 30912},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 49, offset: 31016},
+									pos:  position{line: 1102, col: 49, offset: 30917},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 52, offset: 31019},
+									pos:        position{line: 1102, col: 52, offset: 30920},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8547,39 +8494,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexTypeExternal",
-			pos:  position{line: 1115, col: 1, offset: 31133},
+			pos:  position{line: 1106, col: 1, offset: 31034},
 			expr: &choiceExpr{
-				pos: position{line: 1116, col: 5, offset: 31157},
+				pos: position{line: 1107, col: 5, offset: 31058},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1116, col: 5, offset: 31157},
+						pos: position{line: 1107, col: 5, offset: 31058},
 						run: (*parser).callonComplexTypeExternal2,
 						expr: &seqExpr{
-							pos: position{line: 1116, col: 5, offset: 31157},
+							pos: position{line: 1107, col: 5, offset: 31058},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1116, col: 5, offset: 31157},
+									pos:        position{line: 1107, col: 5, offset: 31058},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 9, offset: 31161},
+									pos:  position{line: 1107, col: 9, offset: 31062},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1116, col: 12, offset: 31164},
+									pos:   position{line: 1107, col: 12, offset: 31065},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1116, col: 19, offset: 31171},
+										pos:  position{line: 1107, col: 19, offset: 31072},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 33, offset: 31185},
+									pos:  position{line: 1107, col: 33, offset: 31086},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1116, col: 36, offset: 31188},
+									pos:        position{line: 1107, col: 36, offset: 31089},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8587,34 +8534,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1119, col: 5, offset: 31283},
+						pos: position{line: 1110, col: 5, offset: 31184},
 						run: (*parser).callonComplexTypeExternal10,
 						expr: &seqExpr{
-							pos: position{line: 1119, col: 5, offset: 31283},
+							pos: position{line: 1110, col: 5, offset: 31184},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1119, col: 5, offset: 31283},
+									pos:        position{line: 1110, col: 5, offset: 31184},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1119, col: 9, offset: 31287},
+									pos:  position{line: 1110, col: 9, offset: 31188},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1119, col: 12, offset: 31290},
+									pos:   position{line: 1110, col: 12, offset: 31191},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1119, col: 16, offset: 31294},
+										pos:  position{line: 1110, col: 16, offset: 31195},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1119, col: 29, offset: 31307},
+									pos:  position{line: 1110, col: 29, offset: 31208},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1119, col: 32, offset: 31310},
+									pos:        position{line: 1110, col: 32, offset: 31211},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8622,34 +8569,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1122, col: 5, offset: 31399},
+						pos: position{line: 1113, col: 5, offset: 31300},
 						run: (*parser).callonComplexTypeExternal18,
 						expr: &seqExpr{
-							pos: position{line: 1122, col: 5, offset: 31399},
+							pos: position{line: 1113, col: 5, offset: 31300},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1122, col: 5, offset: 31399},
+									pos:        position{line: 1113, col: 5, offset: 31300},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1122, col: 10, offset: 31404},
+									pos:  position{line: 1113, col: 10, offset: 31305},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1122, col: 13, offset: 31407},
+									pos:   position{line: 1113, col: 13, offset: 31308},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1122, col: 17, offset: 31411},
+										pos:  position{line: 1113, col: 17, offset: 31312},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1122, col: 30, offset: 31424},
+									pos:  position{line: 1113, col: 30, offset: 31325},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1122, col: 33, offset: 31427},
+									pos:        position{line: 1113, col: 33, offset: 31328},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8657,55 +8604,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1125, col: 5, offset: 31515},
+						pos: position{line: 1116, col: 5, offset: 31416},
 						run: (*parser).callonComplexTypeExternal26,
 						expr: &seqExpr{
-							pos: position{line: 1125, col: 5, offset: 31515},
+							pos: position{line: 1116, col: 5, offset: 31416},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1125, col: 5, offset: 31515},
+									pos:        position{line: 1116, col: 5, offset: 31416},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 10, offset: 31520},
+									pos:  position{line: 1116, col: 10, offset: 31421},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1125, col: 13, offset: 31523},
+									pos:   position{line: 1116, col: 13, offset: 31424},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1125, col: 21, offset: 31531},
+										pos:  position{line: 1116, col: 21, offset: 31432},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 34, offset: 31544},
+									pos:  position{line: 1116, col: 34, offset: 31445},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1125, col: 37, offset: 31547},
+									pos:        position{line: 1116, col: 37, offset: 31448},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 41, offset: 31551},
+									pos:  position{line: 1116, col: 41, offset: 31452},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1125, col: 44, offset: 31554},
+									pos:   position{line: 1116, col: 44, offset: 31455},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1125, col: 52, offset: 31562},
+										pos:  position{line: 1116, col: 52, offset: 31463},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 65, offset: 31575},
+									pos:  position{line: 1116, col: 65, offset: 31476},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1125, col: 68, offset: 31578},
+									pos:        position{line: 1116, col: 68, offset: 31479},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8717,16 +8664,16 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1129, col: 1, offset: 31692},
+			pos:  position{line: 1120, col: 1, offset: 31593},
 			expr: &choiceExpr{
-				pos: position{line: 1130, col: 5, offset: 31710},
+				pos: position{line: 1121, col: 5, offset: 31611},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1130, col: 5, offset: 31710},
+						pos:  position{line: 1121, col: 5, offset: 31611},
 						name: "PrimitiveTypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1131, col: 5, offset: 31736},
+						pos:  position{line: 1122, col: 5, offset: 31637},
 						name: "PrimitiveTypeInternal",
 					},
 				},
@@ -8734,65 +8681,65 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeExternal",
-			pos:  position{line: 1137, col: 1, offset: 31995},
+			pos:  position{line: 1128, col: 1, offset: 31896},
 			expr: &actionExpr{
-				pos: position{line: 1138, col: 5, offset: 32021},
+				pos: position{line: 1129, col: 5, offset: 31922},
 				run: (*parser).callonPrimitiveTypeExternal1,
 				expr: &choiceExpr{
-					pos: position{line: 1138, col: 9, offset: 32025},
+					pos: position{line: 1129, col: 9, offset: 31926},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1138, col: 9, offset: 32025},
+							pos:        position{line: 1129, col: 9, offset: 31926},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1138, col: 19, offset: 32035},
+							pos:        position{line: 1129, col: 19, offset: 31936},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1138, col: 30, offset: 32046},
+							pos:        position{line: 1129, col: 30, offset: 31947},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1138, col: 41, offset: 32057},
+							pos:        position{line: 1129, col: 41, offset: 31958},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1139, col: 9, offset: 32074},
+							pos:        position{line: 1130, col: 9, offset: 31975},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1139, col: 18, offset: 32083},
+							pos:        position{line: 1130, col: 18, offset: 31984},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1139, col: 28, offset: 32093},
+							pos:        position{line: 1130, col: 28, offset: 31994},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1139, col: 38, offset: 32103},
+							pos:        position{line: 1130, col: 38, offset: 32004},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1140, col: 9, offset: 32119},
+							pos:        position{line: 1131, col: 9, offset: 32020},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1141, col: 9, offset: 32137},
+							pos:        position{line: 1132, col: 9, offset: 32038},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1141, col: 18, offset: 32146},
+							pos:        position{line: 1132, col: 18, offset: 32047},
 							val:        "string",
 							ignoreCase: false,
 						},
@@ -8802,55 +8749,55 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeInternal",
-			pos:  position{line: 1152, col: 1, offset: 32787},
+			pos:  position{line: 1143, col: 1, offset: 32688},
 			expr: &actionExpr{
-				pos: position{line: 1153, col: 5, offset: 32813},
+				pos: position{line: 1144, col: 5, offset: 32714},
 				run: (*parser).callonPrimitiveTypeInternal1,
 				expr: &choiceExpr{
-					pos: position{line: 1153, col: 9, offset: 32817},
+					pos: position{line: 1144, col: 9, offset: 32718},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1153, col: 9, offset: 32817},
+							pos:        position{line: 1144, col: 9, offset: 32718},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1153, col: 22, offset: 32830},
+							pos:        position{line: 1144, col: 22, offset: 32731},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1154, col: 9, offset: 32845},
+							pos:        position{line: 1145, col: 9, offset: 32746},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1155, col: 9, offset: 32861},
+							pos:        position{line: 1146, col: 9, offset: 32762},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1156, col: 9, offset: 32879},
+							pos:        position{line: 1147, col: 9, offset: 32780},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1156, col: 16, offset: 32886},
+							pos:        position{line: 1147, col: 16, offset: 32787},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1157, col: 9, offset: 32900},
+							pos:        position{line: 1148, col: 9, offset: 32801},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1157, col: 18, offset: 32909},
+							pos:        position{line: 1148, col: 18, offset: 32810},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1157, col: 28, offset: 32919},
+							pos:        position{line: 1148, col: 28, offset: 32820},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8860,28 +8807,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1161, col: 1, offset: 33035},
+			pos:  position{line: 1152, col: 1, offset: 32936},
 			expr: &actionExpr{
-				pos: position{line: 1162, col: 5, offset: 33053},
+				pos: position{line: 1153, col: 5, offset: 32954},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1162, col: 5, offset: 33053},
+					pos: position{line: 1153, col: 5, offset: 32954},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1162, col: 5, offset: 33053},
+							pos:   position{line: 1153, col: 5, offset: 32954},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1162, col: 11, offset: 33059},
+								pos:  position{line: 1153, col: 11, offset: 32960},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1162, col: 21, offset: 33069},
+							pos:   position{line: 1153, col: 21, offset: 32970},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1162, col: 26, offset: 33074},
+								pos: position{line: 1153, col: 26, offset: 32975},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1162, col: 26, offset: 33074},
+									pos:  position{line: 1153, col: 26, offset: 32975},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -8892,31 +8839,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1166, col: 1, offset: 33173},
+			pos:  position{line: 1157, col: 1, offset: 33074},
 			expr: &actionExpr{
-				pos: position{line: 1166, col: 21, offset: 33193},
+				pos: position{line: 1157, col: 21, offset: 33094},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1166, col: 21, offset: 33193},
+					pos: position{line: 1157, col: 21, offset: 33094},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 21, offset: 33193},
+							pos:  position{line: 1157, col: 21, offset: 33094},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 24, offset: 33196},
+							pos:        position{line: 1157, col: 24, offset: 33097},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 28, offset: 33200},
+							pos:  position{line: 1157, col: 28, offset: 33101},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1166, col: 31, offset: 33203},
+							pos:   position{line: 1157, col: 31, offset: 33104},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1166, col: 35, offset: 33207},
+								pos:  position{line: 1157, col: 35, offset: 33108},
 								name: "TypeField",
 							},
 						},
@@ -8926,39 +8873,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1168, col: 1, offset: 33238},
+			pos:  position{line: 1159, col: 1, offset: 33139},
 			expr: &actionExpr{
-				pos: position{line: 1169, col: 5, offset: 33252},
+				pos: position{line: 1160, col: 5, offset: 33153},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1169, col: 5, offset: 33252},
+					pos: position{line: 1160, col: 5, offset: 33153},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1169, col: 5, offset: 33252},
+							pos:   position{line: 1160, col: 5, offset: 33153},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1169, col: 10, offset: 33257},
+								pos:  position{line: 1160, col: 10, offset: 33158},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1169, col: 20, offset: 33267},
+							pos:  position{line: 1160, col: 20, offset: 33168},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1169, col: 23, offset: 33270},
+							pos:        position{line: 1160, col: 23, offset: 33171},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1169, col: 27, offset: 33274},
+							pos:  position{line: 1160, col: 27, offset: 33175},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1169, col: 30, offset: 33277},
+							pos:   position{line: 1160, col: 30, offset: 33178},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1169, col: 34, offset: 33281},
+								pos:  position{line: 1160, col: 34, offset: 33182},
 								name: "Type",
 							},
 						},
@@ -8968,28 +8915,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListExternal",
-			pos:  position{line: 1173, col: 1, offset: 33363},
+			pos:  position{line: 1164, col: 1, offset: 33264},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 5, offset: 33389},
+				pos: position{line: 1165, col: 5, offset: 33290},
 				run: (*parser).callonTypeFieldListExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1174, col: 5, offset: 33389},
+					pos: position{line: 1165, col: 5, offset: 33290},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1174, col: 5, offset: 33389},
+							pos:   position{line: 1165, col: 5, offset: 33290},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1174, col: 11, offset: 33395},
+								pos:  position{line: 1165, col: 11, offset: 33296},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1174, col: 21, offset: 33405},
+							pos:   position{line: 1165, col: 21, offset: 33306},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1174, col: 26, offset: 33410},
+								pos: position{line: 1165, col: 26, offset: 33311},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1174, col: 26, offset: 33410},
+									pos:  position{line: 1165, col: 26, offset: 33311},
 									name: "TypeFieldListTailExternal",
 								},
 							},
@@ -9000,31 +8947,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTailExternal",
-			pos:  position{line: 1178, col: 1, offset: 33517},
+			pos:  position{line: 1169, col: 1, offset: 33418},
 			expr: &actionExpr{
-				pos: position{line: 1178, col: 29, offset: 33545},
+				pos: position{line: 1169, col: 29, offset: 33446},
 				run: (*parser).callonTypeFieldListTailExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1178, col: 29, offset: 33545},
+					pos: position{line: 1169, col: 29, offset: 33446},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1178, col: 29, offset: 33545},
+							pos:  position{line: 1169, col: 29, offset: 33446},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1178, col: 32, offset: 33548},
+							pos:        position{line: 1169, col: 32, offset: 33449},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1178, col: 36, offset: 33552},
+							pos:  position{line: 1169, col: 36, offset: 33453},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1178, col: 39, offset: 33555},
+							pos:   position{line: 1169, col: 39, offset: 33456},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1178, col: 43, offset: 33559},
+								pos:  position{line: 1169, col: 43, offset: 33460},
 								name: "TypeFieldExternal",
 							},
 						},
@@ -9034,39 +8981,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldExternal",
-			pos:  position{line: 1180, col: 1, offset: 33598},
+			pos:  position{line: 1171, col: 1, offset: 33499},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 5, offset: 33620},
+				pos: position{line: 1172, col: 5, offset: 33521},
 				run: (*parser).callonTypeFieldExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1181, col: 5, offset: 33620},
+					pos: position{line: 1172, col: 5, offset: 33521},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1181, col: 5, offset: 33620},
+							pos:   position{line: 1172, col: 5, offset: 33521},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 10, offset: 33625},
+								pos:  position{line: 1172, col: 10, offset: 33526},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 20, offset: 33635},
+							pos:  position{line: 1172, col: 20, offset: 33536},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1181, col: 23, offset: 33638},
+							pos:        position{line: 1172, col: 23, offset: 33539},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 27, offset: 33642},
+							pos:  position{line: 1172, col: 27, offset: 33543},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 30, offset: 33645},
+							pos:   position{line: 1172, col: 30, offset: 33546},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 34, offset: 33649},
+								pos:  position{line: 1172, col: 34, offset: 33550},
 								name: "TypeExternal",
 							},
 						},
@@ -9076,16 +9023,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1185, col: 1, offset: 33739},
+			pos:  position{line: 1176, col: 1, offset: 33640},
 			expr: &choiceExpr{
-				pos: position{line: 1186, col: 5, offset: 33753},
+				pos: position{line: 1177, col: 5, offset: 33654},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 5, offset: 33753},
+						pos:  position{line: 1177, col: 5, offset: 33654},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1187, col: 5, offset: 33772},
+						pos:  position{line: 1178, col: 5, offset: 33673},
 						name: "QuotedString",
 					},
 				},
@@ -9093,16 +9040,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 1189, col: 1, offset: 33786},
+			pos:  position{line: 1180, col: 1, offset: 33687},
 			expr: &choiceExpr{
-				pos: position{line: 1190, col: 5, offset: 33804},
+				pos: position{line: 1181, col: 5, offset: 33705},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1190, col: 5, offset: 33804},
+						pos:  position{line: 1181, col: 5, offset: 33705},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1190, col: 24, offset: 33823},
+						pos:  position{line: 1181, col: 24, offset: 33724},
 						name: "RelativeOperator",
 					},
 				},
@@ -9110,22 +9057,22 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1192, col: 1, offset: 33841},
+			pos:  position{line: 1183, col: 1, offset: 33742},
 			expr: &actionExpr{
-				pos: position{line: 1192, col: 12, offset: 33852},
+				pos: position{line: 1183, col: 12, offset: 33753},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1192, col: 12, offset: 33852},
+					pos: position{line: 1183, col: 12, offset: 33753},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1192, col: 12, offset: 33852},
+							pos:        position{line: 1183, col: 12, offset: 33753},
 							val:        "and",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1192, col: 19, offset: 33859},
+							pos: position{line: 1183, col: 19, offset: 33760},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1192, col: 20, offset: 33860},
+								pos:  position{line: 1183, col: 20, offset: 33761},
 								name: "IdentifierRest",
 							},
 						},
@@ -9135,22 +9082,22 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1193, col: 1, offset: 33897},
+			pos:  position{line: 1184, col: 1, offset: 33798},
 			expr: &actionExpr{
-				pos: position{line: 1193, col: 11, offset: 33907},
+				pos: position{line: 1184, col: 11, offset: 33808},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1193, col: 11, offset: 33907},
+					pos: position{line: 1184, col: 11, offset: 33808},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1193, col: 11, offset: 33907},
+							pos:        position{line: 1184, col: 11, offset: 33808},
 							val:        "or",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1193, col: 17, offset: 33913},
+							pos: position{line: 1184, col: 17, offset: 33814},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1193, col: 18, offset: 33914},
+								pos:  position{line: 1184, col: 18, offset: 33815},
 								name: "IdentifierRest",
 							},
 						},
@@ -9160,22 +9107,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1194, col: 1, offset: 33950},
+			pos:  position{line: 1185, col: 1, offset: 33851},
 			expr: &actionExpr{
-				pos: position{line: 1194, col: 11, offset: 33960},
+				pos: position{line: 1185, col: 11, offset: 33861},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1194, col: 11, offset: 33960},
+					pos: position{line: 1185, col: 11, offset: 33861},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1194, col: 11, offset: 33960},
+							pos:        position{line: 1185, col: 11, offset: 33861},
 							val:        "in",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1194, col: 17, offset: 33966},
+							pos: position{line: 1185, col: 17, offset: 33867},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1194, col: 18, offset: 33967},
+								pos:  position{line: 1185, col: 18, offset: 33868},
 								name: "IdentifierRest",
 							},
 						},
@@ -9185,22 +9132,22 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1195, col: 1, offset: 34003},
+			pos:  position{line: 1186, col: 1, offset: 33904},
 			expr: &actionExpr{
-				pos: position{line: 1195, col: 12, offset: 34014},
+				pos: position{line: 1186, col: 12, offset: 33915},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1195, col: 12, offset: 34014},
+					pos: position{line: 1186, col: 12, offset: 33915},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1195, col: 12, offset: 34014},
+							pos:        position{line: 1186, col: 12, offset: 33915},
 							val:        "not",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1195, col: 19, offset: 34021},
+							pos: position{line: 1186, col: 19, offset: 33922},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1195, col: 20, offset: 34022},
+								pos:  position{line: 1186, col: 20, offset: 33923},
 								name: "IdentifierRest",
 							},
 						},
@@ -9210,22 +9157,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1196, col: 1, offset: 34059},
+			pos:  position{line: 1187, col: 1, offset: 33960},
 			expr: &actionExpr{
-				pos: position{line: 1196, col: 11, offset: 34069},
+				pos: position{line: 1187, col: 11, offset: 33970},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1196, col: 11, offset: 34069},
+					pos: position{line: 1187, col: 11, offset: 33970},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1196, col: 11, offset: 34069},
+							pos:        position{line: 1187, col: 11, offset: 33970},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1196, col: 17, offset: 34075},
+							pos: position{line: 1187, col: 17, offset: 33976},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1196, col: 18, offset: 34076},
+								pos:  position{line: 1187, col: 18, offset: 33977},
 								name: "IdentifierRest",
 							},
 						},
@@ -9235,9 +9182,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1198, col: 1, offset: 34113},
+			pos:  position{line: 1189, col: 1, offset: 34014},
 			expr: &charClassMatcher{
-				pos:        position{line: 1198, col: 19, offset: 34131},
+				pos:        position{line: 1189, col: 19, offset: 34032},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9247,16 +9194,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1200, col: 1, offset: 34143},
+			pos:  position{line: 1191, col: 1, offset: 34044},
 			expr: &choiceExpr{
-				pos: position{line: 1200, col: 18, offset: 34160},
+				pos: position{line: 1191, col: 18, offset: 34061},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1200, col: 18, offset: 34160},
+						pos:  position{line: 1191, col: 18, offset: 34061},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1200, col: 36, offset: 34178},
+						pos:        position{line: 1191, col: 36, offset: 34079},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9267,15 +9214,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1202, col: 1, offset: 34185},
+			pos:  position{line: 1193, col: 1, offset: 34086},
 			expr: &actionExpr{
-				pos: position{line: 1203, col: 5, offset: 34200},
+				pos: position{line: 1194, col: 5, offset: 34101},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1203, col: 5, offset: 34200},
+					pos:   position{line: 1194, col: 5, offset: 34101},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1203, col: 8, offset: 34203},
+						pos:  position{line: 1194, col: 8, offset: 34104},
 						name: "IdentifierName",
 					},
 				},
@@ -9283,29 +9230,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1205, col: 1, offset: 34284},
+			pos:  position{line: 1196, col: 1, offset: 34185},
 			expr: &choiceExpr{
-				pos: position{line: 1206, col: 5, offset: 34303},
+				pos: position{line: 1197, col: 5, offset: 34204},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1206, col: 5, offset: 34303},
+						pos: position{line: 1197, col: 5, offset: 34204},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1206, col: 5, offset: 34303},
+							pos: position{line: 1197, col: 5, offset: 34204},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1206, col: 5, offset: 34303},
+									pos: position{line: 1197, col: 5, offset: 34204},
 									expr: &seqExpr{
-										pos: position{line: 1206, col: 7, offset: 34305},
+										pos: position{line: 1197, col: 7, offset: 34206},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1206, col: 7, offset: 34305},
+												pos:  position{line: 1197, col: 7, offset: 34206},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1206, col: 15, offset: 34313},
+												pos: position{line: 1197, col: 15, offset: 34214},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1206, col: 16, offset: 34314},
+													pos:  position{line: 1197, col: 16, offset: 34215},
 													name: "IdentifierRest",
 												},
 											},
@@ -9313,13 +9260,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1206, col: 32, offset: 34330},
+									pos:  position{line: 1197, col: 32, offset: 34231},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1206, col: 48, offset: 34346},
+									pos: position{line: 1197, col: 48, offset: 34247},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1206, col: 48, offset: 34346},
+										pos:  position{line: 1197, col: 48, offset: 34247},
 										name: "IdentifierRest",
 									},
 								},
@@ -9327,30 +9274,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1207, col: 5, offset: 34398},
+						pos: position{line: 1198, col: 5, offset: 34299},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1207, col: 5, offset: 34398},
+							pos:        position{line: 1198, col: 5, offset: 34299},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1208, col: 5, offset: 34437},
+						pos: position{line: 1199, col: 5, offset: 34338},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1208, col: 5, offset: 34437},
+							pos: position{line: 1199, col: 5, offset: 34338},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1208, col: 5, offset: 34437},
+									pos:        position{line: 1199, col: 5, offset: 34338},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1208, col: 10, offset: 34442},
+									pos:   position{line: 1199, col: 10, offset: 34343},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1208, col: 13, offset: 34445},
+										pos:  position{line: 1199, col: 13, offset: 34346},
 										name: "IDGuard",
 									},
 								},
@@ -9358,39 +9305,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1210, col: 5, offset: 34536},
+						pos: position{line: 1201, col: 5, offset: 34437},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1210, col: 5, offset: 34536},
+							pos:        position{line: 1201, col: 5, offset: 34437},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1211, col: 5, offset: 34578},
+						pos: position{line: 1202, col: 5, offset: 34479},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1211, col: 5, offset: 34578},
+							pos: position{line: 1202, col: 5, offset: 34479},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1211, col: 5, offset: 34578},
+									pos:   position{line: 1202, col: 5, offset: 34479},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1211, col: 8, offset: 34581},
+										pos:  position{line: 1202, col: 8, offset: 34482},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1211, col: 26, offset: 34599},
+									pos: position{line: 1202, col: 26, offset: 34500},
 									expr: &seqExpr{
-										pos: position{line: 1211, col: 28, offset: 34601},
+										pos: position{line: 1202, col: 28, offset: 34502},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1211, col: 28, offset: 34601},
+												pos:  position{line: 1202, col: 28, offset: 34502},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1211, col: 31, offset: 34604},
+												pos:        position{line: 1202, col: 31, offset: 34505},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9405,24 +9352,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1213, col: 1, offset: 34629},
+			pos:  position{line: 1204, col: 1, offset: 34530},
 			expr: &choiceExpr{
-				pos: position{line: 1214, col: 5, offset: 34641},
+				pos: position{line: 1205, col: 5, offset: 34542},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1214, col: 5, offset: 34641},
+						pos:  position{line: 1205, col: 5, offset: 34542},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 5, offset: 34660},
+						pos:  position{line: 1206, col: 5, offset: 34561},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1216, col: 5, offset: 34676},
+						pos:  position{line: 1207, col: 5, offset: 34577},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 5, offset: 34693},
+						pos:  position{line: 1208, col: 5, offset: 34594},
 						name: "SearchGuard",
 					},
 				},
@@ -9430,24 +9377,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1219, col: 1, offset: 34706},
+			pos:  position{line: 1210, col: 1, offset: 34607},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 5, offset: 34715},
+				pos: position{line: 1211, col: 5, offset: 34616},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 5, offset: 34715},
+					pos: position{line: 1211, col: 5, offset: 34616},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 5, offset: 34715},
+							pos:  position{line: 1211, col: 5, offset: 34616},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1220, col: 14, offset: 34724},
+							pos:        position{line: 1211, col: 14, offset: 34625},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 18, offset: 34728},
+							pos:  position{line: 1211, col: 18, offset: 34629},
 							name: "FullTime",
 						},
 					},
@@ -9456,30 +9403,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1224, col: 1, offset: 34848},
+			pos:  position{line: 1215, col: 1, offset: 34749},
 			expr: &seqExpr{
-				pos: position{line: 1224, col: 12, offset: 34859},
+				pos: position{line: 1215, col: 12, offset: 34760},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 12, offset: 34859},
+						pos:  position{line: 1215, col: 12, offset: 34760},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1224, col: 15, offset: 34862},
+						pos:        position{line: 1215, col: 15, offset: 34763},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 19, offset: 34866},
+						pos:  position{line: 1215, col: 19, offset: 34767},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1224, col: 22, offset: 34869},
+						pos:        position{line: 1215, col: 22, offset: 34770},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 26, offset: 34873},
+						pos:  position{line: 1215, col: 26, offset: 34774},
 						name: "D2",
 					},
 				},
@@ -9487,33 +9434,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1226, col: 1, offset: 34877},
+			pos:  position{line: 1217, col: 1, offset: 34778},
 			expr: &seqExpr{
-				pos: position{line: 1226, col: 6, offset: 34882},
+				pos: position{line: 1217, col: 6, offset: 34783},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1226, col: 6, offset: 34882},
+						pos:        position{line: 1217, col: 6, offset: 34783},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1226, col: 11, offset: 34887},
+						pos:        position{line: 1217, col: 11, offset: 34788},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1226, col: 16, offset: 34892},
+						pos:        position{line: 1217, col: 16, offset: 34793},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1226, col: 21, offset: 34897},
+						pos:        position{line: 1217, col: 21, offset: 34798},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9524,19 +9471,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1227, col: 1, offset: 34903},
+			pos:  position{line: 1218, col: 1, offset: 34804},
 			expr: &seqExpr{
-				pos: position{line: 1227, col: 6, offset: 34908},
+				pos: position{line: 1218, col: 6, offset: 34809},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1227, col: 6, offset: 34908},
+						pos:        position{line: 1218, col: 6, offset: 34809},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1227, col: 11, offset: 34913},
+						pos:        position{line: 1218, col: 11, offset: 34814},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9547,16 +9494,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1229, col: 1, offset: 34920},
+			pos:  position{line: 1220, col: 1, offset: 34821},
 			expr: &seqExpr{
-				pos: position{line: 1229, col: 12, offset: 34931},
+				pos: position{line: 1220, col: 12, offset: 34832},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 12, offset: 34931},
+						pos:  position{line: 1220, col: 12, offset: 34832},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 24, offset: 34943},
+						pos:  position{line: 1220, col: 24, offset: 34844},
 						name: "TimeOffset",
 					},
 				},
@@ -9564,46 +9511,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1231, col: 1, offset: 34955},
+			pos:  position{line: 1222, col: 1, offset: 34856},
 			expr: &seqExpr{
-				pos: position{line: 1231, col: 15, offset: 34969},
+				pos: position{line: 1222, col: 15, offset: 34870},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 15, offset: 34969},
+						pos:  position{line: 1222, col: 15, offset: 34870},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1231, col: 18, offset: 34972},
+						pos:        position{line: 1222, col: 18, offset: 34873},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 22, offset: 34976},
+						pos:  position{line: 1222, col: 22, offset: 34877},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1231, col: 25, offset: 34979},
+						pos:        position{line: 1222, col: 25, offset: 34880},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 29, offset: 34983},
+						pos:  position{line: 1222, col: 29, offset: 34884},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1231, col: 32, offset: 34986},
+						pos: position{line: 1222, col: 32, offset: 34887},
 						expr: &seqExpr{
-							pos: position{line: 1231, col: 33, offset: 34987},
+							pos: position{line: 1222, col: 33, offset: 34888},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1231, col: 33, offset: 34987},
+									pos:        position{line: 1222, col: 33, offset: 34888},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1231, col: 37, offset: 34991},
+									pos: position{line: 1222, col: 37, offset: 34892},
 									expr: &charClassMatcher{
-										pos:        position{line: 1231, col: 37, offset: 34991},
+										pos:        position{line: 1222, col: 37, offset: 34892},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9618,60 +9565,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1233, col: 1, offset: 35001},
+			pos:  position{line: 1224, col: 1, offset: 34902},
 			expr: &choiceExpr{
-				pos: position{line: 1234, col: 5, offset: 35016},
+				pos: position{line: 1225, col: 5, offset: 34917},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1234, col: 5, offset: 35016},
+						pos:        position{line: 1225, col: 5, offset: 34917},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1235, col: 5, offset: 35024},
+						pos: position{line: 1226, col: 5, offset: 34925},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1235, col: 6, offset: 35025},
+								pos: position{line: 1226, col: 6, offset: 34926},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1235, col: 6, offset: 35025},
+										pos:        position{line: 1226, col: 6, offset: 34926},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1235, col: 12, offset: 35031},
+										pos:        position{line: 1226, col: 12, offset: 34932},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1235, col: 17, offset: 35036},
+								pos:  position{line: 1226, col: 17, offset: 34937},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1235, col: 20, offset: 35039},
+								pos:        position{line: 1226, col: 20, offset: 34940},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1235, col: 24, offset: 35043},
+								pos:  position{line: 1226, col: 24, offset: 34944},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1235, col: 27, offset: 35046},
+								pos: position{line: 1226, col: 27, offset: 34947},
 								expr: &seqExpr{
-									pos: position{line: 1235, col: 28, offset: 35047},
+									pos: position{line: 1226, col: 28, offset: 34948},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1235, col: 28, offset: 35047},
+											pos:        position{line: 1226, col: 28, offset: 34948},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1235, col: 32, offset: 35051},
+											pos: position{line: 1226, col: 32, offset: 34952},
 											expr: &charClassMatcher{
-												pos:        position{line: 1235, col: 32, offset: 35051},
+												pos:        position{line: 1226, col: 32, offset: 34952},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9688,32 +9635,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1237, col: 1, offset: 35061},
+			pos:  position{line: 1228, col: 1, offset: 34962},
 			expr: &actionExpr{
-				pos: position{line: 1238, col: 5, offset: 35074},
+				pos: position{line: 1229, col: 5, offset: 34975},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1238, col: 5, offset: 35074},
+					pos: position{line: 1229, col: 5, offset: 34975},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1238, col: 5, offset: 35074},
+							pos: position{line: 1229, col: 5, offset: 34975},
 							expr: &litMatcher{
-								pos:        position{line: 1238, col: 5, offset: 35074},
+								pos:        position{line: 1229, col: 5, offset: 34975},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1238, col: 10, offset: 35079},
+							pos: position{line: 1229, col: 10, offset: 34980},
 							expr: &seqExpr{
-								pos: position{line: 1238, col: 11, offset: 35080},
+								pos: position{line: 1229, col: 11, offset: 34981},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1238, col: 11, offset: 35080},
+										pos:  position{line: 1229, col: 11, offset: 34981},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1238, col: 19, offset: 35088},
+										pos:  position{line: 1229, col: 19, offset: 34989},
 										name: "TimeUnit",
 									},
 								},
@@ -9725,26 +9672,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1242, col: 1, offset: 35214},
+			pos:  position{line: 1233, col: 1, offset: 35115},
 			expr: &seqExpr{
-				pos: position{line: 1242, col: 11, offset: 35224},
+				pos: position{line: 1233, col: 11, offset: 35125},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1242, col: 11, offset: 35224},
+						pos:  position{line: 1233, col: 11, offset: 35125},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1242, col: 16, offset: 35229},
+						pos: position{line: 1233, col: 16, offset: 35130},
 						expr: &seqExpr{
-							pos: position{line: 1242, col: 17, offset: 35230},
+							pos: position{line: 1233, col: 17, offset: 35131},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1242, col: 17, offset: 35230},
+									pos:        position{line: 1233, col: 17, offset: 35131},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1242, col: 21, offset: 35234},
+									pos:  position{line: 1233, col: 21, offset: 35135},
 									name: "UInt",
 								},
 							},
@@ -9755,52 +9702,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1244, col: 1, offset: 35242},
+			pos:  position{line: 1235, col: 1, offset: 35143},
 			expr: &choiceExpr{
-				pos: position{line: 1245, col: 5, offset: 35255},
+				pos: position{line: 1236, col: 5, offset: 35156},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1245, col: 5, offset: 35255},
+						pos:        position{line: 1236, col: 5, offset: 35156},
 						val:        "ns",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1246, col: 5, offset: 35265},
+						pos:        position{line: 1237, col: 5, offset: 35166},
 						val:        "us",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1247, col: 5, offset: 35275},
+						pos:        position{line: 1238, col: 5, offset: 35176},
 						val:        "ms",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1248, col: 5, offset: 35285},
+						pos:        position{line: 1239, col: 5, offset: 35186},
 						val:        "s",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1249, col: 5, offset: 35294},
+						pos:        position{line: 1240, col: 5, offset: 35195},
 						val:        "m",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1250, col: 5, offset: 35303},
+						pos:        position{line: 1241, col: 5, offset: 35204},
 						val:        "h",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1251, col: 5, offset: 35312},
+						pos:        position{line: 1242, col: 5, offset: 35213},
 						val:        "d",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1252, col: 5, offset: 35321},
+						pos:        position{line: 1243, col: 5, offset: 35222},
 						val:        "w",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1253, col: 5, offset: 35330},
+						pos:        position{line: 1244, col: 5, offset: 35231},
 						val:        "y",
 						ignoreCase: true,
 					},
@@ -9809,42 +9756,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1255, col: 1, offset: 35336},
+			pos:  position{line: 1246, col: 1, offset: 35237},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 5, offset: 35343},
+				pos: position{line: 1247, col: 5, offset: 35244},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1256, col: 5, offset: 35343},
+					pos: position{line: 1247, col: 5, offset: 35244},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 5, offset: 35343},
+							pos:  position{line: 1247, col: 5, offset: 35244},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1256, col: 10, offset: 35348},
+							pos:        position{line: 1247, col: 10, offset: 35249},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 14, offset: 35352},
+							pos:  position{line: 1247, col: 14, offset: 35253},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1256, col: 19, offset: 35357},
+							pos:        position{line: 1247, col: 19, offset: 35258},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 23, offset: 35361},
+							pos:  position{line: 1247, col: 23, offset: 35262},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1256, col: 28, offset: 35366},
+							pos:        position{line: 1247, col: 28, offset: 35267},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 32, offset: 35370},
+							pos:  position{line: 1247, col: 32, offset: 35271},
 							name: "UInt",
 						},
 					},
@@ -9853,42 +9800,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1258, col: 1, offset: 35407},
+			pos:  position{line: 1249, col: 1, offset: 35308},
 			expr: &actionExpr{
-				pos: position{line: 1259, col: 5, offset: 35415},
+				pos: position{line: 1250, col: 5, offset: 35316},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1259, col: 5, offset: 35415},
+					pos: position{line: 1250, col: 5, offset: 35316},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1259, col: 5, offset: 35415},
+							pos: position{line: 1250, col: 5, offset: 35316},
 							expr: &seqExpr{
-								pos: position{line: 1259, col: 8, offset: 35418},
+								pos: position{line: 1250, col: 8, offset: 35319},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1259, col: 8, offset: 35418},
+										pos:  position{line: 1250, col: 8, offset: 35319},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1259, col: 12, offset: 35422},
+										pos:        position{line: 1250, col: 12, offset: 35323},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1259, col: 16, offset: 35426},
+										pos:  position{line: 1250, col: 16, offset: 35327},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1259, col: 20, offset: 35430},
+										pos: position{line: 1250, col: 20, offset: 35331},
 										expr: &choiceExpr{
-											pos: position{line: 1259, col: 22, offset: 35432},
+											pos: position{line: 1250, col: 22, offset: 35333},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1259, col: 22, offset: 35432},
+													pos:  position{line: 1250, col: 22, offset: 35333},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1259, col: 33, offset: 35443},
+													pos:        position{line: 1250, col: 33, offset: 35344},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9899,10 +9846,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1259, col: 39, offset: 35449},
+							pos:   position{line: 1250, col: 39, offset: 35350},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1259, col: 41, offset: 35451},
+								pos:  position{line: 1250, col: 41, offset: 35352},
 								name: "IP6Variations",
 							},
 						},
@@ -9912,32 +9859,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1263, col: 1, offset: 35615},
+			pos:  position{line: 1254, col: 1, offset: 35516},
 			expr: &choiceExpr{
-				pos: position{line: 1264, col: 5, offset: 35633},
+				pos: position{line: 1255, col: 5, offset: 35534},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1264, col: 5, offset: 35633},
+						pos: position{line: 1255, col: 5, offset: 35534},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 5, offset: 35633},
+							pos: position{line: 1255, col: 5, offset: 35534},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1264, col: 5, offset: 35633},
+									pos:   position{line: 1255, col: 5, offset: 35534},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1264, col: 7, offset: 35635},
+										pos: position{line: 1255, col: 7, offset: 35536},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1264, col: 7, offset: 35635},
+											pos:  position{line: 1255, col: 7, offset: 35536},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1264, col: 17, offset: 35645},
+									pos:   position{line: 1255, col: 17, offset: 35546},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1264, col: 19, offset: 35647},
+										pos:  position{line: 1255, col: 19, offset: 35548},
 										name: "IP6Tail",
 									},
 								},
@@ -9945,51 +9892,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 35711},
+						pos: position{line: 1258, col: 5, offset: 35612},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1267, col: 5, offset: 35711},
+							pos: position{line: 1258, col: 5, offset: 35612},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1267, col: 5, offset: 35711},
+									pos:   position{line: 1258, col: 5, offset: 35612},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1267, col: 7, offset: 35713},
+										pos:  position{line: 1258, col: 7, offset: 35614},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 11, offset: 35717},
+									pos:   position{line: 1258, col: 11, offset: 35618},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1267, col: 13, offset: 35719},
+										pos: position{line: 1258, col: 13, offset: 35620},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1267, col: 13, offset: 35719},
+											pos:  position{line: 1258, col: 13, offset: 35620},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1267, col: 23, offset: 35729},
+									pos:        position{line: 1258, col: 23, offset: 35630},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 28, offset: 35734},
+									pos:   position{line: 1258, col: 28, offset: 35635},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1267, col: 30, offset: 35736},
+										pos: position{line: 1258, col: 30, offset: 35637},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1267, col: 30, offset: 35736},
+											pos:  position{line: 1258, col: 30, offset: 35637},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 40, offset: 35746},
+									pos:   position{line: 1258, col: 40, offset: 35647},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1267, col: 42, offset: 35748},
+										pos:  position{line: 1258, col: 42, offset: 35649},
 										name: "IP6Tail",
 									},
 								},
@@ -9997,32 +9944,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1270, col: 5, offset: 35847},
+						pos: position{line: 1261, col: 5, offset: 35748},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1270, col: 5, offset: 35847},
+							pos: position{line: 1261, col: 5, offset: 35748},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1270, col: 5, offset: 35847},
+									pos:        position{line: 1261, col: 5, offset: 35748},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1270, col: 10, offset: 35852},
+									pos:   position{line: 1261, col: 10, offset: 35753},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1270, col: 12, offset: 35854},
+										pos: position{line: 1261, col: 12, offset: 35755},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1270, col: 12, offset: 35854},
+											pos:  position{line: 1261, col: 12, offset: 35755},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1270, col: 22, offset: 35864},
+									pos:   position{line: 1261, col: 22, offset: 35765},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1270, col: 24, offset: 35866},
+										pos:  position{line: 1261, col: 24, offset: 35767},
 										name: "IP6Tail",
 									},
 								},
@@ -10030,32 +9977,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1273, col: 5, offset: 35937},
+						pos: position{line: 1264, col: 5, offset: 35838},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1273, col: 5, offset: 35937},
+							pos: position{line: 1264, col: 5, offset: 35838},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1273, col: 5, offset: 35937},
+									pos:   position{line: 1264, col: 5, offset: 35838},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1273, col: 7, offset: 35939},
+										pos:  position{line: 1264, col: 7, offset: 35840},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1273, col: 11, offset: 35943},
+									pos:   position{line: 1264, col: 11, offset: 35844},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1273, col: 13, offset: 35945},
+										pos: position{line: 1264, col: 13, offset: 35846},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1273, col: 13, offset: 35945},
+											pos:  position{line: 1264, col: 13, offset: 35846},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1273, col: 23, offset: 35955},
+									pos:        position{line: 1264, col: 23, offset: 35856},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -10063,10 +10010,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1276, col: 5, offset: 36023},
+						pos: position{line: 1267, col: 5, offset: 35924},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1276, col: 5, offset: 36023},
+							pos:        position{line: 1267, col: 5, offset: 35924},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -10076,16 +10023,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1280, col: 1, offset: 36060},
+			pos:  position{line: 1271, col: 1, offset: 35961},
 			expr: &choiceExpr{
-				pos: position{line: 1281, col: 5, offset: 36072},
+				pos: position{line: 1272, col: 5, offset: 35973},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1281, col: 5, offset: 36072},
+						pos:  position{line: 1272, col: 5, offset: 35973},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1282, col: 5, offset: 36079},
+						pos:  position{line: 1273, col: 5, offset: 35980},
 						name: "Hex",
 					},
 				},
@@ -10093,23 +10040,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1284, col: 1, offset: 36084},
+			pos:  position{line: 1275, col: 1, offset: 35985},
 			expr: &actionExpr{
-				pos: position{line: 1284, col: 12, offset: 36095},
+				pos: position{line: 1275, col: 12, offset: 35996},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1284, col: 12, offset: 36095},
+					pos: position{line: 1275, col: 12, offset: 35996},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1284, col: 12, offset: 36095},
+							pos:        position{line: 1275, col: 12, offset: 35996},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1284, col: 16, offset: 36099},
+							pos:   position{line: 1275, col: 16, offset: 36000},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1284, col: 18, offset: 36101},
+								pos:  position{line: 1275, col: 18, offset: 36002},
 								name: "Hex",
 							},
 						},
@@ -10119,23 +10066,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1286, col: 1, offset: 36139},
+			pos:  position{line: 1277, col: 1, offset: 36040},
 			expr: &actionExpr{
-				pos: position{line: 1286, col: 12, offset: 36150},
+				pos: position{line: 1277, col: 12, offset: 36051},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1286, col: 12, offset: 36150},
+					pos: position{line: 1277, col: 12, offset: 36051},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1286, col: 12, offset: 36150},
+							pos:   position{line: 1277, col: 12, offset: 36051},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1286, col: 14, offset: 36152},
+								pos:  position{line: 1277, col: 14, offset: 36053},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1286, col: 18, offset: 36156},
+							pos:        position{line: 1277, col: 18, offset: 36057},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -10145,31 +10092,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1288, col: 1, offset: 36194},
+			pos:  position{line: 1279, col: 1, offset: 36095},
 			expr: &actionExpr{
-				pos: position{line: 1289, col: 5, offset: 36205},
+				pos: position{line: 1280, col: 5, offset: 36106},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1289, col: 5, offset: 36205},
+					pos: position{line: 1280, col: 5, offset: 36106},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1289, col: 5, offset: 36205},
+							pos:   position{line: 1280, col: 5, offset: 36106},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 7, offset: 36207},
+								pos:  position{line: 1280, col: 7, offset: 36108},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1289, col: 10, offset: 36210},
+							pos:        position{line: 1280, col: 10, offset: 36111},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 14, offset: 36214},
+							pos:   position{line: 1280, col: 14, offset: 36115},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 16, offset: 36216},
+								pos:  position{line: 1280, col: 16, offset: 36117},
 								name: "UInt",
 							},
 						},
@@ -10179,31 +10126,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1293, col: 1, offset: 36289},
+			pos:  position{line: 1284, col: 1, offset: 36190},
 			expr: &actionExpr{
-				pos: position{line: 1294, col: 5, offset: 36300},
+				pos: position{line: 1285, col: 5, offset: 36201},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1294, col: 5, offset: 36300},
+					pos: position{line: 1285, col: 5, offset: 36201},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1294, col: 5, offset: 36300},
+							pos:   position{line: 1285, col: 5, offset: 36201},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1294, col: 7, offset: 36302},
+								pos:  position{line: 1285, col: 7, offset: 36203},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1294, col: 11, offset: 36306},
+							pos:        position{line: 1285, col: 11, offset: 36207},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1294, col: 15, offset: 36310},
+							pos:   position{line: 1285, col: 15, offset: 36211},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1294, col: 17, offset: 36312},
+								pos:  position{line: 1285, col: 17, offset: 36213},
 								name: "UInt",
 							},
 						},
@@ -10213,15 +10160,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1298, col: 1, offset: 36375},
+			pos:  position{line: 1289, col: 1, offset: 36276},
 			expr: &actionExpr{
-				pos: position{line: 1299, col: 4, offset: 36383},
+				pos: position{line: 1290, col: 4, offset: 36284},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1299, col: 4, offset: 36383},
+					pos:   position{line: 1290, col: 4, offset: 36284},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1299, col: 6, offset: 36385},
+						pos:  position{line: 1290, col: 6, offset: 36286},
 						name: "UIntString",
 					},
 				},
@@ -10229,16 +10176,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1301, col: 1, offset: 36425},
+			pos:  position{line: 1292, col: 1, offset: 36326},
 			expr: &choiceExpr{
-				pos: position{line: 1302, col: 5, offset: 36439},
+				pos: position{line: 1293, col: 5, offset: 36340},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1302, col: 5, offset: 36439},
+						pos:  position{line: 1293, col: 5, offset: 36340},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1303, col: 5, offset: 36454},
+						pos:  position{line: 1294, col: 5, offset: 36355},
 						name: "MinusIntString",
 					},
 				},
@@ -10246,14 +10193,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1305, col: 1, offset: 36470},
+			pos:  position{line: 1296, col: 1, offset: 36371},
 			expr: &actionExpr{
-				pos: position{line: 1305, col: 14, offset: 36483},
+				pos: position{line: 1296, col: 14, offset: 36384},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1305, col: 14, offset: 36483},
+					pos: position{line: 1296, col: 14, offset: 36384},
 					expr: &charClassMatcher{
-						pos:        position{line: 1305, col: 14, offset: 36483},
+						pos:        position{line: 1296, col: 14, offset: 36384},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10264,20 +10211,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1307, col: 1, offset: 36522},
+			pos:  position{line: 1298, col: 1, offset: 36423},
 			expr: &actionExpr{
-				pos: position{line: 1308, col: 5, offset: 36541},
+				pos: position{line: 1299, col: 5, offset: 36442},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1308, col: 5, offset: 36541},
+					pos: position{line: 1299, col: 5, offset: 36442},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1308, col: 5, offset: 36541},
+							pos:        position{line: 1299, col: 5, offset: 36442},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1308, col: 9, offset: 36545},
+							pos:  position{line: 1299, col: 9, offset: 36446},
 							name: "UIntString",
 						},
 					},
@@ -10286,28 +10233,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1310, col: 1, offset: 36588},
+			pos:  position{line: 1301, col: 1, offset: 36489},
 			expr: &choiceExpr{
-				pos: position{line: 1311, col: 5, offset: 36604},
+				pos: position{line: 1302, col: 5, offset: 36505},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1311, col: 5, offset: 36604},
+						pos: position{line: 1302, col: 5, offset: 36505},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1311, col: 5, offset: 36604},
+							pos: position{line: 1302, col: 5, offset: 36505},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1311, col: 5, offset: 36604},
+									pos: position{line: 1302, col: 5, offset: 36505},
 									expr: &litMatcher{
-										pos:        position{line: 1311, col: 5, offset: 36604},
+										pos:        position{line: 1302, col: 5, offset: 36505},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1311, col: 10, offset: 36609},
+									pos: position{line: 1302, col: 10, offset: 36510},
 									expr: &charClassMatcher{
-										pos:        position{line: 1311, col: 10, offset: 36609},
+										pos:        position{line: 1302, col: 10, offset: 36510},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10315,14 +10262,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1311, col: 17, offset: 36616},
+									pos:        position{line: 1302, col: 17, offset: 36517},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1311, col: 21, offset: 36620},
+									pos: position{line: 1302, col: 21, offset: 36521},
 									expr: &charClassMatcher{
-										pos:        position{line: 1311, col: 21, offset: 36620},
+										pos:        position{line: 1302, col: 21, offset: 36521},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10330,9 +10277,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1311, col: 28, offset: 36627},
+									pos: position{line: 1302, col: 28, offset: 36528},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1311, col: 28, offset: 36627},
+										pos:  position{line: 1302, col: 28, offset: 36528},
 										name: "ExponentPart",
 									},
 								},
@@ -10340,28 +10287,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 36686},
+						pos: position{line: 1305, col: 5, offset: 36587},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1314, col: 5, offset: 36686},
+							pos: position{line: 1305, col: 5, offset: 36587},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1314, col: 5, offset: 36686},
+									pos: position{line: 1305, col: 5, offset: 36587},
 									expr: &litMatcher{
-										pos:        position{line: 1314, col: 5, offset: 36686},
+										pos:        position{line: 1305, col: 5, offset: 36587},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1314, col: 10, offset: 36691},
+									pos:        position{line: 1305, col: 10, offset: 36592},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1314, col: 14, offset: 36695},
+									pos: position{line: 1305, col: 14, offset: 36596},
 									expr: &charClassMatcher{
-										pos:        position{line: 1314, col: 14, offset: 36695},
+										pos:        position{line: 1305, col: 14, offset: 36596},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10369,9 +10316,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1314, col: 21, offset: 36702},
+									pos: position{line: 1305, col: 21, offset: 36603},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1314, col: 21, offset: 36702},
+										pos:  position{line: 1305, col: 21, offset: 36603},
 										name: "ExponentPart",
 									},
 								},
@@ -10383,19 +10330,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1318, col: 1, offset: 36758},
+			pos:  position{line: 1309, col: 1, offset: 36659},
 			expr: &seqExpr{
-				pos: position{line: 1318, col: 16, offset: 36773},
+				pos: position{line: 1309, col: 16, offset: 36674},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1318, col: 16, offset: 36773},
+						pos:        position{line: 1309, col: 16, offset: 36674},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1318, col: 21, offset: 36778},
+						pos: position{line: 1309, col: 21, offset: 36679},
 						expr: &charClassMatcher{
-							pos:        position{line: 1318, col: 21, offset: 36778},
+							pos:        position{line: 1309, col: 21, offset: 36679},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10403,7 +10350,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1318, col: 27, offset: 36784},
+						pos:  position{line: 1309, col: 27, offset: 36685},
 						name: "UIntString",
 					},
 				},
@@ -10411,14 +10358,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1320, col: 1, offset: 36796},
+			pos:  position{line: 1311, col: 1, offset: 36697},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 7, offset: 36802},
+				pos: position{line: 1311, col: 7, offset: 36703},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1320, col: 7, offset: 36802},
+					pos: position{line: 1311, col: 7, offset: 36703},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1320, col: 7, offset: 36802},
+						pos:  position{line: 1311, col: 7, offset: 36703},
 						name: "HexDigit",
 					},
 				},
@@ -10426,9 +10373,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1322, col: 1, offset: 36844},
+			pos:  position{line: 1313, col: 1, offset: 36745},
 			expr: &charClassMatcher{
-				pos:        position{line: 1322, col: 12, offset: 36855},
+				pos:        position{line: 1313, col: 12, offset: 36756},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10437,34 +10384,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1325, col: 1, offset: 36869},
+			pos:  position{line: 1316, col: 1, offset: 36770},
 			expr: &choiceExpr{
-				pos: position{line: 1326, col: 5, offset: 36886},
+				pos: position{line: 1317, col: 5, offset: 36787},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1326, col: 5, offset: 36886},
+						pos: position{line: 1317, col: 5, offset: 36787},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1326, col: 5, offset: 36886},
+							pos: position{line: 1317, col: 5, offset: 36787},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1326, col: 5, offset: 36886},
+									pos:        position{line: 1317, col: 5, offset: 36787},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1326, col: 9, offset: 36890},
+									pos:   position{line: 1317, col: 9, offset: 36791},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1326, col: 11, offset: 36892},
+										pos: position{line: 1317, col: 11, offset: 36793},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1326, col: 11, offset: 36892},
+											pos:  position{line: 1317, col: 11, offset: 36793},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1326, col: 29, offset: 36910},
+									pos:        position{line: 1317, col: 29, offset: 36811},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10472,29 +10419,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1327, col: 5, offset: 36947},
+						pos: position{line: 1318, col: 5, offset: 36848},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1327, col: 5, offset: 36947},
+							pos: position{line: 1318, col: 5, offset: 36848},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1327, col: 5, offset: 36947},
+									pos:        position{line: 1318, col: 5, offset: 36848},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1327, col: 9, offset: 36951},
+									pos:   position{line: 1318, col: 9, offset: 36852},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1327, col: 11, offset: 36953},
+										pos: position{line: 1318, col: 11, offset: 36854},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1327, col: 11, offset: 36953},
+											pos:  position{line: 1318, col: 11, offset: 36854},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1327, col: 29, offset: 36971},
+									pos:        position{line: 1318, col: 29, offset: 36872},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10506,55 +10453,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1329, col: 1, offset: 37005},
+			pos:  position{line: 1320, col: 1, offset: 36906},
 			expr: &choiceExpr{
-				pos: position{line: 1330, col: 5, offset: 37026},
+				pos: position{line: 1321, col: 5, offset: 36927},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1330, col: 5, offset: 37026},
+						pos: position{line: 1321, col: 5, offset: 36927},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1330, col: 5, offset: 37026},
+							pos: position{line: 1321, col: 5, offset: 36927},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1330, col: 5, offset: 37026},
+									pos: position{line: 1321, col: 5, offset: 36927},
 									expr: &choiceExpr{
-										pos: position{line: 1330, col: 7, offset: 37028},
+										pos: position{line: 1321, col: 7, offset: 36929},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1330, col: 7, offset: 37028},
+												pos:        position{line: 1321, col: 7, offset: 36929},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1330, col: 13, offset: 37034},
+												pos:  position{line: 1321, col: 13, offset: 36935},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1330, col: 26, offset: 37047,
+									line: 1321, col: 26, offset: 36948,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1331, col: 5, offset: 37084},
+						pos: position{line: 1322, col: 5, offset: 36985},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1331, col: 5, offset: 37084},
+							pos: position{line: 1322, col: 5, offset: 36985},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1331, col: 5, offset: 37084},
+									pos:        position{line: 1322, col: 5, offset: 36985},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1331, col: 10, offset: 37089},
+									pos:   position{line: 1322, col: 10, offset: 36990},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1331, col: 12, offset: 37091},
+										pos:  position{line: 1322, col: 12, offset: 36992},
 										name: "EscapeSequence",
 									},
 								},
@@ -10566,28 +10513,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1333, col: 1, offset: 37125},
+			pos:  position{line: 1324, col: 1, offset: 37026},
 			expr: &actionExpr{
-				pos: position{line: 1334, col: 5, offset: 37137},
+				pos: position{line: 1325, col: 5, offset: 37038},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1334, col: 5, offset: 37137},
+					pos: position{line: 1325, col: 5, offset: 37038},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1334, col: 5, offset: 37137},
+							pos:   position{line: 1325, col: 5, offset: 37038},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1334, col: 10, offset: 37142},
+								pos:  position{line: 1325, col: 10, offset: 37043},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1334, col: 23, offset: 37155},
+							pos:   position{line: 1325, col: 23, offset: 37056},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1334, col: 28, offset: 37160},
+								pos: position{line: 1325, col: 28, offset: 37061},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1334, col: 28, offset: 37160},
+									pos:  position{line: 1325, col: 28, offset: 37061},
 									name: "KeyWordRest",
 								},
 							},
@@ -10598,16 +10545,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1336, col: 1, offset: 37222},
+			pos:  position{line: 1327, col: 1, offset: 37123},
 			expr: &choiceExpr{
-				pos: position{line: 1337, col: 5, offset: 37239},
+				pos: position{line: 1328, col: 5, offset: 37140},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1337, col: 5, offset: 37239},
+						pos:  position{line: 1328, col: 5, offset: 37140},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1338, col: 5, offset: 37256},
+						pos:  position{line: 1329, col: 5, offset: 37157},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10615,12 +10562,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1340, col: 1, offset: 37268},
+			pos:  position{line: 1331, col: 1, offset: 37169},
 			expr: &actionExpr{
-				pos: position{line: 1340, col: 16, offset: 37283},
+				pos: position{line: 1331, col: 16, offset: 37184},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1340, col: 16, offset: 37283},
+					pos:        position{line: 1331, col: 16, offset: 37184},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10631,16 +10578,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1342, col: 1, offset: 37332},
+			pos:  position{line: 1333, col: 1, offset: 37233},
 			expr: &choiceExpr{
-				pos: position{line: 1343, col: 5, offset: 37348},
+				pos: position{line: 1334, col: 5, offset: 37249},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1343, col: 5, offset: 37348},
+						pos:  position{line: 1334, col: 5, offset: 37249},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1344, col: 5, offset: 37365},
+						pos:        position{line: 1335, col: 5, offset: 37266},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10651,30 +10598,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1346, col: 1, offset: 37372},
+			pos:  position{line: 1337, col: 1, offset: 37273},
 			expr: &actionExpr{
-				pos: position{line: 1346, col: 14, offset: 37385},
+				pos: position{line: 1337, col: 14, offset: 37286},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1346, col: 14, offset: 37385},
+					pos: position{line: 1337, col: 14, offset: 37286},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1346, col: 14, offset: 37385},
+							pos:        position{line: 1337, col: 14, offset: 37286},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1346, col: 19, offset: 37390},
+							pos:   position{line: 1337, col: 19, offset: 37291},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1346, col: 22, offset: 37393},
+								pos: position{line: 1337, col: 22, offset: 37294},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1346, col: 22, offset: 37393},
+										pos:  position{line: 1337, col: 22, offset: 37294},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1346, col: 38, offset: 37409},
+										pos:  position{line: 1337, col: 38, offset: 37310},
 										name: "EscapeSequence",
 									},
 								},
@@ -10686,42 +10633,42 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 1348, col: 1, offset: 37445},
+			pos:  position{line: 1339, col: 1, offset: 37346},
 			expr: &actionExpr{
-				pos: position{line: 1349, col: 5, offset: 37454},
+				pos: position{line: 1340, col: 5, offset: 37355},
 				run: (*parser).callonGlob1,
 				expr: &seqExpr{
-					pos: position{line: 1349, col: 5, offset: 37454},
+					pos: position{line: 1340, col: 5, offset: 37355},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1349, col: 5, offset: 37454},
+							pos: position{line: 1340, col: 5, offset: 37355},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1349, col: 6, offset: 37455},
+								pos:  position{line: 1340, col: 6, offset: 37356},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1349, col: 22, offset: 37471},
+							pos: position{line: 1340, col: 22, offset: 37372},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1349, col: 23, offset: 37472},
+								pos:  position{line: 1340, col: 23, offset: 37373},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1349, col: 35, offset: 37484},
+							pos:   position{line: 1340, col: 35, offset: 37385},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1349, col: 40, offset: 37489},
+								pos:  position{line: 1340, col: 40, offset: 37390},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1349, col: 50, offset: 37499},
+							pos:   position{line: 1340, col: 50, offset: 37400},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1349, col: 55, offset: 37504},
+								pos: position{line: 1340, col: 55, offset: 37405},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1349, col: 55, offset: 37504},
+									pos:  position{line: 1340, col: 55, offset: 37405},
 									name: "GlobRest",
 								},
 							},
@@ -10732,20 +10679,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1353, col: 1, offset: 37588},
+			pos:  position{line: 1344, col: 1, offset: 37489},
 			expr: &seqExpr{
-				pos: position{line: 1353, col: 19, offset: 37606},
+				pos: position{line: 1344, col: 19, offset: 37507},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1353, col: 19, offset: 37606},
+						pos: position{line: 1344, col: 19, offset: 37507},
 						expr: &litMatcher{
-							pos:        position{line: 1353, col: 19, offset: 37606},
+							pos:        position{line: 1344, col: 19, offset: 37507},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1353, col: 24, offset: 37611},
+						pos:  position{line: 1344, col: 24, offset: 37512},
 						name: "KeyWordStart",
 					},
 				},
@@ -10753,19 +10700,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1354, col: 1, offset: 37624},
+			pos:  position{line: 1345, col: 1, offset: 37525},
 			expr: &seqExpr{
-				pos: position{line: 1354, col: 15, offset: 37638},
+				pos: position{line: 1345, col: 15, offset: 37539},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1354, col: 15, offset: 37638},
+						pos: position{line: 1345, col: 15, offset: 37539},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1354, col: 15, offset: 37638},
+							pos:  position{line: 1345, col: 15, offset: 37539},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1354, col: 28, offset: 37651},
+						pos:        position{line: 1345, col: 28, offset: 37552},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10774,23 +10721,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1356, col: 1, offset: 37656},
+			pos:  position{line: 1347, col: 1, offset: 37557},
 			expr: &choiceExpr{
-				pos: position{line: 1357, col: 5, offset: 37670},
+				pos: position{line: 1348, col: 5, offset: 37571},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1357, col: 5, offset: 37670},
+						pos:  position{line: 1348, col: 5, offset: 37571},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1358, col: 5, offset: 37687},
+						pos:  position{line: 1349, col: 5, offset: 37588},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1359, col: 5, offset: 37699},
+						pos: position{line: 1350, col: 5, offset: 37600},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1359, col: 5, offset: 37699},
+							pos:        position{line: 1350, col: 5, offset: 37600},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10800,16 +10747,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1361, col: 1, offset: 37723},
+			pos:  position{line: 1352, col: 1, offset: 37624},
 			expr: &choiceExpr{
-				pos: position{line: 1362, col: 5, offset: 37736},
+				pos: position{line: 1353, col: 5, offset: 37637},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 5, offset: 37736},
+						pos:  position{line: 1353, col: 5, offset: 37637},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1363, col: 5, offset: 37750},
+						pos:        position{line: 1354, col: 5, offset: 37651},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10820,30 +10767,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1365, col: 1, offset: 37757},
+			pos:  position{line: 1356, col: 1, offset: 37658},
 			expr: &actionExpr{
-				pos: position{line: 1365, col: 11, offset: 37767},
+				pos: position{line: 1356, col: 11, offset: 37668},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1365, col: 11, offset: 37767},
+					pos: position{line: 1356, col: 11, offset: 37668},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1365, col: 11, offset: 37767},
+							pos:        position{line: 1356, col: 11, offset: 37668},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1365, col: 16, offset: 37772},
+							pos:   position{line: 1356, col: 16, offset: 37673},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1365, col: 19, offset: 37775},
+								pos: position{line: 1356, col: 19, offset: 37676},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1365, col: 19, offset: 37775},
+										pos:  position{line: 1356, col: 19, offset: 37676},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1365, col: 32, offset: 37788},
+										pos:  position{line: 1356, col: 32, offset: 37689},
 										name: "EscapeSequence",
 									},
 								},
@@ -10855,30 +10802,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1367, col: 1, offset: 37824},
+			pos:  position{line: 1358, col: 1, offset: 37725},
 			expr: &choiceExpr{
-				pos: position{line: 1368, col: 5, offset: 37839},
+				pos: position{line: 1359, col: 5, offset: 37740},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1368, col: 5, offset: 37839},
+						pos: position{line: 1359, col: 5, offset: 37740},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1368, col: 5, offset: 37839},
+							pos:        position{line: 1359, col: 5, offset: 37740},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 37867},
+						pos: position{line: 1360, col: 5, offset: 37768},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1369, col: 5, offset: 37867},
+							pos:        position{line: 1360, col: 5, offset: 37768},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1370, col: 5, offset: 37897},
+						pos:        position{line: 1361, col: 5, offset: 37798},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10889,55 +10836,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1373, col: 1, offset: 37904},
+			pos:  position{line: 1364, col: 1, offset: 37805},
 			expr: &choiceExpr{
-				pos: position{line: 1374, col: 5, offset: 37925},
+				pos: position{line: 1365, col: 5, offset: 37826},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1374, col: 5, offset: 37925},
+						pos: position{line: 1365, col: 5, offset: 37826},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1374, col: 5, offset: 37925},
+							pos: position{line: 1365, col: 5, offset: 37826},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1374, col: 5, offset: 37925},
+									pos: position{line: 1365, col: 5, offset: 37826},
 									expr: &choiceExpr{
-										pos: position{line: 1374, col: 7, offset: 37927},
+										pos: position{line: 1365, col: 7, offset: 37828},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1374, col: 7, offset: 37927},
+												pos:        position{line: 1365, col: 7, offset: 37828},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1374, col: 13, offset: 37933},
+												pos:  position{line: 1365, col: 13, offset: 37834},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1374, col: 26, offset: 37946,
+									line: 1365, col: 26, offset: 37847,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1375, col: 5, offset: 37983},
+						pos: position{line: 1366, col: 5, offset: 37884},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1375, col: 5, offset: 37983},
+							pos: position{line: 1366, col: 5, offset: 37884},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1375, col: 5, offset: 37983},
+									pos:        position{line: 1366, col: 5, offset: 37884},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1375, col: 10, offset: 37988},
+									pos:   position{line: 1366, col: 10, offset: 37889},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1375, col: 12, offset: 37990},
+										pos:  position{line: 1366, col: 12, offset: 37891},
 										name: "EscapeSequence",
 									},
 								},
@@ -10949,38 +10896,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1377, col: 1, offset: 38024},
+			pos:  position{line: 1368, col: 1, offset: 37925},
 			expr: &choiceExpr{
-				pos: position{line: 1378, col: 5, offset: 38043},
+				pos: position{line: 1369, col: 5, offset: 37944},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1378, col: 5, offset: 38043},
+						pos: position{line: 1369, col: 5, offset: 37944},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 1378, col: 5, offset: 38043},
+							pos: position{line: 1369, col: 5, offset: 37944},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1378, col: 5, offset: 38043},
+									pos:        position{line: 1369, col: 5, offset: 37944},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1378, col: 9, offset: 38047},
+									pos:  position{line: 1369, col: 9, offset: 37948},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1378, col: 18, offset: 38056},
+									pos:  position{line: 1369, col: 18, offset: 37957},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1379, col: 5, offset: 38107},
+						pos:  position{line: 1370, col: 5, offset: 38008},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1380, col: 5, offset: 38128},
+						pos:  position{line: 1371, col: 5, offset: 38029},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10988,79 +10935,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1382, col: 1, offset: 38143},
+			pos:  position{line: 1373, col: 1, offset: 38044},
 			expr: &choiceExpr{
-				pos: position{line: 1383, col: 5, offset: 38164},
+				pos: position{line: 1374, col: 5, offset: 38065},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1383, col: 5, offset: 38164},
+						pos:        position{line: 1374, col: 5, offset: 38065},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1384, col: 5, offset: 38172},
+						pos: position{line: 1375, col: 5, offset: 38073},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1384, col: 5, offset: 38172},
+							pos:        position{line: 1375, col: 5, offset: 38073},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1385, col: 5, offset: 38212},
+						pos:        position{line: 1376, col: 5, offset: 38113},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1386, col: 5, offset: 38221},
+						pos: position{line: 1377, col: 5, offset: 38122},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1386, col: 5, offset: 38221},
+							pos:        position{line: 1377, col: 5, offset: 38122},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1387, col: 5, offset: 38250},
+						pos: position{line: 1378, col: 5, offset: 38151},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1387, col: 5, offset: 38250},
+							pos:        position{line: 1378, col: 5, offset: 38151},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1388, col: 5, offset: 38279},
+						pos: position{line: 1379, col: 5, offset: 38180},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1388, col: 5, offset: 38279},
+							pos:        position{line: 1379, col: 5, offset: 38180},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1389, col: 5, offset: 38308},
+						pos: position{line: 1380, col: 5, offset: 38209},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1389, col: 5, offset: 38308},
+							pos:        position{line: 1380, col: 5, offset: 38209},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1390, col: 5, offset: 38337},
+						pos: position{line: 1381, col: 5, offset: 38238},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1390, col: 5, offset: 38337},
+							pos:        position{line: 1381, col: 5, offset: 38238},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1391, col: 5, offset: 38366},
+						pos: position{line: 1382, col: 5, offset: 38267},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1391, col: 5, offset: 38366},
+							pos:        position{line: 1382, col: 5, offset: 38267},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -11070,30 +11017,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1393, col: 1, offset: 38392},
+			pos:  position{line: 1384, col: 1, offset: 38293},
 			expr: &choiceExpr{
-				pos: position{line: 1394, col: 5, offset: 38410},
+				pos: position{line: 1385, col: 5, offset: 38311},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1394, col: 5, offset: 38410},
+						pos: position{line: 1385, col: 5, offset: 38311},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1394, col: 5, offset: 38410},
+							pos:        position{line: 1385, col: 5, offset: 38311},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1395, col: 5, offset: 38438},
+						pos: position{line: 1386, col: 5, offset: 38339},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1395, col: 5, offset: 38438},
+							pos:        position{line: 1386, col: 5, offset: 38339},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1396, col: 5, offset: 38466},
+						pos:        position{line: 1387, col: 5, offset: 38367},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11104,41 +11051,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1398, col: 1, offset: 38472},
+			pos:  position{line: 1389, col: 1, offset: 38373},
 			expr: &choiceExpr{
-				pos: position{line: 1399, col: 5, offset: 38490},
+				pos: position{line: 1390, col: 5, offset: 38391},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 38490},
+						pos: position{line: 1390, col: 5, offset: 38391},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1399, col: 5, offset: 38490},
+							pos: position{line: 1390, col: 5, offset: 38391},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1399, col: 5, offset: 38490},
+									pos:        position{line: 1390, col: 5, offset: 38391},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1399, col: 9, offset: 38494},
+									pos:   position{line: 1390, col: 9, offset: 38395},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1399, col: 16, offset: 38501},
+										pos: position{line: 1390, col: 16, offset: 38402},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1399, col: 16, offset: 38501},
+												pos:  position{line: 1390, col: 16, offset: 38402},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1399, col: 25, offset: 38510},
+												pos:  position{line: 1390, col: 25, offset: 38411},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1399, col: 34, offset: 38519},
+												pos:  position{line: 1390, col: 34, offset: 38420},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1399, col: 43, offset: 38528},
+												pos:  position{line: 1390, col: 43, offset: 38429},
 												name: "HexDigit",
 											},
 										},
@@ -11148,63 +11095,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1402, col: 5, offset: 38591},
+						pos: position{line: 1393, col: 5, offset: 38492},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1402, col: 5, offset: 38591},
+							pos: position{line: 1393, col: 5, offset: 38492},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1402, col: 5, offset: 38591},
+									pos:        position{line: 1393, col: 5, offset: 38492},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1402, col: 9, offset: 38595},
+									pos:        position{line: 1393, col: 9, offset: 38496},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1402, col: 13, offset: 38599},
+									pos:   position{line: 1393, col: 13, offset: 38500},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1402, col: 20, offset: 38606},
+										pos: position{line: 1393, col: 20, offset: 38507},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1402, col: 20, offset: 38606},
+												pos:  position{line: 1393, col: 20, offset: 38507},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1402, col: 29, offset: 38615},
+												pos: position{line: 1393, col: 29, offset: 38516},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1402, col: 29, offset: 38615},
+													pos:  position{line: 1393, col: 29, offset: 38516},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1402, col: 39, offset: 38625},
+												pos: position{line: 1393, col: 39, offset: 38526},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1402, col: 39, offset: 38625},
+													pos:  position{line: 1393, col: 39, offset: 38526},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1402, col: 49, offset: 38635},
+												pos: position{line: 1393, col: 49, offset: 38536},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1402, col: 49, offset: 38635},
+													pos:  position{line: 1393, col: 49, offset: 38536},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1402, col: 59, offset: 38645},
+												pos: position{line: 1393, col: 59, offset: 38546},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1402, col: 59, offset: 38645},
+													pos:  position{line: 1393, col: 59, offset: 38546},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1402, col: 69, offset: 38655},
+												pos: position{line: 1393, col: 69, offset: 38556},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1402, col: 69, offset: 38655},
+													pos:  position{line: 1393, col: 69, offset: 38556},
 													name: "HexDigit",
 												},
 											},
@@ -11212,7 +11159,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1402, col: 80, offset: 38666},
+									pos:        position{line: 1393, col: 80, offset: 38567},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11224,35 +11171,35 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1406, col: 1, offset: 38720},
+			pos:  position{line: 1397, col: 1, offset: 38621},
 			expr: &actionExpr{
-				pos: position{line: 1407, col: 5, offset: 38731},
+				pos: position{line: 1398, col: 5, offset: 38632},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1407, col: 5, offset: 38731},
+					pos: position{line: 1398, col: 5, offset: 38632},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1407, col: 5, offset: 38731},
+							pos:        position{line: 1398, col: 5, offset: 38632},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1407, col: 9, offset: 38735},
+							pos:   position{line: 1398, col: 9, offset: 38636},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1407, col: 14, offset: 38740},
+								pos:  position{line: 1398, col: 14, offset: 38641},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1407, col: 25, offset: 38751},
+							pos:        position{line: 1398, col: 25, offset: 38652},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1407, col: 29, offset: 38755},
+							pos: position{line: 1398, col: 29, offset: 38656},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1407, col: 30, offset: 38756},
+								pos:  position{line: 1398, col: 30, offset: 38657},
 								name: "KeyWordStart",
 							},
 						},
@@ -11262,24 +11209,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1409, col: 1, offset: 38791},
+			pos:  position{line: 1400, col: 1, offset: 38692},
 			expr: &actionExpr{
-				pos: position{line: 1410, col: 5, offset: 38806},
+				pos: position{line: 1401, col: 5, offset: 38707},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1410, col: 5, offset: 38806},
+					pos: position{line: 1401, col: 5, offset: 38707},
 					expr: &choiceExpr{
-						pos: position{line: 1410, col: 6, offset: 38807},
+						pos: position{line: 1401, col: 6, offset: 38708},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1410, col: 6, offset: 38807},
+								pos:        position{line: 1401, col: 6, offset: 38708},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 1410, col: 13, offset: 38814},
+								pos:        position{line: 1401, col: 13, offset: 38715},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -11290,9 +11237,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1412, col: 1, offset: 38854},
+			pos:  position{line: 1403, col: 1, offset: 38755},
 			expr: &charClassMatcher{
-				pos:        position{line: 1413, col: 5, offset: 38870},
+				pos:        position{line: 1404, col: 5, offset: 38771},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11302,42 +11249,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1415, col: 1, offset: 38885},
+			pos:  position{line: 1406, col: 1, offset: 38786},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1415, col: 6, offset: 38890},
+				pos: position{line: 1406, col: 6, offset: 38791},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1415, col: 6, offset: 38890},
+					pos:  position{line: 1406, col: 6, offset: 38791},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1417, col: 1, offset: 38901},
+			pos:  position{line: 1408, col: 1, offset: 38802},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1417, col: 6, offset: 38906},
+				pos: position{line: 1408, col: 6, offset: 38807},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1417, col: 6, offset: 38906},
+					pos:  position{line: 1408, col: 6, offset: 38807},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1419, col: 1, offset: 38917},
+			pos:  position{line: 1410, col: 1, offset: 38818},
 			expr: &choiceExpr{
-				pos: position{line: 1420, col: 5, offset: 38930},
+				pos: position{line: 1411, col: 5, offset: 38831},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1420, col: 5, offset: 38930},
+						pos:  position{line: 1411, col: 5, offset: 38831},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1421, col: 5, offset: 38945},
+						pos:  position{line: 1412, col: 5, offset: 38846},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1422, col: 5, offset: 38964},
+						pos:  position{line: 1413, col: 5, offset: 38865},
 						name: "Comment",
 					},
 				},
@@ -11345,45 +11292,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1424, col: 1, offset: 38973},
+			pos:  position{line: 1415, col: 1, offset: 38874},
 			expr: &anyMatcher{
-				line: 1425, col: 5, offset: 38993,
+				line: 1416, col: 5, offset: 38894,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1427, col: 1, offset: 38996},
+			pos:         position{line: 1418, col: 1, offset: 38897},
 			expr: &choiceExpr{
-				pos: position{line: 1428, col: 5, offset: 39024},
+				pos: position{line: 1419, col: 5, offset: 38925},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1428, col: 5, offset: 39024},
+						pos:        position{line: 1419, col: 5, offset: 38925},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1429, col: 5, offset: 39033},
+						pos:        position{line: 1420, col: 5, offset: 38934},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1430, col: 5, offset: 39042},
+						pos:        position{line: 1421, col: 5, offset: 38943},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1431, col: 5, offset: 39051},
+						pos:        position{line: 1422, col: 5, offset: 38952},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1432, col: 5, offset: 39059},
+						pos:        position{line: 1423, col: 5, offset: 38960},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1433, col: 5, offset: 39072},
+						pos:        position{line: 1424, col: 5, offset: 38973},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11392,9 +11339,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1435, col: 1, offset: 39082},
+			pos:  position{line: 1426, col: 1, offset: 38983},
 			expr: &charClassMatcher{
-				pos:        position{line: 1436, col: 5, offset: 39101},
+				pos:        position{line: 1427, col: 5, offset: 39002},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11404,45 +11351,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1442, col: 1, offset: 39431},
+			pos:         position{line: 1433, col: 1, offset: 39332},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1445, col: 5, offset: 39502},
+				pos:  position{line: 1436, col: 5, offset: 39403},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1447, col: 1, offset: 39521},
+			pos:  position{line: 1438, col: 1, offset: 39422},
 			expr: &seqExpr{
-				pos: position{line: 1448, col: 5, offset: 39542},
+				pos: position{line: 1439, col: 5, offset: 39443},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1448, col: 5, offset: 39542},
+						pos:        position{line: 1439, col: 5, offset: 39443},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1448, col: 10, offset: 39547},
+						pos: position{line: 1439, col: 10, offset: 39448},
 						expr: &seqExpr{
-							pos: position{line: 1448, col: 11, offset: 39548},
+							pos: position{line: 1439, col: 11, offset: 39449},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1448, col: 11, offset: 39548},
+									pos: position{line: 1439, col: 11, offset: 39449},
 									expr: &litMatcher{
-										pos:        position{line: 1448, col: 12, offset: 39549},
+										pos:        position{line: 1439, col: 12, offset: 39450},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1448, col: 17, offset: 39554},
+									pos:  position{line: 1439, col: 17, offset: 39455},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1448, col: 35, offset: 39572},
+						pos:        position{line: 1439, col: 35, offset: 39473},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11451,29 +11398,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1450, col: 1, offset: 39578},
+			pos:  position{line: 1441, col: 1, offset: 39479},
 			expr: &seqExpr{
-				pos: position{line: 1451, col: 5, offset: 39600},
+				pos: position{line: 1442, col: 5, offset: 39501},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1451, col: 5, offset: 39600},
+						pos:        position{line: 1442, col: 5, offset: 39501},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1451, col: 10, offset: 39605},
+						pos: position{line: 1442, col: 10, offset: 39506},
 						expr: &seqExpr{
-							pos: position{line: 1451, col: 11, offset: 39606},
+							pos: position{line: 1442, col: 11, offset: 39507},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1451, col: 11, offset: 39606},
+									pos: position{line: 1442, col: 11, offset: 39507},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1451, col: 12, offset: 39607},
+										pos:  position{line: 1442, col: 12, offset: 39508},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1451, col: 27, offset: 39622},
+									pos:  position{line: 1442, col: 27, offset: 39523},
 									name: "SourceCharacter",
 								},
 							},
@@ -11484,19 +11431,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1453, col: 1, offset: 39641},
+			pos:  position{line: 1444, col: 1, offset: 39542},
 			expr: &seqExpr{
-				pos: position{line: 1453, col: 7, offset: 39647},
+				pos: position{line: 1444, col: 7, offset: 39548},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1453, col: 7, offset: 39647},
+						pos: position{line: 1444, col: 7, offset: 39548},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1453, col: 7, offset: 39647},
+							pos:  position{line: 1444, col: 7, offset: 39548},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1453, col: 19, offset: 39659},
+						pos:  position{line: 1444, col: 19, offset: 39560},
 						name: "LineTerminator",
 					},
 				},
@@ -11504,16 +11451,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1455, col: 1, offset: 39675},
+			pos:  position{line: 1446, col: 1, offset: 39576},
 			expr: &choiceExpr{
-				pos: position{line: 1455, col: 7, offset: 39681},
+				pos: position{line: 1446, col: 7, offset: 39582},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1455, col: 7, offset: 39681},
+						pos:  position{line: 1446, col: 7, offset: 39582},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1455, col: 11, offset: 39685},
+						pos:  position{line: 1446, col: 11, offset: 39586},
 						name: "EOF",
 					},
 				},
@@ -11521,11 +11468,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1457, col: 1, offset: 39690},
+			pos:  position{line: 1448, col: 1, offset: 39591},
 			expr: &notExpr{
-				pos: position{line: 1457, col: 7, offset: 39696},
+				pos: position{line: 1448, col: 7, offset: 39597},
 				expr: &anyMatcher{
-					line: 1457, col: 8, offset: 39697,
+					line: 1448, col: 8, offset: 39598,
 				},
 			},
 		},
@@ -11623,7 +11570,7 @@ func (p *parser) callonSequentialTail1() (interface{}, error) {
 }
 
 func (c *current) onParallel2(first, rest interface{}) (interface{}, error) {
-	return append([]interface{}{first}, (rest.([]interface{}))...), nil
+	return append([]interface{}{first}, (rest.([]interface{})[0].([]interface{}))...), nil
 
 }
 
@@ -11633,51 +11580,41 @@ func (p *parser) callonParallel2() (interface{}, error) {
 	return p.cur.onParallel2(stack["first"], stack["rest"])
 }
 
-func (c *current) onParallel9(first interface{}) (interface{}, error) {
+func (c *current) onParallel14(first interface{}) (interface{}, error) {
 	return []interface{}{first}, nil
 
 }
 
-func (p *parser) callonParallel9() (interface{}, error) {
+func (p *parser) callonParallel14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onParallel9(stack["first"])
+	return p.cur.onParallel14(stack["first"])
 }
 
-func (c *current) onParallelTail1(ch interface{}) (interface{}, error) {
-	return ch, nil
-}
-
-func (p *parser) callonParallelTail1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onParallelTail1(stack["ch"])
-}
-
-func (c *current) onSwitchBranch2(e, proc interface{}) (interface{}, error) {
-	return map[string]interface{}{"expr": e, "proc": proc}, nil
+func (c *current) onSwitchBranch2(proc interface{}) (interface{}, error) {
+	return map[string]interface{}{"expr": map[string]interface{}{"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}, nil
 
 }
 
 func (p *parser) callonSwitchBranch2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSwitchBranch2(stack["e"], stack["proc"])
+	return p.cur.onSwitchBranch2(stack["proc"])
 }
 
-func (c *current) onSwitchBranch14(proc interface{}) (interface{}, error) {
-	return map[string]interface{}{"expr": map[string]interface{}{"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}, nil
+func (c *current) onSwitchBranch12(e, proc interface{}) (interface{}, error) {
+	return map[string]interface{}{"expr": e, "proc": proc}, nil
 
 }
 
-func (p *parser) callonSwitchBranch14() (interface{}, error) {
+func (p *parser) callonSwitchBranch12() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSwitchBranch14(stack["proc"])
+	return p.cur.onSwitchBranch12(stack["e"], stack["proc"])
 }
 
 func (c *current) onSwitch2(first, rest interface{}) (interface{}, error) {
-	return append([]interface{}{first}, (rest.([]interface{}))...), nil
+	return append([]interface{}{first}, (rest.([]interface{})[0].([]interface{}))...), nil
 
 }
 
@@ -11687,19 +11624,19 @@ func (p *parser) callonSwitch2() (interface{}, error) {
 	return p.cur.onSwitch2(stack["first"], stack["rest"])
 }
 
-func (c *current) onSwitch9(first interface{}) (interface{}, error) {
+func (c *current) onSwitch10(first interface{}) (interface{}, error) {
 	return []interface{}{first}, nil
 
 }
 
-func (p *parser) callonSwitch9() (interface{}, error) {
+func (p *parser) callonSwitch10() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSwitch9(stack["first"])
+	return p.cur.onSwitch10(stack["first"])
 }
 
 func (c *current) onFromTrunks2(first, rest interface{}) (interface{}, error) {
-	return append([]interface{}{first}, (rest.([]interface{}))...), nil
+	return append([]interface{}{first}, (rest.([]interface{})[0].([]interface{}))...), nil
 
 }
 
@@ -11709,15 +11646,15 @@ func (p *parser) callonFromTrunks2() (interface{}, error) {
 	return p.cur.onFromTrunks2(stack["first"], stack["rest"])
 }
 
-func (c *current) onFromTrunks9(first interface{}) (interface{}, error) {
+func (c *current) onFromTrunks10(first interface{}) (interface{}, error) {
 	return []interface{}{first}, nil
 
 }
 
-func (p *parser) callonFromTrunks9() (interface{}, error) {
+func (p *parser) callonFromTrunks10() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFromTrunks9(stack["first"])
+	return p.cur.onFromTrunks10(stack["first"])
 }
 
 func (c *current) onFromTrunk1(source, seq interface{}) (interface{}, error) {
@@ -11751,16 +11688,6 @@ func (p *parser) callonFromTrunkSeq9() (interface{}, error) {
 	return p.cur.onFromTrunkSeq9()
 }
 
-func (c *current) onFromTrunkTail1(trunk interface{}) (interface{}, error) {
-	return trunk, nil
-}
-
-func (p *parser) callonFromTrunkTail1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFromTrunkTail1(stack["trunk"])
-}
-
 func (c *current) onOperation2(procArray interface{}) (interface{}, error) {
 	return map[string]interface{}{"kind": "Parallel", "procs": procArray}, nil
 
@@ -11772,57 +11699,57 @@ func (p *parser) callonOperation2() (interface{}, error) {
 	return p.cur.onOperation2(stack["procArray"])
 }
 
-func (c *current) onOperation14(caseArray interface{}) (interface{}, error) {
+func (c *current) onOperation12(caseArray interface{}) (interface{}, error) {
 	return map[string]interface{}{"kind": "Switch", "cases": caseArray}, nil
 
 }
 
-func (p *parser) callonOperation14() (interface{}, error) {
+func (p *parser) callonOperation12() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOperation14(stack["caseArray"])
+	return p.cur.onOperation12(stack["caseArray"])
 }
 
-func (c *current) onOperation24(trunks interface{}) (interface{}, error) {
+func (c *current) onOperation22(trunks interface{}) (interface{}, error) {
 	return map[string]interface{}{"kind": "From", "trunks": trunks}, nil
 
 }
 
-func (p *parser) callonOperation24() (interface{}, error) {
+func (p *parser) callonOperation22() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOperation24(stack["trunks"])
+	return p.cur.onOperation22(stack["trunks"])
 }
 
-func (c *current) onOperation38(f interface{}) (interface{}, error) {
+func (c *current) onOperation33(f interface{}) (interface{}, error) {
 	return f, nil
 }
 
-func (p *parser) callonOperation38() (interface{}, error) {
+func (p *parser) callonOperation33() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOperation38(stack["f"])
+	return p.cur.onOperation33(stack["f"])
 }
 
-func (c *current) onOperation44(a interface{}) (interface{}, error) {
+func (c *current) onOperation39(a interface{}) (interface{}, error) {
 	return a, nil
 }
 
-func (p *parser) callonOperation44() (interface{}, error) {
+func (p *parser) callonOperation39() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOperation44(stack["a"])
+	return p.cur.onOperation39(stack["a"])
 }
 
-func (c *current) onOperation50(expr interface{}) (interface{}, error) {
+func (c *current) onOperation45(expr interface{}) (interface{}, error) {
 	return map[string]interface{}{"kind": "Filter", "expr": expr}, nil
 
 }
 
-func (p *parser) callonOperation50() (interface{}, error) {
+func (p *parser) callonOperation45() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOperation50(stack["expr"])
+	return p.cur.onOperation45(stack["expr"])
 }
 
 func (c *current) onComparator1() (interface{}, error) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -172,102 +172,100 @@ function peg$parse(input, options) {
             return {"kind": "Sequential", "procs": [op]}
           },
       peg$c15 = function(p) { return p },
-      peg$c16 = function(first, rest) {
-            return [first, ... rest]
+      peg$c16 = "=>",
+      peg$c17 = peg$literalExpectation("=>", false),
+      peg$c18 = function(first, rest) {
+            return [first, ... rest[0]]
           },
-      peg$c17 = function(first) {
+      peg$c19 = function(first) {
             return [first]
           },
-      peg$c18 = "=>",
-      peg$c19 = peg$literalExpectation("=>", false),
-      peg$c20 = function(ch) { return ch },
+      peg$c20 = function(proc) {
+            return {"expr": {"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}
+          },
       peg$c21 = function(e, proc) {
             return {"expr": e, "proc": proc}
           },
-      peg$c22 = function(proc) {
-            return {"expr": {"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}
-          },
-      peg$c23 = "case",
-      peg$c24 = peg$literalExpectation("case", true),
-      peg$c25 = "default",
-      peg$c26 = peg$literalExpectation("default", true),
-      peg$c27 = function(source, seq) {
+      peg$c22 = "default",
+      peg$c23 = peg$literalExpectation("default", true),
+      peg$c24 = function(source, seq) {
             return {"kind": "Trunk", "source": source, "seq":seq }
           },
-      peg$c28 = function(seq) { return seq },
-      peg$c29 = "",
-      peg$c30 = function() { return null},
-      peg$c31 = function(trunk) { return trunk },
-      peg$c32 = "split",
-      peg$c33 = peg$literalExpectation("split", false),
-      peg$c34 = "(",
-      peg$c35 = peg$literalExpectation("(", false),
-      peg$c36 = ")",
-      peg$c37 = peg$literalExpectation(")", false),
-      peg$c38 = function(procArray) {
+      peg$c25 = function(seq) { return seq },
+      peg$c26 = "",
+      peg$c27 = function() { return null},
+      peg$c28 = "split",
+      peg$c29 = peg$literalExpectation("split", false),
+      peg$c30 = "(",
+      peg$c31 = peg$literalExpectation("(", false),
+      peg$c32 = ")",
+      peg$c33 = peg$literalExpectation(")", false),
+      peg$c34 = function(procArray) {
             return {"kind": "Parallel", "procs": procArray}
           },
-      peg$c39 = "switch",
-      peg$c40 = peg$literalExpectation("switch", false),
-      peg$c41 = function(caseArray) {
+      peg$c35 = "switch",
+      peg$c36 = peg$literalExpectation("switch", false),
+      peg$c37 = function(caseArray) {
             return {"kind": "Switch", "cases": caseArray}
           },
-      peg$c42 = "from",
-      peg$c43 = peg$literalExpectation("from", false),
-      peg$c44 = function(trunks) {
+      peg$c38 = "from",
+      peg$c39 = peg$literalExpectation("from", false),
+      peg$c40 = function(trunks) {
             return {"kind": "From", "trunks": trunks}
           },
-      peg$c45 = function(f) { return f },
-      peg$c46 = function(a) { return a },
-      peg$c47 = function(expr) {
+      peg$c41 = function(f) { return f },
+      peg$c42 = function(a) { return a },
+      peg$c43 = function(expr) {
             return {"kind": "Filter", "expr": expr}
           },
-      peg$c48 = "|",
-      peg$c49 = peg$literalExpectation("|", false),
-      peg$c50 = "{",
-      peg$c51 = peg$literalExpectation("{", false),
-      peg$c52 = "[",
-      peg$c53 = peg$literalExpectation("[", false),
-      peg$c54 = ":",
-      peg$c55 = peg$literalExpectation(":", false),
-      peg$c56 = "matches",
-      peg$c57 = peg$literalExpectation("matches", false),
-      peg$c58 = "==",
-      peg$c59 = peg$literalExpectation("==", false),
-      peg$c60 = "!=",
-      peg$c61 = peg$literalExpectation("!=", false),
-      peg$c62 = "in",
-      peg$c63 = peg$literalExpectation("in", false),
-      peg$c64 = "<=",
-      peg$c65 = peg$literalExpectation("<=", false),
-      peg$c66 = "<",
-      peg$c67 = peg$literalExpectation("<", false),
-      peg$c68 = ">=",
-      peg$c69 = peg$literalExpectation(">=", false),
-      peg$c70 = ">",
-      peg$c71 = peg$literalExpectation(">", false),
-      peg$c72 = function() { return text() },
-      peg$c73 = "-with",
-      peg$c74 = peg$literalExpectation("-with", false),
-      peg$c75 = ",",
-      peg$c76 = peg$literalExpectation(",", false),
-      peg$c77 = function(first, rest) {
+      peg$c44 = /^[);]/,
+      peg$c45 = peg$classExpectation([")", ";"], false, false),
+      peg$c46 = "|",
+      peg$c47 = peg$literalExpectation("|", false),
+      peg$c48 = "{",
+      peg$c49 = peg$literalExpectation("{", false),
+      peg$c50 = "[",
+      peg$c51 = peg$literalExpectation("[", false),
+      peg$c52 = ":",
+      peg$c53 = peg$literalExpectation(":", false),
+      peg$c54 = "matches",
+      peg$c55 = peg$literalExpectation("matches", false),
+      peg$c56 = "==",
+      peg$c57 = peg$literalExpectation("==", false),
+      peg$c58 = "!=",
+      peg$c59 = peg$literalExpectation("!=", false),
+      peg$c60 = "in",
+      peg$c61 = peg$literalExpectation("in", false),
+      peg$c62 = "<=",
+      peg$c63 = peg$literalExpectation("<=", false),
+      peg$c64 = "<",
+      peg$c65 = peg$literalExpectation("<", false),
+      peg$c66 = ">=",
+      peg$c67 = peg$literalExpectation(">=", false),
+      peg$c68 = ">",
+      peg$c69 = peg$literalExpectation(">", false),
+      peg$c70 = function() { return text() },
+      peg$c71 = "-with",
+      peg$c72 = peg$literalExpectation("-with", false),
+      peg$c73 = ",",
+      peg$c74 = peg$literalExpectation(",", false),
+      peg$c75 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c78 = function(t) { return ["or", t] },
-      peg$c79 = function(first, expr) { return ["and", expr] },
-      peg$c80 = function(first, rest) {
+      peg$c76 = function(t) { return ["or", t] },
+      peg$c77 = function(first, expr) { return ["and", expr] },
+      peg$c78 = function(first, rest) {
             return makeBinaryExprChain(first,rest)
           },
-      peg$c81 = "!",
-      peg$c82 = peg$literalExpectation("!", false),
-      peg$c83 = function(e) {
+      peg$c79 = "!",
+      peg$c80 = peg$literalExpectation("!", false),
+      peg$c81 = function(e) {
             return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c84 = function(expr) { return expr },
-      peg$c85 = "*",
-      peg$c86 = peg$literalExpectation("*", false),
-      peg$c87 = function(compareOp, v) {
+      peg$c82 = function(expr) { return expr },
+      peg$c83 = "*",
+      peg$c84 = peg$literalExpectation("*", false),
+      peg$c85 = function(compareOp, v) {
             return {"kind": "Call", "name": "or",
               
             "args": [
@@ -294,8 +292,8 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c88 = function(match) { return match },
-      peg$c89 = function(v) {
+      peg$c86 = function(match) { return match },
+      peg$c87 = function(v) {
             return {"kind": "Call", "name": "or",
               
             "args": [
@@ -322,80 +320,83 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c90 = function(search) { return search },
-      peg$c91 = function(v) {
+      peg$c88 = function(search) { return search },
+      peg$c89 = function(v) {
             return {"kind": "Search", "text": text(), "value": v}
           },
-      peg$c92 = function() {
+      peg$c90 = function() {
             return {"kind": "Primitive", "type": "bool", "text": "true"}
           },
-      peg$c93 = function(v) {
+      peg$c91 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": v}
           },
-      peg$c94 = function(pattern) {
+      peg$c92 = function(pattern) {
             return {"kind": "RegexpSearch", "pattern": pattern}
           },
-      peg$c95 = peg$literalExpectation("matches", true),
-      peg$c96 = function(f, pattern) {
+      peg$c93 = peg$literalExpectation("matches", true),
+      peg$c94 = function(f, pattern) {
             return {"kind": "RegexpMatch", "pattern": pattern, "expr": f}
           },
-      peg$c97 = "type(",
-      peg$c98 = peg$literalExpectation("type(", false),
-      peg$c99 = function(every, keys, limit) {
+      peg$c95 = "type(",
+      peg$c96 = peg$literalExpectation("type(", false),
+      peg$c97 = function(every, keys, limit) {
             return {"kind": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
           },
-      peg$c100 = function(every, aggs, keys, limit) {
+      peg$c98 = function(every, aggs, keys, limit) {
             let p = {"kind": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
             }
             return p
           },
-      peg$c101 = "summarize",
-      peg$c102 = peg$literalExpectation("summarize", false),
-      peg$c103 = "every",
-      peg$c104 = peg$literalExpectation("every", true),
-      peg$c105 = function(dur) { return dur },
-      peg$c106 = function() { return null },
-      peg$c107 = function(columns) { return columns },
-      peg$c108 = "with",
-      peg$c109 = peg$literalExpectation("with", false),
-      peg$c110 = "-limit",
-      peg$c111 = peg$literalExpectation("-limit", false),
-      peg$c112 = function(limit) { return limit },
-      peg$c113 = function() { return 0 },
-      peg$c114 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c115 = function(first, expr) { return expr },
-      peg$c116 = ":=",
-      peg$c117 = peg$literalExpectation(":=", false),
-      peg$c118 = function(lval, agg) {
+      peg$c99 = "summarize",
+      peg$c100 = peg$literalExpectation("summarize", false),
+      peg$c101 = "every",
+      peg$c102 = peg$literalExpectation("every", true),
+      peg$c103 = function(dur) { return dur },
+      peg$c104 = function() { return null },
+      peg$c105 = function(columns) { return columns },
+      peg$c106 = "with",
+      peg$c107 = peg$literalExpectation("with", false),
+      peg$c108 = "-limit",
+      peg$c109 = peg$literalExpectation("-limit", false),
+      peg$c110 = function(limit) { return limit },
+      peg$c111 = function() { return 0 },
+      peg$c112 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c113 = function(first, expr) { return expr },
+      peg$c114 = function(first, rest) {
+            return [first, ... rest]
+          },
+      peg$c115 = ":=",
+      peg$c116 = peg$literalExpectation(":=", false),
+      peg$c117 = function(lval, agg) {
             return {"kind": "Assignment", "lhs": lval, "rhs": agg}
           },
-      peg$c119 = function(agg) {
+      peg$c118 = function(agg) {
             return {"kind": "Assignment", "lhs": null, "rhs": agg}
           },
-      peg$c120 = ".",
-      peg$c121 = peg$literalExpectation(".", false),
-      peg$c122 = function(op, expr, where) {
+      peg$c119 = ".",
+      peg$c120 = peg$literalExpectation(".", false),
+      peg$c121 = function(op, expr, where) {
             let r = {"kind": "Agg", "name": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c123 = "where",
-      peg$c124 = peg$literalExpectation("where", false),
-      peg$c125 = function(first, rest) {
+      peg$c122 = "where",
+      peg$c123 = peg$literalExpectation("where", false),
+      peg$c124 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c126 = "sort",
-      peg$c127 = peg$literalExpectation("sort", true),
-      peg$c128 = function(args, l) { return l },
-      peg$c129 = function(args, list) {
+      peg$c125 = "sort",
+      peg$c126 = peg$literalExpectation("sort", true),
+      peg$c127 = function(args, l) { return l },
+      peg$c128 = function(args, list) {
             let argm = args
             let proc = {"kind": "Sort", "args": list, "order": "asc", "nullsfirst": false}
             if ( "r" in argm) {
@@ -408,24 +409,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c130 = function(args) { return makeArgMap(args) },
-      peg$c131 = "-r",
-      peg$c132 = peg$literalExpectation("-r", false),
-      peg$c133 = function() { return {"name": "r", "value": null} },
-      peg$c134 = "-nulls",
-      peg$c135 = peg$literalExpectation("-nulls", false),
-      peg$c136 = "first",
-      peg$c137 = peg$literalExpectation("first", false),
-      peg$c138 = "last",
-      peg$c139 = peg$literalExpectation("last", false),
-      peg$c140 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c141 = "top",
-      peg$c142 = peg$literalExpectation("top", true),
-      peg$c143 = function(n) { return n},
-      peg$c144 = "-flush",
-      peg$c145 = peg$literalExpectation("-flush", false),
-      peg$c146 = function(limit, flush, f) { return f },
-      peg$c147 = function(limit, flush, fields) {
+      peg$c129 = function(args) { return makeArgMap(args) },
+      peg$c130 = "-r",
+      peg$c131 = peg$literalExpectation("-r", false),
+      peg$c132 = function() { return {"name": "r", "value": null} },
+      peg$c133 = "-nulls",
+      peg$c134 = peg$literalExpectation("-nulls", false),
+      peg$c135 = "first",
+      peg$c136 = peg$literalExpectation("first", false),
+      peg$c137 = "last",
+      peg$c138 = peg$literalExpectation("last", false),
+      peg$c139 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c140 = "top",
+      peg$c141 = peg$literalExpectation("top", true),
+      peg$c142 = function(n) { return n},
+      peg$c143 = "-flush",
+      peg$c144 = peg$literalExpectation("-flush", false),
+      peg$c145 = function(limit, flush, f) { return f },
+      peg$c146 = function(limit, flush, fields) {
             let proc = {"kind": "Top", "limit": 0, "args": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
@@ -438,93 +439,93 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c148 = "cut",
-      peg$c149 = peg$literalExpectation("cut", true),
-      peg$c150 = function(args) {
+      peg$c147 = "cut",
+      peg$c148 = peg$literalExpectation("cut", true),
+      peg$c149 = function(args) {
             return {"kind": "Cut", "args": args}
           },
-      peg$c151 = "pick",
-      peg$c152 = peg$literalExpectation("pick", true),
-      peg$c153 = function(args) {
+      peg$c150 = "pick",
+      peg$c151 = peg$literalExpectation("pick", true),
+      peg$c152 = function(args) {
             return {"kind": "Pick", "args": args}
           },
-      peg$c154 = "drop",
-      peg$c155 = peg$literalExpectation("drop", true),
-      peg$c156 = function(args) {
+      peg$c153 = "drop",
+      peg$c154 = peg$literalExpectation("drop", true),
+      peg$c155 = function(args) {
             return {"kind": "Drop", "args": args}
           },
-      peg$c157 = "head",
-      peg$c158 = peg$literalExpectation("head", true),
-      peg$c159 = function(count) { return {"kind": "Head", "count": count} },
-      peg$c160 = function() { return {"kind": "Head", "count": 1} },
-      peg$c161 = "tail",
-      peg$c162 = peg$literalExpectation("tail", true),
-      peg$c163 = function(count) { return {"kind": "Tail", "count": count} },
-      peg$c164 = function() { return {"kind": "Tail", "count": 1} },
-      peg$c165 = "filter",
-      peg$c166 = peg$literalExpectation("filter", true),
-      peg$c167 = function(op) {
+      peg$c156 = "head",
+      peg$c157 = peg$literalExpectation("head", true),
+      peg$c158 = function(count) { return {"kind": "Head", "count": count} },
+      peg$c159 = function() { return {"kind": "Head", "count": 1} },
+      peg$c160 = "tail",
+      peg$c161 = peg$literalExpectation("tail", true),
+      peg$c162 = function(count) { return {"kind": "Tail", "count": count} },
+      peg$c163 = function() { return {"kind": "Tail", "count": 1} },
+      peg$c164 = "filter",
+      peg$c165 = peg$literalExpectation("filter", true),
+      peg$c166 = function(op) {
             return op
           },
-      peg$c168 = "uniq",
-      peg$c169 = peg$literalExpectation("uniq", true),
-      peg$c170 = "-c",
-      peg$c171 = peg$literalExpectation("-c", false),
-      peg$c172 = function() {
+      peg$c167 = "uniq",
+      peg$c168 = peg$literalExpectation("uniq", true),
+      peg$c169 = "-c",
+      peg$c170 = peg$literalExpectation("-c", false),
+      peg$c171 = function() {
             return {"kind": "Uniq", "cflag": true}
           },
-      peg$c173 = function() {
+      peg$c172 = function() {
             return {"kind": "Uniq", "cflag": false}
           },
-      peg$c174 = "put",
-      peg$c175 = peg$literalExpectation("put", true),
-      peg$c176 = function(args) {
+      peg$c173 = "put",
+      peg$c174 = peg$literalExpectation("put", true),
+      peg$c175 = function(args) {
             return {"kind": "Put", "args": args}
           },
-      peg$c177 = "rename",
-      peg$c178 = peg$literalExpectation("rename", true),
-      peg$c179 = function(first, cl) { return cl },
-      peg$c180 = function(first, rest) {
+      peg$c176 = "rename",
+      peg$c177 = peg$literalExpectation("rename", true),
+      peg$c178 = function(first, cl) { return cl },
+      peg$c179 = function(first, rest) {
             return {"kind": "Rename", "args": [first, ... rest]}
           },
-      peg$c181 = "fuse",
-      peg$c182 = peg$literalExpectation("fuse", true),
-      peg$c183 = function() {
+      peg$c180 = "fuse",
+      peg$c181 = peg$literalExpectation("fuse", true),
+      peg$c182 = function() {
             return {"kind": "Fuse"}
           },
-      peg$c184 = "shape",
-      peg$c185 = peg$literalExpectation("shape", true),
-      peg$c186 = function() {
+      peg$c183 = "shape",
+      peg$c184 = peg$literalExpectation("shape", true),
+      peg$c185 = function() {
             return {"kind": "Shape"}
           },
-      peg$c187 = "join",
-      peg$c188 = peg$literalExpectation("join", true),
-      peg$c189 = function(style, leftKey, rightKey, columns) {
+      peg$c186 = "join",
+      peg$c187 = peg$literalExpectation("join", true),
+      peg$c188 = function(style, leftKey, rightKey, columns) {
             let proc = {"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": null}
             if (columns) {
               proc["args"] = columns[1]
             }
             return proc
           },
-      peg$c190 = function(style, key, columns) {
+      peg$c189 = function(style, key, columns) {
             let proc = {"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": null}
             if (columns) {
               proc["args"] = columns[1]
             }
             return proc
           },
-      peg$c191 = "inner",
-      peg$c192 = peg$literalExpectation("inner", true),
-      peg$c193 = function() { return "inner" },
-      peg$c194 = "left",
-      peg$c195 = peg$literalExpectation("left", true),
-      peg$c196 = function() { return "left" },
-      peg$c197 = "right",
-      peg$c198 = peg$literalExpectation("right", true),
-      peg$c199 = function() { return "right" },
-      peg$c200 = "sample",
-      peg$c201 = peg$literalExpectation("sample", true),
-      peg$c202 = function(e) {
+      peg$c190 = "inner",
+      peg$c191 = peg$literalExpectation("inner", true),
+      peg$c192 = function() { return "inner" },
+      peg$c193 = "left",
+      peg$c194 = peg$literalExpectation("left", true),
+      peg$c195 = function() { return "left" },
+      peg$c196 = "right",
+      peg$c197 = peg$literalExpectation("right", true),
+      peg$c198 = function() { return "right" },
+      peg$c199 = "sample",
+      peg$c200 = peg$literalExpectation("sample", true),
+      peg$c201 = function(e) {
             return {"kind": "Sequential", "procs": [
               
             {"kind": "Summarize",
@@ -560,79 +561,79 @@ function peg$parse(input, options) {
             "rhs": {"kind": "ID", "name": "sample"}}]}]}
           
           },
-      peg$c203 = function(lval) { return lval},
-      peg$c204 = function() { return {"kind":"Root"} },
-      peg$c205 = function(source) {
+      peg$c202 = function(lval) { return lval},
+      peg$c203 = function() { return {"kind":"Root"} },
+      peg$c204 = function(source) {
             return {"kind":"From", "trunks": [{"kind": "Trunk","source": source}]}
           },
-      peg$c206 = "file",
-      peg$c207 = peg$literalExpectation("file", true),
-      peg$c208 = function(path, format, layout) {
+      peg$c205 = "file",
+      peg$c206 = peg$literalExpectation("file", true),
+      peg$c207 = function(path, format, layout) {
             return {"kind": "File", "path": path, "format": format, "layout": layout }
           },
-      peg$c209 = peg$literalExpectation("from", true),
-      peg$c210 = function(body) { return body },
-      peg$c211 = function(name, at, over, order) {
+      peg$c208 = peg$literalExpectation("from", true),
+      peg$c209 = function(body) { return body },
+      peg$c210 = function(name, at, over, order) {
             return {"kind": "Pool", "name": name, "at": at, "range": over, "scan_order": order}
           },
-      peg$c212 = "get",
-      peg$c213 = peg$literalExpectation("get", true),
-      peg$c214 = function(url, format, layout) {
+      peg$c211 = "get",
+      peg$c212 = peg$literalExpectation("get", true),
+      peg$c213 = function(url, format, layout) {
             return {"kind": "HTTP", "url": url, "format": format, "layout": layout }
           },
-      peg$c215 = "http:",
-      peg$c216 = peg$literalExpectation("http:", false),
-      peg$c217 = "https:",
-      peg$c218 = peg$literalExpectation("https:", false),
-      peg$c219 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?;:[\]{}~|+\-]/,
-      peg$c220 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ";", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
-      peg$c221 = "at",
-      peg$c222 = peg$literalExpectation("at", true),
-      peg$c223 = function(id) { return id },
-      peg$c224 = /^[0-9a-zA-Z]/,
-      peg$c225 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
-      peg$c226 = "over",
-      peg$c227 = peg$literalExpectation("over", true),
-      peg$c228 = "to",
-      peg$c229 = peg$literalExpectation("to", true),
-      peg$c230 = function(lower, upper) {
+      peg$c214 = "http:",
+      peg$c215 = peg$literalExpectation("http:", false),
+      peg$c216 = "https:",
+      peg$c217 = peg$literalExpectation("https:", false),
+      peg$c218 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
+      peg$c219 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
+      peg$c220 = "at",
+      peg$c221 = peg$literalExpectation("at", true),
+      peg$c222 = function(id) { return id },
+      peg$c223 = /^[0-9a-zA-Z]/,
+      peg$c224 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
+      peg$c225 = "over",
+      peg$c226 = peg$literalExpectation("over", true),
+      peg$c227 = "to",
+      peg$c228 = peg$literalExpectation("to", true),
+      peg$c229 = function(lower, upper) {
             return {"kind":"Range","lower": lower, "upper": upper}
           },
-      peg$c231 = function(val) { return val },
-      peg$c232 = function(name) { return name },
-      peg$c233 = function(s) { return s },
-      peg$c234 = "order",
-      peg$c235 = peg$literalExpectation("order", true),
-      peg$c236 = function(keys, order) {
+      peg$c230 = function(val) { return val },
+      peg$c231 = function(name) { return name },
+      peg$c232 = function(s) { return s },
+      peg$c233 = "order",
+      peg$c234 = peg$literalExpectation("order", true),
+      peg$c235 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c237 = "format",
-      peg$c238 = peg$literalExpectation("format", true),
-      peg$c239 = function() { return "" },
-      peg$c240 = ":asc",
-      peg$c241 = peg$literalExpectation(":asc", true),
-      peg$c242 = function() { return "asc" },
-      peg$c243 = ":desc",
-      peg$c244 = peg$literalExpectation(":desc", true),
-      peg$c245 = function() { return "desc" },
-      peg$c246 = "asc",
-      peg$c247 = peg$literalExpectation("asc", true),
-      peg$c248 = "desc",
-      peg$c249 = peg$literalExpectation("desc", true),
-      peg$c250 = "pass",
-      peg$c251 = peg$literalExpectation("pass", true),
-      peg$c252 = function() {
+      peg$c236 = "format",
+      peg$c237 = peg$literalExpectation("format", true),
+      peg$c238 = function() { return "" },
+      peg$c239 = ":asc",
+      peg$c240 = peg$literalExpectation(":asc", true),
+      peg$c241 = function() { return "asc" },
+      peg$c242 = ":desc",
+      peg$c243 = peg$literalExpectation(":desc", true),
+      peg$c244 = function() { return "desc" },
+      peg$c245 = "asc",
+      peg$c246 = peg$literalExpectation("asc", true),
+      peg$c247 = "desc",
+      peg$c248 = peg$literalExpectation("desc", true),
+      peg$c249 = "pass",
+      peg$c250 = peg$literalExpectation("pass", true),
+      peg$c251 = function() {
             return {"kind":"Pass"}
           },
-      peg$c253 = "explode",
-      peg$c254 = peg$literalExpectation("explode", true),
-      peg$c255 = function(args, typ, as) {
+      peg$c252 = "explode",
+      peg$c253 = peg$literalExpectation("explode", true),
+      peg$c254 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c256 = function(typ) { return typ},
-      peg$c257 = function(lhs) { return lhs },
-      peg$c258 = function(first, lval) { return lval },
-      peg$c259 = function(first, rest) {
+      peg$c255 = function(typ) { return typ},
+      peg$c256 = function(lhs) { return lhs },
+      peg$c257 = function(first, lval) { return lval },
+      peg$c258 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -641,53 +642,53 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c260 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c261 = "?",
-      peg$c262 = peg$literalExpectation("?", false),
-      peg$c263 = function(condition, thenClause, elseClause) {
+      peg$c259 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c260 = "?",
+      peg$c261 = peg$literalExpectation("?", false),
+      peg$c262 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c264 = function(first, op, expr) { return [op, expr] },
-      peg$c265 = function(first, rest) {
+      peg$c263 = function(first, op, expr) { return [op, expr] },
+      peg$c264 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c266 = function(first, comp, expr) { return [comp, expr] },
-      peg$c267 = function() { return "="},
-      peg$c268 = "+",
-      peg$c269 = peg$literalExpectation("+", false),
-      peg$c270 = "-",
-      peg$c271 = peg$literalExpectation("-", false),
-      peg$c272 = "/",
-      peg$c273 = peg$literalExpectation("/", false),
-      peg$c274 = function(e) {
+      peg$c265 = function(first, comp, expr) { return [comp, expr] },
+      peg$c266 = function() { return "="},
+      peg$c267 = "+",
+      peg$c268 = peg$literalExpectation("+", false),
+      peg$c269 = "-",
+      peg$c270 = peg$literalExpectation("-", false),
+      peg$c271 = "/",
+      peg$c272 = peg$literalExpectation("/", false),
+      peg$c273 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c275 = function(typ) { return typ },
-      peg$c276 = "not",
-      peg$c277 = peg$literalExpectation("not", false),
-      peg$c278 = "match",
-      peg$c279 = peg$literalExpectation("match", false),
-      peg$c280 = "select",
-      peg$c281 = peg$literalExpectation("select", false),
-      peg$c282 = function(args, methods) {
+      peg$c274 = function(typ) { return typ },
+      peg$c275 = "not",
+      peg$c276 = peg$literalExpectation("not", false),
+      peg$c277 = "match",
+      peg$c278 = peg$literalExpectation("match", false),
+      peg$c279 = "select",
+      peg$c280 = peg$literalExpectation("select", false),
+      peg$c281 = function(args, methods) {
             return {"kind":"SelectExpr", "selectors":args, "methods": methods}
           },
-      peg$c283 = function(methods) { return methods },
-      peg$c284 = function(typ, expr) {
+      peg$c282 = function(methods) { return methods },
+      peg$c283 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c285 = function(fn, args) {
+      peg$c284 = function(fn, args) {
             return {"kind": "Call", "name": fn, "args": args}
           },
-      peg$c286 = function() { return [] },
-      peg$c287 = function(first, e) { return e },
-      peg$c288 = function(e) { return e },
-      peg$c289 = function() {
+      peg$c285 = function() { return [] },
+      peg$c286 = function(first, e) { return e },
+      peg$c287 = function(e) { return e },
+      peg$c288 = function() {
             return {"kind":"Root"}
           },
-      peg$c290 = "this",
-      peg$c291 = peg$literalExpectation("this", false),
-      peg$c292 = function(field) {
+      peg$c289 = "this",
+      peg$c290 = peg$literalExpectation("this", false),
+      peg$c291 = function(field) {
             return {"kind": "BinaryExpr", "op":".",
                            
             "lhs":{"kind":"Root"},
@@ -696,9 +697,9 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c293 = "]",
-      peg$c294 = peg$literalExpectation("]", false),
-      peg$c295 = function(expr) {
+      peg$c292 = "]",
+      peg$c293 = peg$literalExpectation("]", false),
+      peg$c294 = function(expr) {
             return {"kind": "BinaryExpr", "op":"[",
                            
             "lhs":{"kind":"Root"},
@@ -707,58 +708,58 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c296 = function(from, to) {
+      peg$c295 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c297 = function(to) {
+      peg$c296 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c298 = function(from) {
+      peg$c297 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c299 = function(expr) { return ["[", expr] },
-      peg$c300 = function(id) { return [".", id] },
-      peg$c301 = "}",
-      peg$c302 = peg$literalExpectation("}", false),
-      peg$c303 = function(fields) {
+      peg$c298 = function(expr) { return ["[", expr] },
+      peg$c299 = function(id) { return [".", id] },
+      peg$c300 = "}",
+      peg$c301 = peg$literalExpectation("}", false),
+      peg$c302 = function(fields) {
             return {"kind":"RecordExpr", "fields":fields }
           },
-      peg$c304 = function(first, rest) {
+      peg$c303 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c305 = function(name, value) {
+      peg$c304 = function(name, value) {
             return {"name": name, "value": value}
           },
-      peg$c306 = function(exprs) {
+      peg$c305 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c307 = "|[",
-      peg$c308 = peg$literalExpectation("|[", false),
-      peg$c309 = "]|",
-      peg$c310 = peg$literalExpectation("]|", false),
-      peg$c311 = function(exprs) {
+      peg$c306 = "|[",
+      peg$c307 = peg$literalExpectation("|[", false),
+      peg$c308 = "]|",
+      peg$c309 = peg$literalExpectation("]|", false),
+      peg$c310 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c312 = "|{",
-      peg$c313 = peg$literalExpectation("|{", false),
-      peg$c314 = "}|",
-      peg$c315 = peg$literalExpectation("}|", false),
-      peg$c316 = function(exprs) {
+      peg$c311 = "|{",
+      peg$c312 = peg$literalExpectation("|{", false),
+      peg$c313 = "}|",
+      peg$c314 = peg$literalExpectation("}|", false),
+      peg$c315 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c317 = function(key, value) {
+      peg$c316 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c318 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c317 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -780,13 +781,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c319 = function(assignments) { return assignments },
-      peg$c320 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c321 = function(table, alias) {
+      peg$c318 = function(assignments) { return assignments },
+      peg$c319 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c320 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c322 = function(first, join) { return join },
-      peg$c323 = function(style, table, alias, leftKey, rightKey) {
+      peg$c321 = function(first, join) { return join },
+      peg$c322 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -804,278 +805,278 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c324 = function(style) { return style },
-      peg$c325 = function(keys, order) {
+      peg$c323 = function(style) { return style },
+      peg$c324 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c326 = function(dir) { return dir },
-      peg$c327 = function(count) { return count },
-      peg$c328 = peg$literalExpectation("select", true),
-      peg$c329 = function() { return "select" },
-      peg$c330 = "as",
-      peg$c331 = peg$literalExpectation("as", true),
-      peg$c332 = function() { return "as" },
-      peg$c333 = function() { return "from" },
-      peg$c334 = function() { return "join" },
-      peg$c335 = peg$literalExpectation("where", true),
-      peg$c336 = function() { return "where" },
-      peg$c337 = "group",
-      peg$c338 = peg$literalExpectation("group", true),
-      peg$c339 = function() { return "group" },
-      peg$c340 = "having",
-      peg$c341 = peg$literalExpectation("having", true),
-      peg$c342 = function() { return "having" },
-      peg$c343 = function() { return "order" },
-      peg$c344 = "on",
-      peg$c345 = peg$literalExpectation("on", true),
-      peg$c346 = function() { return "on" },
-      peg$c347 = "limit",
-      peg$c348 = peg$literalExpectation("limit", true),
-      peg$c349 = function() { return "limit" },
-      peg$c350 = function(v) {
+      peg$c325 = function(dir) { return dir },
+      peg$c326 = function(count) { return count },
+      peg$c327 = peg$literalExpectation("select", true),
+      peg$c328 = function() { return "select" },
+      peg$c329 = "as",
+      peg$c330 = peg$literalExpectation("as", true),
+      peg$c331 = function() { return "as" },
+      peg$c332 = function() { return "from" },
+      peg$c333 = function() { return "join" },
+      peg$c334 = peg$literalExpectation("where", true),
+      peg$c335 = function() { return "where" },
+      peg$c336 = "group",
+      peg$c337 = peg$literalExpectation("group", true),
+      peg$c338 = function() { return "group" },
+      peg$c339 = "having",
+      peg$c340 = peg$literalExpectation("having", true),
+      peg$c341 = function() { return "having" },
+      peg$c342 = function() { return "order" },
+      peg$c343 = "on",
+      peg$c344 = peg$literalExpectation("on", true),
+      peg$c345 = function() { return "on" },
+      peg$c346 = "limit",
+      peg$c347 = peg$literalExpectation("limit", true),
+      peg$c348 = function() { return "limit" },
+      peg$c349 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c351 = function(v) {
+      peg$c350 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c352 = function(v) {
+      peg$c351 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c353 = function(v) {
+      peg$c352 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c354 = "true",
-      peg$c355 = peg$literalExpectation("true", false),
-      peg$c356 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c357 = "false",
-      peg$c358 = peg$literalExpectation("false", false),
-      peg$c359 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c360 = "null",
-      peg$c361 = peg$literalExpectation("null", false),
-      peg$c362 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c363 = function(typ) {
+      peg$c353 = "true",
+      peg$c354 = peg$literalExpectation("true", false),
+      peg$c355 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c356 = "false",
+      peg$c357 = peg$literalExpectation("false", false),
+      peg$c358 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c359 = "null",
+      peg$c360 = peg$literalExpectation("null", false),
+      peg$c361 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c362 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c364 = function(name, typ) {
+      peg$c363 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c365 = function(name) {
+      peg$c364 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c366 = function(u) { return u },
-      peg$c367 = function(types) {
+      peg$c365 = function(u) { return u },
+      peg$c366 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c368 = function(fields) {
+      peg$c367 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c369 = function(typ) {
+      peg$c368 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c370 = function(typ) {
+      peg$c369 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c371 = function(keyType, valType) {
+      peg$c370 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c372 = "uint8",
-      peg$c373 = peg$literalExpectation("uint8", false),
-      peg$c374 = "uint16",
-      peg$c375 = peg$literalExpectation("uint16", false),
-      peg$c376 = "uint32",
-      peg$c377 = peg$literalExpectation("uint32", false),
-      peg$c378 = "uint64",
-      peg$c379 = peg$literalExpectation("uint64", false),
-      peg$c380 = "int8",
-      peg$c381 = peg$literalExpectation("int8", false),
-      peg$c382 = "int16",
-      peg$c383 = peg$literalExpectation("int16", false),
-      peg$c384 = "int32",
-      peg$c385 = peg$literalExpectation("int32", false),
-      peg$c386 = "int64",
-      peg$c387 = peg$literalExpectation("int64", false),
-      peg$c388 = "float64",
-      peg$c389 = peg$literalExpectation("float64", false),
-      peg$c390 = "bool",
-      peg$c391 = peg$literalExpectation("bool", false),
-      peg$c392 = "string",
-      peg$c393 = peg$literalExpectation("string", false),
-      peg$c394 = function() {
+      peg$c371 = "uint8",
+      peg$c372 = peg$literalExpectation("uint8", false),
+      peg$c373 = "uint16",
+      peg$c374 = peg$literalExpectation("uint16", false),
+      peg$c375 = "uint32",
+      peg$c376 = peg$literalExpectation("uint32", false),
+      peg$c377 = "uint64",
+      peg$c378 = peg$literalExpectation("uint64", false),
+      peg$c379 = "int8",
+      peg$c380 = peg$literalExpectation("int8", false),
+      peg$c381 = "int16",
+      peg$c382 = peg$literalExpectation("int16", false),
+      peg$c383 = "int32",
+      peg$c384 = peg$literalExpectation("int32", false),
+      peg$c385 = "int64",
+      peg$c386 = peg$literalExpectation("int64", false),
+      peg$c387 = "float64",
+      peg$c388 = peg$literalExpectation("float64", false),
+      peg$c389 = "bool",
+      peg$c390 = peg$literalExpectation("bool", false),
+      peg$c391 = "string",
+      peg$c392 = peg$literalExpectation("string", false),
+      peg$c393 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c395 = "duration",
-      peg$c396 = peg$literalExpectation("duration", false),
-      peg$c397 = "time",
-      peg$c398 = peg$literalExpectation("time", false),
-      peg$c399 = "bytes",
-      peg$c400 = peg$literalExpectation("bytes", false),
-      peg$c401 = "bstring",
-      peg$c402 = peg$literalExpectation("bstring", false),
-      peg$c403 = "ip",
-      peg$c404 = peg$literalExpectation("ip", false),
-      peg$c405 = "net",
-      peg$c406 = peg$literalExpectation("net", false),
-      peg$c407 = "error",
-      peg$c408 = peg$literalExpectation("error", false),
-      peg$c409 = function(name, typ) {
+      peg$c394 = "duration",
+      peg$c395 = peg$literalExpectation("duration", false),
+      peg$c396 = "time",
+      peg$c397 = peg$literalExpectation("time", false),
+      peg$c398 = "bytes",
+      peg$c399 = peg$literalExpectation("bytes", false),
+      peg$c400 = "bstring",
+      peg$c401 = peg$literalExpectation("bstring", false),
+      peg$c402 = "ip",
+      peg$c403 = peg$literalExpectation("ip", false),
+      peg$c404 = "net",
+      peg$c405 = peg$literalExpectation("net", false),
+      peg$c406 = "error",
+      peg$c407 = peg$literalExpectation("error", false),
+      peg$c408 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c410 = "and",
-      peg$c411 = peg$literalExpectation("and", true),
-      peg$c412 = function() { return "and" },
-      peg$c413 = "or",
-      peg$c414 = peg$literalExpectation("or", true),
-      peg$c415 = function() { return "or" },
-      peg$c416 = peg$literalExpectation("in", true),
-      peg$c417 = function() { return "in" },
-      peg$c418 = peg$literalExpectation("not", true),
-      peg$c419 = function() { return "not" },
-      peg$c420 = "by",
-      peg$c421 = peg$literalExpectation("by", true),
-      peg$c422 = function() { return "by" },
-      peg$c423 = /^[A-Za-z_$]/,
-      peg$c424 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c425 = /^[0-9]/,
-      peg$c426 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c427 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c428 = function() {  return text() },
-      peg$c429 = "$",
-      peg$c430 = peg$literalExpectation("$", false),
-      peg$c431 = "\\",
-      peg$c432 = peg$literalExpectation("\\", false),
-      peg$c433 = "T",
-      peg$c434 = peg$literalExpectation("T", false),
-      peg$c435 = function() {
+      peg$c409 = "and",
+      peg$c410 = peg$literalExpectation("and", true),
+      peg$c411 = function() { return "and" },
+      peg$c412 = "or",
+      peg$c413 = peg$literalExpectation("or", true),
+      peg$c414 = function() { return "or" },
+      peg$c415 = peg$literalExpectation("in", true),
+      peg$c416 = function() { return "in" },
+      peg$c417 = peg$literalExpectation("not", true),
+      peg$c418 = function() { return "not" },
+      peg$c419 = "by",
+      peg$c420 = peg$literalExpectation("by", true),
+      peg$c421 = function() { return "by" },
+      peg$c422 = /^[A-Za-z_$]/,
+      peg$c423 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c424 = /^[0-9]/,
+      peg$c425 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c426 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c427 = function() {  return text() },
+      peg$c428 = "$",
+      peg$c429 = peg$literalExpectation("$", false),
+      peg$c430 = "\\",
+      peg$c431 = peg$literalExpectation("\\", false),
+      peg$c432 = "T",
+      peg$c433 = peg$literalExpectation("T", false),
+      peg$c434 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c436 = "Z",
-      peg$c437 = peg$literalExpectation("Z", false),
-      peg$c438 = function() {
+      peg$c435 = "Z",
+      peg$c436 = peg$literalExpectation("Z", false),
+      peg$c437 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c439 = "ns",
-      peg$c440 = peg$literalExpectation("ns", true),
-      peg$c441 = "us",
-      peg$c442 = peg$literalExpectation("us", true),
-      peg$c443 = "ms",
-      peg$c444 = peg$literalExpectation("ms", true),
-      peg$c445 = "s",
-      peg$c446 = peg$literalExpectation("s", true),
-      peg$c447 = "m",
-      peg$c448 = peg$literalExpectation("m", true),
-      peg$c449 = "h",
-      peg$c450 = peg$literalExpectation("h", true),
-      peg$c451 = "d",
-      peg$c452 = peg$literalExpectation("d", true),
-      peg$c453 = "w",
-      peg$c454 = peg$literalExpectation("w", true),
-      peg$c455 = "y",
-      peg$c456 = peg$literalExpectation("y", true),
-      peg$c457 = function(a, b) {
+      peg$c438 = "ns",
+      peg$c439 = peg$literalExpectation("ns", true),
+      peg$c440 = "us",
+      peg$c441 = peg$literalExpectation("us", true),
+      peg$c442 = "ms",
+      peg$c443 = peg$literalExpectation("ms", true),
+      peg$c444 = "s",
+      peg$c445 = peg$literalExpectation("s", true),
+      peg$c446 = "m",
+      peg$c447 = peg$literalExpectation("m", true),
+      peg$c448 = "h",
+      peg$c449 = peg$literalExpectation("h", true),
+      peg$c450 = "d",
+      peg$c451 = peg$literalExpectation("d", true),
+      peg$c452 = "w",
+      peg$c453 = peg$literalExpectation("w", true),
+      peg$c454 = "y",
+      peg$c455 = peg$literalExpectation("y", true),
+      peg$c456 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c458 = "::",
-      peg$c459 = peg$literalExpectation("::", false),
-      peg$c460 = function(a, b, d, e) {
+      peg$c457 = "::",
+      peg$c458 = peg$literalExpectation("::", false),
+      peg$c459 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c461 = function(a, b) {
+      peg$c460 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c462 = function(a, b) {
+      peg$c461 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c463 = function() {
+      peg$c462 = function() {
             return "::"
           },
-      peg$c464 = function(v) { return ":" + v },
-      peg$c465 = function(v) { return v + ":" },
-      peg$c466 = function(a, m) {
+      peg$c463 = function(v) { return ":" + v },
+      peg$c464 = function(v) { return v + ":" },
+      peg$c465 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c467 = function(a, m) {
+      peg$c466 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c468 = function(s) { return parseInt(s) },
-      peg$c469 = function() {
+      peg$c467 = function(s) { return parseInt(s) },
+      peg$c468 = function() {
             return text()
           },
-      peg$c470 = "e",
-      peg$c471 = peg$literalExpectation("e", true),
-      peg$c472 = /^[+\-]/,
-      peg$c473 = peg$classExpectation(["+", "-"], false, false),
-      peg$c474 = /^[0-9a-fA-F]/,
-      peg$c475 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c476 = "\"",
-      peg$c477 = peg$literalExpectation("\"", false),
-      peg$c478 = function(v) { return joinChars(v) },
-      peg$c479 = "'",
-      peg$c480 = peg$literalExpectation("'", false),
-      peg$c481 = peg$anyExpectation(),
-      peg$c482 = function(head, tail) { return head + joinChars(tail) },
-      peg$c483 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c484 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c485 = function(head, tail) {
+      peg$c469 = "e",
+      peg$c470 = peg$literalExpectation("e", true),
+      peg$c471 = /^[+\-]/,
+      peg$c472 = peg$classExpectation(["+", "-"], false, false),
+      peg$c473 = /^[0-9a-fA-F]/,
+      peg$c474 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c475 = "\"",
+      peg$c476 = peg$literalExpectation("\"", false),
+      peg$c477 = function(v) { return joinChars(v) },
+      peg$c478 = "'",
+      peg$c479 = peg$literalExpectation("'", false),
+      peg$c480 = peg$anyExpectation(),
+      peg$c481 = function(head, tail) { return head + joinChars(tail) },
+      peg$c482 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c483 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c484 = function(head, tail) {
             return reglob.Reglob(head + joinChars(tail))
           },
-      peg$c486 = function() { return "*"},
-      peg$c487 = function() { return "=" },
-      peg$c488 = function() { return "\\*" },
-      peg$c489 = "x",
-      peg$c490 = peg$literalExpectation("x", false),
-      peg$c491 = function() { return "\\" + text() },
-      peg$c492 = "b",
-      peg$c493 = peg$literalExpectation("b", false),
-      peg$c494 = function() { return "\b" },
-      peg$c495 = "f",
-      peg$c496 = peg$literalExpectation("f", false),
-      peg$c497 = function() { return "\f" },
-      peg$c498 = "n",
-      peg$c499 = peg$literalExpectation("n", false),
-      peg$c500 = function() { return "\n" },
-      peg$c501 = "r",
-      peg$c502 = peg$literalExpectation("r", false),
-      peg$c503 = function() { return "\r" },
-      peg$c504 = "t",
-      peg$c505 = peg$literalExpectation("t", false),
-      peg$c506 = function() { return "\t" },
-      peg$c507 = "v",
-      peg$c508 = peg$literalExpectation("v", false),
-      peg$c509 = function() { return "\v" },
-      peg$c510 = function() { return "*" },
-      peg$c511 = "u",
-      peg$c512 = peg$literalExpectation("u", false),
-      peg$c513 = function(chars) {
+      peg$c485 = function() { return "*"},
+      peg$c486 = function() { return "=" },
+      peg$c487 = function() { return "\\*" },
+      peg$c488 = "x",
+      peg$c489 = peg$literalExpectation("x", false),
+      peg$c490 = function() { return "\\" + text() },
+      peg$c491 = "b",
+      peg$c492 = peg$literalExpectation("b", false),
+      peg$c493 = function() { return "\b" },
+      peg$c494 = "f",
+      peg$c495 = peg$literalExpectation("f", false),
+      peg$c496 = function() { return "\f" },
+      peg$c497 = "n",
+      peg$c498 = peg$literalExpectation("n", false),
+      peg$c499 = function() { return "\n" },
+      peg$c500 = "r",
+      peg$c501 = peg$literalExpectation("r", false),
+      peg$c502 = function() { return "\r" },
+      peg$c503 = "t",
+      peg$c504 = peg$literalExpectation("t", false),
+      peg$c505 = function() { return "\t" },
+      peg$c506 = "v",
+      peg$c507 = peg$literalExpectation("v", false),
+      peg$c508 = function() { return "\v" },
+      peg$c509 = function() { return "*" },
+      peg$c510 = "u",
+      peg$c511 = peg$literalExpectation("u", false),
+      peg$c512 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c514 = /^[^\/\\]/,
-      peg$c515 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c516 = "\\/",
-      peg$c517 = peg$literalExpectation("\\/", false),
-      peg$c518 = /^[\0-\x1F\\]/,
-      peg$c519 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c520 = peg$otherExpectation("whitespace"),
-      peg$c521 = "\t",
-      peg$c522 = peg$literalExpectation("\t", false),
-      peg$c523 = "\x0B",
-      peg$c524 = peg$literalExpectation("\x0B", false),
-      peg$c525 = "\f",
-      peg$c526 = peg$literalExpectation("\f", false),
-      peg$c527 = " ",
-      peg$c528 = peg$literalExpectation(" ", false),
-      peg$c529 = "\xA0",
-      peg$c530 = peg$literalExpectation("\xA0", false),
-      peg$c531 = "\uFEFF",
-      peg$c532 = peg$literalExpectation("\uFEFF", false),
-      peg$c533 = /^[\n\r\u2028\u2029]/,
-      peg$c534 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c535 = peg$otherExpectation("comment"),
-      peg$c536 = "/*",
-      peg$c537 = peg$literalExpectation("/*", false),
-      peg$c538 = "*/",
-      peg$c539 = peg$literalExpectation("*/", false),
-      peg$c540 = "//",
-      peg$c541 = peg$literalExpectation("//", false),
+      peg$c513 = /^[^\/\\]/,
+      peg$c514 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c515 = "\\/",
+      peg$c516 = peg$literalExpectation("\\/", false),
+      peg$c517 = /^[\0-\x1F\\]/,
+      peg$c518 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c519 = peg$otherExpectation("whitespace"),
+      peg$c520 = "\t",
+      peg$c521 = peg$literalExpectation("\t", false),
+      peg$c522 = "\x0B",
+      peg$c523 = peg$literalExpectation("\x0B", false),
+      peg$c524 = "\f",
+      peg$c525 = peg$literalExpectation("\f", false),
+      peg$c526 = " ",
+      peg$c527 = peg$literalExpectation(" ", false),
+      peg$c528 = "\xA0",
+      peg$c529 = peg$literalExpectation("\xA0", false),
+      peg$c530 = "\uFEFF",
+      peg$c531 = peg$literalExpectation("\uFEFF", false),
+      peg$c532 = /^[\n\r\u2028\u2029]/,
+      peg$c533 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c534 = peg$otherExpectation("comment"),
+      peg$c535 = "/*",
+      peg$c536 = peg$literalExpectation("/*", false),
+      peg$c537 = "*/",
+      peg$c538 = peg$literalExpectation("*/", false),
+      peg$c539 = "//",
+      peg$c540 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1583,120 +1584,47 @@ function peg$parse(input, options) {
   }
 
   function peg$parseParallel() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSequential();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseParallelTail();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseParallelTail();
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseSequential();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c17(s1);
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseParallelTail() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c18) {
-        s2 = peg$c18;
-        peg$currPos += 2;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseSequential();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c20(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseSwitchBranch() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    s1 = peg$parse__();
+    if (input.substr(peg$currPos, 2) === peg$c16) {
+      s1 = peg$c16;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c17); }
+    }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseCaseToken();
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
+        s3 = peg$parseSequential();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseSearchBoolean();
+          s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parse__();
+            if (input.charCodeAt(peg$currPos) === 59) {
+              s5 = peg$c7;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c8); }
+            }
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c18) {
-                s6 = peg$c18;
-                peg$currPos += 2;
-              } else {
-                s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c19); }
-              }
+              s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
-                s7 = peg$parse__();
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parseSequential();
-                  if (s8 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c21(s4, s8);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
+                s7 = [];
+                s8 = peg$parseParallel();
+                if (s8 !== peg$FAILED) {
+                  while (s8 !== peg$FAILED) {
+                    s7.push(s8);
+                    s8 = peg$parseParallel();
                   }
+                } else {
+                  s7 = peg$FAILED;
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c18(s3, s7);
+                  s0 = s1;
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1727,27 +1655,152 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parse__();
+      if (input.substr(peg$currPos, 2) === peg$c16) {
+        s1 = peg$c16;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+      }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseDefaultToken();
+        s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parse__();
+          s3 = peg$parseSequential();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c18) {
-              s4 = peg$c18;
-              peg$currPos += 2;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c19); }
-            }
+            s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parse__();
+              if (input.charCodeAt(peg$currPos) === 59) {
+                s5 = peg$c7;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c8); }
+              }
               if (s5 !== peg$FAILED) {
-                s6 = peg$parseSequential();
-                if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c19(s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSwitchBranch() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseDefaultToken();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c16) {
+          s3 = peg$c16;
+          peg$currPos += 2;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseSequential();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 59) {
+                  s7 = peg$c7;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                }
+                if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c22(s6);
+                  s1 = peg$c20(s5);
                   s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseSearchBoolean();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__();
+        if (s2 !== peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c16) {
+            s3 = peg$c16;
+            peg$currPos += 2;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseSequential();
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parse__();
+                if (s6 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 59) {
+                    s7 = peg$c7;
+                    peg$currPos++;
+                  } else {
+                    s7 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                  }
+                  if (s7 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c21(s1, s5);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1778,25 +1831,31 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSwitch() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parseSwitchBranch();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseSwitchBranch();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseSwitchBranch();
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
-        s0 = s1;
+        s3 = [];
+        s4 = peg$parseSwitch();
+        if (s4 !== peg$FAILED) {
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parseSwitch();
+          }
+        } else {
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c18(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1810,23 +1869,9 @@ function peg$parse(input, options) {
       s1 = peg$parseSwitchBranch();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c17(s1);
+        s1 = peg$c19(s1);
       }
       s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseCaseToken() {
-    var s0;
-
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c23) {
-      s0 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c24); }
     }
 
     return s0;
@@ -1835,37 +1880,43 @@ function peg$parse(input, options) {
   function peg$parseDefaultToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c25) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c22) {
       s0 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c26); }
+      if (peg$silentFails === 0) { peg$fail(peg$c23); }
     }
 
     return s0;
   }
 
   function peg$parseFromTrunks() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parseFromTrunk();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseFromTrunkTail();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseFromTrunkTail();
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
-        s0 = s1;
+        s3 = [];
+        s4 = peg$parseFromTrunks();
+        if (s4 !== peg$FAILED) {
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parseFromTrunks();
+          }
+        } else {
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c18(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1879,7 +1930,7 @@ function peg$parse(input, options) {
       s1 = peg$parseFromTrunk();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c17(s1);
+        s1 = peg$c19(s1);
       }
       s0 = s1;
     }
@@ -1888,16 +1939,34 @@ function peg$parse(input, options) {
   }
 
   function peg$parseFromTrunk() {
-    var s0, s1, s2;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parseFromSource();
     if (s1 !== peg$FAILED) {
       s2 = peg$parseFromTrunkSeq();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c27(s1, s2);
-        s0 = s1;
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 59) {
+            s4 = peg$c7;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c8); }
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c24(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1916,12 +1985,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c18) {
-        s2 = peg$c18;
+      if (input.substr(peg$currPos, 2) === peg$c16) {
+        s2 = peg$c16;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1929,7 +1998,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequential();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c28(s4);
+            s1 = peg$c25(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1949,61 +2018,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c30();
+        s1 = peg$c27();
       }
       s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFromTrunkTail() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$currPos;
-    s2 = peg$parse__();
-    if (s2 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 59) {
-        s3 = peg$c7;
-        peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c8); }
-      }
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s2 = [s2, s3, s4];
-          s1 = s2;
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s1;
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseFromTrunk();
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c31(s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
     }
 
     return s0;
@@ -2027,62 +2047,44 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOperation() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c32) {
-      s1 = peg$c32;
+    if (input.substr(peg$currPos, 5) === peg$c28) {
+      s1 = peg$c28;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c33); }
+      if (peg$silentFails === 0) { peg$fail(peg$c29); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c18) {
-              s5 = peg$c18;
-              peg$currPos += 2;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c19); }
-            }
+            s5 = peg$parseParallel();
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
-                s7 = peg$parseParallel();
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c32;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                }
                 if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
-                  if (s8 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 41) {
-                      s9 = peg$c36;
-                      peg$currPos++;
-                    } else {
-                      s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c37); }
-                    }
-                    if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c38(s7);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
+                  peg$savedPos = s0;
+                  s1 = peg$c34(s5);
+                  s0 = s1;
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -2113,22 +2115,22 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c39) {
-        s1 = peg$c39;
+      if (input.substr(peg$currPos, 6) === peg$c35) {
+        s1 = peg$c35;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c36); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c34;
+            s3 = peg$c30;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -2138,15 +2140,15 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c36;
+                    s7 = peg$c32;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c41(s5);
+                    s1 = peg$c37(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -2178,22 +2180,22 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c42) {
-          s1 = peg$c42;
+        if (input.substr(peg$currPos, 4) === peg$c38) {
+          s1 = peg$c38;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c43); }
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s3 = peg$c34;
+              s3 = peg$c30;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c35); }
+              if (peg$silentFails === 0) { peg$fail(peg$c31); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
@@ -2202,38 +2204,17 @@ function peg$parse(input, options) {
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parse__();
                   if (s6 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 59) {
-                      s7 = peg$c7;
+                    if (input.charCodeAt(peg$currPos) === 41) {
+                      s7 = peg$c32;
                       peg$currPos++;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c8); }
-                    }
-                    if (s7 === peg$FAILED) {
-                      s7 = null;
+                      if (peg$silentFails === 0) { peg$fail(peg$c33); }
                     }
                     if (s7 !== peg$FAILED) {
-                      s8 = peg$parse__();
-                      if (s8 !== peg$FAILED) {
-                        if (input.charCodeAt(peg$currPos) === 41) {
-                          s9 = peg$c36;
-                          peg$currPos++;
-                        } else {
-                          s9 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c37); }
-                        }
-                        if (s9 !== peg$FAILED) {
-                          peg$savedPos = s0;
-                          s1 = peg$c44(s5);
-                          s0 = s1;
-                        } else {
-                          peg$currPos = s0;
-                          s0 = peg$FAILED;
-                        }
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
+                      peg$savedPos = s0;
+                      s1 = peg$c40(s5);
+                      s0 = s1;
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -2280,7 +2261,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c45(s1);
+                s1 = peg$c41(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2306,7 +2287,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c46(s1);
+                  s1 = peg$c42(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2332,7 +2313,7 @@ function peg$parse(input, options) {
                   }
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c47(s1);
+                    s1 = peg$c43(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -2360,20 +2341,20 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePipe();
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c18) {
-          s2 = peg$c18;
+        if (input.substr(peg$currPos, 2) === peg$c16) {
+          s2 = peg$c16;
           peg$currPos += 2;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c19); }
+          if (peg$silentFails === 0) { peg$fail(peg$c17); }
         }
         if (s2 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 41) {
-            s2 = peg$c36;
+          if (peg$c44.test(input.charAt(peg$currPos))) {
+            s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c37); }
+            if (peg$silentFails === 0) { peg$fail(peg$c45); }
           }
           if (s2 === peg$FAILED) {
             s2 = peg$parseEOF();
@@ -2400,29 +2381,29 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 124) {
-      s1 = peg$c48;
+      s1 = peg$c46;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s3 = peg$c50;
+        s3 = peg$c48;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
       }
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s3 = peg$c52;
+          s3 = peg$c50;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
       }
       peg$silentFails--;
@@ -2456,12 +2437,12 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c18) {
-        s4 = peg$c18;
+      if (input.substr(peg$currPos, 2) === peg$c16) {
+        s4 = peg$c16;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       peg$silentFails--;
       if (s4 === peg$FAILED) {
@@ -2489,35 +2470,35 @@ function peg$parse(input, options) {
           s2 = peg$parseMultiplicativeOperator();
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s2 = peg$c54;
+              s2 = peg$c52;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s2 = peg$c34;
+                s2 = peg$c30;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                if (peg$silentFails === 0) { peg$fail(peg$c31); }
               }
               if (s2 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s2 = peg$c52;
+                  s2 = peg$c50;
                   peg$currPos++;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c51); }
                 }
                 if (s2 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 7) === peg$c56) {
-                    s2 = peg$c56;
+                  if (input.substr(peg$currPos, 7) === peg$c54) {
+                    s2 = peg$c54;
                     peg$currPos += 7;
                   } else {
                     s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c57); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c55); }
                   }
                 }
               }
@@ -2544,60 +2525,60 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c58) {
-      s1 = peg$c58;
+    if (input.substr(peg$currPos, 2) === peg$c56) {
+      s1 = peg$c56;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c60) {
-        s1 = peg$c60;
+      if (input.substr(peg$currPos, 2) === peg$c58) {
+        s1 = peg$c58;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c59); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c62) {
-          s1 = peg$c62;
+        if (input.substr(peg$currPos, 2) === peg$c60) {
+          s1 = peg$c60;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c63); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c64) {
-            s1 = peg$c64;
+          if (input.substr(peg$currPos, 2) === peg$c62) {
+            s1 = peg$c62;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
+            if (peg$silentFails === 0) { peg$fail(peg$c63); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c66;
+              s1 = peg$c64;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c67); }
+              if (peg$silentFails === 0) { peg$fail(peg$c65); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c68) {
-                s1 = peg$c68;
+              if (input.substr(peg$currPos, 2) === peg$c66) {
+                s1 = peg$c66;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                if (peg$silentFails === 0) { peg$fail(peg$c67); }
               }
               if (s1 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 62) {
-                  s1 = peg$c70;
+                  s1 = peg$c68;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c71); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c69); }
                 }
               }
             }
@@ -2607,7 +2588,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -2622,12 +2603,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseByToken();
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c73) {
-          s2 = peg$c73;
+        if (input.substr(peg$currPos, 5) === peg$c71) {
+          s2 = peg$c71;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c72); }
         }
       }
       if (s2 !== peg$FAILED) {
@@ -2652,11 +2633,11 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s2 = peg$c75;
+          s2 = peg$c73;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -2688,7 +2669,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c77(s1, s2);
+        s1 = peg$c75(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2715,7 +2696,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchAnd();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c78(s4);
+            s1 = peg$c76(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2769,7 +2750,7 @@ function peg$parse(input, options) {
           s6 = peg$parseSearchFactor();
           if (s6 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c79(s1, s6);
+            s4 = peg$c77(s1, s6);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2810,7 +2791,7 @@ function peg$parse(input, options) {
             s6 = peg$parseSearchFactor();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s6);
+              s4 = peg$c77(s1, s6);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2827,7 +2808,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c78(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2863,11 +2844,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c81;
+        s2 = peg$c79;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2887,7 +2868,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c83(s2);
+        s1 = peg$c81(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2902,11 +2883,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c34;
+          s1 = peg$c30;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -2916,15 +2897,15 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c36;
+                  s5 = peg$c32;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c84(s3);
+                  s1 = peg$c82(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2957,11 +2938,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c85;
+      s1 = peg$c83;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -2973,7 +2954,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c87(s3, s5);
+              s1 = peg$c85(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3011,7 +2992,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c88(s1);
+          s1 = peg$c86(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3032,15 +3013,15 @@ function peg$parse(input, options) {
               s4 = peg$parse_();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 42) {
-                  s5 = peg$c85;
+                  s5 = peg$c83;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c86); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c84); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c89(s1);
+                  s1 = peg$c87(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3100,7 +3081,7 @@ function peg$parse(input, options) {
       s2 = peg$parsePatternSearch();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c90(s2);
+        s1 = peg$c88(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3151,7 +3132,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c91(s2);
+            s1 = peg$c89(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3168,11 +3149,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c85;
+          s1 = peg$c83;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
@@ -3187,7 +3168,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c92();
+            s1 = peg$c90();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3226,7 +3207,7 @@ function peg$parse(input, options) {
         s2 = peg$parseKeyWord();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c93(s2);
+          s1 = peg$c91(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3248,7 +3229,7 @@ function peg$parse(input, options) {
     s1 = peg$parsePattern();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c94(s1);
+      s1 = peg$c92(s1);
     }
     s0 = s1;
 
@@ -3263,12 +3244,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c56) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c54) {
           s3 = input.substr(peg$currPos, 7);
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c95); }
+          if (peg$silentFails === 0) { peg$fail(peg$c93); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3276,7 +3257,7 @@ function peg$parse(input, options) {
             s5 = peg$parsePattern();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c96(s1, s5);
+              s1 = peg$c94(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3328,25 +3309,22 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$parseByToken();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseCaseToken();
+                s0 = peg$parseDefaultToken();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseDefaultToken();
+                  if (input.substr(peg$currPos, 5) === peg$c95) {
+                    s0 = peg$c95;
+                    peg$currPos += 5;
+                  } else {
+                    s0 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                  }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c97) {
-                      s0 = peg$c97;
-                      peg$currPos += 5;
+                    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c54) {
+                      s0 = input.substr(peg$currPos, 7);
+                      peg$currPos += 7;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c98); }
-                    }
-                    if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c56) {
-                        s0 = input.substr(peg$currPos, 7);
-                        peg$currPos += 7;
-                      } else {
-                        s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c95); }
-                      }
+                      if (peg$silentFails === 0) { peg$fail(peg$c93); }
                     }
                   }
                 }
@@ -3373,7 +3351,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLimitArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c99(s2, s3, s4);
+            s1 = peg$c97(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3421,7 +3399,7 @@ function peg$parse(input, options) {
               s5 = peg$parseLimitArg();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c100(s2, s3, s4, s5);
+                s1 = peg$c98(s2, s3, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3452,12 +3430,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c101) {
-      s1 = peg$c101;
+    if (input.substr(peg$currPos, 9) === peg$c99) {
+      s1 = peg$c99;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c102); }
+      if (peg$silentFails === 0) { peg$fail(peg$c100); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3473,7 +3451,7 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$c29;
+      s0 = peg$c26;
     }
 
     return s0;
@@ -3483,12 +3461,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c103) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c101) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c104); }
+      if (peg$silentFails === 0) { peg$fail(peg$c102); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3498,7 +3476,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c105(s3);
+            s1 = peg$c103(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3518,10 +3496,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -3540,7 +3518,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c107(s3);
+          s1 = peg$c105(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3564,22 +3542,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c108) {
-        s2 = peg$c108;
+      if (input.substr(peg$currPos, 4) === peg$c106) {
+        s2 = peg$c106;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c109); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c110) {
-            s4 = peg$c110;
+          if (input.substr(peg$currPos, 6) === peg$c108) {
+            s4 = peg$c108;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c111); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3587,7 +3565,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c112(s6);
+                s1 = peg$c110(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3615,10 +3593,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113();
+        s1 = peg$c111();
       }
       s0 = s1;
     }
@@ -3635,7 +3613,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1);
+        s1 = peg$c112(s1);
       }
       s0 = s1;
     }
@@ -3654,11 +3632,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3666,7 +3644,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c115(s1, s7);
+              s4 = peg$c113(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3690,11 +3668,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3702,7 +3680,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c115(s1, s7);
+                s4 = peg$c113(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3723,7 +3701,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3745,12 +3723,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c116) {
-          s3 = peg$c116;
+        if (input.substr(peg$currPos, 2) === peg$c115) {
+          s3 = peg$c115;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c116); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3758,7 +3736,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAgg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c118(s1, s5);
+              s1 = peg$c117(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3785,7 +3763,7 @@ function peg$parse(input, options) {
       s1 = peg$parseAgg();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c119(s1);
+        s1 = peg$c118(s1);
       }
       s0 = s1;
     }
@@ -3813,11 +3791,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c34;
+            s4 = peg$c30;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -3830,11 +3808,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c36;
+                    s8 = peg$c32;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$currPos;
@@ -3843,11 +3821,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c120;
+                        s12 = peg$c119;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c120); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3874,7 +3852,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c122(s2, s6, s10);
+                        s1 = peg$c121(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3940,12 +3918,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c123) {
-        s2 = peg$c123;
+      if (input.substr(peg$currPos, 5) === peg$c122) {
+        s2 = peg$c122;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c124); }
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3953,7 +3931,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c84(s4);
+            s1 = peg$c82(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3986,11 +3964,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4021,11 +3999,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4053,7 +4031,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c125(s1, s2);
+        s1 = peg$c124(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4133,12 +4111,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c125) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      if (peg$silentFails === 0) { peg$fail(peg$c126); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -4149,7 +4127,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c128(s2, s5);
+            s4 = peg$c127(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -4164,7 +4142,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c129(s2, s3);
+          s1 = peg$c128(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4193,7 +4171,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c46(s4);
+        s3 = peg$c42(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -4211,7 +4189,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c46(s4);
+          s3 = peg$c42(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4224,7 +4202,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c130(s1);
+      s1 = peg$c129(s1);
     }
     s0 = s1;
 
@@ -4235,55 +4213,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c131) {
-      s1 = peg$c131;
+    if (input.substr(peg$currPos, 2) === peg$c130) {
+      s1 = peg$c130;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c132); }
+      if (peg$silentFails === 0) { peg$fail(peg$c131); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c133();
+      s1 = peg$c132();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c134) {
-        s1 = peg$c134;
+      if (input.substr(peg$currPos, 6) === peg$c133) {
+        s1 = peg$c133;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c135); }
+        if (peg$silentFails === 0) { peg$fail(peg$c134); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c136) {
-            s4 = peg$c136;
+          if (input.substr(peg$currPos, 5) === peg$c135) {
+            s4 = peg$c135;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c137); }
+            if (peg$silentFails === 0) { peg$fail(peg$c136); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c138) {
-              s4 = peg$c138;
+            if (input.substr(peg$currPos, 4) === peg$c137) {
+              s4 = peg$c137;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c139); }
+              if (peg$silentFails === 0) { peg$fail(peg$c138); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c72();
+            s4 = peg$c70();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c140(s3);
+            s1 = peg$c139(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4306,12 +4284,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c141) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c140) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c142); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4320,7 +4298,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c143(s4);
+          s3 = peg$c142(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4337,12 +4315,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c144) {
-            s5 = peg$c144;
+          if (input.substr(peg$currPos, 6) === peg$c143) {
+            s5 = peg$c143;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c145); }
+            if (peg$silentFails === 0) { peg$fail(peg$c144); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -4365,7 +4343,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c146(s2, s3, s6);
+              s5 = peg$c145(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -4380,7 +4358,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c147(s2, s3, s4);
+            s1 = peg$c146(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4406,12 +4384,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c148) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c147) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c149); }
+      if (peg$silentFails === 0) { peg$fail(peg$c148); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4419,7 +4397,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c150(s3);
+          s1 = peg$c149(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4441,12 +4419,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c152); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4454,7 +4432,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c153(s3);
+          s1 = peg$c152(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4476,12 +4454,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c154); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4489,7 +4467,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c156(s3);
+          s1 = peg$c155(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4511,12 +4489,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c157) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c156) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c158); }
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4524,7 +4502,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c159(s3);
+          s1 = peg$c158(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4540,16 +4518,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c157) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c156) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c158); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c160();
+        s1 = peg$c159();
       }
       s0 = s1;
     }
@@ -4561,12 +4539,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c161) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c162); }
+      if (peg$silentFails === 0) { peg$fail(peg$c161); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4574,7 +4552,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c163(s3);
+          s1 = peg$c162(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4590,16 +4568,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c161) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c162); }
+        if (peg$silentFails === 0) { peg$fail(peg$c161); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c164();
+        s1 = peg$c163();
       }
       s0 = s1;
     }
@@ -4611,12 +4589,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c165) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c164) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c166); }
+      if (peg$silentFails === 0) { peg$fail(peg$c165); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4624,7 +4602,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c167(s3);
+          s1 = peg$c166(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4649,7 +4627,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSearchBoolean();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c43(s1);
     }
     s0 = s1;
 
@@ -4660,26 +4638,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c168) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c167) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c168); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c170) {
-          s3 = peg$c170;
+        if (input.substr(peg$currPos, 2) === peg$c169) {
+          s3 = peg$c169;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c171); }
+          if (peg$silentFails === 0) { peg$fail(peg$c170); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c172();
+          s1 = peg$c171();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4695,16 +4673,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c168) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c167) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c169); }
+        if (peg$silentFails === 0) { peg$fail(peg$c168); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c173();
+        s1 = peg$c172();
       }
       s0 = s1;
     }
@@ -4716,12 +4694,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c174) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c173) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      if (peg$silentFails === 0) { peg$fail(peg$c174); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4729,7 +4707,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s3);
+          s1 = peg$c175(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4751,12 +4729,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c177) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c176) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c178); }
+      if (peg$silentFails === 0) { peg$fail(peg$c177); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4768,11 +4746,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c75;
+              s7 = peg$c73;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c76); }
+              if (peg$silentFails === 0) { peg$fail(peg$c74); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -4780,7 +4758,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c179(s3, s9);
+                  s6 = peg$c178(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4804,11 +4782,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c75;
+                s7 = peg$c73;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                if (peg$silentFails === 0) { peg$fail(peg$c74); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -4816,7 +4794,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c179(s3, s9);
+                    s6 = peg$c178(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4837,7 +4815,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c180(s3, s4);
+            s1 = peg$c179(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4863,12 +4841,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c181) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c182); }
+      if (peg$silentFails === 0) { peg$fail(peg$c181); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4877,11 +4855,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c34;
+          s5 = peg$c30;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4903,7 +4881,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c183();
+        s1 = peg$c182();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4921,16 +4899,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c184) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c183) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
+      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c186();
+      s1 = peg$c185();
     }
     s0 = s1;
 
@@ -4943,12 +4921,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseJoinStyle();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c188); }
+        if (peg$silentFails === 0) { peg$fail(peg$c187); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4993,7 +4971,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c189(s1, s6, s10, s11);
+                          s1 = peg$c188(s1, s6, s10, s11);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -5043,12 +5021,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parseJoinStyle();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
           s2 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c188); }
+          if (peg$silentFails === 0) { peg$fail(peg$c187); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5079,7 +5057,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c190(s1, s6, s7);
+                    s1 = peg$c189(s1, s6, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5118,18 +5096,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c191) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c190) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
+      if (peg$silentFails === 0) { peg$fail(peg$c191); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c193();
+        s1 = peg$c192();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5141,18 +5119,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c194) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c193) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c194); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c196();
+          s1 = peg$c195();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5164,18 +5142,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c197) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c196) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c198); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c199();
+            s1 = peg$c198();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5187,10 +5165,10 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$c29;
+          s1 = peg$c26;
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c193();
+            s1 = peg$c192();
           }
           s0 = s1;
         }
@@ -5207,25 +5185,25 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c34;
+        s1 = peg$c30;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c36;
+            s3 = peg$c32;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c37); }
+            if (peg$silentFails === 0) { peg$fail(peg$c33); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c84(s2);
+            s1 = peg$c82(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5248,18 +5226,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c200) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c199) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c201); }
+      if (peg$silentFails === 0) { peg$fail(peg$c200); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSampleExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c202(s2);
+        s1 = peg$c201(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5282,7 +5260,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c203(s2);
+        s1 = peg$c202(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5294,10 +5272,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c204();
+        s1 = peg$c203();
       }
       s0 = s1;
     }
@@ -5312,7 +5290,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFromAny();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c205(s1);
+      s1 = peg$c204(s1);
     }
     s0 = s1;
 
@@ -5337,12 +5315,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c206) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c205) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c207); }
+      if (peg$silentFails === 0) { peg$fail(peg$c206); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5354,7 +5332,7 @@ function peg$parse(input, options) {
             s5 = peg$parseLayoutArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c208(s3, s4, s5);
+              s1 = peg$c207(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5384,12 +5362,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c42) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c209); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5397,7 +5375,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePoolBody();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c210(s3);
+          s1 = peg$c209(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5428,7 +5406,7 @@ function peg$parse(input, options) {
           s4 = peg$parseOrderArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c211(s1, s2, s3, s4);
+            s1 = peg$c210(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5454,12 +5432,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c212) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c211) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c213); }
+      if (peg$silentFails === 0) { peg$fail(peg$c212); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5471,7 +5449,7 @@ function peg$parse(input, options) {
             s5 = peg$parseLayoutArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c214(s3, s4, s5);
+              s1 = peg$c213(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5501,27 +5479,27 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c215) {
-      s1 = peg$c215;
+    if (input.substr(peg$currPos, 5) === peg$c214) {
+      s1 = peg$c214;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c216); }
+      if (peg$silentFails === 0) { peg$fail(peg$c215); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c217) {
-        s1 = peg$c217;
+      if (input.substr(peg$currPos, 6) === peg$c216) {
+        s1 = peg$c216;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c218); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePath();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5536,7 +5514,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parsePath() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = peg$parseQuotedString();
@@ -5548,50 +5526,32 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c219.test(input.charAt(peg$currPos))) {
+      if (peg$c218.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c220); }
+        if (peg$silentFails === 0) { peg$fail(peg$c219); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c219.test(input.charAt(peg$currPos))) {
+          if (peg$c218.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c220); }
+            if (peg$silentFails === 0) { peg$fail(peg$c219); }
           }
         }
       } else {
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        s3 = peg$parseEOT();
-        peg$silentFails--;
-        if (s3 !== peg$FAILED) {
-          peg$currPos = s2;
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c72();
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
+        peg$savedPos = s0;
+        s1 = peg$c70();
       }
+      s0 = s1;
     }
 
     return s0;
@@ -5603,12 +5563,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c221) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c220) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c222); }
+        if (peg$silentFails === 0) { peg$fail(peg$c221); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5616,7 +5576,7 @@ function peg$parse(input, options) {
           s4 = peg$parseKSUID();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c223(s4);
+            s1 = peg$c222(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5636,10 +5596,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -5652,22 +5612,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c224.test(input.charAt(peg$currPos))) {
+    if (peg$c223.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c225); }
+      if (peg$silentFails === 0) { peg$fail(peg$c224); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c224.test(input.charAt(peg$currPos))) {
+        if (peg$c223.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c225); }
+          if (peg$silentFails === 0) { peg$fail(peg$c224); }
         }
       }
     } else {
@@ -5675,7 +5635,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -5688,12 +5648,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c226) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c225) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c226); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5702,12 +5662,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
+              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c227) {
                 s6 = input.substr(peg$currPos, 2);
                 peg$currPos += 2;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c229); }
+                if (peg$silentFails === 0) { peg$fail(peg$c228); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parse_();
@@ -5715,7 +5675,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseLiteral();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c230(s4, s8);
+                    s1 = peg$c229(s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5751,10 +5711,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -5768,12 +5728,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c227) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c229); }
+        if (peg$silentFails === 0) { peg$fail(peg$c228); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5781,7 +5741,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLiteral();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c231(s4);
+            s1 = peg$c230(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5801,10 +5761,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -5819,7 +5779,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c232(s1);
+      s1 = peg$c231(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5827,7 +5787,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKSUID();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c223(s1);
+        s1 = peg$c222(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -5835,7 +5795,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c233(s1);
+          s1 = peg$c232(s1);
         }
         s0 = s1;
       }
@@ -5850,12 +5810,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c234) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c235); }
+        if (peg$silentFails === 0) { peg$fail(peg$c234); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5865,7 +5825,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c236(s4, s5);
+              s1 = peg$c235(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5889,10 +5849,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -5906,12 +5866,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c237) {
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c236) {
         s2 = input.substr(peg$currPos, 6);
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c238); }
+        if (peg$silentFails === 0) { peg$fail(peg$c237); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5919,7 +5879,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c231(s4);
+            s1 = peg$c230(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5939,10 +5899,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c239();
+        s1 = peg$c238();
       }
       s0 = s1;
     }
@@ -5954,38 +5914,38 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c239) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c242();
+      s1 = peg$c241();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c243) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c242) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c244); }
+        if (peg$silentFails === 0) { peg$fail(peg$c243); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245();
+        s1 = peg$c244();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c29;
+        s1 = peg$c26;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c242();
+          s1 = peg$c241();
         }
         s0 = s1;
       }
@@ -6000,26 +5960,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c234) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c235); }
+        if (peg$silentFails === 0) { peg$fail(peg$c234); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c246) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
             s4 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c247); }
+            if (peg$silentFails === 0) { peg$fail(peg$c246); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c242();
+            s1 = peg$c241();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6041,26 +6001,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c234) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
           s2 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c235); }
+          if (peg$silentFails === 0) { peg$fail(peg$c234); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c248) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
               s4 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c248); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c245();
+              s1 = peg$c244();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6080,10 +6040,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c29;
+        s1 = peg$c26;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c239();
+          s1 = peg$c238();
         }
         s0 = s1;
       }
@@ -6096,16 +6056,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c250) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c249) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c251); }
+      if (peg$silentFails === 0) { peg$fail(peg$c250); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c252();
+      s1 = peg$c251();
     }
     s0 = s1;
 
@@ -6116,12 +6076,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c253) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c252) {
       s1 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6133,7 +6093,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAsArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c255(s3, s4, s5);
+              s1 = peg$c254(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6172,7 +6132,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c256(s4);
+            s1 = peg$c255(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6207,7 +6167,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c257(s4);
+            s1 = peg$c256(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6227,10 +6187,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c30();
+        s1 = peg$c27();
       }
       s0 = s1;
     }
@@ -6249,11 +6209,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6261,7 +6221,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c258(s1, s7);
+              s4 = peg$c257(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6285,11 +6245,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6297,7 +6257,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c258(s1, s7);
+                s4 = peg$c257(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6318,7 +6278,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6343,11 +6303,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6378,11 +6338,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6410,7 +6370,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c259(s1, s2);
+        s1 = peg$c258(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6432,12 +6392,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c116) {
-          s3 = peg$c116;
+        if (input.substr(peg$currPos, 2) === peg$c115) {
+          s3 = peg$c115;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c116); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6445,7 +6405,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c260(s1, s5);
+              s1 = peg$c259(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6488,11 +6448,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c261;
+          s3 = peg$c260;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c262); }
+          if (peg$silentFails === 0) { peg$fail(peg$c261); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6502,11 +6462,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c54;
+                  s7 = peg$c52;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -6514,7 +6474,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c263(s1, s5, s9);
+                      s1 = peg$c262(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6576,7 +6536,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6606,7 +6566,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6627,7 +6587,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6658,7 +6618,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6688,7 +6648,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6709,7 +6669,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6742,7 +6702,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c266(s1, s5, s7);
+                s4 = peg$c265(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6772,7 +6732,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRelativeExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s3;
-                  s4 = peg$c266(s1, s5, s7);
+                  s4 = peg$c265(s1, s5, s7);
                   s3 = s4;
                 } else {
                   peg$currPos = s3;
@@ -6793,7 +6753,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c265(s1, s2);
+          s1 = peg$c264(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6812,30 +6772,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c58) {
-      s1 = peg$c58;
+    if (input.substr(peg$currPos, 2) === peg$c56) {
+      s1 = peg$c56;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c267();
+      s1 = peg$c266();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c60) {
-        s1 = peg$c60;
+      if (input.substr(peg$currPos, 2) === peg$c58) {
+        s1 = peg$c58;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c59); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
       }
       s0 = s1;
     }
@@ -6849,16 +6809,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c62) {
-        s1 = peg$c62;
+      if (input.substr(peg$currPos, 2) === peg$c60) {
+        s1 = peg$c60;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
       }
       s0 = s1;
     }
@@ -6883,7 +6843,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6913,7 +6873,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6934,7 +6894,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6952,43 +6912,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c64) {
-      s1 = peg$c64;
+    if (input.substr(peg$currPos, 2) === peg$c62) {
+      s1 = peg$c62;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c63); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c66;
+        s1 = peg$c64;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c67); }
+        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c68) {
-          s1 = peg$c68;
+        if (input.substr(peg$currPos, 2) === peg$c66) {
+          s1 = peg$c66;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c67); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c70;
+            s1 = peg$c68;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c71); }
+            if (peg$silentFails === 0) { peg$fail(peg$c69); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7012,7 +6972,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7042,7 +7002,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7063,7 +7023,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7082,24 +7042,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c268;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c269); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c270;
+        s1 = peg$c269;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c271); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7123,7 +7083,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s5, s7);
+              s4 = peg$c263(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7153,7 +7113,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7174,7 +7134,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7193,24 +7153,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c85;
+      s1 = peg$c83;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c272;
+        s1 = peg$c271;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c273); }
+        if (peg$silentFails === 0) { peg$fail(peg$c272); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7222,11 +7182,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c81;
+      s1 = peg$c79;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7234,7 +7194,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c274(s3);
+          s1 = peg$c273(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7271,11 +7231,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s5 = peg$c34;
+              s5 = peg$c30;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c35); }
+              if (peg$silentFails === 0) { peg$fail(peg$c31); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -7297,7 +7257,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s1);
+            s1 = peg$c274(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7319,7 +7279,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c77(s1, s2);
+              s1 = peg$c75(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7341,7 +7301,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c77(s1, s2);
+                s1 = peg$c75(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7374,11 +7334,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -7402,28 +7362,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c276) {
-      s0 = peg$c276;
+    if (input.substr(peg$currPos, 3) === peg$c275) {
+      s0 = peg$c275;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c278) {
-        s0 = peg$c278;
+      if (input.substr(peg$currPos, 5) === peg$c277) {
+        s0 = peg$c277;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c280) {
-          s0 = peg$c280;
+        if (input.substr(peg$currPos, 6) === peg$c279) {
+          s0 = peg$c279;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -7444,36 +7404,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c278) {
-      s1 = peg$c278;
+    if (input.substr(peg$currPos, 5) === peg$c277) {
+      s1 = peg$c277;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c36;
+              s5 = peg$c32;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c37); }
+              if (peg$silentFails === 0) { peg$fail(peg$c33); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c84(s4);
+              s1 = peg$c82(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7503,22 +7463,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c280) {
-      s1 = peg$c280;
+    if (input.substr(peg$currPos, 6) === peg$c279) {
+      s1 = peg$c279;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+      if (peg$silentFails === 0) { peg$fail(peg$c280); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7528,17 +7488,17 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c36;
+                  s7 = peg$c32;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parseMethods();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c282(s5, s8);
+                    s1 = peg$c281(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7592,15 +7552,15 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c283(s1);
+      s1 = peg$c282(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -7615,11 +7575,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c120;
+        s2 = peg$c119;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7627,7 +7587,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFunction();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c45(s4);
+            s1 = peg$c41(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7658,11 +7618,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7672,15 +7632,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c36;
+                  s7 = peg$c32;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c284(s1, s5);
+                  s1 = peg$c283(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7734,11 +7694,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c34;
+            s4 = peg$c30;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -7748,15 +7708,15 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c36;
+                    s8 = peg$c32;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c285(s2, s6);
+                    s1 = peg$c284(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7803,7 +7763,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c286();
+        s1 = peg$c285();
       }
       s0 = s1;
     }
@@ -7822,11 +7782,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -7834,7 +7794,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c287(s1, s7);
+              s4 = peg$c286(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7858,11 +7818,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -7870,7 +7830,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c287(s1, s7);
+                s4 = peg$c286(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7891,7 +7851,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7923,7 +7883,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExprPattern();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c288(s2);
+        s1 = peg$c287(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7951,7 +7911,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c77(s1, s2);
+        s1 = peg$c75(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7973,7 +7933,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c77(s1, s2);
+          s1 = peg$c75(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7995,7 +7955,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c77(s1, s2);
+            s1 = peg$c75(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8008,15 +7968,15 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 46) {
-            s1 = peg$c120;
+            s1 = peg$c119;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c120); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c289();
+            s1 = peg$c288();
           }
           s0 = s1;
         }
@@ -8030,16 +7990,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c290) {
-      s1 = peg$c290;
+    if (input.substr(peg$currPos, 4) === peg$c289) {
+      s1 = peg$c289;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c290); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c204();
+      s1 = peg$c203();
     }
     s0 = s1;
 
@@ -8051,17 +8011,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c120;
+      s1 = peg$c119;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c120); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c292(s2);
+        s1 = peg$c291(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8074,33 +8034,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c120;
+        s1 = peg$c119;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c52;
+          s2 = peg$c50;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c293;
+              s4 = peg$c292;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c294); }
+              if (peg$silentFails === 0) { peg$fail(peg$c293); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c295(s3);
+              s1 = peg$c294(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8128,11 +8088,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c52;
+      s1 = peg$c50;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c51); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -8140,11 +8100,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c54;
+            s4 = peg$c52;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -8152,15 +8112,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c293;
+                  s7 = peg$c292;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c296(s2, s6);
+                  s1 = peg$c295(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8193,21 +8153,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c52;
+        s1 = peg$c50;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c54;
+            s3 = peg$c52;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -8215,15 +8175,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c293;
+                  s6 = peg$c292;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c297(s5);
+                  s1 = peg$c296(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8252,11 +8212,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c52;
+          s1 = peg$c50;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseAdditiveExpr();
@@ -8264,25 +8224,25 @@ function peg$parse(input, options) {
             s3 = peg$parse__();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c54;
+                s4 = peg$c52;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                if (peg$silentFails === 0) { peg$fail(peg$c53); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c293;
+                    s6 = peg$c292;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c293); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c298(s2);
+                    s1 = peg$c297(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8311,25 +8271,25 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c52;
+            s1 = peg$c50;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c51); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c293;
+                s3 = peg$c292;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                if (peg$silentFails === 0) { peg$fail(peg$c293); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c299(s2);
+                s1 = peg$c298(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8346,21 +8306,21 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c120;
+              s1 = peg$c119;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c121); }
+              if (peg$silentFails === 0) { peg$fail(peg$c120); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
               peg$silentFails++;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s3 = peg$c120;
+                s3 = peg$c119;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               peg$silentFails--;
               if (s3 === peg$FAILED) {
@@ -8373,7 +8333,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c300(s3);
+                  s1 = peg$c299(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8410,11 +8370,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 40) {
-                s1 = peg$c34;
+                s1 = peg$c30;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                if (peg$silentFails === 0) { peg$fail(peg$c31); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -8424,15 +8384,15 @@ function peg$parse(input, options) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s5 = peg$c36;
+                        s5 = peg$c32;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c33); }
                       }
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c84(s3);
+                        s1 = peg$c82(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -8468,11 +8428,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c50;
+      s1 = peg$c48;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8482,15 +8442,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c301;
+              s5 = peg$c300;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s3);
+              s1 = peg$c302(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8530,7 +8490,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8551,11 +8511,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8563,7 +8523,7 @@ function peg$parse(input, options) {
           s4 = peg$parseField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c45(s4);
+            s1 = peg$c41(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8594,11 +8554,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c54;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8606,7 +8566,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305(s1, s5);
+              s1 = peg$c304(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8637,11 +8597,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c52;
+      s1 = peg$c50;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c51); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8651,15 +8611,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c293;
+              s5 = peg$c292;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c294); }
+              if (peg$silentFails === 0) { peg$fail(peg$c293); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c306(s3);
+              s1 = peg$c305(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8689,12 +8649,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c307) {
-      s1 = peg$c307;
+    if (input.substr(peg$currPos, 2) === peg$c306) {
+      s1 = peg$c306;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c308); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8703,16 +8663,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c309) {
-              s5 = peg$c309;
+            if (input.substr(peg$currPos, 2) === peg$c308) {
+              s5 = peg$c308;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s3);
+              s1 = peg$c310(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8742,12 +8702,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c312) {
-      s1 = peg$c312;
+    if (input.substr(peg$currPos, 2) === peg$c311) {
+      s1 = peg$c311;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8756,16 +8716,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c314) {
-              s5 = peg$c314;
+            if (input.substr(peg$currPos, 2) === peg$c313) {
+              s5 = peg$c313;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c315); }
+              if (peg$silentFails === 0) { peg$fail(peg$c314); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c316(s3);
+              s1 = peg$c315(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8805,7 +8765,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8820,7 +8780,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c286();
+        s1 = peg$c285();
       }
       s0 = s1;
     }
@@ -8835,11 +8795,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8847,7 +8807,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c288(s4);
+            s1 = peg$c287(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8878,11 +8838,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c54;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8890,7 +8850,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c317(s1, s5);
+              s1 = peg$c316(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8937,7 +8897,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c318(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c317(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8984,15 +8944,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 42) {
-          s3 = peg$c85;
+          s3 = peg$c83;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106();
+          s1 = peg$c104();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9015,7 +8975,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c319(s3);
+            s1 = peg$c318(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9049,7 +9009,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s1, s5);
+              s1 = peg$c319(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9076,7 +9036,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1);
+        s1 = peg$c112(s1);
       }
       s0 = s1;
     }
@@ -9095,11 +9055,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -9107,7 +9067,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSQLAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c115(s1, s7);
+              s4 = peg$c113(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9131,11 +9091,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -9143,7 +9103,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSQLAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c115(s1, s7);
+                s4 = peg$c113(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9164,7 +9124,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9193,7 +9153,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSQLAlias();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c321(s4, s5);
+              s1 = peg$c320(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9224,15 +9184,15 @@ function peg$parse(input, options) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 42) {
-              s4 = peg$c85;
+              s4 = peg$c83;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c86); }
+              if (peg$silentFails === 0) { peg$fail(peg$c84); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c106();
+              s1 = peg$c104();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9252,10 +9212,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c29;
+        s1 = peg$c26;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106();
+          s1 = peg$c104();
         }
         s0 = s1;
       }
@@ -9277,7 +9237,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c223(s4);
+            s1 = peg$c222(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9302,7 +9262,7 @@ function peg$parse(input, options) {
         s2 = peg$parseDerefExpr();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c223(s2);
+          s1 = peg$c222(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9314,10 +9274,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c29;
+        s1 = peg$c26;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106();
+          s1 = peg$c104();
         }
         s0 = s1;
       }
@@ -9337,7 +9297,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c322(s1, s4);
+        s4 = peg$c321(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9346,13 +9306,13 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c322(s1, s4);
+          s4 = peg$c321(s1, s4);
         }
         s3 = s4;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c16(s1, s2);
+        s1 = peg$c114(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9364,10 +9324,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9414,7 +9374,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c323(s1, s5, s6, s10, s14);
+                                s1 = peg$c322(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9491,7 +9451,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c324(s2);
+        s1 = peg$c323(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9503,10 +9463,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c193();
+        s1 = peg$c192();
       }
       s0 = s1;
     }
@@ -9527,7 +9487,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c84(s4);
+            s1 = peg$c82(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9547,10 +9507,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9575,7 +9535,7 @@ function peg$parse(input, options) {
               s6 = peg$parseFieldExprs();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c107(s6);
+                s1 = peg$c105(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9603,10 +9563,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9627,7 +9587,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c84(s4);
+            s1 = peg$c82(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9647,10 +9607,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9677,7 +9637,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c325(s6, s7);
+                  s1 = peg$c324(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9709,10 +9669,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c106();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -9732,7 +9692,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c326(s2);
+        s1 = peg$c325(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9744,10 +9704,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c242();
+        s1 = peg$c241();
       }
       s0 = s1;
     }
@@ -9768,7 +9728,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c327(s4);
+            s1 = peg$c326(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9788,10 +9748,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c29;
+      s1 = peg$c26;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113();
+        s1 = peg$c111();
       }
       s0 = s1;
     }
@@ -9803,16 +9763,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c280) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c279) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c329();
+      s1 = peg$c328();
     }
     s0 = s1;
 
@@ -9823,16 +9783,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c330) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c329) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c332();
+      s1 = peg$c331();
     }
     s0 = s1;
 
@@ -9843,16 +9803,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c42) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c209); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c333();
+      s1 = peg$c332();
     }
     s0 = s1;
 
@@ -9863,16 +9823,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+      if (peg$silentFails === 0) { peg$fail(peg$c187); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c334();
+      s1 = peg$c333();
     }
     s0 = s1;
 
@@ -9883,16 +9843,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c123) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c122) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c336();
+      s1 = peg$c335();
     }
     s0 = s1;
 
@@ -9903,16 +9863,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c337) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c336) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339();
+      s1 = peg$c338();
     }
     s0 = s1;
 
@@ -9923,16 +9883,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c340) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c339) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c341();
     }
     s0 = s1;
 
@@ -9943,16 +9903,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c234) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c343();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -9963,16 +9923,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c344) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c343) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c346();
+      s1 = peg$c345();
     }
     s0 = s1;
 
@@ -9983,16 +9943,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c347) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c349();
+      s1 = peg$c348();
     }
     s0 = s1;
 
@@ -10003,16 +9963,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c246) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c242();
+      s1 = peg$c241();
     }
     s0 = s1;
 
@@ -10023,16 +9983,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c248) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c245();
+      s1 = peg$c244();
     }
     s0 = s1;
 
@@ -10043,16 +10003,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c194) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c193) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c196();
+      s1 = peg$c195();
     }
     s0 = s1;
 
@@ -10063,16 +10023,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c197) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c196) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c198); }
+      if (peg$silentFails === 0) { peg$fail(peg$c197); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c199();
+      s1 = peg$c198();
     }
     s0 = s1;
 
@@ -10083,16 +10043,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c191) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c190) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
+      if (peg$silentFails === 0) { peg$fail(peg$c191); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c193();
+      s1 = peg$c192();
     }
     s0 = s1;
 
@@ -10176,7 +10136,7 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c93(s1);
+      s1 = peg$c91(s1);
     }
     s0 = s1;
 
@@ -10201,7 +10161,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1);
+        s1 = peg$c349(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10216,7 +10176,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1);
+        s1 = peg$c349(s1);
       }
       s0 = s1;
     }
@@ -10242,7 +10202,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351(s1);
+        s1 = peg$c350(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10257,7 +10217,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351(s1);
+        s1 = peg$c350(s1);
       }
       s0 = s1;
     }
@@ -10272,7 +10232,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c352(s1);
+      s1 = peg$c351(s1);
     }
     s0 = s1;
 
@@ -10286,7 +10246,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c353(s1);
+      s1 = peg$c352(s1);
     }
     s0 = s1;
 
@@ -10297,30 +10257,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c354) {
-      s1 = peg$c354;
+    if (input.substr(peg$currPos, 4) === peg$c353) {
+      s1 = peg$c353;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c354); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c355();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c357) {
-        s1 = peg$c357;
+      if (input.substr(peg$currPos, 5) === peg$c356) {
+        s1 = peg$c356;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c358); }
+        if (peg$silentFails === 0) { peg$fail(peg$c357); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359();
+        s1 = peg$c358();
       }
       s0 = s1;
     }
@@ -10332,16 +10292,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c360) {
-      s1 = peg$c360;
+    if (input.substr(peg$currPos, 4) === peg$c359) {
+      s1 = peg$c359;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10380,7 +10340,7 @@ function peg$parse(input, options) {
       s2 = peg$parseTypeExternal();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c363(s2);
+        s1 = peg$c362(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10427,7 +10387,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s1);
+            s1 = peg$c274(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10472,11 +10432,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c34;
+          s3 = peg$c30;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -10486,15 +10446,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c36;
+                  s7 = peg$c32;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c256(s5);
+                  s1 = peg$c255(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10537,11 +10497,11 @@ function peg$parse(input, options) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c34;
+            s3 = peg$c30;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -10551,15 +10511,15 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c36;
+                    s7 = peg$c32;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c275(s5);
+                    s1 = peg$c274(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10612,7 +10572,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c232(s1);
+        s1 = peg$c231(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10639,11 +10599,11 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s5 = peg$c34;
+                s5 = peg$c30;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                if (peg$silentFails === 0) { peg$fail(peg$c31); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse__();
@@ -10653,15 +10613,15 @@ function peg$parse(input, options) {
                     s8 = peg$parse__();
                     if (s8 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s9 = peg$c36;
+                        s9 = peg$c32;
                         peg$currPos++;
                       } else {
                         s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c33); }
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c364(s1, s7);
+                        s1 = peg$c363(s1, s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10704,17 +10664,17 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c365(s1);
+          s1 = peg$c364(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c34;
+            s1 = peg$c30;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10722,15 +10682,15 @@ function peg$parse(input, options) {
               s3 = peg$parseTypeUnion();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s4 = peg$c36;
+                  s4 = peg$c32;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c366(s3);
+                  s1 = peg$c365(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10762,7 +10722,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c367(s1);
+      s1 = peg$c366(s1);
     }
     s0 = s1;
 
@@ -10787,7 +10747,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10808,11 +10768,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -10820,7 +10780,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s4);
+            s1 = peg$c274(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10847,11 +10807,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c50;
+      s1 = peg$c48;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -10861,15 +10821,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c301;
+              s5 = peg$c300;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c368(s3);
+              s1 = peg$c367(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10894,11 +10854,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c52;
+        s1 = peg$c50;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -10908,15 +10868,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c293;
+                s5 = peg$c292;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                if (peg$silentFails === 0) { peg$fail(peg$c293); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c369(s3);
+                s1 = peg$c368(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10940,12 +10900,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c307) {
-          s1 = peg$c307;
+        if (input.substr(peg$currPos, 2) === peg$c306) {
+          s1 = peg$c306;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c308); }
+          if (peg$silentFails === 0) { peg$fail(peg$c307); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10954,16 +10914,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c309) {
-                  s5 = peg$c309;
+                if (input.substr(peg$currPos, 2) === peg$c308) {
+                  s5 = peg$c308;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c310); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c309); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c370(s3);
+                  s1 = peg$c369(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10987,12 +10947,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c312) {
-            s1 = peg$c312;
+          if (input.substr(peg$currPos, 2) === peg$c311) {
+            s1 = peg$c311;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c313); }
+            if (peg$silentFails === 0) { peg$fail(peg$c312); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11002,11 +10962,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c75;
+                    s5 = peg$c73;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c74); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -11015,16 +10975,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c314) {
-                            s9 = peg$c314;
+                          if (input.substr(peg$currPos, 2) === peg$c313) {
+                            s9 = peg$c313;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c315); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c314); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c371(s3, s7);
+                            s1 = peg$c370(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11074,11 +11034,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c50;
+      s1 = peg$c48;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11088,15 +11048,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c301;
+              s5 = peg$c300;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c368(s3);
+              s1 = peg$c367(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11121,11 +11081,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c52;
+        s1 = peg$c50;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -11135,15 +11095,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c293;
+                s5 = peg$c292;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                if (peg$silentFails === 0) { peg$fail(peg$c293); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c369(s3);
+                s1 = peg$c368(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11167,12 +11127,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c307) {
-          s1 = peg$c307;
+        if (input.substr(peg$currPos, 2) === peg$c306) {
+          s1 = peg$c306;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c308); }
+          if (peg$silentFails === 0) { peg$fail(peg$c307); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11181,16 +11141,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c309) {
-                  s5 = peg$c309;
+                if (input.substr(peg$currPos, 2) === peg$c308) {
+                  s5 = peg$c308;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c310); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c309); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c370(s3);
+                  s1 = peg$c369(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11214,12 +11174,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c312) {
-            s1 = peg$c312;
+          if (input.substr(peg$currPos, 2) === peg$c311) {
+            s1 = peg$c311;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c313); }
+            if (peg$silentFails === 0) { peg$fail(peg$c312); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11229,11 +11189,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c75;
+                    s5 = peg$c73;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c74); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -11242,16 +11202,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c314) {
-                            s9 = peg$c314;
+                          if (input.substr(peg$currPos, 2) === peg$c313) {
+                            s9 = peg$c313;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c315); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c314); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c371(s3, s7);
+                            s1 = peg$c370(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11311,92 +11271,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c372) {
-      s1 = peg$c372;
+    if (input.substr(peg$currPos, 5) === peg$c371) {
+      s1 = peg$c371;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c374) {
-        s1 = peg$c374;
+      if (input.substr(peg$currPos, 6) === peg$c373) {
+        s1 = peg$c373;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c375); }
+        if (peg$silentFails === 0) { peg$fail(peg$c374); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c376) {
-          s1 = peg$c376;
+        if (input.substr(peg$currPos, 6) === peg$c375) {
+          s1 = peg$c375;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c377); }
+          if (peg$silentFails === 0) { peg$fail(peg$c376); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c378) {
-            s1 = peg$c378;
+          if (input.substr(peg$currPos, 6) === peg$c377) {
+            s1 = peg$c377;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c379); }
+            if (peg$silentFails === 0) { peg$fail(peg$c378); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c380) {
-              s1 = peg$c380;
+            if (input.substr(peg$currPos, 4) === peg$c379) {
+              s1 = peg$c379;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c381); }
+              if (peg$silentFails === 0) { peg$fail(peg$c380); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c382) {
-                s1 = peg$c382;
+              if (input.substr(peg$currPos, 5) === peg$c381) {
+                s1 = peg$c381;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c383); }
+                if (peg$silentFails === 0) { peg$fail(peg$c382); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c384) {
-                  s1 = peg$c384;
+                if (input.substr(peg$currPos, 5) === peg$c383) {
+                  s1 = peg$c383;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c385); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c384); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c386) {
-                    s1 = peg$c386;
+                  if (input.substr(peg$currPos, 5) === peg$c385) {
+                    s1 = peg$c385;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c387); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c386); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c388) {
-                      s1 = peg$c388;
+                    if (input.substr(peg$currPos, 7) === peg$c387) {
+                      s1 = peg$c387;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c388); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c390) {
-                        s1 = peg$c390;
+                      if (input.substr(peg$currPos, 4) === peg$c389) {
+                        s1 = peg$c389;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c391); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c390); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c392) {
-                          s1 = peg$c392;
+                        if (input.substr(peg$currPos, 6) === peg$c391) {
+                          s1 = peg$c391;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c392); }
                         }
                       }
                     }
@@ -11410,7 +11370,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c394();
+      s1 = peg$c393();
     }
     s0 = s1;
 
@@ -11421,52 +11381,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c395) {
-      s1 = peg$c395;
+    if (input.substr(peg$currPos, 8) === peg$c394) {
+      s1 = peg$c394;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c396); }
+      if (peg$silentFails === 0) { peg$fail(peg$c395); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c397) {
-        s1 = peg$c397;
+      if (input.substr(peg$currPos, 4) === peg$c396) {
+        s1 = peg$c396;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c398); }
+        if (peg$silentFails === 0) { peg$fail(peg$c397); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c399) {
-          s1 = peg$c399;
+        if (input.substr(peg$currPos, 5) === peg$c398) {
+          s1 = peg$c398;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c400); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c401) {
-            s1 = peg$c401;
+          if (input.substr(peg$currPos, 7) === peg$c400) {
+            s1 = peg$c400;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c402); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c403) {
-              s1 = peg$c403;
+            if (input.substr(peg$currPos, 2) === peg$c402) {
+              s1 = peg$c402;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c404); }
+              if (peg$silentFails === 0) { peg$fail(peg$c403); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c405) {
-                s1 = peg$c405;
+              if (input.substr(peg$currPos, 3) === peg$c404) {
+                s1 = peg$c404;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c406); }
+                if (peg$silentFails === 0) { peg$fail(peg$c405); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11477,20 +11437,20 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c407) {
-                    s1 = peg$c407;
+                  if (input.substr(peg$currPos, 5) === peg$c406) {
+                    s1 = peg$c406;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c408); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c407); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c360) {
-                      s1 = peg$c360;
+                    if (input.substr(peg$currPos, 4) === peg$c359) {
+                      s1 = peg$c359;
                       peg$currPos += 4;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c360); }
                     }
                   }
                 }
@@ -11502,7 +11462,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c394();
+      s1 = peg$c393();
     }
     s0 = s1;
 
@@ -11523,7 +11483,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11544,11 +11504,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -11556,7 +11516,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s4);
+            s1 = peg$c274(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11587,11 +11547,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c54;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -11599,7 +11559,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c409(s1, s5);
+              s1 = peg$c408(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11639,7 +11599,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c304(s1, s2);
+        s1 = peg$c303(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11660,11 +11620,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c75;
+        s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -11672,7 +11632,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeFieldExternal();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s4);
+            s1 = peg$c274(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11703,11 +11663,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c54;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -11715,7 +11675,7 @@ function peg$parse(input, options) {
             s5 = peg$parseTypeExternal();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c409(s1, s5);
+              s1 = peg$c408(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11767,12 +11727,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c410) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c409) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c410); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11787,7 +11747,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c412();
+        s1 = peg$c411();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11805,12 +11765,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c413) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c412) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c414); }
+      if (peg$silentFails === 0) { peg$fail(peg$c413); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11825,7 +11785,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c415();
+        s1 = peg$c414();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11843,12 +11803,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c62) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c415); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11863,7 +11823,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c417();
+        s1 = peg$c416();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11881,12 +11841,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c276) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c275) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c418); }
+      if (peg$silentFails === 0) { peg$fail(peg$c417); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11901,7 +11861,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c419();
+        s1 = peg$c418();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11919,12 +11879,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c420) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c419) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11939,7 +11899,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c422();
+        s1 = peg$c421();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11956,12 +11916,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c423.test(input.charAt(peg$currPos))) {
+    if (peg$c422.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c424); }
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
     }
 
     return s0;
@@ -11972,12 +11932,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
     }
 
@@ -11991,7 +11951,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c427(s1);
+      s1 = peg$c426(s1);
     }
     s0 = s1;
 
@@ -12046,7 +12006,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c428();
+          s1 = peg$c427();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12063,31 +12023,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c429;
+        s1 = peg$c428;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c430); }
+        if (peg$silentFails === 0) { peg$fail(peg$c429); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c431;
+          s1 = peg$c430;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c432); }
+          if (peg$silentFails === 0) { peg$fail(peg$c431); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c223(s2);
+            s1 = peg$c222(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -12108,7 +12068,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c72();
+            s1 = peg$c70();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -12121,11 +12081,11 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s5 = peg$c34;
+                  s5 = peg$c30;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c31); }
                 }
                 if (s5 !== peg$FAILED) {
                   s4 = [s4, s5];
@@ -12147,7 +12107,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c223(s1);
+                s1 = peg$c222(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12189,17 +12149,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c433;
+        s2 = peg$c432;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c434); }
+        if (peg$silentFails === 0) { peg$fail(peg$c433); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c435();
+          s1 = peg$c434();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12224,21 +12184,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c270;
+        s2 = peg$c269;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c271); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c270;
+            s4 = peg$c269;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c271); }
+            if (peg$silentFails === 0) { peg$fail(peg$c270); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12273,36 +12233,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c425.test(input.charAt(peg$currPos))) {
+    if (peg$c424.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c425.test(input.charAt(peg$currPos))) {
+        if (peg$c424.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c426); }
+          if (peg$silentFails === 0) { peg$fail(peg$c425); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c425.test(input.charAt(peg$currPos))) {
+          if (peg$c424.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c426); }
+            if (peg$silentFails === 0) { peg$fail(peg$c425); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12331,20 +12291,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c425.test(input.charAt(peg$currPos))) {
+    if (peg$c424.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12390,51 +12350,51 @@ function peg$parse(input, options) {
     s1 = peg$parseD2();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c54;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c54;
+            s4 = peg$c52;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
             if (s5 !== peg$FAILED) {
               s6 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c120;
+                s7 = peg$c119;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c425.test(input.charAt(peg$currPos))) {
+                if (peg$c424.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c425.test(input.charAt(peg$currPos))) {
+                    if (peg$c424.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
                     }
                   }
                 } else {
@@ -12489,69 +12449,69 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c436;
+      s0 = peg$c435;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c437); }
+      if (peg$silentFails === 0) { peg$fail(peg$c436); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c268;
+        s1 = peg$c267;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c269); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c270;
+          s1 = peg$c269;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c271); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseD2();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c54;
+            s3 = peg$c52;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parseD2();
             if (s4 !== peg$FAILED) {
               s5 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c120;
+                s6 = peg$c119;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c425.test(input.charAt(peg$currPos))) {
+                if (peg$c424.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c425.test(input.charAt(peg$currPos))) {
+                    if (peg$c424.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
                     }
                   }
                 } else {
@@ -12604,11 +12564,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c270;
+      s1 = peg$c269;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12654,7 +12614,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c438();
+        s1 = peg$c437();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12676,11 +12636,11 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c120;
+        s3 = peg$c119;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseUInt();
@@ -12716,76 +12676,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c439) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c438) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c440); }
+      if (peg$silentFails === 0) { peg$fail(peg$c439); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c441) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c440) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c442); }
+        if (peg$silentFails === 0) { peg$fail(peg$c441); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c443) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c442) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c444); }
+          if (peg$silentFails === 0) { peg$fail(peg$c443); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c445) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c444) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c446); }
+            if (peg$silentFails === 0) { peg$fail(peg$c445); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c447) {
+            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c446) {
               s0 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c448); }
+              if (peg$silentFails === 0) { peg$fail(peg$c447); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c449) {
+              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c448) {
                 s0 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                if (peg$silentFails === 0) { peg$fail(peg$c449); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c451) {
+                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c450) {
                   s0 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c452); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c451); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c453) {
+                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c452) {
                     s0 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c454); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c453); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c455) {
+                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c454) {
                       s0 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c456); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c455); }
                     }
                   }
                 }
@@ -12806,37 +12766,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c120;
+        s2 = peg$c119;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c120;
+            s4 = peg$c119;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c120); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c120;
+                s6 = peg$c119;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c72();
+                  s1 = peg$c70();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -12880,11 +12840,11 @@ function peg$parse(input, options) {
     s3 = peg$parseHex();
     if (s3 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s4 = peg$c54;
+        s4 = peg$c52;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parseHex();
@@ -12894,11 +12854,11 @@ function peg$parse(input, options) {
           s7 = peg$parseHexDigit();
           if (s7 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s7 = peg$c54;
+              s7 = peg$c52;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
           }
           peg$silentFails--;
@@ -12970,7 +12930,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c457(s1, s2);
+        s1 = peg$c456(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12991,12 +12951,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c458) {
-            s3 = peg$c458;
+          if (input.substr(peg$currPos, 2) === peg$c457) {
+            s3 = peg$c457;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c459); }
+            if (peg$silentFails === 0) { peg$fail(peg$c458); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13009,7 +12969,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c460(s1, s2, s4, s5);
+                s1 = peg$c459(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13033,12 +12993,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c458) {
-          s1 = peg$c458;
+        if (input.substr(peg$currPos, 2) === peg$c457) {
+          s1 = peg$c457;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c459); }
+          if (peg$silentFails === 0) { peg$fail(peg$c458); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13051,7 +13011,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c461(s2, s3);
+              s1 = peg$c460(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13076,16 +13036,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c458) {
-                s3 = peg$c458;
+              if (input.substr(peg$currPos, 2) === peg$c457) {
+                s3 = peg$c457;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c459); }
+                if (peg$silentFails === 0) { peg$fail(peg$c458); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c462(s1, s2);
+                s1 = peg$c461(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13101,16 +13061,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c458) {
-              s1 = peg$c458;
+            if (input.substr(peg$currPos, 2) === peg$c457) {
+              s1 = peg$c457;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c459); }
+              if (peg$silentFails === 0) { peg$fail(peg$c458); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c463();
+              s1 = peg$c462();
             }
             s0 = s1;
           }
@@ -13137,17 +13097,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c54;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c464(s2);
+        s1 = peg$c463(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13168,15 +13128,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c54;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c465(s1);
+        s1 = peg$c464(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13197,17 +13157,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c272;
+        s2 = peg$c271;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c273); }
+        if (peg$silentFails === 0) { peg$fail(peg$c272); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c466(s1, s3);
+          s1 = peg$c465(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13232,17 +13192,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c272;
+        s2 = peg$c271;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c273); }
+        if (peg$silentFails === 0) { peg$fail(peg$c272); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c467(s1, s3);
+          s1 = peg$c466(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13267,7 +13227,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c468(s1);
+      s1 = peg$c467(s1);
     }
     s0 = s1;
 
@@ -13290,22 +13250,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c425.test(input.charAt(peg$currPos))) {
+    if (peg$c424.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c425.test(input.charAt(peg$currPos))) {
+        if (peg$c424.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c426); }
+          if (peg$silentFails === 0) { peg$fail(peg$c425); }
         }
       }
     } else {
@@ -13313,7 +13273,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13325,17 +13285,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c270;
+      s1 = peg$c269;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13354,33 +13314,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c270;
+      s1 = peg$c269;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c425.test(input.charAt(peg$currPos))) {
+          if (peg$c424.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c426); }
+            if (peg$silentFails === 0) { peg$fail(peg$c425); }
           }
         }
       } else {
@@ -13388,30 +13348,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c120;
+          s3 = peg$c119;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c120); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c425.test(input.charAt(peg$currPos))) {
+          if (peg$c424.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c426); }
+            if (peg$silentFails === 0) { peg$fail(peg$c425); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c425.test(input.charAt(peg$currPos))) {
+              if (peg$c424.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                if (peg$silentFails === 0) { peg$fail(peg$c425); }
               }
             }
           } else {
@@ -13424,7 +13384,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c469();
+              s1 = peg$c468();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13449,41 +13409,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c270;
+        s1 = peg$c269;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c271); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c120;
+          s2 = peg$c119;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c120); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c425.test(input.charAt(peg$currPos))) {
+          if (peg$c424.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c426); }
+            if (peg$silentFails === 0) { peg$fail(peg$c425); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c425.test(input.charAt(peg$currPos))) {
+              if (peg$c424.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                if (peg$silentFails === 0) { peg$fail(peg$c425); }
               }
             }
           } else {
@@ -13496,7 +13456,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c469();
+              s1 = peg$c468();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13523,20 +13483,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c470) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c469) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c470); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c472.test(input.charAt(peg$currPos))) {
+      if (peg$c471.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c473); }
+        if (peg$silentFails === 0) { peg$fail(peg$c472); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13578,7 +13538,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13588,12 +13548,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c474.test(input.charAt(peg$currPos))) {
+    if (peg$c473.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c474); }
     }
 
     return s0;
@@ -13604,11 +13564,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c476;
+      s1 = peg$c475;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c477); }
+      if (peg$silentFails === 0) { peg$fail(peg$c476); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13619,15 +13579,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c476;
+          s3 = peg$c475;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c477); }
+          if (peg$silentFails === 0) { peg$fail(peg$c476); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c478(s2);
+          s1 = peg$c477(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13644,11 +13604,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c479;
+        s1 = peg$c478;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c479); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13659,15 +13619,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c479;
+            s3 = peg$c478;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c480); }
+            if (peg$silentFails === 0) { peg$fail(peg$c479); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c478(s2);
+            s1 = peg$c477(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13693,11 +13653,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c476;
+      s2 = peg$c475;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c477); }
+      if (peg$silentFails === 0) { peg$fail(peg$c476); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13715,11 +13675,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c481); }
+        if (peg$silentFails === 0) { peg$fail(peg$c480); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13732,17 +13692,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c431;
+        s1 = peg$c430;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c432); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c233(s2);
+          s1 = peg$c232(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13771,7 +13731,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c482(s1, s2);
+        s1 = peg$c481(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13800,16 +13760,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c483.test(input.charAt(peg$currPos))) {
+    if (peg$c482.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c484); }
+      if (peg$silentFails === 0) { peg$fail(peg$c483); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13821,12 +13781,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
     }
 
@@ -13838,11 +13798,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c431;
+      s1 = peg$c430;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c432); }
+      if (peg$silentFails === 0) { peg$fail(peg$c431); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13851,7 +13811,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c233(s2);
+        s1 = peg$c232(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13901,7 +13861,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c485(s3, s4);
+            s1 = peg$c484(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13929,20 +13889,20 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     if (input.charCodeAt(peg$currPos) === 42) {
-      s2 = peg$c85;
+      s2 = peg$c83;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c85;
+        s2 = peg$c83;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -13974,11 +13934,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c85;
+        s2 = peg$c83;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -14004,15 +13964,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c85;
+          s1 = peg$c83;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c486();
+          s1 = peg$c485();
         }
         s0 = s1;
       }
@@ -14026,12 +13986,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c425.test(input.charAt(peg$currPos))) {
+      if (peg$c424.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
     }
 
@@ -14043,11 +14003,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c431;
+      s1 = peg$c430;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c432); }
+      if (peg$silentFails === 0) { peg$fail(peg$c431); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14056,7 +14016,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c233(s2);
+        s1 = peg$c232(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14083,30 +14043,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c487();
+      s1 = peg$c486();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c85;
+        s1 = peg$c83;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c488();
+        s1 = peg$c487();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c472.test(input.charAt(peg$currPos))) {
+        if (peg$c471.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c473); }
+          if (peg$silentFails === 0) { peg$fail(peg$c472); }
         }
       }
     }
@@ -14121,11 +14081,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c479;
+      s2 = peg$c478;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c479); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14143,11 +14103,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c481); }
+        if (peg$silentFails === 0) { peg$fail(peg$c480); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14160,17 +14120,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c431;
+        s1 = peg$c430;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c432); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c233(s2);
+          s1 = peg$c232(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14190,11 +14150,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c489;
+      s1 = peg$c488;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c490); }
+      if (peg$silentFails === 0) { peg$fail(peg$c489); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -14202,7 +14162,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c491();
+          s1 = peg$c490();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14230,116 +14190,116 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c479;
+      s0 = peg$c478;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c479); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c476;
+        s1 = peg$c475;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c477); }
+        if (peg$silentFails === 0) { peg$fail(peg$c476); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c70();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c431;
+          s0 = peg$c430;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c432); }
+          if (peg$silentFails === 0) { peg$fail(peg$c431); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c492;
+            s1 = peg$c491;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c494();
+            s1 = peg$c493();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c495;
+              s1 = peg$c494;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c496); }
+              if (peg$silentFails === 0) { peg$fail(peg$c495); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c497();
+              s1 = peg$c496();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c498;
+                s1 = peg$c497;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c499); }
+                if (peg$silentFails === 0) { peg$fail(peg$c498); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c500();
+                s1 = peg$c499();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c501;
+                  s1 = peg$c500;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c502); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c501); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c503();
+                  s1 = peg$c502();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c504;
+                    s1 = peg$c503;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c505); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c504); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c506();
+                    s1 = peg$c505();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c507;
+                      s1 = peg$c506;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c508); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c507); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c509();
+                      s1 = peg$c508();
                     }
                     s0 = s1;
                   }
@@ -14367,30 +14327,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c487();
+      s1 = peg$c486();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c85;
+        s1 = peg$c83;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c510();
+        s1 = peg$c509();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c472.test(input.charAt(peg$currPos))) {
+        if (peg$c471.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c473); }
+          if (peg$silentFails === 0) { peg$fail(peg$c472); }
         }
       }
     }
@@ -14403,11 +14363,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c511;
+      s1 = peg$c510;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c512); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14439,7 +14399,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c513(s2);
+        s1 = peg$c512(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14452,19 +14412,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c511;
+        s1 = peg$c510;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c512); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c50;
+          s2 = peg$c48;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -14523,15 +14483,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c301;
+              s4 = peg$c300;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c513(s3);
+              s1 = peg$c512(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14559,21 +14519,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c272;
+      s1 = peg$c271;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c273); }
+      if (peg$silentFails === 0) { peg$fail(peg$c272); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c272;
+          s3 = peg$c271;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c272); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14588,7 +14548,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c210(s2);
+            s1 = peg$c209(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14615,39 +14575,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c514.test(input.charAt(peg$currPos))) {
+    if (peg$c513.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c515); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c516) {
-        s2 = peg$c516;
+      if (input.substr(peg$currPos, 2) === peg$c515) {
+        s2 = peg$c515;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c517); }
+        if (peg$silentFails === 0) { peg$fail(peg$c516); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c514.test(input.charAt(peg$currPos))) {
+        if (peg$c513.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c515); }
+          if (peg$silentFails === 0) { peg$fail(peg$c514); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c516) {
-            s2 = peg$c516;
+          if (input.substr(peg$currPos, 2) === peg$c515) {
+            s2 = peg$c515;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c517); }
+            if (peg$silentFails === 0) { peg$fail(peg$c516); }
           }
         }
       }
@@ -14656,7 +14616,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -14666,12 +14626,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c518.test(input.charAt(peg$currPos))) {
+    if (peg$c517.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c518); }
     }
 
     return s0;
@@ -14729,7 +14689,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c481); }
+      if (peg$silentFails === 0) { peg$fail(peg$c480); }
     }
 
     return s0;
@@ -14740,51 +14700,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c521;
+      s0 = peg$c520;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c521); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c523;
+        s0 = peg$c522;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c523); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c525;
+          s0 = peg$c524;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c526); }
+          if (peg$silentFails === 0) { peg$fail(peg$c525); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c527;
+            s0 = peg$c526;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c527); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c529;
+              s0 = peg$c528;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c530); }
+              if (peg$silentFails === 0) { peg$fail(peg$c529); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c531;
+                s0 = peg$c530;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c532); }
+                if (peg$silentFails === 0) { peg$fail(peg$c531); }
               }
             }
           }
@@ -14794,7 +14754,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c520); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
 
     return s0;
@@ -14803,12 +14763,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c533.test(input.charAt(peg$currPos))) {
+    if (peg$c532.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c534); }
+      if (peg$silentFails === 0) { peg$fail(peg$c533); }
     }
 
     return s0;
@@ -14822,7 +14782,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c535); }
+      if (peg$silentFails === 0) { peg$fail(peg$c534); }
     }
 
     return s0;
@@ -14832,24 +14792,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c536) {
-      s1 = peg$c536;
+    if (input.substr(peg$currPos, 2) === peg$c535) {
+      s1 = peg$c535;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c537); }
+      if (peg$silentFails === 0) { peg$fail(peg$c536); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c538) {
-        s5 = peg$c538;
+      if (input.substr(peg$currPos, 2) === peg$c537) {
+        s5 = peg$c537;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c539); }
+        if (peg$silentFails === 0) { peg$fail(peg$c538); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -14876,12 +14836,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c538) {
-          s5 = peg$c538;
+        if (input.substr(peg$currPos, 2) === peg$c537) {
+          s5 = peg$c537;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c539); }
+          if (peg$silentFails === 0) { peg$fail(peg$c538); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -14905,12 +14865,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c538) {
-          s3 = peg$c538;
+        if (input.substr(peg$currPos, 2) === peg$c537) {
+          s3 = peg$c537;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c539); }
+          if (peg$silentFails === 0) { peg$fail(peg$c538); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -14935,12 +14895,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c540) {
-      s1 = peg$c540;
+    if (input.substr(peg$currPos, 2) === peg$c539) {
+      s1 = peg$c539;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c541); }
+      if (peg$silentFails === 0) { peg$fail(peg$c540); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15058,7 +15018,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c481); }
+      if (peg$silentFails === 0) { peg$fail(peg$c480); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -174,98 +174,93 @@ function peg$parse(input, options) {
       peg$c15 = function(p) { return p },
       peg$c16 = "=>",
       peg$c17 = peg$literalExpectation("=>", false),
-      peg$c18 = function(first, rest) {
-            return [first, ... rest[0]]
-          },
-      peg$c19 = function(first) {
-            return [first]
+      peg$c18 = function(s) { return s },
+      peg$c19 = function(e, proc) {
+            return {"expr": e, "proc": proc}
           },
       peg$c20 = function(proc) {
             return {"expr": {"kind": "Primitive", "type": "bool", "text": "true"}, "proc": proc}
           },
-      peg$c21 = function(e, proc) {
-            return {"expr": e, "proc": proc}
+      peg$c21 = "default",
+      peg$c22 = peg$literalExpectation("default", true),
+      peg$c23 = function(source, seq) {
+            return {"kind": "Trunk", "source": source, "seq": seq}
           },
-      peg$c22 = "default",
-      peg$c23 = peg$literalExpectation("default", true),
-      peg$c24 = function(source, seq) {
-            return {"kind": "Trunk", "source": source, "seq":seq }
-          },
-      peg$c25 = function(seq) { return seq },
-      peg$c26 = "",
-      peg$c27 = function() { return null},
-      peg$c28 = "split",
-      peg$c29 = peg$literalExpectation("split", false),
-      peg$c30 = "(",
-      peg$c31 = peg$literalExpectation("(", false),
-      peg$c32 = ")",
-      peg$c33 = peg$literalExpectation(")", false),
-      peg$c34 = function(procArray) {
+      peg$c24 = function(seq) { return seq },
+      peg$c25 = "",
+      peg$c26 = function() { return null},
+      peg$c27 = "split",
+      peg$c28 = peg$literalExpectation("split", false),
+      peg$c29 = "(",
+      peg$c30 = peg$literalExpectation("(", false),
+      peg$c31 = ")",
+      peg$c32 = peg$literalExpectation(")", false),
+      peg$c33 = function(procArray) {
             return {"kind": "Parallel", "procs": procArray}
           },
-      peg$c35 = "switch",
-      peg$c36 = peg$literalExpectation("switch", false),
-      peg$c37 = function(caseArray) {
+      peg$c34 = "switch",
+      peg$c35 = peg$literalExpectation("switch", false),
+      peg$c36 = function(caseArray) {
             return {"kind": "Switch", "cases": caseArray}
           },
-      peg$c38 = "from",
-      peg$c39 = peg$literalExpectation("from", false),
-      peg$c40 = function(trunks) {
+      peg$c37 = "from",
+      peg$c38 = peg$literalExpectation("from", false),
+      peg$c39 = function(trunks) {
             return {"kind": "From", "trunks": trunks}
           },
-      peg$c41 = function(f) { return f },
-      peg$c42 = function(a) { return a },
-      peg$c43 = function(expr) {
+      peg$c40 = function(f) { return f },
+      peg$c41 = function(a) { return a },
+      peg$c42 = function(expr) {
             return {"kind": "Filter", "expr": expr}
           },
-      peg$c44 = /^[);]/,
-      peg$c45 = peg$classExpectation([")", ";"], false, false),
-      peg$c46 = "|",
-      peg$c47 = peg$literalExpectation("|", false),
-      peg$c48 = "{",
-      peg$c49 = peg$literalExpectation("{", false),
-      peg$c50 = "[",
-      peg$c51 = peg$literalExpectation("[", false),
-      peg$c52 = ":",
-      peg$c53 = peg$literalExpectation(":", false),
-      peg$c54 = "matches",
-      peg$c55 = peg$literalExpectation("matches", false),
-      peg$c56 = "==",
-      peg$c57 = peg$literalExpectation("==", false),
-      peg$c58 = "!=",
-      peg$c59 = peg$literalExpectation("!=", false),
-      peg$c60 = "in",
-      peg$c61 = peg$literalExpectation("in", false),
-      peg$c62 = "<=",
-      peg$c63 = peg$literalExpectation("<=", false),
-      peg$c64 = "<",
-      peg$c65 = peg$literalExpectation("<", false),
-      peg$c66 = ">=",
-      peg$c67 = peg$literalExpectation(">=", false),
-      peg$c68 = ">",
-      peg$c69 = peg$literalExpectation(">", false),
-      peg$c70 = function() { return text() },
-      peg$c71 = "-with",
-      peg$c72 = peg$literalExpectation("-with", false),
-      peg$c73 = ",",
-      peg$c74 = peg$literalExpectation(",", false),
-      peg$c75 = function(first, rest) {
+      peg$c43 = /^[);]/,
+      peg$c44 = peg$classExpectation([")", ";"], false, false),
+      peg$c45 = "|",
+      peg$c46 = peg$literalExpectation("|", false),
+      peg$c47 = "{",
+      peg$c48 = peg$literalExpectation("{", false),
+      peg$c49 = "[",
+      peg$c50 = peg$literalExpectation("[", false),
+      peg$c51 = ":",
+      peg$c52 = peg$literalExpectation(":", false),
+      peg$c53 = "matches",
+      peg$c54 = peg$literalExpectation("matches", false),
+      peg$c55 = "==",
+      peg$c56 = peg$literalExpectation("==", false),
+      peg$c57 = "!=",
+      peg$c58 = peg$literalExpectation("!=", false),
+      peg$c59 = "in",
+      peg$c60 = peg$literalExpectation("in", false),
+      peg$c61 = "<=",
+      peg$c62 = peg$literalExpectation("<=", false),
+      peg$c63 = "<",
+      peg$c64 = peg$literalExpectation("<", false),
+      peg$c65 = ">=",
+      peg$c66 = peg$literalExpectation(">=", false),
+      peg$c67 = ">",
+      peg$c68 = peg$literalExpectation(">", false),
+      peg$c69 = function() { return text() },
+      peg$c70 = "-with",
+      peg$c71 = peg$literalExpectation("-with", false),
+      peg$c72 = ",",
+      peg$c73 = peg$literalExpectation(",", false),
+      peg$c74 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c76 = function(t) { return ["or", t] },
-      peg$c77 = function(first, expr) { return ["and", expr] },
-      peg$c78 = function(first, rest) {
+      peg$c75 = function(t) { return ["or", t] },
+      peg$c76 = function(first, expr) { return ["and", expr] },
+      peg$c77 = function(first, rest) {
             return makeBinaryExprChain(first,rest)
           },
-      peg$c79 = "!",
-      peg$c80 = peg$literalExpectation("!", false),
-      peg$c81 = function(e) {
+      peg$c78 = "!",
+      peg$c79 = peg$literalExpectation("!", false),
+      peg$c80 = function(e) {
             return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c82 = function(expr) { return expr },
-      peg$c83 = "*",
-      peg$c84 = peg$literalExpectation("*", false),
-      peg$c85 = function(compareOp, v) {
+      peg$c81 = function(expr) { return expr },
+      peg$c82 = "*",
+      peg$c83 = peg$literalExpectation("*", false),
+      peg$c84 = function(compareOp, v) {
             return {"kind": "Call", "name": "or",
               
             "args": [
@@ -292,8 +287,8 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c86 = function(match) { return match },
-      peg$c87 = function(v) {
+      peg$c85 = function(match) { return match },
+      peg$c86 = function(v) {
             return {"kind": "Call", "name": "or",
               
             "args": [
@@ -320,83 +315,83 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c88 = function(search) { return search },
-      peg$c89 = function(v) {
+      peg$c87 = function(search) { return search },
+      peg$c88 = function(v) {
             return {"kind": "Search", "text": text(), "value": v}
           },
-      peg$c90 = function() {
+      peg$c89 = function() {
             return {"kind": "Primitive", "type": "bool", "text": "true"}
           },
-      peg$c91 = function(v) {
+      peg$c90 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": v}
           },
-      peg$c92 = function(pattern) {
+      peg$c91 = function(pattern) {
             return {"kind": "RegexpSearch", "pattern": pattern}
           },
-      peg$c93 = peg$literalExpectation("matches", true),
-      peg$c94 = function(f, pattern) {
+      peg$c92 = peg$literalExpectation("matches", true),
+      peg$c93 = function(f, pattern) {
             return {"kind": "RegexpMatch", "pattern": pattern, "expr": f}
           },
-      peg$c95 = "type(",
-      peg$c96 = peg$literalExpectation("type(", false),
-      peg$c97 = function(every, keys, limit) {
+      peg$c94 = "type(",
+      peg$c95 = peg$literalExpectation("type(", false),
+      peg$c96 = function(every, keys, limit) {
             return {"kind": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
           },
-      peg$c98 = function(every, aggs, keys, limit) {
+      peg$c97 = function(every, aggs, keys, limit) {
             let p = {"kind": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
             }
             return p
           },
-      peg$c99 = "summarize",
-      peg$c100 = peg$literalExpectation("summarize", false),
-      peg$c101 = "every",
-      peg$c102 = peg$literalExpectation("every", true),
-      peg$c103 = function(dur) { return dur },
-      peg$c104 = function() { return null },
-      peg$c105 = function(columns) { return columns },
-      peg$c106 = "with",
-      peg$c107 = peg$literalExpectation("with", false),
-      peg$c108 = "-limit",
-      peg$c109 = peg$literalExpectation("-limit", false),
-      peg$c110 = function(limit) { return limit },
-      peg$c111 = function() { return 0 },
-      peg$c112 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c113 = function(first, expr) { return expr },
-      peg$c114 = function(first, rest) {
+      peg$c98 = "summarize",
+      peg$c99 = peg$literalExpectation("summarize", false),
+      peg$c100 = "every",
+      peg$c101 = peg$literalExpectation("every", true),
+      peg$c102 = function(dur) { return dur },
+      peg$c103 = function() { return null },
+      peg$c104 = function(columns) { return columns },
+      peg$c105 = "with",
+      peg$c106 = peg$literalExpectation("with", false),
+      peg$c107 = "-limit",
+      peg$c108 = peg$literalExpectation("-limit", false),
+      peg$c109 = function(limit) { return limit },
+      peg$c110 = function() { return 0 },
+      peg$c111 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c112 = function(first, expr) { return expr },
+      peg$c113 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c115 = ":=",
-      peg$c116 = peg$literalExpectation(":=", false),
-      peg$c117 = function(lval, agg) {
+      peg$c114 = ":=",
+      peg$c115 = peg$literalExpectation(":=", false),
+      peg$c116 = function(lval, agg) {
             return {"kind": "Assignment", "lhs": lval, "rhs": agg}
           },
-      peg$c118 = function(agg) {
+      peg$c117 = function(agg) {
             return {"kind": "Assignment", "lhs": null, "rhs": agg}
           },
-      peg$c119 = ".",
-      peg$c120 = peg$literalExpectation(".", false),
-      peg$c121 = function(op, expr, where) {
+      peg$c118 = ".",
+      peg$c119 = peg$literalExpectation(".", false),
+      peg$c120 = function(op, expr, where) {
             let r = {"kind": "Agg", "name": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c122 = "where",
-      peg$c123 = peg$literalExpectation("where", false),
-      peg$c124 = function(first, rest) {
+      peg$c121 = "where",
+      peg$c122 = peg$literalExpectation("where", false),
+      peg$c123 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c125 = "sort",
-      peg$c126 = peg$literalExpectation("sort", true),
-      peg$c127 = function(args, l) { return l },
-      peg$c128 = function(args, list) {
+      peg$c124 = "sort",
+      peg$c125 = peg$literalExpectation("sort", true),
+      peg$c126 = function(args, l) { return l },
+      peg$c127 = function(args, list) {
             let argm = args
             let proc = {"kind": "Sort", "args": list, "order": "asc", "nullsfirst": false}
             if ( "r" in argm) {
@@ -409,24 +404,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c129 = function(args) { return makeArgMap(args) },
-      peg$c130 = "-r",
-      peg$c131 = peg$literalExpectation("-r", false),
-      peg$c132 = function() { return {"name": "r", "value": null} },
-      peg$c133 = "-nulls",
-      peg$c134 = peg$literalExpectation("-nulls", false),
-      peg$c135 = "first",
-      peg$c136 = peg$literalExpectation("first", false),
-      peg$c137 = "last",
-      peg$c138 = peg$literalExpectation("last", false),
-      peg$c139 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c140 = "top",
-      peg$c141 = peg$literalExpectation("top", true),
-      peg$c142 = function(n) { return n},
-      peg$c143 = "-flush",
-      peg$c144 = peg$literalExpectation("-flush", false),
-      peg$c145 = function(limit, flush, f) { return f },
-      peg$c146 = function(limit, flush, fields) {
+      peg$c128 = function(args) { return makeArgMap(args) },
+      peg$c129 = "-r",
+      peg$c130 = peg$literalExpectation("-r", false),
+      peg$c131 = function() { return {"name": "r", "value": null} },
+      peg$c132 = "-nulls",
+      peg$c133 = peg$literalExpectation("-nulls", false),
+      peg$c134 = "first",
+      peg$c135 = peg$literalExpectation("first", false),
+      peg$c136 = "last",
+      peg$c137 = peg$literalExpectation("last", false),
+      peg$c138 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c139 = "top",
+      peg$c140 = peg$literalExpectation("top", true),
+      peg$c141 = function(n) { return n},
+      peg$c142 = "-flush",
+      peg$c143 = peg$literalExpectation("-flush", false),
+      peg$c144 = function(limit, flush, f) { return f },
+      peg$c145 = function(limit, flush, fields) {
             let proc = {"kind": "Top", "limit": 0, "args": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
@@ -439,93 +434,93 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c147 = "cut",
-      peg$c148 = peg$literalExpectation("cut", true),
-      peg$c149 = function(args) {
+      peg$c146 = "cut",
+      peg$c147 = peg$literalExpectation("cut", true),
+      peg$c148 = function(args) {
             return {"kind": "Cut", "args": args}
           },
-      peg$c150 = "pick",
-      peg$c151 = peg$literalExpectation("pick", true),
-      peg$c152 = function(args) {
+      peg$c149 = "pick",
+      peg$c150 = peg$literalExpectation("pick", true),
+      peg$c151 = function(args) {
             return {"kind": "Pick", "args": args}
           },
-      peg$c153 = "drop",
-      peg$c154 = peg$literalExpectation("drop", true),
-      peg$c155 = function(args) {
+      peg$c152 = "drop",
+      peg$c153 = peg$literalExpectation("drop", true),
+      peg$c154 = function(args) {
             return {"kind": "Drop", "args": args}
           },
-      peg$c156 = "head",
-      peg$c157 = peg$literalExpectation("head", true),
-      peg$c158 = function(count) { return {"kind": "Head", "count": count} },
-      peg$c159 = function() { return {"kind": "Head", "count": 1} },
-      peg$c160 = "tail",
-      peg$c161 = peg$literalExpectation("tail", true),
-      peg$c162 = function(count) { return {"kind": "Tail", "count": count} },
-      peg$c163 = function() { return {"kind": "Tail", "count": 1} },
-      peg$c164 = "filter",
-      peg$c165 = peg$literalExpectation("filter", true),
-      peg$c166 = function(op) {
+      peg$c155 = "head",
+      peg$c156 = peg$literalExpectation("head", true),
+      peg$c157 = function(count) { return {"kind": "Head", "count": count} },
+      peg$c158 = function() { return {"kind": "Head", "count": 1} },
+      peg$c159 = "tail",
+      peg$c160 = peg$literalExpectation("tail", true),
+      peg$c161 = function(count) { return {"kind": "Tail", "count": count} },
+      peg$c162 = function() { return {"kind": "Tail", "count": 1} },
+      peg$c163 = "filter",
+      peg$c164 = peg$literalExpectation("filter", true),
+      peg$c165 = function(op) {
             return op
           },
-      peg$c167 = "uniq",
-      peg$c168 = peg$literalExpectation("uniq", true),
-      peg$c169 = "-c",
-      peg$c170 = peg$literalExpectation("-c", false),
-      peg$c171 = function() {
+      peg$c166 = "uniq",
+      peg$c167 = peg$literalExpectation("uniq", true),
+      peg$c168 = "-c",
+      peg$c169 = peg$literalExpectation("-c", false),
+      peg$c170 = function() {
             return {"kind": "Uniq", "cflag": true}
           },
-      peg$c172 = function() {
+      peg$c171 = function() {
             return {"kind": "Uniq", "cflag": false}
           },
-      peg$c173 = "put",
-      peg$c174 = peg$literalExpectation("put", true),
-      peg$c175 = function(args) {
+      peg$c172 = "put",
+      peg$c173 = peg$literalExpectation("put", true),
+      peg$c174 = function(args) {
             return {"kind": "Put", "args": args}
           },
-      peg$c176 = "rename",
-      peg$c177 = peg$literalExpectation("rename", true),
-      peg$c178 = function(first, cl) { return cl },
-      peg$c179 = function(first, rest) {
+      peg$c175 = "rename",
+      peg$c176 = peg$literalExpectation("rename", true),
+      peg$c177 = function(first, cl) { return cl },
+      peg$c178 = function(first, rest) {
             return {"kind": "Rename", "args": [first, ... rest]}
           },
-      peg$c180 = "fuse",
-      peg$c181 = peg$literalExpectation("fuse", true),
-      peg$c182 = function() {
+      peg$c179 = "fuse",
+      peg$c180 = peg$literalExpectation("fuse", true),
+      peg$c181 = function() {
             return {"kind": "Fuse"}
           },
-      peg$c183 = "shape",
-      peg$c184 = peg$literalExpectation("shape", true),
-      peg$c185 = function() {
+      peg$c182 = "shape",
+      peg$c183 = peg$literalExpectation("shape", true),
+      peg$c184 = function() {
             return {"kind": "Shape"}
           },
-      peg$c186 = "join",
-      peg$c187 = peg$literalExpectation("join", true),
-      peg$c188 = function(style, leftKey, rightKey, columns) {
+      peg$c185 = "join",
+      peg$c186 = peg$literalExpectation("join", true),
+      peg$c187 = function(style, leftKey, rightKey, columns) {
             let proc = {"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": null}
             if (columns) {
               proc["args"] = columns[1]
             }
             return proc
           },
-      peg$c189 = function(style, key, columns) {
+      peg$c188 = function(style, key, columns) {
             let proc = {"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": null}
             if (columns) {
               proc["args"] = columns[1]
             }
             return proc
           },
-      peg$c190 = "inner",
-      peg$c191 = peg$literalExpectation("inner", true),
-      peg$c192 = function() { return "inner" },
-      peg$c193 = "left",
-      peg$c194 = peg$literalExpectation("left", true),
-      peg$c195 = function() { return "left" },
-      peg$c196 = "right",
-      peg$c197 = peg$literalExpectation("right", true),
-      peg$c198 = function() { return "right" },
-      peg$c199 = "sample",
-      peg$c200 = peg$literalExpectation("sample", true),
-      peg$c201 = function(e) {
+      peg$c189 = "inner",
+      peg$c190 = peg$literalExpectation("inner", true),
+      peg$c191 = function() { return "inner" },
+      peg$c192 = "left",
+      peg$c193 = peg$literalExpectation("left", true),
+      peg$c194 = function() { return "left" },
+      peg$c195 = "right",
+      peg$c196 = peg$literalExpectation("right", true),
+      peg$c197 = function() { return "right" },
+      peg$c198 = "sample",
+      peg$c199 = peg$literalExpectation("sample", true),
+      peg$c200 = function(e) {
             return {"kind": "Sequential", "procs": [
               
             {"kind": "Summarize",
@@ -561,79 +556,78 @@ function peg$parse(input, options) {
             "rhs": {"kind": "ID", "name": "sample"}}]}]}
           
           },
-      peg$c202 = function(lval) { return lval},
-      peg$c203 = function() { return {"kind":"Root"} },
-      peg$c204 = function(source) {
+      peg$c201 = function(lval) { return lval},
+      peg$c202 = function() { return {"kind":"Root"} },
+      peg$c203 = function(source) {
             return {"kind":"From", "trunks": [{"kind": "Trunk","source": source}]}
           },
-      peg$c205 = "file",
-      peg$c206 = peg$literalExpectation("file", true),
-      peg$c207 = function(path, format, layout) {
+      peg$c204 = "file",
+      peg$c205 = peg$literalExpectation("file", true),
+      peg$c206 = function(path, format, layout) {
             return {"kind": "File", "path": path, "format": format, "layout": layout }
           },
-      peg$c208 = peg$literalExpectation("from", true),
-      peg$c209 = function(body) { return body },
-      peg$c210 = function(name, at, over, order) {
+      peg$c207 = peg$literalExpectation("from", true),
+      peg$c208 = function(body) { return body },
+      peg$c209 = function(name, at, over, order) {
             return {"kind": "Pool", "name": name, "at": at, "range": over, "scan_order": order}
           },
-      peg$c211 = "get",
-      peg$c212 = peg$literalExpectation("get", true),
-      peg$c213 = function(url, format, layout) {
+      peg$c210 = "get",
+      peg$c211 = peg$literalExpectation("get", true),
+      peg$c212 = function(url, format, layout) {
             return {"kind": "HTTP", "url": url, "format": format, "layout": layout }
           },
-      peg$c214 = "http:",
-      peg$c215 = peg$literalExpectation("http:", false),
-      peg$c216 = "https:",
-      peg$c217 = peg$literalExpectation("https:", false),
-      peg$c218 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
-      peg$c219 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
-      peg$c220 = "at",
-      peg$c221 = peg$literalExpectation("at", true),
-      peg$c222 = function(id) { return id },
-      peg$c223 = /^[0-9a-zA-Z]/,
-      peg$c224 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
-      peg$c225 = "over",
-      peg$c226 = peg$literalExpectation("over", true),
-      peg$c227 = "to",
-      peg$c228 = peg$literalExpectation("to", true),
-      peg$c229 = function(lower, upper) {
+      peg$c213 = "http:",
+      peg$c214 = peg$literalExpectation("http:", false),
+      peg$c215 = "https:",
+      peg$c216 = peg$literalExpectation("https:", false),
+      peg$c217 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
+      peg$c218 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
+      peg$c219 = "at",
+      peg$c220 = peg$literalExpectation("at", true),
+      peg$c221 = function(id) { return id },
+      peg$c222 = /^[0-9a-zA-Z]/,
+      peg$c223 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
+      peg$c224 = "over",
+      peg$c225 = peg$literalExpectation("over", true),
+      peg$c226 = "to",
+      peg$c227 = peg$literalExpectation("to", true),
+      peg$c228 = function(lower, upper) {
             return {"kind":"Range","lower": lower, "upper": upper}
           },
-      peg$c230 = function(val) { return val },
-      peg$c231 = function(name) { return name },
-      peg$c232 = function(s) { return s },
-      peg$c233 = "order",
-      peg$c234 = peg$literalExpectation("order", true),
-      peg$c235 = function(keys, order) {
+      peg$c229 = function(val) { return val },
+      peg$c230 = function(name) { return name },
+      peg$c231 = "order",
+      peg$c232 = peg$literalExpectation("order", true),
+      peg$c233 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c236 = "format",
-      peg$c237 = peg$literalExpectation("format", true),
-      peg$c238 = function() { return "" },
-      peg$c239 = ":asc",
-      peg$c240 = peg$literalExpectation(":asc", true),
-      peg$c241 = function() { return "asc" },
-      peg$c242 = ":desc",
-      peg$c243 = peg$literalExpectation(":desc", true),
-      peg$c244 = function() { return "desc" },
-      peg$c245 = "asc",
-      peg$c246 = peg$literalExpectation("asc", true),
-      peg$c247 = "desc",
-      peg$c248 = peg$literalExpectation("desc", true),
-      peg$c249 = "pass",
-      peg$c250 = peg$literalExpectation("pass", true),
-      peg$c251 = function() {
+      peg$c234 = "format",
+      peg$c235 = peg$literalExpectation("format", true),
+      peg$c236 = function() { return "" },
+      peg$c237 = ":asc",
+      peg$c238 = peg$literalExpectation(":asc", true),
+      peg$c239 = function() { return "asc" },
+      peg$c240 = ":desc",
+      peg$c241 = peg$literalExpectation(":desc", true),
+      peg$c242 = function() { return "desc" },
+      peg$c243 = "asc",
+      peg$c244 = peg$literalExpectation("asc", true),
+      peg$c245 = "desc",
+      peg$c246 = peg$literalExpectation("desc", true),
+      peg$c247 = "pass",
+      peg$c248 = peg$literalExpectation("pass", true),
+      peg$c249 = function() {
             return {"kind":"Pass"}
           },
-      peg$c252 = "explode",
-      peg$c253 = peg$literalExpectation("explode", true),
-      peg$c254 = function(args, typ, as) {
+      peg$c250 = "explode",
+      peg$c251 = peg$literalExpectation("explode", true),
+      peg$c252 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c255 = function(typ) { return typ},
-      peg$c256 = function(lhs) { return lhs },
-      peg$c257 = function(first, lval) { return lval },
-      peg$c258 = function(first, rest) {
+      peg$c253 = function(typ) { return typ},
+      peg$c254 = function(lhs) { return lhs },
+      peg$c255 = function(first, lval) { return lval },
+      peg$c256 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -642,53 +636,53 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c259 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c260 = "?",
-      peg$c261 = peg$literalExpectation("?", false),
-      peg$c262 = function(condition, thenClause, elseClause) {
+      peg$c257 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c258 = "?",
+      peg$c259 = peg$literalExpectation("?", false),
+      peg$c260 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c263 = function(first, op, expr) { return [op, expr] },
-      peg$c264 = function(first, rest) {
+      peg$c261 = function(first, op, expr) { return [op, expr] },
+      peg$c262 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c265 = function(first, comp, expr) { return [comp, expr] },
-      peg$c266 = function() { return "="},
-      peg$c267 = "+",
-      peg$c268 = peg$literalExpectation("+", false),
-      peg$c269 = "-",
-      peg$c270 = peg$literalExpectation("-", false),
-      peg$c271 = "/",
-      peg$c272 = peg$literalExpectation("/", false),
-      peg$c273 = function(e) {
+      peg$c263 = function(first, comp, expr) { return [comp, expr] },
+      peg$c264 = function() { return "="},
+      peg$c265 = "+",
+      peg$c266 = peg$literalExpectation("+", false),
+      peg$c267 = "-",
+      peg$c268 = peg$literalExpectation("-", false),
+      peg$c269 = "/",
+      peg$c270 = peg$literalExpectation("/", false),
+      peg$c271 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c274 = function(typ) { return typ },
-      peg$c275 = "not",
-      peg$c276 = peg$literalExpectation("not", false),
-      peg$c277 = "match",
-      peg$c278 = peg$literalExpectation("match", false),
-      peg$c279 = "select",
-      peg$c280 = peg$literalExpectation("select", false),
-      peg$c281 = function(args, methods) {
+      peg$c272 = function(typ) { return typ },
+      peg$c273 = "not",
+      peg$c274 = peg$literalExpectation("not", false),
+      peg$c275 = "match",
+      peg$c276 = peg$literalExpectation("match", false),
+      peg$c277 = "select",
+      peg$c278 = peg$literalExpectation("select", false),
+      peg$c279 = function(args, methods) {
             return {"kind":"SelectExpr", "selectors":args, "methods": methods}
           },
-      peg$c282 = function(methods) { return methods },
-      peg$c283 = function(typ, expr) {
+      peg$c280 = function(methods) { return methods },
+      peg$c281 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c284 = function(fn, args) {
+      peg$c282 = function(fn, args) {
             return {"kind": "Call", "name": fn, "args": args}
           },
-      peg$c285 = function() { return [] },
-      peg$c286 = function(first, e) { return e },
-      peg$c287 = function(e) { return e },
-      peg$c288 = function() {
+      peg$c283 = function() { return [] },
+      peg$c284 = function(first, e) { return e },
+      peg$c285 = function(e) { return e },
+      peg$c286 = function() {
             return {"kind":"Root"}
           },
-      peg$c289 = "this",
-      peg$c290 = peg$literalExpectation("this", false),
-      peg$c291 = function(field) {
+      peg$c287 = "this",
+      peg$c288 = peg$literalExpectation("this", false),
+      peg$c289 = function(field) {
             return {"kind": "BinaryExpr", "op":".",
                            
             "lhs":{"kind":"Root"},
@@ -697,9 +691,9 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c292 = "]",
-      peg$c293 = peg$literalExpectation("]", false),
-      peg$c294 = function(expr) {
+      peg$c290 = "]",
+      peg$c291 = peg$literalExpectation("]", false),
+      peg$c292 = function(expr) {
             return {"kind": "BinaryExpr", "op":"[",
                            
             "lhs":{"kind":"Root"},
@@ -708,58 +702,58 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c295 = function(from, to) {
+      peg$c293 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c296 = function(to) {
+      peg$c294 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c297 = function(from) {
+      peg$c295 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c298 = function(expr) { return ["[", expr] },
-      peg$c299 = function(id) { return [".", id] },
-      peg$c300 = "}",
-      peg$c301 = peg$literalExpectation("}", false),
-      peg$c302 = function(fields) {
+      peg$c296 = function(expr) { return ["[", expr] },
+      peg$c297 = function(id) { return [".", id] },
+      peg$c298 = "}",
+      peg$c299 = peg$literalExpectation("}", false),
+      peg$c300 = function(fields) {
             return {"kind":"RecordExpr", "fields":fields }
           },
-      peg$c303 = function(first, rest) {
+      peg$c301 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c304 = function(name, value) {
+      peg$c302 = function(name, value) {
             return {"name": name, "value": value}
           },
-      peg$c305 = function(exprs) {
+      peg$c303 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c306 = "|[",
-      peg$c307 = peg$literalExpectation("|[", false),
-      peg$c308 = "]|",
-      peg$c309 = peg$literalExpectation("]|", false),
-      peg$c310 = function(exprs) {
+      peg$c304 = "|[",
+      peg$c305 = peg$literalExpectation("|[", false),
+      peg$c306 = "]|",
+      peg$c307 = peg$literalExpectation("]|", false),
+      peg$c308 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c311 = "|{",
-      peg$c312 = peg$literalExpectation("|{", false),
-      peg$c313 = "}|",
-      peg$c314 = peg$literalExpectation("}|", false),
-      peg$c315 = function(exprs) {
+      peg$c309 = "|{",
+      peg$c310 = peg$literalExpectation("|{", false),
+      peg$c311 = "}|",
+      peg$c312 = peg$literalExpectation("}|", false),
+      peg$c313 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c316 = function(key, value) {
+      peg$c314 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c317 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c315 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -781,13 +775,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c318 = function(assignments) { return assignments },
-      peg$c319 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c320 = function(table, alias) {
+      peg$c316 = function(assignments) { return assignments },
+      peg$c317 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c318 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c321 = function(first, join) { return join },
-      peg$c322 = function(style, table, alias, leftKey, rightKey) {
+      peg$c319 = function(first, join) { return join },
+      peg$c320 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -805,278 +799,278 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c323 = function(style) { return style },
-      peg$c324 = function(keys, order) {
+      peg$c321 = function(style) { return style },
+      peg$c322 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c325 = function(dir) { return dir },
-      peg$c326 = function(count) { return count },
-      peg$c327 = peg$literalExpectation("select", true),
-      peg$c328 = function() { return "select" },
-      peg$c329 = "as",
-      peg$c330 = peg$literalExpectation("as", true),
-      peg$c331 = function() { return "as" },
-      peg$c332 = function() { return "from" },
-      peg$c333 = function() { return "join" },
-      peg$c334 = peg$literalExpectation("where", true),
-      peg$c335 = function() { return "where" },
-      peg$c336 = "group",
-      peg$c337 = peg$literalExpectation("group", true),
-      peg$c338 = function() { return "group" },
-      peg$c339 = "having",
-      peg$c340 = peg$literalExpectation("having", true),
-      peg$c341 = function() { return "having" },
-      peg$c342 = function() { return "order" },
-      peg$c343 = "on",
-      peg$c344 = peg$literalExpectation("on", true),
-      peg$c345 = function() { return "on" },
-      peg$c346 = "limit",
-      peg$c347 = peg$literalExpectation("limit", true),
-      peg$c348 = function() { return "limit" },
-      peg$c349 = function(v) {
+      peg$c323 = function(dir) { return dir },
+      peg$c324 = function(count) { return count },
+      peg$c325 = peg$literalExpectation("select", true),
+      peg$c326 = function() { return "select" },
+      peg$c327 = "as",
+      peg$c328 = peg$literalExpectation("as", true),
+      peg$c329 = function() { return "as" },
+      peg$c330 = function() { return "from" },
+      peg$c331 = function() { return "join" },
+      peg$c332 = peg$literalExpectation("where", true),
+      peg$c333 = function() { return "where" },
+      peg$c334 = "group",
+      peg$c335 = peg$literalExpectation("group", true),
+      peg$c336 = function() { return "group" },
+      peg$c337 = "having",
+      peg$c338 = peg$literalExpectation("having", true),
+      peg$c339 = function() { return "having" },
+      peg$c340 = function() { return "order" },
+      peg$c341 = "on",
+      peg$c342 = peg$literalExpectation("on", true),
+      peg$c343 = function() { return "on" },
+      peg$c344 = "limit",
+      peg$c345 = peg$literalExpectation("limit", true),
+      peg$c346 = function() { return "limit" },
+      peg$c347 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c350 = function(v) {
+      peg$c348 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c351 = function(v) {
+      peg$c349 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c352 = function(v) {
+      peg$c350 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c353 = "true",
-      peg$c354 = peg$literalExpectation("true", false),
-      peg$c355 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c356 = "false",
-      peg$c357 = peg$literalExpectation("false", false),
-      peg$c358 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c359 = "null",
-      peg$c360 = peg$literalExpectation("null", false),
-      peg$c361 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c362 = function(typ) {
+      peg$c351 = "true",
+      peg$c352 = peg$literalExpectation("true", false),
+      peg$c353 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c354 = "false",
+      peg$c355 = peg$literalExpectation("false", false),
+      peg$c356 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c357 = "null",
+      peg$c358 = peg$literalExpectation("null", false),
+      peg$c359 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c360 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c363 = function(name, typ) {
+      peg$c361 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c364 = function(name) {
+      peg$c362 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c365 = function(u) { return u },
-      peg$c366 = function(types) {
+      peg$c363 = function(u) { return u },
+      peg$c364 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c367 = function(fields) {
+      peg$c365 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c368 = function(typ) {
+      peg$c366 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c369 = function(typ) {
+      peg$c367 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c370 = function(keyType, valType) {
+      peg$c368 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c371 = "uint8",
-      peg$c372 = peg$literalExpectation("uint8", false),
-      peg$c373 = "uint16",
-      peg$c374 = peg$literalExpectation("uint16", false),
-      peg$c375 = "uint32",
-      peg$c376 = peg$literalExpectation("uint32", false),
-      peg$c377 = "uint64",
-      peg$c378 = peg$literalExpectation("uint64", false),
-      peg$c379 = "int8",
-      peg$c380 = peg$literalExpectation("int8", false),
-      peg$c381 = "int16",
-      peg$c382 = peg$literalExpectation("int16", false),
-      peg$c383 = "int32",
-      peg$c384 = peg$literalExpectation("int32", false),
-      peg$c385 = "int64",
-      peg$c386 = peg$literalExpectation("int64", false),
-      peg$c387 = "float64",
-      peg$c388 = peg$literalExpectation("float64", false),
-      peg$c389 = "bool",
-      peg$c390 = peg$literalExpectation("bool", false),
-      peg$c391 = "string",
-      peg$c392 = peg$literalExpectation("string", false),
-      peg$c393 = function() {
+      peg$c369 = "uint8",
+      peg$c370 = peg$literalExpectation("uint8", false),
+      peg$c371 = "uint16",
+      peg$c372 = peg$literalExpectation("uint16", false),
+      peg$c373 = "uint32",
+      peg$c374 = peg$literalExpectation("uint32", false),
+      peg$c375 = "uint64",
+      peg$c376 = peg$literalExpectation("uint64", false),
+      peg$c377 = "int8",
+      peg$c378 = peg$literalExpectation("int8", false),
+      peg$c379 = "int16",
+      peg$c380 = peg$literalExpectation("int16", false),
+      peg$c381 = "int32",
+      peg$c382 = peg$literalExpectation("int32", false),
+      peg$c383 = "int64",
+      peg$c384 = peg$literalExpectation("int64", false),
+      peg$c385 = "float64",
+      peg$c386 = peg$literalExpectation("float64", false),
+      peg$c387 = "bool",
+      peg$c388 = peg$literalExpectation("bool", false),
+      peg$c389 = "string",
+      peg$c390 = peg$literalExpectation("string", false),
+      peg$c391 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c394 = "duration",
-      peg$c395 = peg$literalExpectation("duration", false),
-      peg$c396 = "time",
-      peg$c397 = peg$literalExpectation("time", false),
-      peg$c398 = "bytes",
-      peg$c399 = peg$literalExpectation("bytes", false),
-      peg$c400 = "bstring",
-      peg$c401 = peg$literalExpectation("bstring", false),
-      peg$c402 = "ip",
-      peg$c403 = peg$literalExpectation("ip", false),
-      peg$c404 = "net",
-      peg$c405 = peg$literalExpectation("net", false),
-      peg$c406 = "error",
-      peg$c407 = peg$literalExpectation("error", false),
-      peg$c408 = function(name, typ) {
+      peg$c392 = "duration",
+      peg$c393 = peg$literalExpectation("duration", false),
+      peg$c394 = "time",
+      peg$c395 = peg$literalExpectation("time", false),
+      peg$c396 = "bytes",
+      peg$c397 = peg$literalExpectation("bytes", false),
+      peg$c398 = "bstring",
+      peg$c399 = peg$literalExpectation("bstring", false),
+      peg$c400 = "ip",
+      peg$c401 = peg$literalExpectation("ip", false),
+      peg$c402 = "net",
+      peg$c403 = peg$literalExpectation("net", false),
+      peg$c404 = "error",
+      peg$c405 = peg$literalExpectation("error", false),
+      peg$c406 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c409 = "and",
-      peg$c410 = peg$literalExpectation("and", true),
-      peg$c411 = function() { return "and" },
-      peg$c412 = "or",
-      peg$c413 = peg$literalExpectation("or", true),
-      peg$c414 = function() { return "or" },
-      peg$c415 = peg$literalExpectation("in", true),
-      peg$c416 = function() { return "in" },
-      peg$c417 = peg$literalExpectation("not", true),
-      peg$c418 = function() { return "not" },
-      peg$c419 = "by",
-      peg$c420 = peg$literalExpectation("by", true),
-      peg$c421 = function() { return "by" },
-      peg$c422 = /^[A-Za-z_$]/,
-      peg$c423 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c424 = /^[0-9]/,
-      peg$c425 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c426 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c427 = function() {  return text() },
-      peg$c428 = "$",
-      peg$c429 = peg$literalExpectation("$", false),
-      peg$c430 = "\\",
-      peg$c431 = peg$literalExpectation("\\", false),
-      peg$c432 = "T",
-      peg$c433 = peg$literalExpectation("T", false),
-      peg$c434 = function() {
+      peg$c407 = "and",
+      peg$c408 = peg$literalExpectation("and", true),
+      peg$c409 = function() { return "and" },
+      peg$c410 = "or",
+      peg$c411 = peg$literalExpectation("or", true),
+      peg$c412 = function() { return "or" },
+      peg$c413 = peg$literalExpectation("in", true),
+      peg$c414 = function() { return "in" },
+      peg$c415 = peg$literalExpectation("not", true),
+      peg$c416 = function() { return "not" },
+      peg$c417 = "by",
+      peg$c418 = peg$literalExpectation("by", true),
+      peg$c419 = function() { return "by" },
+      peg$c420 = /^[A-Za-z_$]/,
+      peg$c421 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c422 = /^[0-9]/,
+      peg$c423 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c424 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c425 = function() {  return text() },
+      peg$c426 = "$",
+      peg$c427 = peg$literalExpectation("$", false),
+      peg$c428 = "\\",
+      peg$c429 = peg$literalExpectation("\\", false),
+      peg$c430 = "T",
+      peg$c431 = peg$literalExpectation("T", false),
+      peg$c432 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c435 = "Z",
-      peg$c436 = peg$literalExpectation("Z", false),
-      peg$c437 = function() {
+      peg$c433 = "Z",
+      peg$c434 = peg$literalExpectation("Z", false),
+      peg$c435 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c438 = "ns",
-      peg$c439 = peg$literalExpectation("ns", true),
-      peg$c440 = "us",
-      peg$c441 = peg$literalExpectation("us", true),
-      peg$c442 = "ms",
-      peg$c443 = peg$literalExpectation("ms", true),
-      peg$c444 = "s",
-      peg$c445 = peg$literalExpectation("s", true),
-      peg$c446 = "m",
-      peg$c447 = peg$literalExpectation("m", true),
-      peg$c448 = "h",
-      peg$c449 = peg$literalExpectation("h", true),
-      peg$c450 = "d",
-      peg$c451 = peg$literalExpectation("d", true),
-      peg$c452 = "w",
-      peg$c453 = peg$literalExpectation("w", true),
-      peg$c454 = "y",
-      peg$c455 = peg$literalExpectation("y", true),
-      peg$c456 = function(a, b) {
+      peg$c436 = "ns",
+      peg$c437 = peg$literalExpectation("ns", true),
+      peg$c438 = "us",
+      peg$c439 = peg$literalExpectation("us", true),
+      peg$c440 = "ms",
+      peg$c441 = peg$literalExpectation("ms", true),
+      peg$c442 = "s",
+      peg$c443 = peg$literalExpectation("s", true),
+      peg$c444 = "m",
+      peg$c445 = peg$literalExpectation("m", true),
+      peg$c446 = "h",
+      peg$c447 = peg$literalExpectation("h", true),
+      peg$c448 = "d",
+      peg$c449 = peg$literalExpectation("d", true),
+      peg$c450 = "w",
+      peg$c451 = peg$literalExpectation("w", true),
+      peg$c452 = "y",
+      peg$c453 = peg$literalExpectation("y", true),
+      peg$c454 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c457 = "::",
-      peg$c458 = peg$literalExpectation("::", false),
-      peg$c459 = function(a, b, d, e) {
+      peg$c455 = "::",
+      peg$c456 = peg$literalExpectation("::", false),
+      peg$c457 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c460 = function(a, b) {
+      peg$c458 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c461 = function(a, b) {
+      peg$c459 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c462 = function() {
+      peg$c460 = function() {
             return "::"
           },
-      peg$c463 = function(v) { return ":" + v },
-      peg$c464 = function(v) { return v + ":" },
-      peg$c465 = function(a, m) {
+      peg$c461 = function(v) { return ":" + v },
+      peg$c462 = function(v) { return v + ":" },
+      peg$c463 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c466 = function(a, m) {
+      peg$c464 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c467 = function(s) { return parseInt(s) },
-      peg$c468 = function() {
+      peg$c465 = function(s) { return parseInt(s) },
+      peg$c466 = function() {
             return text()
           },
-      peg$c469 = "e",
-      peg$c470 = peg$literalExpectation("e", true),
-      peg$c471 = /^[+\-]/,
-      peg$c472 = peg$classExpectation(["+", "-"], false, false),
-      peg$c473 = /^[0-9a-fA-F]/,
-      peg$c474 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c475 = "\"",
-      peg$c476 = peg$literalExpectation("\"", false),
-      peg$c477 = function(v) { return joinChars(v) },
-      peg$c478 = "'",
-      peg$c479 = peg$literalExpectation("'", false),
-      peg$c480 = peg$anyExpectation(),
-      peg$c481 = function(head, tail) { return head + joinChars(tail) },
-      peg$c482 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c483 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c484 = function(head, tail) {
+      peg$c467 = "e",
+      peg$c468 = peg$literalExpectation("e", true),
+      peg$c469 = /^[+\-]/,
+      peg$c470 = peg$classExpectation(["+", "-"], false, false),
+      peg$c471 = /^[0-9a-fA-F]/,
+      peg$c472 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c473 = "\"",
+      peg$c474 = peg$literalExpectation("\"", false),
+      peg$c475 = function(v) { return joinChars(v) },
+      peg$c476 = "'",
+      peg$c477 = peg$literalExpectation("'", false),
+      peg$c478 = peg$anyExpectation(),
+      peg$c479 = function(head, tail) { return head + joinChars(tail) },
+      peg$c480 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c481 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c482 = function(head, tail) {
             return reglob.Reglob(head + joinChars(tail))
           },
-      peg$c485 = function() { return "*"},
-      peg$c486 = function() { return "=" },
-      peg$c487 = function() { return "\\*" },
-      peg$c488 = "x",
-      peg$c489 = peg$literalExpectation("x", false),
-      peg$c490 = function() { return "\\" + text() },
-      peg$c491 = "b",
-      peg$c492 = peg$literalExpectation("b", false),
-      peg$c493 = function() { return "\b" },
-      peg$c494 = "f",
-      peg$c495 = peg$literalExpectation("f", false),
-      peg$c496 = function() { return "\f" },
-      peg$c497 = "n",
-      peg$c498 = peg$literalExpectation("n", false),
-      peg$c499 = function() { return "\n" },
-      peg$c500 = "r",
-      peg$c501 = peg$literalExpectation("r", false),
-      peg$c502 = function() { return "\r" },
-      peg$c503 = "t",
-      peg$c504 = peg$literalExpectation("t", false),
-      peg$c505 = function() { return "\t" },
-      peg$c506 = "v",
-      peg$c507 = peg$literalExpectation("v", false),
-      peg$c508 = function() { return "\v" },
-      peg$c509 = function() { return "*" },
-      peg$c510 = "u",
-      peg$c511 = peg$literalExpectation("u", false),
-      peg$c512 = function(chars) {
+      peg$c483 = function() { return "*"},
+      peg$c484 = function() { return "=" },
+      peg$c485 = function() { return "\\*" },
+      peg$c486 = "x",
+      peg$c487 = peg$literalExpectation("x", false),
+      peg$c488 = function() { return "\\" + text() },
+      peg$c489 = "b",
+      peg$c490 = peg$literalExpectation("b", false),
+      peg$c491 = function() { return "\b" },
+      peg$c492 = "f",
+      peg$c493 = peg$literalExpectation("f", false),
+      peg$c494 = function() { return "\f" },
+      peg$c495 = "n",
+      peg$c496 = peg$literalExpectation("n", false),
+      peg$c497 = function() { return "\n" },
+      peg$c498 = "r",
+      peg$c499 = peg$literalExpectation("r", false),
+      peg$c500 = function() { return "\r" },
+      peg$c501 = "t",
+      peg$c502 = peg$literalExpectation("t", false),
+      peg$c503 = function() { return "\t" },
+      peg$c504 = "v",
+      peg$c505 = peg$literalExpectation("v", false),
+      peg$c506 = function() { return "\v" },
+      peg$c507 = function() { return "*" },
+      peg$c508 = "u",
+      peg$c509 = peg$literalExpectation("u", false),
+      peg$c510 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c513 = /^[^\/\\]/,
-      peg$c514 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c515 = "\\/",
-      peg$c516 = peg$literalExpectation("\\/", false),
-      peg$c517 = /^[\0-\x1F\\]/,
-      peg$c518 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c519 = peg$otherExpectation("whitespace"),
-      peg$c520 = "\t",
-      peg$c521 = peg$literalExpectation("\t", false),
-      peg$c522 = "\x0B",
-      peg$c523 = peg$literalExpectation("\x0B", false),
-      peg$c524 = "\f",
-      peg$c525 = peg$literalExpectation("\f", false),
-      peg$c526 = " ",
-      peg$c527 = peg$literalExpectation(" ", false),
-      peg$c528 = "\xA0",
-      peg$c529 = peg$literalExpectation("\xA0", false),
-      peg$c530 = "\uFEFF",
-      peg$c531 = peg$literalExpectation("\uFEFF", false),
-      peg$c532 = /^[\n\r\u2028\u2029]/,
-      peg$c533 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c534 = peg$otherExpectation("comment"),
-      peg$c535 = "/*",
-      peg$c536 = peg$literalExpectation("/*", false),
-      peg$c537 = "*/",
-      peg$c538 = peg$literalExpectation("*/", false),
-      peg$c539 = "//",
-      peg$c540 = peg$literalExpectation("//", false),
+      peg$c511 = /^[^\/\\]/,
+      peg$c512 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c513 = "\\/",
+      peg$c514 = peg$literalExpectation("\\/", false),
+      peg$c515 = /^[\0-\x1F\\]/,
+      peg$c516 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c517 = peg$otherExpectation("whitespace"),
+      peg$c518 = "\t",
+      peg$c519 = peg$literalExpectation("\t", false),
+      peg$c520 = "\x0B",
+      peg$c521 = peg$literalExpectation("\x0B", false),
+      peg$c522 = "\f",
+      peg$c523 = peg$literalExpectation("\f", false),
+      peg$c524 = " ",
+      peg$c525 = peg$literalExpectation(" ", false),
+      peg$c526 = "\xA0",
+      peg$c527 = peg$literalExpectation("\xA0", false),
+      peg$c528 = "\uFEFF",
+      peg$c529 = peg$literalExpectation("\uFEFF", false),
+      peg$c530 = /^[\n\r\u2028\u2029]/,
+      peg$c531 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c532 = peg$otherExpectation("comment"),
+      peg$c533 = "/*",
+      peg$c534 = peg$literalExpectation("/*", false),
+      peg$c535 = "*/",
+      peg$c536 = peg$literalExpectation("*/", false),
+      peg$c537 = "//",
+      peg$c538 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1584,101 +1578,35 @@ function peg$parse(input, options) {
   }
 
   function peg$parseParallel() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c16) {
-      s1 = peg$c16;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c17); }
-    }
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseSequential();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c7;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c8); }
-            }
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
-              if (s6 !== peg$FAILED) {
-                s7 = [];
-                s8 = peg$parseParallel();
-                if (s8 !== peg$FAILED) {
-                  while (s8 !== peg$FAILED) {
-                    s7.push(s8);
-                    s8 = peg$parseParallel();
-                  }
-                } else {
-                  s7 = peg$FAILED;
-                }
-                if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c18(s3, s7);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
       if (input.substr(peg$currPos, 2) === peg$c16) {
-        s1 = peg$c16;
+        s2 = peg$c16;
         peg$currPos += 2;
       } else {
-        s1 = peg$FAILED;
+        s2 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseSequential();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseSequential();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse__();
+            if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 59) {
-                s5 = peg$c7;
+                s6 = peg$c7;
                 peg$currPos++;
               } else {
-                s5 = peg$FAILED;
+                s6 = peg$FAILED;
                 if (peg$silentFails === 0) { peg$fail(peg$c8); }
               }
-              if (s5 !== peg$FAILED) {
+              if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c19(s3);
+                s1 = peg$c18(s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1700,44 +1628,53 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     return s0;
   }
 
   function peg$parseSwitchBranch() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    s1 = peg$parseDefaultToken();
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
+      s2 = peg$parseSearchBoolean();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c16) {
-          s3 = peg$c16;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
-        }
+        s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          if (input.substr(peg$currPos, 2) === peg$c16) {
+            s4 = peg$c16;
+            peg$currPos += 2;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseSequential();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
+              s6 = peg$parseSequential();
               if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 59) {
-                  s7 = peg$c7;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c8); }
-                }
+                s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c20(s5);
-                  s0 = s1;
+                  if (input.charCodeAt(peg$currPos) === 59) {
+                    s8 = peg$c7;
+                    peg$currPos++;
+                  } else {
+                    s8 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                  }
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c19(s2, s6);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1768,35 +1705,41 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseSearchBoolean();
+      s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
+        s2 = peg$parseDefaultToken();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c16) {
-            s3 = peg$c16;
-            peg$currPos += 2;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
-          }
+          s3 = peg$parse__();
           if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
+            if (input.substr(peg$currPos, 2) === peg$c16) {
+              s4 = peg$c16;
+              peg$currPos += 2;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseSequential();
+              s5 = peg$parse__();
               if (s5 !== peg$FAILED) {
-                s6 = peg$parse__();
+                s6 = peg$parseSequential();
                 if (s6 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 59) {
-                    s7 = peg$c7;
-                    peg$currPos++;
-                  } else {
-                    s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
-                  }
+                  s7 = peg$parse__();
                   if (s7 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c21(s1, s5);
-                    s0 = s1;
+                    if (input.charCodeAt(peg$currPos) === 59) {
+                      s8 = peg$c7;
+                      peg$currPos++;
+                    } else {
+                      s8 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                    }
+                    if (s8 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c20(s6);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1830,135 +1773,50 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSwitch() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSwitchBranch();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseSwitch();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parseSwitch();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c18(s1, s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseSwitchBranch();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c19(s1);
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
   function peg$parseDefaultToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c22) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c21) {
       s0 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c23); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseFromTrunks() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFromTrunk();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseFromTrunks();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parseFromTrunks();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c18(s1, s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseFromTrunk();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c19(s1);
-      }
-      s0 = s1;
+      if (peg$silentFails === 0) { peg$fail(peg$c22); }
     }
 
     return s0;
   }
 
   function peg$parseFromTrunk() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    s1 = peg$parseFromSource();
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseFromTrunkSeq();
+      s2 = peg$parseFromSource();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
+        s3 = peg$parseFromTrunkSeq();
+        if (s3 === peg$FAILED) {
+          s3 = null;
+        }
         if (s3 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 59) {
-            s4 = peg$c7;
-            peg$currPos++;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c8); }
-          }
+          s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c24(s1, s2);
-            s0 = s1;
+            if (input.charCodeAt(peg$currPos) === 59) {
+              s5 = peg$c7;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c8); }
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c23(s2, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1998,7 +1856,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequential();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c25(s4);
+            s1 = peg$c24(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2018,10 +1876,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c27();
+        s1 = peg$c26();
       }
       s0 = s1;
     }
@@ -2047,48 +1905,51 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOperation() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c28) {
-      s1 = peg$c28;
+    if (input.substr(peg$currPos, 5) === peg$c27) {
+      s1 = peg$c27;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c29); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          s4 = [];
+          s5 = peg$parseParallel();
+          if (s5 !== peg$FAILED) {
+            while (s5 !== peg$FAILED) {
+              s4.push(s5);
+              s5 = peg$parseParallel();
+            }
+          } else {
+            s4 = peg$FAILED;
+          }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseParallel();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
+              if (input.charCodeAt(peg$currPos) === 41) {
+                s6 = peg$c31;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c32); }
+              }
               if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c32;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
-                }
-                if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c34(s5);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
+                peg$savedPos = s0;
+                s1 = peg$c33(s4);
+                s0 = s1;
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2115,45 +1976,48 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c35) {
-        s1 = peg$c35;
+      if (input.substr(peg$currPos, 6) === peg$c34) {
+        s1 = peg$c34;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c30;
+            s3 = peg$c29;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
+            s4 = [];
+            s5 = peg$parseSwitchBranch();
+            if (s5 !== peg$FAILED) {
+              while (s5 !== peg$FAILED) {
+                s4.push(s5);
+                s5 = peg$parseSwitchBranch();
+              }
+            } else {
+              s4 = peg$FAILED;
+            }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseSwitch();
+              s5 = peg$parse__();
               if (s5 !== peg$FAILED) {
-                s6 = peg$parse__();
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s6 = peg$c31;
+                  peg$currPos++;
+                } else {
+                  s6 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
+                }
                 if (s6 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c32;
-                    peg$currPos++;
-                  } else {
-                    s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
-                  }
-                  if (s7 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c37(s5);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
+                  peg$savedPos = s0;
+                  s1 = peg$c36(s4);
+                  s0 = s1;
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -2180,45 +2044,48 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c38) {
-          s1 = peg$c38;
+        if (input.substr(peg$currPos, 4) === peg$c37) {
+          s1 = peg$c37;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c39); }
+          if (peg$silentFails === 0) { peg$fail(peg$c38); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s3 = peg$c30;
+              s3 = peg$c29;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c31); }
+              if (peg$silentFails === 0) { peg$fail(peg$c30); }
             }
             if (s3 !== peg$FAILED) {
-              s4 = peg$parse__();
+              s4 = [];
+              s5 = peg$parseFromTrunk();
+              if (s5 !== peg$FAILED) {
+                while (s5 !== peg$FAILED) {
+                  s4.push(s5);
+                  s5 = peg$parseFromTrunk();
+                }
+              } else {
+                s4 = peg$FAILED;
+              }
               if (s4 !== peg$FAILED) {
-                s5 = peg$parseFromTrunks();
+                s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
-                  s6 = peg$parse__();
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s6 = peg$c31;
+                    peg$currPos++;
+                  } else {
+                    s6 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c32); }
+                  }
                   if (s6 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 41) {
-                      s7 = peg$c32;
-                      peg$currPos++;
-                    } else {
-                      s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c33); }
-                    }
-                    if (s7 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c40(s5);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
+                    peg$savedPos = s0;
+                    s1 = peg$c39(s4);
+                    s0 = s1;
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -2261,7 +2128,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c41(s1);
+                s1 = peg$c40(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2287,7 +2154,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c42(s1);
+                  s1 = peg$c41(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2313,7 +2180,7 @@ function peg$parse(input, options) {
                   }
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c43(s1);
+                    s1 = peg$c42(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -2349,12 +2216,12 @@ function peg$parse(input, options) {
           if (peg$silentFails === 0) { peg$fail(peg$c17); }
         }
         if (s2 === peg$FAILED) {
-          if (peg$c44.test(input.charAt(peg$currPos))) {
+          if (peg$c43.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c45); }
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
           }
           if (s2 === peg$FAILED) {
             s2 = peg$parseEOF();
@@ -2381,29 +2248,29 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 124) {
-      s1 = peg$c46;
+      s1 = peg$c45;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      if (peg$silentFails === 0) { peg$fail(peg$c46); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s3 = peg$c48;
+        s3 = peg$c47;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        if (peg$silentFails === 0) { peg$fail(peg$c48); }
       }
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s3 = peg$c50;
+          s3 = peg$c49;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
       }
       peg$silentFails--;
@@ -2470,35 +2337,35 @@ function peg$parse(input, options) {
           s2 = peg$parseMultiplicativeOperator();
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s2 = peg$c52;
+              s2 = peg$c51;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c53); }
+              if (peg$silentFails === 0) { peg$fail(peg$c52); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s2 = peg$c30;
+                s2 = peg$c29;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                if (peg$silentFails === 0) { peg$fail(peg$c30); }
               }
               if (s2 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s2 = peg$c50;
+                  s2 = peg$c49;
                   peg$currPos++;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c51); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c50); }
                 }
                 if (s2 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 7) === peg$c54) {
-                    s2 = peg$c54;
+                  if (input.substr(peg$currPos, 7) === peg$c53) {
+                    s2 = peg$c53;
                     peg$currPos += 7;
                   } else {
                     s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c54); }
                   }
                 }
               }
@@ -2525,60 +2392,60 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c56) {
-      s1 = peg$c56;
+    if (input.substr(peg$currPos, 2) === peg$c55) {
+      s1 = peg$c55;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c57); }
+      if (peg$silentFails === 0) { peg$fail(peg$c56); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c58) {
-        s1 = peg$c58;
+      if (input.substr(peg$currPos, 2) === peg$c57) {
+        s1 = peg$c57;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c60) {
-          s1 = peg$c60;
+        if (input.substr(peg$currPos, 2) === peg$c59) {
+          s1 = peg$c59;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c61); }
+          if (peg$silentFails === 0) { peg$fail(peg$c60); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c62) {
-            s1 = peg$c62;
+          if (input.substr(peg$currPos, 2) === peg$c61) {
+            s1 = peg$c61;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c63); }
+            if (peg$silentFails === 0) { peg$fail(peg$c62); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c64;
+              s1 = peg$c63;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c65); }
+              if (peg$silentFails === 0) { peg$fail(peg$c64); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c66) {
-                s1 = peg$c66;
+              if (input.substr(peg$currPos, 2) === peg$c65) {
+                s1 = peg$c65;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c67); }
+                if (peg$silentFails === 0) { peg$fail(peg$c66); }
               }
               if (s1 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 62) {
-                  s1 = peg$c68;
+                  s1 = peg$c67;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c68); }
                 }
               }
             }
@@ -2588,7 +2455,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -2603,12 +2470,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseByToken();
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c71) {
-          s2 = peg$c71;
+        if (input.substr(peg$currPos, 5) === peg$c70) {
+          s2 = peg$c70;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c72); }
+          if (peg$silentFails === 0) { peg$fail(peg$c71); }
         }
       }
       if (s2 !== peg$FAILED) {
@@ -2633,11 +2500,11 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s2 = peg$c73;
+          s2 = peg$c72;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -2669,7 +2536,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c75(s1, s2);
+        s1 = peg$c74(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2696,7 +2563,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchAnd();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c76(s4);
+            s1 = peg$c75(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2750,7 +2617,7 @@ function peg$parse(input, options) {
           s6 = peg$parseSearchFactor();
           if (s6 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c77(s1, s6);
+            s4 = peg$c76(s1, s6);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2791,7 +2658,7 @@ function peg$parse(input, options) {
             s6 = peg$parseSearchFactor();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c77(s1, s6);
+              s4 = peg$c76(s1, s6);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2808,7 +2675,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s1, s2);
+        s1 = peg$c77(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2844,11 +2711,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c79;
+        s2 = peg$c78;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2868,7 +2735,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c81(s2);
+        s1 = peg$c80(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2883,11 +2750,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c30;
+          s1 = peg$c29;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -2897,15 +2764,15 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c32;
+                  s5 = peg$c31;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c82(s3);
+                  s1 = peg$c81(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2938,11 +2805,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c83;
+      s1 = peg$c82;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -2954,7 +2821,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c85(s3, s5);
+              s1 = peg$c84(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2992,7 +2859,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c86(s1);
+          s1 = peg$c85(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3013,15 +2880,15 @@ function peg$parse(input, options) {
               s4 = peg$parse_();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 42) {
-                  s5 = peg$c83;
+                  s5 = peg$c82;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c84); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c83); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c87(s1);
+                  s1 = peg$c86(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3081,7 +2948,7 @@ function peg$parse(input, options) {
       s2 = peg$parsePatternSearch();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c88(s2);
+        s1 = peg$c87(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3132,7 +2999,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c89(s2);
+            s1 = peg$c88(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3149,11 +3016,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c83;
+          s1 = peg$c82;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
@@ -3168,7 +3035,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c90();
+            s1 = peg$c89();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3207,7 +3074,7 @@ function peg$parse(input, options) {
         s2 = peg$parseKeyWord();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c91(s2);
+          s1 = peg$c90(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3229,7 +3096,7 @@ function peg$parse(input, options) {
     s1 = peg$parsePattern();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c92(s1);
+      s1 = peg$c91(s1);
     }
     s0 = s1;
 
@@ -3244,12 +3111,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c54) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c53) {
           s3 = input.substr(peg$currPos, 7);
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c93); }
+          if (peg$silentFails === 0) { peg$fail(peg$c92); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3257,7 +3124,7 @@ function peg$parse(input, options) {
             s5 = peg$parsePattern();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c94(s1, s5);
+              s1 = peg$c93(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3311,20 +3178,20 @@ function peg$parse(input, options) {
               if (s0 === peg$FAILED) {
                 s0 = peg$parseDefaultToken();
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c95) {
-                    s0 = peg$c95;
+                  if (input.substr(peg$currPos, 5) === peg$c94) {
+                    s0 = peg$c94;
                     peg$currPos += 5;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c95); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c54) {
+                    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c53) {
                       s0 = input.substr(peg$currPos, 7);
                       peg$currPos += 7;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c92); }
                     }
                   }
                 }
@@ -3351,7 +3218,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLimitArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c97(s2, s3, s4);
+            s1 = peg$c96(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3399,7 +3266,7 @@ function peg$parse(input, options) {
               s5 = peg$parseLimitArg();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c98(s2, s3, s4, s5);
+                s1 = peg$c97(s2, s3, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3430,12 +3297,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c99) {
-      s1 = peg$c99;
+    if (input.substr(peg$currPos, 9) === peg$c98) {
+      s1 = peg$c98;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3451,7 +3318,7 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$c26;
+      s0 = peg$c25;
     }
 
     return s0;
@@ -3461,12 +3328,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c101) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c100) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c102); }
+      if (peg$silentFails === 0) { peg$fail(peg$c101); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3476,7 +3343,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c103(s3);
+            s1 = peg$c102(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3496,10 +3363,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -3518,7 +3385,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c105(s3);
+          s1 = peg$c104(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3542,22 +3409,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c106) {
-        s2 = peg$c106;
+      if (input.substr(peg$currPos, 4) === peg$c105) {
+        s2 = peg$c105;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c108) {
-            s4 = peg$c108;
+          if (input.substr(peg$currPos, 6) === peg$c107) {
+            s4 = peg$c107;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c109); }
+            if (peg$silentFails === 0) { peg$fail(peg$c108); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3565,7 +3432,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c110(s6);
+                s1 = peg$c109(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3593,10 +3460,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c111();
+        s1 = peg$c110();
       }
       s0 = s1;
     }
@@ -3613,7 +3480,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112(s1);
+        s1 = peg$c111(s1);
       }
       s0 = s1;
     }
@@ -3632,11 +3499,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3644,7 +3511,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c113(s1, s7);
+              s4 = peg$c112(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3668,11 +3535,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3680,7 +3547,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c113(s1, s7);
+                s4 = peg$c112(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3701,7 +3568,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3723,12 +3590,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c115) {
-          s3 = peg$c115;
+        if (input.substr(peg$currPos, 2) === peg$c114) {
+          s3 = peg$c114;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c116); }
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3736,7 +3603,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAgg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c117(s1, s5);
+              s1 = peg$c116(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3763,7 +3630,7 @@ function peg$parse(input, options) {
       s1 = peg$parseAgg();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c118(s1);
+        s1 = peg$c117(s1);
       }
       s0 = s1;
     }
@@ -3791,11 +3658,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c30;
+            s4 = peg$c29;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -3808,11 +3675,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c32;
+                    s8 = peg$c31;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c32); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$currPos;
@@ -3821,11 +3688,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c119;
+                        s12 = peg$c118;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c119); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3852,7 +3719,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c121(s2, s6, s10);
+                        s1 = peg$c120(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3918,12 +3785,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c122) {
-        s2 = peg$c122;
+      if (input.substr(peg$currPos, 5) === peg$c121) {
+        s2 = peg$c121;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+        if (peg$silentFails === 0) { peg$fail(peg$c122); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3931,7 +3798,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s4);
+            s1 = peg$c81(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3964,11 +3831,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3999,11 +3866,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4031,7 +3898,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c124(s1, s2);
+        s1 = peg$c123(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4111,12 +3978,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c125) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -4127,7 +3994,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c127(s2, s5);
+            s4 = peg$c126(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -4142,7 +4009,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c128(s2, s3);
+          s1 = peg$c127(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4171,7 +4038,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c42(s4);
+        s3 = peg$c41(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -4189,7 +4056,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c42(s4);
+          s3 = peg$c41(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4202,7 +4069,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c129(s1);
+      s1 = peg$c128(s1);
     }
     s0 = s1;
 
@@ -4213,55 +4080,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c130) {
-      s1 = peg$c130;
+    if (input.substr(peg$currPos, 2) === peg$c129) {
+      s1 = peg$c129;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c131); }
+      if (peg$silentFails === 0) { peg$fail(peg$c130); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c132();
+      s1 = peg$c131();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c133) {
-        s1 = peg$c133;
+      if (input.substr(peg$currPos, 6) === peg$c132) {
+        s1 = peg$c132;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c134); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c135) {
-            s4 = peg$c135;
+          if (input.substr(peg$currPos, 5) === peg$c134) {
+            s4 = peg$c134;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c136); }
+            if (peg$silentFails === 0) { peg$fail(peg$c135); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c137) {
-              s4 = peg$c137;
+            if (input.substr(peg$currPos, 4) === peg$c136) {
+              s4 = peg$c136;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c138); }
+              if (peg$silentFails === 0) { peg$fail(peg$c137); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c70();
+            s4 = peg$c69();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c139(s3);
+            s1 = peg$c138(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4284,12 +4151,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c140) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c139) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4298,7 +4165,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c142(s4);
+          s3 = peg$c141(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4315,12 +4182,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c143) {
-            s5 = peg$c143;
+          if (input.substr(peg$currPos, 6) === peg$c142) {
+            s5 = peg$c142;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c144); }
+            if (peg$silentFails === 0) { peg$fail(peg$c143); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -4343,7 +4210,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c145(s2, s3, s6);
+              s5 = peg$c144(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -4358,7 +4225,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c146(s2, s3, s4);
+            s1 = peg$c145(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4384,12 +4251,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c146) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c147); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4397,7 +4264,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c149(s3);
+          s1 = peg$c148(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4419,12 +4286,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c149) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4432,7 +4299,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c152(s3);
+          s1 = peg$c151(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4454,12 +4321,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c152) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c154); }
+      if (peg$silentFails === 0) { peg$fail(peg$c153); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4467,7 +4334,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c155(s3);
+          s1 = peg$c154(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4489,12 +4356,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c156) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c155) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c156); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4502,7 +4369,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c158(s3);
+          s1 = peg$c157(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4518,16 +4385,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c156) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c155) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c157); }
+        if (peg$silentFails === 0) { peg$fail(peg$c156); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c159();
+        s1 = peg$c158();
       }
       s0 = s1;
     }
@@ -4539,12 +4406,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c159) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c161); }
+      if (peg$silentFails === 0) { peg$fail(peg$c160); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4552,7 +4419,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c162(s3);
+          s1 = peg$c161(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4568,16 +4435,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c159) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c161); }
+        if (peg$silentFails === 0) { peg$fail(peg$c160); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c163();
+        s1 = peg$c162();
       }
       s0 = s1;
     }
@@ -4589,12 +4456,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c164) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c163) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c165); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4602,7 +4469,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c166(s3);
+          s1 = peg$c165(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4627,7 +4494,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSearchBoolean();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c43(s1);
+      s1 = peg$c42(s1);
     }
     s0 = s1;
 
@@ -4638,26 +4505,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c167) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c168); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c169) {
-          s3 = peg$c169;
+        if (input.substr(peg$currPos, 2) === peg$c168) {
+          s3 = peg$c168;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c170); }
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c171();
+          s1 = peg$c170();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4673,16 +4540,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c167) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c168); }
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172();
+        s1 = peg$c171();
       }
       s0 = s1;
     }
@@ -4694,12 +4561,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c173) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c172) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c174); }
+      if (peg$silentFails === 0) { peg$fail(peg$c173); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4707,7 +4574,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c175(s3);
+          s1 = peg$c174(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4729,12 +4596,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c176) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c175) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+      if (peg$silentFails === 0) { peg$fail(peg$c176); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4746,11 +4613,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c73;
+              s7 = peg$c72;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              if (peg$silentFails === 0) { peg$fail(peg$c73); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -4758,7 +4625,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c178(s3, s9);
+                  s6 = peg$c177(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4782,11 +4649,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c73;
+                s7 = peg$c72;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                if (peg$silentFails === 0) { peg$fail(peg$c73); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -4794,7 +4661,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c178(s3, s9);
+                    s6 = peg$c177(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4815,7 +4682,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c179(s3, s4);
+            s1 = peg$c178(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4841,12 +4708,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c179) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c180); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4855,11 +4722,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c30;
+          s5 = peg$c29;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4881,7 +4748,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c182();
+        s1 = peg$c181();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4899,16 +4766,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c183) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c182) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c184); }
+      if (peg$silentFails === 0) { peg$fail(peg$c183); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c185();
+      s1 = peg$c184();
     }
     s0 = s1;
 
@@ -4921,12 +4788,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseJoinStyle();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c185) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4971,7 +4838,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c188(s1, s6, s10, s11);
+                          s1 = peg$c187(s1, s6, s10, s11);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -5021,12 +4888,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parseJoinStyle();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c185) {
           s2 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5057,7 +4924,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c189(s1, s6, s7);
+                    s1 = peg$c188(s1, s6, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5096,18 +4963,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c190) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c189) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c191); }
+      if (peg$silentFails === 0) { peg$fail(peg$c190); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c192();
+        s1 = peg$c191();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5119,18 +4986,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c193) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c192) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c194); }
+        if (peg$silentFails === 0) { peg$fail(peg$c193); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c195();
+          s1 = peg$c194();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5142,18 +5009,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c196) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c195) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c198();
+            s1 = peg$c197();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5165,10 +5032,10 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$c26;
+          s1 = peg$c25;
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c192();
+            s1 = peg$c191();
           }
           s0 = s1;
         }
@@ -5185,25 +5052,25 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c30;
+        s1 = peg$c29;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c31); }
+        if (peg$silentFails === 0) { peg$fail(peg$c30); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c32;
+            s3 = peg$c31;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c33); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s2);
+            s1 = peg$c81(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5226,18 +5093,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c199) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c198) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c200); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSampleExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c201(s2);
+        s1 = peg$c200(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5260,7 +5127,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c202(s2);
+        s1 = peg$c201(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5272,10 +5139,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c203();
+        s1 = peg$c202();
       }
       s0 = s1;
     }
@@ -5290,7 +5157,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFromAny();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c204(s1);
+      s1 = peg$c203(s1);
     }
     s0 = s1;
 
@@ -5315,12 +5182,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c205) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c204) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c206); }
+      if (peg$silentFails === 0) { peg$fail(peg$c205); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5332,7 +5199,7 @@ function peg$parse(input, options) {
             s5 = peg$parseLayoutArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c207(s3, s4, s5);
+              s1 = peg$c206(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5362,12 +5229,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c37) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c208); }
+      if (peg$silentFails === 0) { peg$fail(peg$c207); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5375,7 +5242,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePoolBody();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c209(s3);
+          s1 = peg$c208(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5406,7 +5273,7 @@ function peg$parse(input, options) {
           s4 = peg$parseOrderArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c210(s1, s2, s3, s4);
+            s1 = peg$c209(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5432,12 +5299,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c211) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c210) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c212); }
+      if (peg$silentFails === 0) { peg$fail(peg$c211); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5449,7 +5316,7 @@ function peg$parse(input, options) {
             s5 = peg$parseLayoutArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c213(s3, s4, s5);
+              s1 = peg$c212(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5479,27 +5346,27 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c214) {
-      s1 = peg$c214;
+    if (input.substr(peg$currPos, 5) === peg$c213) {
+      s1 = peg$c213;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+      if (peg$silentFails === 0) { peg$fail(peg$c214); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c216) {
-        s1 = peg$c216;
+      if (input.substr(peg$currPos, 6) === peg$c215) {
+        s1 = peg$c215;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c216); }
       }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePath();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5526,22 +5393,22 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c218.test(input.charAt(peg$currPos))) {
+      if (peg$c217.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c219); }
+        if (peg$silentFails === 0) { peg$fail(peg$c218); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c218.test(input.charAt(peg$currPos))) {
+          if (peg$c217.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c219); }
+            if (peg$silentFails === 0) { peg$fail(peg$c218); }
           }
         }
       } else {
@@ -5549,7 +5416,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
     }
@@ -5563,12 +5430,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c220) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c219) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c221); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5576,7 +5443,7 @@ function peg$parse(input, options) {
           s4 = peg$parseKSUID();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c222(s4);
+            s1 = peg$c221(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5596,10 +5463,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -5612,22 +5479,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c223.test(input.charAt(peg$currPos))) {
+    if (peg$c222.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c224); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c223.test(input.charAt(peg$currPos))) {
+        if (peg$c222.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c224); }
+          if (peg$silentFails === 0) { peg$fail(peg$c223); }
         }
       }
     } else {
@@ -5635,7 +5502,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -5648,12 +5515,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c225) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c224) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c226); }
+        if (peg$silentFails === 0) { peg$fail(peg$c225); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5662,12 +5529,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c227) {
+              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c226) {
                 s6 = input.substr(peg$currPos, 2);
                 peg$currPos += 2;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c228); }
+                if (peg$silentFails === 0) { peg$fail(peg$c227); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parse_();
@@ -5675,7 +5542,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseLiteral();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c229(s4, s8);
+                    s1 = peg$c228(s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5711,10 +5578,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -5728,12 +5595,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c227) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c226) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c228); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5741,7 +5608,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLiteral();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s4);
+            s1 = peg$c229(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5761,10 +5628,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -5779,7 +5646,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c231(s1);
+      s1 = peg$c230(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5787,7 +5654,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKSUID();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c222(s1);
+        s1 = peg$c221(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -5795,7 +5662,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c232(s1);
+          s1 = peg$c18(s1);
         }
         s0 = s1;
       }
@@ -5810,12 +5677,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c231) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c234); }
+        if (peg$silentFails === 0) { peg$fail(peg$c232); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5825,7 +5692,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c235(s4, s5);
+              s1 = peg$c233(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5849,10 +5716,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -5866,12 +5733,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c236) {
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c234) {
         s2 = input.substr(peg$currPos, 6);
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c237); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5879,7 +5746,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s4);
+            s1 = peg$c229(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5899,10 +5766,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c238();
+        s1 = peg$c236();
       }
       s0 = s1;
     }
@@ -5914,38 +5781,38 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c239) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c237) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c241();
+      s1 = peg$c239();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c242) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c243); }
+        if (peg$silentFails === 0) { peg$fail(peg$c241); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c244();
+        s1 = peg$c242();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c26;
+        s1 = peg$c25;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c241();
+          s1 = peg$c239();
         }
         s0 = s1;
       }
@@ -5960,26 +5827,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c231) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c234); }
+        if (peg$silentFails === 0) { peg$fail(peg$c232); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c243) {
             s4 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c246); }
+            if (peg$silentFails === 0) { peg$fail(peg$c244); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c241();
+            s1 = peg$c239();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6001,26 +5868,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c231) {
           s2 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c234); }
+          if (peg$silentFails === 0) { peg$fail(peg$c232); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c245) {
               s4 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c248); }
+              if (peg$silentFails === 0) { peg$fail(peg$c246); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c244();
+              s1 = peg$c242();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6040,10 +5907,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c26;
+        s1 = peg$c25;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c238();
+          s1 = peg$c236();
         }
         s0 = s1;
       }
@@ -6056,16 +5923,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c249) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c250); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c251();
+      s1 = peg$c249();
     }
     s0 = s1;
 
@@ -6076,12 +5943,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c252) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c250) {
       s1 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6093,7 +5960,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAsArg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c254(s3, s4, s5);
+              s1 = peg$c252(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6132,7 +5999,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c255(s4);
+            s1 = peg$c253(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6167,7 +6034,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c256(s4);
+            s1 = peg$c254(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6187,10 +6054,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c27();
+        s1 = peg$c26();
       }
       s0 = s1;
     }
@@ -6209,11 +6076,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6221,7 +6088,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c257(s1, s7);
+              s4 = peg$c255(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6245,11 +6112,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6257,7 +6124,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c257(s1, s7);
+                s4 = peg$c255(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6278,7 +6145,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6303,11 +6170,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6338,11 +6205,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6370,7 +6237,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c258(s1, s2);
+        s1 = peg$c256(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6392,12 +6259,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c115) {
-          s3 = peg$c115;
+        if (input.substr(peg$currPos, 2) === peg$c114) {
+          s3 = peg$c114;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c116); }
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6405,7 +6272,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c259(s1, s5);
+              s1 = peg$c257(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6448,11 +6315,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c260;
+          s3 = peg$c258;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c261); }
+          if (peg$silentFails === 0) { peg$fail(peg$c259); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6462,11 +6329,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c52;
+                  s7 = peg$c51;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c52); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -6474,7 +6341,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c262(s1, s5, s9);
+                      s1 = peg$c260(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6536,7 +6403,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6566,7 +6433,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6587,7 +6454,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6618,7 +6485,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6648,7 +6515,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6669,7 +6536,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6702,7 +6569,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c265(s1, s5, s7);
+                s4 = peg$c263(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6732,7 +6599,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRelativeExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s3;
-                  s4 = peg$c265(s1, s5, s7);
+                  s4 = peg$c263(s1, s5, s7);
                   s3 = s4;
                 } else {
                   peg$currPos = s3;
@@ -6753,7 +6620,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c264(s1, s2);
+          s1 = peg$c262(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6772,30 +6639,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c56) {
-      s1 = peg$c56;
+    if (input.substr(peg$currPos, 2) === peg$c55) {
+      s1 = peg$c55;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c57); }
+      if (peg$silentFails === 0) { peg$fail(peg$c56); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c266();
+      s1 = peg$c264();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c58) {
-        s1 = peg$c58;
+      if (input.substr(peg$currPos, 2) === peg$c57) {
+        s1 = peg$c57;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
     }
@@ -6809,16 +6676,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c60) {
-        s1 = peg$c60;
+      if (input.substr(peg$currPos, 2) === peg$c59) {
+        s1 = peg$c59;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c60); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
     }
@@ -6843,7 +6710,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6873,7 +6740,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6894,7 +6761,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6912,43 +6779,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c62) {
-      s1 = peg$c62;
+    if (input.substr(peg$currPos, 2) === peg$c61) {
+      s1 = peg$c61;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c63); }
+      if (peg$silentFails === 0) { peg$fail(peg$c62); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c64;
+        s1 = peg$c63;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c65); }
+        if (peg$silentFails === 0) { peg$fail(peg$c64); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c66) {
-          s1 = peg$c66;
+        if (input.substr(peg$currPos, 2) === peg$c65) {
+          s1 = peg$c65;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c67); }
+          if (peg$silentFails === 0) { peg$fail(peg$c66); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c68;
+            s1 = peg$c67;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c69); }
+            if (peg$silentFails === 0) { peg$fail(peg$c68); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -6972,7 +6839,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7002,7 +6869,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7023,7 +6890,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7042,24 +6909,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c267;
+      s1 = peg$c265;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c269;
+        s1 = peg$c267;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c270); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -7083,7 +6950,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s5, s7);
+              s4 = peg$c261(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7113,7 +6980,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s5, s7);
+                s4 = peg$c261(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7134,7 +7001,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c262(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7153,24 +7020,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c83;
+      s1 = peg$c82;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c271;
+        s1 = peg$c269;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c272); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -7182,11 +7049,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c79;
+      s1 = peg$c78;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c79); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7194,7 +7061,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c273(s3);
+          s1 = peg$c271(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7231,11 +7098,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s5 = peg$c30;
+              s5 = peg$c29;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c31); }
+              if (peg$silentFails === 0) { peg$fail(peg$c30); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -7257,7 +7124,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s1);
+            s1 = peg$c272(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7279,7 +7146,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c75(s1, s2);
+              s1 = peg$c74(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7301,7 +7168,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c75(s1, s2);
+                s1 = peg$c74(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7334,11 +7201,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -7362,28 +7229,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c275) {
-      s0 = peg$c275;
+    if (input.substr(peg$currPos, 3) === peg$c273) {
+      s0 = peg$c273;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c277) {
-        s0 = peg$c277;
+      if (input.substr(peg$currPos, 5) === peg$c275) {
+        s0 = peg$c275;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c279) {
-          s0 = peg$c279;
+        if (input.substr(peg$currPos, 6) === peg$c277) {
+          s0 = peg$c277;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c280); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -7404,36 +7271,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c277) {
-      s1 = peg$c277;
+    if (input.substr(peg$currPos, 5) === peg$c275) {
+      s1 = peg$c275;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c32;
+              s5 = peg$c31;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c33); }
+              if (peg$silentFails === 0) { peg$fail(peg$c32); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c82(s4);
+              s1 = peg$c81(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7463,22 +7330,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c279) {
-      s1 = peg$c279;
+    if (input.substr(peg$currPos, 6) === peg$c277) {
+      s1 = peg$c277;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7488,17 +7355,17 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c32;
+                  s7 = peg$c31;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parseMethods();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c281(s5, s8);
+                    s1 = peg$c279(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7552,15 +7419,15 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c282(s1);
+      s1 = peg$c280(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -7575,11 +7442,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c119;
+        s2 = peg$c118;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7587,7 +7454,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFunction();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c41(s4);
+            s1 = peg$c40(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7618,11 +7485,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7632,15 +7499,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c32;
+                  s7 = peg$c31;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c283(s1, s5);
+                  s1 = peg$c281(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7694,11 +7561,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c30;
+            s4 = peg$c29;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -7708,15 +7575,15 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c32;
+                    s8 = peg$c31;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c32); }
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c284(s2, s6);
+                    s1 = peg$c282(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7763,7 +7630,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c285();
+        s1 = peg$c283();
       }
       s0 = s1;
     }
@@ -7782,11 +7649,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -7794,7 +7661,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c286(s1, s7);
+              s4 = peg$c284(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7818,11 +7685,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -7830,7 +7697,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c286(s1, s7);
+                s4 = peg$c284(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7851,7 +7718,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7883,7 +7750,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExprPattern();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c287(s2);
+        s1 = peg$c285(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7911,7 +7778,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c75(s1, s2);
+        s1 = peg$c74(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7933,7 +7800,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c75(s1, s2);
+          s1 = peg$c74(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7955,7 +7822,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c75(s1, s2);
+            s1 = peg$c74(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7968,15 +7835,15 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 46) {
-            s1 = peg$c119;
+            s1 = peg$c118;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c120); }
+            if (peg$silentFails === 0) { peg$fail(peg$c119); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c288();
+            s1 = peg$c286();
           }
           s0 = s1;
         }
@@ -7990,16 +7857,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c289) {
-      s1 = peg$c289;
+    if (input.substr(peg$currPos, 4) === peg$c287) {
+      s1 = peg$c287;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c203();
+      s1 = peg$c202();
     }
     s0 = s1;
 
@@ -8011,17 +7878,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c119;
+      s1 = peg$c118;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c120); }
+      if (peg$silentFails === 0) { peg$fail(peg$c119); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c291(s2);
+        s1 = peg$c289(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8034,33 +7901,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c119;
+        s1 = peg$c118;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c50;
+          s2 = peg$c49;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c292;
+              s4 = peg$c290;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c293); }
+              if (peg$silentFails === 0) { peg$fail(peg$c291); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c294(s3);
+              s1 = peg$c292(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8088,11 +7955,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c50;
+      s1 = peg$c49;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -8100,11 +7967,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c52;
+            s4 = peg$c51;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -8112,15 +7979,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c292;
+                  s7 = peg$c290;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c291); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c295(s2, s6);
+                  s1 = peg$c293(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8153,21 +8020,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c50;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c52;
+            s3 = peg$c51;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -8175,15 +8042,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c292;
+                  s6 = peg$c290;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c291); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c296(s5);
+                  s1 = peg$c294(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8212,11 +8079,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c50;
+          s1 = peg$c49;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseAdditiveExpr();
@@ -8224,25 +8091,25 @@ function peg$parse(input, options) {
             s3 = peg$parse__();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c52;
+                s4 = peg$c51;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                if (peg$silentFails === 0) { peg$fail(peg$c52); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c292;
+                    s6 = peg$c290;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c291); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c297(s2);
+                    s1 = peg$c295(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8271,25 +8138,25 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c50;
+            s1 = peg$c49;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c51); }
+            if (peg$silentFails === 0) { peg$fail(peg$c50); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c292;
+                s3 = peg$c290;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                if (peg$silentFails === 0) { peg$fail(peg$c291); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c298(s2);
+                s1 = peg$c296(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8306,21 +8173,21 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c119;
+              s1 = peg$c118;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c120); }
+              if (peg$silentFails === 0) { peg$fail(peg$c119); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
               peg$silentFails++;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s3 = peg$c119;
+                s3 = peg$c118;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c119); }
               }
               peg$silentFails--;
               if (s3 === peg$FAILED) {
@@ -8333,7 +8200,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c299(s3);
+                  s1 = peg$c297(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8370,11 +8237,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 40) {
-                s1 = peg$c30;
+                s1 = peg$c29;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                if (peg$silentFails === 0) { peg$fail(peg$c30); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -8384,15 +8251,15 @@ function peg$parse(input, options) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s5 = peg$c32;
+                        s5 = peg$c31;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c32); }
                       }
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c82(s3);
+                        s1 = peg$c81(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -8428,11 +8295,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c48;
+      s1 = peg$c47;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c48); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8442,15 +8309,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c300;
+              s5 = peg$c298;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c302(s3);
+              s1 = peg$c300(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8490,7 +8357,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8511,11 +8378,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8523,7 +8390,7 @@ function peg$parse(input, options) {
           s4 = peg$parseField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c41(s4);
+            s1 = peg$c40(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8554,11 +8421,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c52;
+          s3 = peg$c51;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8566,7 +8433,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c304(s1, s5);
+              s1 = peg$c302(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8597,11 +8464,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c50;
+      s1 = peg$c49;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8611,15 +8478,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c292;
+              s5 = peg$c290;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c293); }
+              if (peg$silentFails === 0) { peg$fail(peg$c291); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305(s3);
+              s1 = peg$c303(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8649,12 +8516,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c306) {
-      s1 = peg$c306;
+    if (input.substr(peg$currPos, 2) === peg$c304) {
+      s1 = peg$c304;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c307); }
+      if (peg$silentFails === 0) { peg$fail(peg$c305); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8663,16 +8530,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c308) {
-              s5 = peg$c308;
+            if (input.substr(peg$currPos, 2) === peg$c306) {
+              s5 = peg$c306;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c309); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c310(s3);
+              s1 = peg$c308(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8702,12 +8569,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c311) {
-      s1 = peg$c311;
+    if (input.substr(peg$currPos, 2) === peg$c309) {
+      s1 = peg$c309;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c312); }
+      if (peg$silentFails === 0) { peg$fail(peg$c310); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8716,16 +8583,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c313) {
-              s5 = peg$c313;
+            if (input.substr(peg$currPos, 2) === peg$c311) {
+              s5 = peg$c311;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c314); }
+              if (peg$silentFails === 0) { peg$fail(peg$c312); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s3);
+              s1 = peg$c313(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8765,7 +8632,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8780,7 +8647,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c285();
+        s1 = peg$c283();
       }
       s0 = s1;
     }
@@ -8795,11 +8662,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8807,7 +8674,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c287(s4);
+            s1 = peg$c285(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8838,11 +8705,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c52;
+          s3 = peg$c51;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8850,7 +8717,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c316(s1, s5);
+              s1 = peg$c314(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8897,7 +8764,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c317(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c315(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8944,15 +8811,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 42) {
-          s3 = peg$c83;
+          s3 = peg$c82;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104();
+          s1 = peg$c103();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8975,7 +8842,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c318(s3);
+            s1 = peg$c316(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9009,7 +8876,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319(s1, s5);
+              s1 = peg$c317(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9036,7 +8903,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112(s1);
+        s1 = peg$c111(s1);
       }
       s0 = s1;
     }
@@ -9055,11 +8922,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -9067,7 +8934,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSQLAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c113(s1, s7);
+              s4 = peg$c112(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9091,11 +8958,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -9103,7 +8970,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSQLAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c113(s1, s7);
+                s4 = peg$c112(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9124,7 +8991,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9153,7 +9020,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSQLAlias();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s4, s5);
+              s1 = peg$c318(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9184,15 +9051,15 @@ function peg$parse(input, options) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 42) {
-              s4 = peg$c83;
+              s4 = peg$c82;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c84); }
+              if (peg$silentFails === 0) { peg$fail(peg$c83); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c104();
+              s1 = peg$c103();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9212,10 +9079,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c26;
+        s1 = peg$c25;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104();
+          s1 = peg$c103();
         }
         s0 = s1;
       }
@@ -9237,7 +9104,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c222(s4);
+            s1 = peg$c221(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9262,7 +9129,7 @@ function peg$parse(input, options) {
         s2 = peg$parseDerefExpr();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c222(s2);
+          s1 = peg$c221(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9274,10 +9141,10 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c26;
+        s1 = peg$c25;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104();
+          s1 = peg$c103();
         }
         s0 = s1;
       }
@@ -9297,7 +9164,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c321(s1, s4);
+        s4 = peg$c319(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9306,13 +9173,13 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c321(s1, s4);
+          s4 = peg$c319(s1, s4);
         }
         s3 = s4;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9324,10 +9191,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9374,7 +9241,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c322(s1, s5, s6, s10, s14);
+                                s1 = peg$c320(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9451,7 +9318,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c323(s2);
+        s1 = peg$c321(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9463,10 +9330,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c192();
+        s1 = peg$c191();
       }
       s0 = s1;
     }
@@ -9487,7 +9354,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s4);
+            s1 = peg$c81(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9507,10 +9374,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9535,7 +9402,7 @@ function peg$parse(input, options) {
               s6 = peg$parseFieldExprs();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c105(s6);
+                s1 = peg$c104(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9563,10 +9430,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9587,7 +9454,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s4);
+            s1 = peg$c81(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9607,10 +9474,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9637,7 +9504,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c324(s6, s7);
+                  s1 = peg$c322(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9669,10 +9536,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c103();
       }
       s0 = s1;
     }
@@ -9692,7 +9559,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c325(s2);
+        s1 = peg$c323(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9704,10 +9571,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c241();
+        s1 = peg$c239();
       }
       s0 = s1;
     }
@@ -9728,7 +9595,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s4);
+            s1 = peg$c324(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9748,10 +9615,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c26;
+      s1 = peg$c25;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c111();
+        s1 = peg$c110();
       }
       s0 = s1;
     }
@@ -9763,16 +9630,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c279) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c277) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328();
+      s1 = peg$c326();
     }
     s0 = s1;
 
@@ -9783,16 +9650,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c329) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c327) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c328); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c331();
+      s1 = peg$c329();
     }
     s0 = s1;
 
@@ -9803,16 +9670,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c37) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c208); }
+      if (peg$silentFails === 0) { peg$fail(peg$c207); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c332();
+      s1 = peg$c330();
     }
     s0 = s1;
 
@@ -9823,16 +9690,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c186) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c185) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c187); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c333();
+      s1 = peg$c331();
     }
     s0 = s1;
 
@@ -9843,16 +9710,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c122) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c121) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c334); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c335();
+      s1 = peg$c333();
     }
     s0 = s1;
 
@@ -9863,16 +9730,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c336) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c334) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c337); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c338();
+      s1 = peg$c336();
     }
     s0 = s1;
 
@@ -9883,16 +9750,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c337) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341();
+      s1 = peg$c339();
     }
     s0 = s1;
 
@@ -9903,16 +9770,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c233) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c231) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c232); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c340();
     }
     s0 = s1;
 
@@ -9923,16 +9790,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c343) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c341) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c345();
+      s1 = peg$c343();
     }
     s0 = s1;
 
@@ -9943,16 +9810,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c344) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -9963,16 +9830,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c243) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c241();
+      s1 = peg$c239();
     }
     s0 = s1;
 
@@ -9983,16 +9850,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c245) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c248); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c244();
+      s1 = peg$c242();
     }
     s0 = s1;
 
@@ -10003,16 +9870,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c193) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c192) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      if (peg$silentFails === 0) { peg$fail(peg$c193); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c195();
+      s1 = peg$c194();
     }
     s0 = s1;
 
@@ -10023,16 +9890,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c196) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c195) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c197); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c198();
+      s1 = peg$c197();
     }
     s0 = s1;
 
@@ -10043,16 +9910,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c190) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c189) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c191); }
+      if (peg$silentFails === 0) { peg$fail(peg$c190); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c192();
+      s1 = peg$c191();
     }
     s0 = s1;
 
@@ -10136,7 +10003,7 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c91(s1);
+      s1 = peg$c90(s1);
     }
     s0 = s1;
 
@@ -10161,7 +10028,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c349(s1);
+        s1 = peg$c347(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10176,7 +10043,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c349(s1);
+        s1 = peg$c347(s1);
       }
       s0 = s1;
     }
@@ -10202,7 +10069,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1);
+        s1 = peg$c348(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10217,7 +10084,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1);
+        s1 = peg$c348(s1);
       }
       s0 = s1;
     }
@@ -10232,7 +10099,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351(s1);
+      s1 = peg$c349(s1);
     }
     s0 = s1;
 
@@ -10246,7 +10113,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c352(s1);
+      s1 = peg$c350(s1);
     }
     s0 = s1;
 
@@ -10257,30 +10124,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c353) {
-      s1 = peg$c353;
+    if (input.substr(peg$currPos, 4) === peg$c351) {
+      s1 = peg$c351;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c355();
+      s1 = peg$c353();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c356) {
-        s1 = peg$c356;
+      if (input.substr(peg$currPos, 5) === peg$c354) {
+        s1 = peg$c354;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c357); }
+        if (peg$silentFails === 0) { peg$fail(peg$c355); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c358();
+        s1 = peg$c356();
       }
       s0 = s1;
     }
@@ -10292,16 +10159,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c359) {
-      s1 = peg$c359;
+    if (input.substr(peg$currPos, 4) === peg$c357) {
+      s1 = peg$c357;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c358); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c361();
+      s1 = peg$c359();
     }
     s0 = s1;
 
@@ -10340,7 +10207,7 @@ function peg$parse(input, options) {
       s2 = peg$parseTypeExternal();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c362(s2);
+        s1 = peg$c360(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10387,7 +10254,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s1);
+            s1 = peg$c272(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10432,11 +10299,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c30;
+          s3 = peg$c29;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -10446,15 +10313,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c32;
+                  s7 = peg$c31;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c255(s5);
+                  s1 = peg$c253(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10497,11 +10364,11 @@ function peg$parse(input, options) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c30;
+            s3 = peg$c29;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -10511,15 +10378,15 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c32;
+                    s7 = peg$c31;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c32); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c274(s5);
+                    s1 = peg$c272(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10572,7 +10439,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c231(s1);
+        s1 = peg$c230(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10599,11 +10466,11 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s5 = peg$c30;
+                s5 = peg$c29;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                if (peg$silentFails === 0) { peg$fail(peg$c30); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse__();
@@ -10613,15 +10480,15 @@ function peg$parse(input, options) {
                     s8 = peg$parse__();
                     if (s8 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s9 = peg$c32;
+                        s9 = peg$c31;
                         peg$currPos++;
                       } else {
                         s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c32); }
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c363(s1, s7);
+                        s1 = peg$c361(s1, s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10664,17 +10531,17 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c364(s1);
+          s1 = peg$c362(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c30;
+            s1 = peg$c29;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10682,15 +10549,15 @@ function peg$parse(input, options) {
               s3 = peg$parseTypeUnion();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s4 = peg$c32;
+                  s4 = peg$c31;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c365(s3);
+                  s1 = peg$c363(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10722,7 +10589,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c366(s1);
+      s1 = peg$c364(s1);
     }
     s0 = s1;
 
@@ -10747,7 +10614,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10768,11 +10635,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -10780,7 +10647,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s4);
+            s1 = peg$c272(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10807,11 +10674,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c48;
+      s1 = peg$c47;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c48); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -10821,15 +10688,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c300;
+              s5 = peg$c298;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c367(s3);
+              s1 = peg$c365(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10854,11 +10721,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c50;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -10868,15 +10735,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c292;
+                s5 = peg$c290;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                if (peg$silentFails === 0) { peg$fail(peg$c291); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c368(s3);
+                s1 = peg$c366(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10900,12 +10767,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c306) {
-          s1 = peg$c306;
+        if (input.substr(peg$currPos, 2) === peg$c304) {
+          s1 = peg$c304;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c305); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10914,16 +10781,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c308) {
-                  s5 = peg$c308;
+                if (input.substr(peg$currPos, 2) === peg$c306) {
+                  s5 = peg$c306;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c307); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c369(s3);
+                  s1 = peg$c367(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10947,12 +10814,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c311) {
-            s1 = peg$c311;
+          if (input.substr(peg$currPos, 2) === peg$c309) {
+            s1 = peg$c309;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c312); }
+            if (peg$silentFails === 0) { peg$fail(peg$c310); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10962,11 +10829,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c73;
+                    s5 = peg$c72;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c73); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -10975,16 +10842,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c313) {
-                            s9 = peg$c313;
+                          if (input.substr(peg$currPos, 2) === peg$c311) {
+                            s9 = peg$c311;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c314); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c312); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c370(s3, s7);
+                            s1 = peg$c368(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11034,11 +10901,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c48;
+      s1 = peg$c47;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c48); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11048,15 +10915,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c300;
+              s5 = peg$c298;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c367(s3);
+              s1 = peg$c365(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11081,11 +10948,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c50;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -11095,15 +10962,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c292;
+                s5 = peg$c290;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                if (peg$silentFails === 0) { peg$fail(peg$c291); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c368(s3);
+                s1 = peg$c366(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11127,12 +10994,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c306) {
-          s1 = peg$c306;
+        if (input.substr(peg$currPos, 2) === peg$c304) {
+          s1 = peg$c304;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c305); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11141,16 +11008,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c308) {
-                  s5 = peg$c308;
+                if (input.substr(peg$currPos, 2) === peg$c306) {
+                  s5 = peg$c306;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c307); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c369(s3);
+                  s1 = peg$c367(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11174,12 +11041,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c311) {
-            s1 = peg$c311;
+          if (input.substr(peg$currPos, 2) === peg$c309) {
+            s1 = peg$c309;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c312); }
+            if (peg$silentFails === 0) { peg$fail(peg$c310); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11189,11 +11056,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c73;
+                    s5 = peg$c72;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c73); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -11202,16 +11069,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c313) {
-                            s9 = peg$c313;
+                          if (input.substr(peg$currPos, 2) === peg$c311) {
+                            s9 = peg$c311;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c314); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c312); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c370(s3, s7);
+                            s1 = peg$c368(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11271,92 +11138,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c371) {
-      s1 = peg$c371;
+    if (input.substr(peg$currPos, 5) === peg$c369) {
+      s1 = peg$c369;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c373) {
-        s1 = peg$c373;
+      if (input.substr(peg$currPos, 6) === peg$c371) {
+        s1 = peg$c371;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c374); }
+        if (peg$silentFails === 0) { peg$fail(peg$c372); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c375) {
-          s1 = peg$c375;
+        if (input.substr(peg$currPos, 6) === peg$c373) {
+          s1 = peg$c373;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c376); }
+          if (peg$silentFails === 0) { peg$fail(peg$c374); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c377) {
-            s1 = peg$c377;
+          if (input.substr(peg$currPos, 6) === peg$c375) {
+            s1 = peg$c375;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c378); }
+            if (peg$silentFails === 0) { peg$fail(peg$c376); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c379) {
-              s1 = peg$c379;
+            if (input.substr(peg$currPos, 4) === peg$c377) {
+              s1 = peg$c377;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c380); }
+              if (peg$silentFails === 0) { peg$fail(peg$c378); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c381) {
-                s1 = peg$c381;
+              if (input.substr(peg$currPos, 5) === peg$c379) {
+                s1 = peg$c379;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c382); }
+                if (peg$silentFails === 0) { peg$fail(peg$c380); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c383) {
-                  s1 = peg$c383;
+                if (input.substr(peg$currPos, 5) === peg$c381) {
+                  s1 = peg$c381;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c384); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c382); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c385) {
-                    s1 = peg$c385;
+                  if (input.substr(peg$currPos, 5) === peg$c383) {
+                    s1 = peg$c383;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c384); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c387) {
-                      s1 = peg$c387;
+                    if (input.substr(peg$currPos, 7) === peg$c385) {
+                      s1 = peg$c385;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c386); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c389) {
-                        s1 = peg$c389;
+                      if (input.substr(peg$currPos, 4) === peg$c387) {
+                        s1 = peg$c387;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c388); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c391) {
-                          s1 = peg$c391;
+                        if (input.substr(peg$currPos, 6) === peg$c389) {
+                          s1 = peg$c389;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c392); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c390); }
                         }
                       }
                     }
@@ -11370,7 +11237,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c393();
+      s1 = peg$c391();
     }
     s0 = s1;
 
@@ -11381,52 +11248,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c394) {
-      s1 = peg$c394;
+    if (input.substr(peg$currPos, 8) === peg$c392) {
+      s1 = peg$c392;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c396) {
-        s1 = peg$c396;
+      if (input.substr(peg$currPos, 4) === peg$c394) {
+        s1 = peg$c394;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c397); }
+        if (peg$silentFails === 0) { peg$fail(peg$c395); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c398) {
-          s1 = peg$c398;
+        if (input.substr(peg$currPos, 5) === peg$c396) {
+          s1 = peg$c396;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c399); }
+          if (peg$silentFails === 0) { peg$fail(peg$c397); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c400) {
-            s1 = peg$c400;
+          if (input.substr(peg$currPos, 7) === peg$c398) {
+            s1 = peg$c398;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c401); }
+            if (peg$silentFails === 0) { peg$fail(peg$c399); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c402) {
-              s1 = peg$c402;
+            if (input.substr(peg$currPos, 2) === peg$c400) {
+              s1 = peg$c400;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c403); }
+              if (peg$silentFails === 0) { peg$fail(peg$c401); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c404) {
-                s1 = peg$c404;
+              if (input.substr(peg$currPos, 3) === peg$c402) {
+                s1 = peg$c402;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c405); }
+                if (peg$silentFails === 0) { peg$fail(peg$c403); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11437,20 +11304,20 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c406) {
-                    s1 = peg$c406;
+                  if (input.substr(peg$currPos, 5) === peg$c404) {
+                    s1 = peg$c404;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c407); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c405); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c359) {
-                      s1 = peg$c359;
+                    if (input.substr(peg$currPos, 4) === peg$c357) {
+                      s1 = peg$c357;
                       peg$currPos += 4;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c358); }
                     }
                   }
                 }
@@ -11462,7 +11329,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c393();
+      s1 = peg$c391();
     }
     s0 = s1;
 
@@ -11483,7 +11350,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11504,11 +11371,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -11516,7 +11383,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s4);
+            s1 = peg$c272(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11547,11 +11414,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c52;
+          s3 = peg$c51;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -11559,7 +11426,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c408(s1, s5);
+              s1 = peg$c406(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11599,7 +11466,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11620,11 +11487,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c73;
+        s2 = peg$c72;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -11632,7 +11499,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeFieldExternal();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c274(s4);
+            s1 = peg$c272(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11663,11 +11530,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c52;
+          s3 = peg$c51;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -11675,7 +11542,7 @@ function peg$parse(input, options) {
             s5 = peg$parseTypeExternal();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c408(s1, s5);
+              s1 = peg$c406(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11727,12 +11594,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c409) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c407) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11747,7 +11614,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c411();
+        s1 = peg$c409();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11765,7 +11632,45 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c412) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c410) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c412();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseInToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c59) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
@@ -11799,13 +11704,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseInToken() {
+  function peg$parseNotToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c273) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c415); }
@@ -11837,54 +11742,16 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseNotToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c275) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c417); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c418();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parseByToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c419) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c417) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c420); }
+      if (peg$silentFails === 0) { peg$fail(peg$c418); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11899,7 +11766,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c421();
+        s1 = peg$c419();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11916,12 +11783,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c422.test(input.charAt(peg$currPos))) {
+    if (peg$c420.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c423); }
+      if (peg$silentFails === 0) { peg$fail(peg$c421); }
     }
 
     return s0;
@@ -11932,12 +11799,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
     }
 
@@ -11951,7 +11818,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c426(s1);
+      s1 = peg$c424(s1);
     }
     s0 = s1;
 
@@ -12006,7 +11873,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c427();
+          s1 = peg$c425();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12023,31 +11890,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c428;
+        s1 = peg$c426;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c429); }
+        if (peg$silentFails === 0) { peg$fail(peg$c427); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c430;
+          s1 = peg$c428;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+          if (peg$silentFails === 0) { peg$fail(peg$c429); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c222(s2);
+            s1 = peg$c221(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -12068,7 +11935,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c70();
+            s1 = peg$c69();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -12081,11 +11948,11 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s5 = peg$c30;
+                  s5 = peg$c29;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c30); }
                 }
                 if (s5 !== peg$FAILED) {
                   s4 = [s4, s5];
@@ -12107,7 +11974,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c222(s1);
+                s1 = peg$c221(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12149,17 +12016,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c432;
+        s2 = peg$c430;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c433); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c434();
+          s1 = peg$c432();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12184,21 +12051,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c269;
+        s2 = peg$c267;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c270); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c269;
+            s4 = peg$c267;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c270); }
+            if (peg$silentFails === 0) { peg$fail(peg$c268); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12233,36 +12100,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c424.test(input.charAt(peg$currPos))) {
+    if (peg$c422.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c424.test(input.charAt(peg$currPos))) {
+        if (peg$c422.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c425); }
+          if (peg$silentFails === 0) { peg$fail(peg$c423); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c424.test(input.charAt(peg$currPos))) {
+          if (peg$c422.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c425); }
+            if (peg$silentFails === 0) { peg$fail(peg$c423); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12291,20 +12158,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c424.test(input.charAt(peg$currPos))) {
+    if (peg$c422.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12350,51 +12217,51 @@ function peg$parse(input, options) {
     s1 = peg$parseD2();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c52;
+        s2 = peg$c51;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c52;
+            s4 = peg$c51;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
             if (s5 !== peg$FAILED) {
               s6 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c119;
+                s7 = peg$c118;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c119); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c424.test(input.charAt(peg$currPos))) {
+                if (peg$c422.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c424.test(input.charAt(peg$currPos))) {
+                    if (peg$c422.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c423); }
                     }
                   }
                 } else {
@@ -12449,69 +12316,69 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c435;
+      s0 = peg$c433;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c436); }
+      if (peg$silentFails === 0) { peg$fail(peg$c434); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c267;
+        s1 = peg$c265;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c266); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c269;
+          s1 = peg$c267;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c268); }
         }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseD2();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c52;
+            s3 = peg$c51;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parseD2();
             if (s4 !== peg$FAILED) {
               s5 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c119;
+                s6 = peg$c118;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c119); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c424.test(input.charAt(peg$currPos))) {
+                if (peg$c422.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c424.test(input.charAt(peg$currPos))) {
+                    if (peg$c422.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c423); }
                     }
                   }
                 } else {
@@ -12564,11 +12431,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c269;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c270); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12614,7 +12481,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c437();
+        s1 = peg$c435();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12636,11 +12503,11 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c119;
+        s3 = peg$c118;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseUInt();
@@ -12676,76 +12543,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c438) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c436) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c439); }
+      if (peg$silentFails === 0) { peg$fail(peg$c437); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c440) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c438) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c441); }
+        if (peg$silentFails === 0) { peg$fail(peg$c439); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c442) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c440) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c443); }
+          if (peg$silentFails === 0) { peg$fail(peg$c441); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c444) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c442) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c445); }
+            if (peg$silentFails === 0) { peg$fail(peg$c443); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c446) {
+            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c444) {
               s0 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c447); }
+              if (peg$silentFails === 0) { peg$fail(peg$c445); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c448) {
+              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c446) {
                 s0 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c449); }
+                if (peg$silentFails === 0) { peg$fail(peg$c447); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c450) {
+                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c448) {
                   s0 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c451); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c449); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c452) {
+                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c450) {
                     s0 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c453); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c451); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c454) {
+                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c452) {
                       s0 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c455); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c453); }
                     }
                   }
                 }
@@ -12766,37 +12633,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c119;
+        s2 = peg$c118;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c119;
+            s4 = peg$c118;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c120); }
+            if (peg$silentFails === 0) { peg$fail(peg$c119); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c119;
+                s6 = peg$c118;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c119); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c70();
+                  s1 = peg$c69();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -12840,11 +12707,11 @@ function peg$parse(input, options) {
     s3 = peg$parseHex();
     if (s3 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s4 = peg$c52;
+        s4 = peg$c51;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parseHex();
@@ -12854,11 +12721,11 @@ function peg$parse(input, options) {
           s7 = peg$parseHexDigit();
           if (s7 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s7 = peg$c52;
+              s7 = peg$c51;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c53); }
+              if (peg$silentFails === 0) { peg$fail(peg$c52); }
             }
           }
           peg$silentFails--;
@@ -12930,7 +12797,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c456(s1, s2);
+        s1 = peg$c454(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12951,12 +12818,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c457) {
-            s3 = peg$c457;
+          if (input.substr(peg$currPos, 2) === peg$c455) {
+            s3 = peg$c455;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c458); }
+            if (peg$silentFails === 0) { peg$fail(peg$c456); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12969,7 +12836,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c459(s1, s2, s4, s5);
+                s1 = peg$c457(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12993,12 +12860,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c457) {
-          s1 = peg$c457;
+        if (input.substr(peg$currPos, 2) === peg$c455) {
+          s1 = peg$c455;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c458); }
+          if (peg$silentFails === 0) { peg$fail(peg$c456); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13011,7 +12878,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c460(s2, s3);
+              s1 = peg$c458(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13036,16 +12903,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c457) {
-                s3 = peg$c457;
+              if (input.substr(peg$currPos, 2) === peg$c455) {
+                s3 = peg$c455;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c458); }
+                if (peg$silentFails === 0) { peg$fail(peg$c456); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c461(s1, s2);
+                s1 = peg$c459(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13061,16 +12928,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c457) {
-              s1 = peg$c457;
+            if (input.substr(peg$currPos, 2) === peg$c455) {
+              s1 = peg$c455;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c458); }
+              if (peg$silentFails === 0) { peg$fail(peg$c456); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c462();
+              s1 = peg$c460();
             }
             s0 = s1;
           }
@@ -13097,17 +12964,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c52;
+      s1 = peg$c51;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c52); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c463(s2);
+        s1 = peg$c461(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13128,15 +12995,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c52;
+        s2 = peg$c51;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c464(s1);
+        s1 = peg$c462(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13157,17 +13024,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c271;
+        s2 = peg$c269;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c272); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c465(s1, s3);
+          s1 = peg$c463(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13192,17 +13059,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c271;
+        s2 = peg$c269;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c272); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c466(s1, s3);
+          s1 = peg$c464(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13227,7 +13094,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c467(s1);
+      s1 = peg$c465(s1);
     }
     s0 = s1;
 
@@ -13250,22 +13117,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c424.test(input.charAt(peg$currPos))) {
+    if (peg$c422.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c425); }
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c424.test(input.charAt(peg$currPos))) {
+        if (peg$c422.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c425); }
+          if (peg$silentFails === 0) { peg$fail(peg$c423); }
         }
       }
     } else {
@@ -13273,7 +13140,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -13285,17 +13152,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c269;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c270); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13314,33 +13181,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c269;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c270); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c424.test(input.charAt(peg$currPos))) {
+          if (peg$c422.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c425); }
+            if (peg$silentFails === 0) { peg$fail(peg$c423); }
           }
         }
       } else {
@@ -13348,30 +13215,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c119;
+          s3 = peg$c118;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c120); }
+          if (peg$silentFails === 0) { peg$fail(peg$c119); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c424.test(input.charAt(peg$currPos))) {
+          if (peg$c422.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c425); }
+            if (peg$silentFails === 0) { peg$fail(peg$c423); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c424.test(input.charAt(peg$currPos))) {
+              if (peg$c422.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                if (peg$silentFails === 0) { peg$fail(peg$c423); }
               }
             }
           } else {
@@ -13384,7 +13251,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c468();
+              s1 = peg$c466();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13409,41 +13276,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c269;
+        s1 = peg$c267;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c270); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c119;
+          s2 = peg$c118;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c120); }
+          if (peg$silentFails === 0) { peg$fail(peg$c119); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c424.test(input.charAt(peg$currPos))) {
+          if (peg$c422.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c425); }
+            if (peg$silentFails === 0) { peg$fail(peg$c423); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c424.test(input.charAt(peg$currPos))) {
+              if (peg$c422.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                if (peg$silentFails === 0) { peg$fail(peg$c423); }
               }
             }
           } else {
@@ -13456,7 +13323,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c468();
+              s1 = peg$c466();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13483,20 +13350,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c469) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c467) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c470); }
+      if (peg$silentFails === 0) { peg$fail(peg$c468); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c471.test(input.charAt(peg$currPos))) {
+      if (peg$c469.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c472); }
+        if (peg$silentFails === 0) { peg$fail(peg$c470); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13538,7 +13405,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -13548,12 +13415,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c473.test(input.charAt(peg$currPos))) {
+    if (peg$c471.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c474); }
+      if (peg$silentFails === 0) { peg$fail(peg$c472); }
     }
 
     return s0;
@@ -13564,11 +13431,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c475;
+      s1 = peg$c473;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c474); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13579,15 +13446,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c475;
+          s3 = peg$c473;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c476); }
+          if (peg$silentFails === 0) { peg$fail(peg$c474); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c477(s2);
+          s1 = peg$c475(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13604,11 +13471,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c478;
+        s1 = peg$c476;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c479); }
+        if (peg$silentFails === 0) { peg$fail(peg$c477); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13619,15 +13486,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c478;
+            s3 = peg$c476;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c479); }
+            if (peg$silentFails === 0) { peg$fail(peg$c477); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c477(s2);
+            s1 = peg$c475(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13653,11 +13520,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c475;
+      s2 = peg$c473;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c474); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13675,11 +13542,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c478); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13692,17 +13559,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c430;
+        s1 = peg$c428;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c431); }
+        if (peg$silentFails === 0) { peg$fail(peg$c429); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c232(s2);
+          s1 = peg$c18(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13731,7 +13598,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c481(s1, s2);
+        s1 = peg$c479(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13760,16 +13627,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c482.test(input.charAt(peg$currPos))) {
+    if (peg$c480.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c483); }
+      if (peg$silentFails === 0) { peg$fail(peg$c481); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -13781,12 +13648,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
     }
 
@@ -13798,11 +13665,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c430;
+      s1 = peg$c428;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c431); }
+      if (peg$silentFails === 0) { peg$fail(peg$c429); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13811,7 +13678,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c232(s2);
+        s1 = peg$c18(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13861,7 +13728,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c484(s3, s4);
+            s1 = peg$c482(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13889,20 +13756,20 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     if (input.charCodeAt(peg$currPos) === 42) {
-      s2 = peg$c83;
+      s2 = peg$c82;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c83;
+        s2 = peg$c82;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -13934,11 +13801,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c83;
+        s2 = peg$c82;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13964,15 +13831,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c83;
+          s1 = peg$c82;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c485();
+          s1 = peg$c483();
         }
         s0 = s1;
       }
@@ -13986,12 +13853,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c424.test(input.charAt(peg$currPos))) {
+      if (peg$c422.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c423); }
       }
     }
 
@@ -14003,11 +13870,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c430;
+      s1 = peg$c428;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c431); }
+      if (peg$silentFails === 0) { peg$fail(peg$c429); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14016,7 +13883,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c232(s2);
+        s1 = peg$c18(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14043,30 +13910,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c486();
+      s1 = peg$c484();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c83;
+        s1 = peg$c82;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c487();
+        s1 = peg$c485();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c471.test(input.charAt(peg$currPos))) {
+        if (peg$c469.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c472); }
+          if (peg$silentFails === 0) { peg$fail(peg$c470); }
         }
       }
     }
@@ -14081,11 +13948,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c478;
+      s2 = peg$c476;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c479); }
+      if (peg$silentFails === 0) { peg$fail(peg$c477); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14103,11 +13970,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c478); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14120,17 +13987,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c430;
+        s1 = peg$c428;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c431); }
+        if (peg$silentFails === 0) { peg$fail(peg$c429); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c232(s2);
+          s1 = peg$c18(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14150,11 +14017,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c488;
+      s1 = peg$c486;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c489); }
+      if (peg$silentFails === 0) { peg$fail(peg$c487); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -14162,7 +14029,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c490();
+          s1 = peg$c488();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14190,116 +14057,116 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c478;
+      s0 = peg$c476;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c479); }
+      if (peg$silentFails === 0) { peg$fail(peg$c477); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c475;
+        s1 = peg$c473;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c476); }
+        if (peg$silentFails === 0) { peg$fail(peg$c474); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c69();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c430;
+          s0 = peg$c428;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+          if (peg$silentFails === 0) { peg$fail(peg$c429); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c491;
+            s1 = peg$c489;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c492); }
+            if (peg$silentFails === 0) { peg$fail(peg$c490); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c493();
+            s1 = peg$c491();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c494;
+              s1 = peg$c492;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c495); }
+              if (peg$silentFails === 0) { peg$fail(peg$c493); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c496();
+              s1 = peg$c494();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c497;
+                s1 = peg$c495;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c498); }
+                if (peg$silentFails === 0) { peg$fail(peg$c496); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c499();
+                s1 = peg$c497();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c500;
+                  s1 = peg$c498;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c501); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c499); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c502();
+                  s1 = peg$c500();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c503;
+                    s1 = peg$c501;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c504); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c502); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c505();
+                    s1 = peg$c503();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c506;
+                      s1 = peg$c504;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c507); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c505); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c508();
+                      s1 = peg$c506();
                     }
                     s0 = s1;
                   }
@@ -14327,30 +14194,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c486();
+      s1 = peg$c484();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c83;
+        s1 = peg$c82;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c509();
+        s1 = peg$c507();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c471.test(input.charAt(peg$currPos))) {
+        if (peg$c469.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c472); }
+          if (peg$silentFails === 0) { peg$fail(peg$c470); }
         }
       }
     }
@@ -14363,11 +14230,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c510;
+      s1 = peg$c508;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c511); }
+      if (peg$silentFails === 0) { peg$fail(peg$c509); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14399,7 +14266,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c512(s2);
+        s1 = peg$c510(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14412,19 +14279,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c510;
+        s1 = peg$c508;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c511); }
+        if (peg$silentFails === 0) { peg$fail(peg$c509); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c48;
+          s2 = peg$c47;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          if (peg$silentFails === 0) { peg$fail(peg$c48); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -14483,15 +14350,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c300;
+              s4 = peg$c298;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c512(s3);
+              s1 = peg$c510(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14519,21 +14386,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c271;
+      s1 = peg$c269;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c271;
+          s3 = peg$c269;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c272); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14548,7 +14415,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c209(s2);
+            s1 = peg$c208(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14575,39 +14442,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c513.test(input.charAt(peg$currPos))) {
+    if (peg$c511.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c512); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c515) {
-        s2 = peg$c515;
+      if (input.substr(peg$currPos, 2) === peg$c513) {
+        s2 = peg$c513;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c513.test(input.charAt(peg$currPos))) {
+        if (peg$c511.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c514); }
+          if (peg$silentFails === 0) { peg$fail(peg$c512); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c515) {
-            s2 = peg$c515;
+          if (input.substr(peg$currPos, 2) === peg$c513) {
+            s2 = peg$c513;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c516); }
+            if (peg$silentFails === 0) { peg$fail(peg$c514); }
           }
         }
       }
@@ -14616,7 +14483,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c69();
     }
     s0 = s1;
 
@@ -14626,12 +14493,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c517.test(input.charAt(peg$currPos))) {
+    if (peg$c515.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c518); }
+      if (peg$silentFails === 0) { peg$fail(peg$c516); }
     }
 
     return s0;
@@ -14689,7 +14556,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c478); }
     }
 
     return s0;
@@ -14700,51 +14567,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c520;
+      s0 = peg$c518;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c521); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c522;
+        s0 = peg$c520;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c523); }
+        if (peg$silentFails === 0) { peg$fail(peg$c521); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c524;
+          s0 = peg$c522;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c525); }
+          if (peg$silentFails === 0) { peg$fail(peg$c523); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c526;
+            s0 = peg$c524;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c527); }
+            if (peg$silentFails === 0) { peg$fail(peg$c525); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c528;
+              s0 = peg$c526;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c529); }
+              if (peg$silentFails === 0) { peg$fail(peg$c527); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c530;
+                s0 = peg$c528;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c531); }
+                if (peg$silentFails === 0) { peg$fail(peg$c529); }
               }
             }
           }
@@ -14754,7 +14621,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -14763,12 +14630,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c532.test(input.charAt(peg$currPos))) {
+    if (peg$c530.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c533); }
+      if (peg$silentFails === 0) { peg$fail(peg$c531); }
     }
 
     return s0;
@@ -14782,7 +14649,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c534); }
+      if (peg$silentFails === 0) { peg$fail(peg$c532); }
     }
 
     return s0;
@@ -14792,24 +14659,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c535) {
-      s1 = peg$c535;
+    if (input.substr(peg$currPos, 2) === peg$c533) {
+      s1 = peg$c533;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c536); }
+      if (peg$silentFails === 0) { peg$fail(peg$c534); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c537) {
-        s5 = peg$c537;
+      if (input.substr(peg$currPos, 2) === peg$c535) {
+        s5 = peg$c535;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c538); }
+        if (peg$silentFails === 0) { peg$fail(peg$c536); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -14836,12 +14703,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c537) {
-          s5 = peg$c537;
+        if (input.substr(peg$currPos, 2) === peg$c535) {
+          s5 = peg$c535;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c538); }
+          if (peg$silentFails === 0) { peg$fail(peg$c536); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -14865,12 +14732,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c537) {
-          s3 = peg$c537;
+        if (input.substr(peg$currPos, 2) === peg$c535) {
+          s3 = peg$c535;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c538); }
+          if (peg$silentFails === 0) { peg$fail(peg$c536); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -14895,12 +14762,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c539) {
-      s1 = peg$c539;
+    if (input.substr(peg$currPos, 2) === peg$c537) {
+      s1 = peg$c537;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c540); }
+      if (peg$silentFails === 0) { peg$fail(peg$c538); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15018,7 +14885,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c478); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -82,42 +82,21 @@ Sequential
 SequentialTail = __ Pipe __ p:Operation { RETURN(p) }
 
 Parallel
-  = "=>" __ first:Sequential __ ";" __ rest:Parallel+ {
-      RETURN(PREPEND(first, ASSERT_ARRAY(rest)[0]))
-    }
-  / "=>" __ first:Sequential __ ";" {
-      RETURN(ARRAY(first))
-    }
+  = __ "=>" __ s:Sequential __ ";" { RETURN(s) }
 
 SwitchBranch
-  =  DefaultToken __ "=>" __ proc:Sequential __ ";" {
-      RETURN(MAP("expr": MAP("kind": "Primitive", "type": "bool", "text": "true"), "proc": proc))
-    }
-  / e:SearchBoolean __ "=>" __ proc:Sequential __ ";" {
+  = __ e:SearchBoolean __ "=>" __ proc:Sequential __ ";" {
       RETURN(MAP("expr": e, "proc": proc))
     }
-
-Switch
-  = first:SwitchBranch __ rest:Switch+ {
-      RETURN(PREPEND(first, ASSERT_ARRAY(rest)[0]))
-    }
-  / first:SwitchBranch {
-      RETURN(ARRAY(first))
+  / __ DefaultToken __ "=>" __ proc:Sequential __ ";" {
+      RETURN(MAP("expr": MAP("kind": "Primitive", "type": "bool", "text": "true"), "proc": proc))
     }
 
 DefaultToken = "default"i
 
-FromTrunks
-  = first:FromTrunk __ rest:FromTrunks+ {
-      RETURN(PREPEND(first, ASSERT_ARRAY(rest)[0]))
-    }
-  / first:FromTrunk {
-      RETURN(ARRAY(first))
-    }
-
 FromTrunk
-  = source:FromSource seq:FromTrunkSeq __ ";" {
-      RETURN(MAP("kind": "Trunk", "source": source, "seq":seq ))
+  = __ source:FromSource  seq:FromTrunkSeq? __ ";" {
+      RETURN(MAP("kind": "Trunk", "source": source, "seq": seq))
     }
 
 FromTrunkSeq
@@ -131,13 +110,13 @@ FromSource
   / PoolBody
 
 Operation
-  = "split" __ "(" __ procArray:Parallel __ ")" {
+  = "split" __ "(" procArray:Parallel+ __ ")" {
       RETURN(MAP("kind": "Parallel", "procs": procArray))
     }
-  / "switch" __ "(" __ caseArray:Switch __ ")" {
+  / "switch" __ "(" caseArray:SwitchBranch+ __ ")" {
       RETURN(MAP("kind": "Switch", "cases": caseArray))
     }
-  / "from" __ "(" __ trunks:FromTrunks __ ")" {
+  / "from" __ "(" trunks:FromTrunk+ __ ")" {
       RETURN(MAP("kind": "From", "trunks": trunks))
     }
   / Operator

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -82,54 +82,47 @@ Sequential
 SequentialTail = __ Pipe __ p:Operation { RETURN(p) }
 
 Parallel
-  = first:Sequential rest:ParallelTail+ {
-      RETURN(PREPEND(first, rest))
+  = "=>" __ first:Sequential __ ";" __ rest:Parallel+ {
+      RETURN(PREPEND(first, ASSERT_ARRAY(rest)[0]))
     }
-  / first:Sequential {
+  / "=>" __ first:Sequential __ ";" {
       RETURN(ARRAY(first))
     }
 
-ParallelTail
-  = __ "=>" __ ch:Sequential { RETURN(ch) }
-
 SwitchBranch
-  = __ CaseToken _ e:SearchBoolean __ "=>" __ proc:Sequential {
-      RETURN(MAP("expr": e, "proc": proc))
-    }
-  / __ DefaultToken __ "=>" __ proc:Sequential {
+  =  DefaultToken __ "=>" __ proc:Sequential __ ";" {
       RETURN(MAP("expr": MAP("kind": "Primitive", "type": "bool", "text": "true"), "proc": proc))
+    }
+  / e:SearchBoolean __ "=>" __ proc:Sequential __ ";" {
+      RETURN(MAP("expr": e, "proc": proc))
     }
 
 Switch
-  = first:SwitchBranch rest:SwitchBranch+ {
-      RETURN(PREPEND(first, rest))
+  = first:SwitchBranch __ rest:Switch+ {
+      RETURN(PREPEND(first, ASSERT_ARRAY(rest)[0]))
     }
   / first:SwitchBranch {
       RETURN(ARRAY(first))
     }
 
-CaseToken = "case"i
 DefaultToken = "default"i
 
 FromTrunks
-  = first:FromTrunk rest:FromTrunkTail+ {
-      RETURN(PREPEND(first, rest))
+  = first:FromTrunk __ rest:FromTrunks+ {
+      RETURN(PREPEND(first, ASSERT_ARRAY(rest)[0]))
     }
   / first:FromTrunk {
       RETURN(ARRAY(first))
     }
 
 FromTrunk
-  = source:FromSource seq:FromTrunkSeq {
+  = source:FromSource seq:FromTrunkSeq __ ";" {
       RETURN(MAP("kind": "Trunk", "source": source, "seq":seq ))
     }
 
 FromTrunkSeq
   = __ "=>" __ seq:Sequential { RETURN(seq) }
   / "" { RETURN(NULL)}
-
-FromTrunkTail
-  = (__ ";" __ ) trunk:FromTrunk { RETURN(trunk) }
 
 FromSource
   = FileProc
@@ -138,13 +131,13 @@ FromSource
   / PoolBody
 
 Operation
-  = "split" __ "(" __ "=>" __ procArray:Parallel __ ")" {
+  = "split" __ "(" __ procArray:Parallel __ ")" {
       RETURN(MAP("kind": "Parallel", "procs": procArray))
     }
   / "switch" __ "(" __ caseArray:Switch __ ")" {
       RETURN(MAP("kind": "Switch", "cases": caseArray))
     }
-  / "from" __ "(" __ trunks:FromTrunks __ ";"? __ ")" {
+  / "from" __ "(" __ trunks:FromTrunks __ ")" {
       RETURN(MAP("kind": "From", "trunks": trunks))
     }
   / Operator
@@ -154,7 +147,7 @@ Operation
       RETURN(MAP("kind": "Filter", "expr": expr))
     }
 
-EndOfOp = __ (Pipe / "=>" / ")" / EOF)
+EndOfOp = __ (Pipe / "=>" / [);] / EOF)
 Pipe = "|" !("{" / "[")
 
 ExprGuard = __ ((!"=>" Comparator) / AdditiveOperator / MultiplicativeOperator / ":" / "(" / "[" / "matches")
@@ -244,7 +237,6 @@ SearchGuard
   / NotToken
   / InToken
   / ByToken
-  / CaseToken
   / DefaultToken
   / "type("
   / "matches"i
@@ -528,7 +520,7 @@ URL = ("http:" / "https:") Path { RETURN(TEXT) }
 
 Path
   = v:QuotedString { RETURN(v) }
-  / [0-9a-zA-Z!@$%^&*()_=<>,./?;:[\]{}~|+-]+ &EOT { RETURN(TEXT) }
+  / [0-9a-zA-Z!@$%^&*()_=<>,./?:[\]{}~|+-]+ { RETURN(TEXT) }
 
 PoolAt
   = _ "at"i _ id:KSUID { RETURN(id) }

--- a/compiler/parser/valid.zed
+++ b/compiler/parser/valid.zed
@@ -7,9 +7,11 @@ foo | count()
 _path=='conn'
 _path=='conn' id.resp_p==80
 * | count(), sum(foo)
-* | split (=>count() by _path =>count() by addr)
+* | split (=>count() by _path; =>count() by addr;)
+* | switch (foo => count() by _path; field==1 => count() by addr;)
 * | count() by _path | count() by addr
-* | split (=>count() by _path =>sort) | split (=>count() by addr)
+* | split (=>count() by _path; =>sort;) | split (=>count() by addr;)
+* | switch (foo => count() by _path; field==1 => sort;) | switch (* =>count() by addr;)
 * | sort -r
 * | sort -r a, b, c
 * | sort -r a, b, c

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -496,8 +496,8 @@ The Zed script `inner-join-streamed.zed`:
 
 ```mdtest-input inner-join-streamed.zed
 switch (
-  case has(color) => sort flavor
-  case has(age) => sort likes
+  has(color) => sort flavor;
+  has(age) => sort likes;
 ) | inner join on flavor=likes eater:=name
 ```
 

--- a/expr/ztests/type-map.yaml
+++ b/expr/ztests/type-map.yaml
@@ -6,8 +6,8 @@ zed: |
     "dns": dns
   }|
   split (
-    => cut schema:=schemas[_path]
-    => missing(schemas[_path]) | put _UNCLASSIFIED:=true
+    => cut schema:=schemas[_path];
+    => missing(schemas[_path]) | put _UNCLASSIFIED:=true;
   ) | sort .
 
 input: |

--- a/proc/switcher/ztests/switch-default.yaml
+++ b/proc/switcher/ztests/switch-default.yaml
@@ -1,9 +1,9 @@
 zed: |
   switch (
-     case a == 2 => put v:='two'
-     case a == 1 => put v:='one'
-     case a == 3 => filter null
-     default => count() | put a:=-1
+     a == 2 => put v:='two';
+     a == 1 => put v:='one';
+     a == 3 => filter null;
+     default => count() | put a:=-1;
      ) | sort a
 
 input: |

--- a/proc/switcher/ztests/switch.yaml
+++ b/proc/switcher/ztests/switch.yaml
@@ -1,9 +1,9 @@
 zed: |
   switch (
-     case a == 2 => put v:='two'
-     case a == 1 => put v:='one'
-     case a == 3 => filter null
-     case * => count() | put a:=-1
+     a == 2 => put v:='two';
+     a == 1 => put v:='one';
+     a == 3 => filter null;
+     * => count() | put a:=-1;
      ) | sort a
 
 input: |

--- a/proc/ztests/rename-share.yaml
+++ b/proc/ztests/rename-share.yaml
@@ -1,5 +1,5 @@
 # tests that a rename isn't visible to other procs operating on same records.
-zed: '* | split (=>rename id2:=id =>cut id.orig_h) | sort id'
+zed: '* | split (=>rename id2:=id; =>cut id.orig_h;) | sort id'
 
 input: |
   {id:{orig_h:39681 (port=(uint16)),resp_h:3389 (port)} (=0)} (=1)

--- a/zfmt/ztests/parallel.yaml
+++ b/zfmt/ztests/parallel.yaml
@@ -1,5 +1,5 @@
 script: |
-  zed compile -s -C 'file bar | foo | split (=> count() by x:=this["@foo"] => sum(x) => put a:=b*c ) | cut cake | sort -r x'
+  zed compile -s -C 'file bar | foo | split (=> count() by x:=this["@foo"]; => sum(x); => put a:=b*c;) | cut cake | sort -r x'
 
 outputs:
   - name: stdout


### PR DESCRIPTION
The from, split, and switch operations have different rules governing
how their clauses are delimited.  Unify their syntax by dropping
switch's case keyword and requiring semicolon termination of clauses for
all three.

This covers most of #2849 but does not add its proposed `switch _path ( "conn" => ...; "dns" => ...; default => ...)` syntax.