### PR TITLE
expr: allow shaper to cast to union

### DIFF
--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -231,12 +231,14 @@ func castType(zctx *zson.Context, inType, specType zng.Type) (zng.Type, error) {
 			return zctx.LookupTypeArray(out), nil
 		}
 		return zctx.LookupTypeSet(out), nil
-	default:
-		// Non-castable type pair with at least one
-		// (non-record) container: output column is left
-		// unchanged.
-		return inType, nil
 	}
+	if bestUnionSelector(inType, specType) > -1 {
+		return specType, nil
+	}
+	// Non-castable type pair with at least one
+	// (non-record) container: output column is left
+	// unchanged.
+	return inType, nil
 }
 
 func isCollectionType(t zng.Type) bool {
@@ -245,6 +247,38 @@ func isCollectionType(t zng.Type) bool {
 		return true
 	}
 	return false
+}
+
+// bestUnionSelector tries to return the most specific union selector for in
+// within spec.  It returns -1 if spec is not a union or contains no type
+// compatible with in.  (Types are compatible if they have the same underlying
+// type.)  If spec contains in, bestUnionSelector returns its selector.
+// Otherwise, if spec contains in's underlying type, bestUnionSelector returns
+// its selector.  Finally, bestUnionSelector returns the smallest selector in
+// spec whose type is compatible with in.
+func bestUnionSelector(in, spec zng.Type) int {
+	specUnion, ok := zng.AliasOf(spec).(*zng.TypeUnion)
+	if !ok {
+		return -1
+	}
+	aliasOfIn := zng.AliasOf(in)
+	underlying := -1
+	compatible := -1
+	for i, t := range specUnion.Types {
+		if t == in {
+			return i
+		}
+		if t == aliasOfIn && underlying == -1 {
+			underlying = i
+		}
+		if zng.AliasOf(t) == aliasOfIn && compatible == -1 {
+			compatible = i
+		}
+	}
+	if underlying != -1 {
+		return underlying
+	}
+	return compatible
 }
 
 // cropRecordType applies a crop (as specified by the record type 'spec')
@@ -425,6 +459,7 @@ const (
 	copyPrimitive op = iota // copy field fromIndex from input record
 	copyContainer
 	castPrimitive // cast field fromIndex from fromType to toType
+	castUnion     // cast field fromIndex from fromType to union with selector toSelector
 	null          // write null
 	array         // build array
 	set           // build set
@@ -434,10 +469,11 @@ const (
 // A step is a recursive data structure encoding a series of
 // copy/cast steps to be carried out over an input record.
 type step struct {
-	op        op
-	fromIndex int
-	fromType  zng.Type // for castPrimitive
-	toType    zng.Type // for castPrimitive
+	op         op
+	fromIndex  int
+	fromType   zng.Type // for castPrimitive and castUnion
+	toSelector int      // for castUnion
+	toType     zng.Type // for castPrimitive
 	// if op == record, contains one op for each column.
 	// if op == array, contains one op for all array elements.
 	children []step
@@ -490,10 +526,11 @@ func createStep(in, out zng.Type) (step, error) {
 		if _, ok := out.(*zng.TypeSet); ok {
 			return createStepSet(zng.InnerType(in), zng.InnerType(out))
 		}
-		fallthrough
-	default:
-		return step{}, fmt.Errorf("createStep incompatible column types %s and %s\n", in, out)
 	}
+	if s := bestUnionSelector(in, out); s != -1 {
+		return step{op: castUnion, fromType: in, toSelector: s}, nil
+	}
+	return step{}, fmt.Errorf("createStep: incompatible types %s and %s", in, out)
 }
 
 func createStepArray(in, out zng.Type) (step, error) {
@@ -554,6 +591,8 @@ func (s *step) build(in zcode.Bytes, b *zcode.Builder) *zng.Value {
 		if zerr := s.castPrimitive(in, b); zerr != nil {
 			return zerr
 		}
+	case castUnion:
+		zng.BuildUnion(b, s.toSelector, in, zng.IsContainerType(s.fromType))
 	case record:
 		if in == nil {
 			b.AppendNull()

--- a/expr/shaper_test.go
+++ b/expr/shaper_test.go
@@ -1,0 +1,51 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/brimdata/zed/zng"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBestUnionSelector(t *testing.T) {
+	u8 := zng.TypeUint8
+	zctx := zng.NewContext()
+	u8alias1, err := zctx.LookupTypeAlias("u8alias1", u8)
+	require.NoError(t, err)
+	u8alias2, err := zctx.LookupTypeAlias("u8alias2", u8)
+	require.NoError(t, err)
+	u8alias3, err := zctx.LookupTypeAlias("u8alias3", u8)
+	require.NoError(t, err)
+
+	assert.Equal(t, -1, bestUnionSelector(u8, nil))
+	assert.Equal(t, -1, bestUnionSelector(u8, u8))
+	assert.Equal(t, -1, bestUnionSelector(zng.TypeUint16, zctx.LookupTypeUnion([]zng.Type{u8})))
+
+	test := func(expected, needle zng.Type, haystack []zng.Type) {
+		t.Helper()
+		union := zctx.LookupTypeUnion(haystack)
+		typ, err := union.TypeIndex(bestUnionSelector(needle, union))
+		if assert.NoError(t, err) {
+			assert.Equal(t, expected, typ)
+		}
+
+	}
+
+	// Needle is in haystack.
+	test(u8, u8, []zng.Type{u8, u8alias1, u8alias2})
+	test(u8, u8, []zng.Type{u8alias2, u8alias1, u8})
+	test(u8, u8, []zng.Type{u8alias1, u8, u8alias2})
+	test(u8alias2, u8alias2, []zng.Type{u8, u8alias1, u8alias2})
+	test(u8alias2, u8alias2, []zng.Type{u8alias2, u8alias1, u8})
+	test(u8alias2, u8alias2, []zng.Type{u8, u8alias2, u8alias1})
+
+	// Underlying type of needle is in haystack.
+	test(u8, u8alias1, []zng.Type{u8, u8alias2, u8alias3})
+	test(u8, u8alias1, []zng.Type{u8alias3, u8alias2, u8})
+	test(u8, u8alias1, []zng.Type{u8alias2, u8, u8alias3})
+
+	// Type compatible with needle is in haystack.
+	test(u8alias1, u8, []zng.Type{u8alias1, u8alias2, u8alias3})
+	test(u8alias3, u8alias1, []zng.Type{u8alias3, u8alias2})
+}

--- a/expr/ztests/shape-cast-union.yaml
+++ b/expr/ztests/shape-cast-union.yaml
@@ -1,0 +1,20 @@
+zed: |
+  type string_alias=string
+  type union=(int64,string,string_alias)
+  put this:=cast({a:union})
+
+input: |
+  {a: null}
+  {a: null (int64)}
+  {a: null (string)}
+  {a: 1}
+  {a: "hello"}
+  {a: "goodbye" (=string_alias)} (=0)
+
+output: |
+  {a:null (union=(0=((int64,string,string_alias=(string)))))} (=1)
+  {a:null} (1)
+  {a:null} (1)
+  {a:1} (1)
+  {a:"hello"} (1)
+  {a:"goodbye" (string_alias)} (1)

--- a/zng/union.go
+++ b/zng/union.go
@@ -80,3 +80,19 @@ func (t *TypeUnion) Format(zv zcode.Bytes) string {
 	}
 	return fmt.Sprintf("%s (%s) %s", typ.Format(iv), typ, t)
 }
+
+// BuildUnion appends to b a union described by selector, val, and container.
+func BuildUnion(b *zcode.Builder, selector int, val zcode.Bytes, container bool) {
+	if val == nil {
+		b.AppendNull()
+		return
+	}
+	b.BeginContainer()
+	b.AppendPrimitive(EncodeInt(int64(selector)))
+	if container {
+		b.AppendContainer(val)
+	} else {
+		b.AppendPrimitive(val)
+	}
+	b.EndContainer()
+}


### PR DESCRIPTION
A shaper can now cast a value to a union type provided the value's
underlying type is the underlying type of one of the union's types.