### PR TITLE
Compare Funcs: try coerce when types are not equal

### DIFF
--- a/expr/coerce/coerce.go
+++ b/expr/coerce/coerce.go
@@ -50,6 +50,12 @@ func (c *Pair) Equal() bool {
 func (c *Pair) Coerce(a, b zng.Value) (int, error) {
 	c.A = a.Bytes
 	c.B = b.Bytes
+	if a.Type == nil {
+		a.Type = zng.TypeNull
+	}
+	if b.Type == nil {
+		b.Type = zng.TypeNull
+	}
 	aid := a.Type.ID()
 	bid := b.Type.ID()
 	if aid == bid {

--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -129,7 +129,7 @@ func (p *Proc) setJoinKey(key zng.Value) {
 }
 
 func (p *Proc) getJoinSet(leftKey zng.Value) ([]*zng.Record, error) {
-	if leftKey.Equal(p.joinKey) {
+	if p.compare(leftKey, p.joinKey) == 0 {
 		return p.joinSet, nil
 	}
 	for {
@@ -145,12 +145,13 @@ func (p *Proc) getJoinSet(leftKey zng.Value) ([]*zng.Record, error) {
 			}
 			return nil, err
 		}
-		if leftKey.Equal(rightKey) {
+		cmp := p.compare(leftKey, rightKey)
+		if cmp == 0 {
 			p.setJoinKey(leftKey)
 			p.joinSet, err = p.readJoinSet(p.joinKey)
 			return p.joinSet, err
 		}
-		if p.compare(leftKey, rightKey) < 0 {
+		if cmp < 0 {
 			// If the left key is smaller than the next eligible
 			// join key, then there is nothing to join for this
 			// record.
@@ -184,7 +185,7 @@ func (p *Proc) readJoinSet(joinKey zng.Value) ([]*zng.Record, error) {
 			}
 			return nil, err
 		}
-		if !key.Equal(joinKey) {
+		if p.compare(key, joinKey) != 0 {
 			return recs, nil
 		}
 		recs = append(recs, rec.Keep())

--- a/proc/join/ztests/comparable-types.yaml
+++ b/proc/join/ztests/comparable-types.yaml
@@ -1,0 +1,21 @@
+script: zq -z -I test.zed -o results.zson 
+
+inputs:
+  - name: test.zed
+    data: |
+      from (
+        file a.zson;
+        file b.zson;
+      ) | left join on a=b vb:=vb
+  - name: a.zson
+    data: |
+      {a:"hello",va:"value a"}
+  - name: b.zson
+    data: |
+      {b:"hello" (bstring),vb:"value b"}
+
+outputs:
+  - name: results.zson 
+    data: |
+      {a:"hello",va:"value a",vb:"value b"}
+

--- a/proc/join/ztests/comparable-types.yaml
+++ b/proc/join/ztests/comparable-types.yaml
@@ -1,4 +1,4 @@
-script: zq -z -I test.zed -o results.zson 
+script: zq -z -I test.zed
 
 inputs:
   - name: test.zed

--- a/proc/join/ztests/comparable-types.yaml
+++ b/proc/join/ztests/comparable-types.yaml
@@ -15,7 +15,6 @@ inputs:
       {b:"hello" (bstring),vb:"value b"}
 
 outputs:
-  - name: results.zson 
+  - name: stdout
     data: |
       {a:"hello",va:"value a",vb:"value b"}
-

--- a/proc/switcher/ztests/switch.yaml
+++ b/proc/switcher/ztests/switch.yaml
@@ -13,6 +13,6 @@ input: |
   {a:4,s:"c"} (0)
 
 output: |
-  {a:1 (int32),s:"a",v:"one"} (=0)
-  {a:2,s:"B",v:"two"} (0)
-  {count:1 (uint64),a:-1} (=1)
+  {count:1 (uint64),a:-1} (=0)
+  {a:1 (int32),s:"a",v:"one"} (=1)
+  {a:2,s:"B",v:"two"} (1)


### PR DESCRIPTION
The allows users to join on comparable types (e.g. bstring and strings)
but also improves sort operations.

Closes #2779