### PR TITLE
replace fuse operator field renaming with union

### DIFF
--- a/expr/agg/fuse.go
+++ b/expr/agg/fuse.go
@@ -37,8 +37,6 @@ func (f *fuse) Result(zctx *zson.Context) (zng.Value, error) {
 	if err != nil {
 		return zng.Value{}, err
 	}
-	schema.unify = true
-
 	for _, p := range f.partials {
 		typ, err := zctx.LookupByValue(p.Bytes)
 		if err != nil {

--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -206,7 +206,7 @@ func castRecordType(zctx *zson.Context, input, spec *zng.TypeRecord) (*zng.TypeR
 
 func castType(zctx *zson.Context, inType, specType zng.Type) (zng.Type, error) {
 	if _, ok := specType.(*zng.TypeMap); ok {
-		return nil, fmt.Errorf("cannot yet use maps in shaping functions")
+		return nil, fmt.Errorf("cannot yet use maps in shaping functions (issue #2894)")
 	}
 	switch {
 	case inType.ID() == zng.IDNull:

--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -92,7 +92,10 @@ func (s *ConstShaper) Apply(in *zng.Record) (*zng.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	return zng.NewRecord(v.Type.(*zng.TypeRecord), v.Bytes), nil
+	if !zng.IsRecordType(v.Type) {
+		return nil, fmt.Errorf("shaper returned non-record value %s", zson.String(v))
+	}
+	return zng.NewRecord(v.Type, v.Bytes), nil
 }
 
 func (c *ConstShaper) Eval(in *zng.Record) (zng.Value, error) {
@@ -100,10 +103,7 @@ func (c *ConstShaper) Eval(in *zng.Record) (zng.Value, error) {
 	if err != nil {
 		return zng.Value{}, err
 	}
-	inType, ok := inVal.Type.(*zng.TypeRecord)
-	if !ok {
-		return inVal, nil
-	}
+	inType := zng.AliasOf(inVal.Type).(*zng.TypeRecord)
 	id := in.Type.ID()
 	s, ok := c.shapers[id]
 	if !ok {
@@ -190,9 +190,6 @@ func castRecordType(zctx *zson.Context, input, spec *zng.TypeRecord) (*zng.TypeR
 			continue
 		}
 		specCol := spec.Columns[ind]
-		if _, ok := specCol.Type.(*zng.TypeMap); ok {
-			return nil, fmt.Errorf("cannot yet use maps in shaping functions")
-		}
 		if inCol.Type.ID() == specCol.Type.ID() {
 			// Field has same type in cast: output type unmodified.
 			cols = append(cols, specCol)
@@ -208,6 +205,9 @@ func castRecordType(zctx *zson.Context, input, spec *zng.TypeRecord) (*zng.TypeR
 }
 
 func castType(zctx *zson.Context, inType, specType zng.Type) (zng.Type, error) {
+	if _, ok := specType.(*zng.TypeMap); ok {
+		return nil, fmt.Errorf("cannot yet use maps in shaping functions")
+	}
 	switch {
 	case inType.ID() == zng.IDNull:
 		return specType, nil

--- a/proc/fuse/fuser.go
+++ b/proc/fuse/fuser.go
@@ -3,7 +3,6 @@ package fuse
 import (
 	"github.com/brimdata/zed/expr"
 	"github.com/brimdata/zed/expr/agg"
-	"github.com/brimdata/zed/proc/rename"
 	"github.com/brimdata/zed/proc/spill"
 	"github.com/brimdata/zed/zng"
 	"github.com/brimdata/zed/zson"
@@ -19,21 +18,25 @@ type Fuser struct {
 	nbytes  int
 	recs    []*zng.Record
 	spiller *spill.File
-	types   map[zng.Type]int
 
-	shaper   *expr.ConstShaper
-	renamers map[int]*rename.Function
+	types      map[zng.Type]struct{}
+	uberSchema *agg.Schema
+	shaper     *expr.ConstShaper
 }
 
 // NewFuser returns a new Fuser.  The Fuser buffers records in memory until
 // their cumulative size (measured in zcode.Bytes length) exceeds memMaxBytes,
 // at which point it buffers them in a temporary file.
 func NewFuser(zctx *zson.Context, memMaxBytes int) *Fuser {
+	s, err := agg.NewSchema(zctx)
+	if err != nil {
+		panic(err)
+	}
 	return &Fuser{
 		zctx:        zctx,
 		memMaxBytes: memMaxBytes,
-		types:       make(map[zng.Type]int),
-		renamers:    make(map[int]*rename.Function),
+		types:       make(map[zng.Type]struct{}),
+		uberSchema:  s,
 	}
 }
 
@@ -47,11 +50,14 @@ func (f *Fuser) Close() error {
 
 // Write buffers rec. If called after Read, Write panics.
 func (f *Fuser) Write(rec *zng.Record) error {
-	if f.finished() {
+	if f.shaper != nil {
 		panic("fuser: write after read")
 	}
 	if _, ok := f.types[rec.Type]; !ok {
-		f.types[rec.Type] = len(f.types)
+		f.types[rec.Type] = struct{}{}
+		if err := f.uberSchema.Mixin(zng.TypeRecordOf(rec.Type)); err != nil {
+			return err
+		}
 	}
 	if f.spiller != nil {
 		return f.spiller.Write(rec)
@@ -80,65 +86,21 @@ func (f *Fuser) stash(rec *zng.Record) error {
 	return nil
 }
 
-func (f *Fuser) finished() bool {
-	return f.shaper != nil
-}
-
-func (f *Fuser) finish() error {
-	uber, err := agg.NewSchema(f.zctx)
-	if err != nil {
-		return err
-	}
-	for _, typ := range typesInOrder(f.types) {
-		if typ != nil {
-			if err = uber.Mixin(zng.AliasOf(typ).(*zng.TypeRecord)); err != nil {
-				return err
-			}
-		}
-	}
-
-	f.shaper = expr.NewConstShaper(f.zctx, &expr.RootRecord{}, uber.Type, expr.Fill|expr.Order)
-	for typ, renames := range uber.Renames {
-		f.renamers[typ] = rename.NewFunction(f.zctx, renames.Srcs, renames.Dsts)
-	}
-
-	if f.spiller != nil {
-		return f.spiller.Rewind(f.zctx)
-	}
-	return nil
-}
-
-func typesInOrder(in map[zng.Type]int) []zng.Type {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]zng.Type, len(in))
-	for typ, position := range in {
-		out[position] = typ
-	}
-	return out
-}
-
 // Read returns the next buffered record after transforming it to the unified
 // schema.
 func (f *Fuser) Read() (*zng.Record, error) {
-	if !f.finished() {
-		if err := f.finish(); err != nil {
-			return nil, err
+	if f.shaper == nil {
+		f.shaper = expr.NewConstShaper(f.zctx, &expr.RootRecord{}, f.uberSchema.Type, expr.Cast|expr.Fill|expr.Order)
+		if f.spiller != nil {
+			if err := f.spiller.Rewind(f.zctx); err != nil {
+				return nil, err
+			}
 		}
 	}
 	rec, err := f.next()
 	if rec == nil || err != nil {
 		return nil, err
 	}
-
-	if renamer, ok := f.renamers[rec.Type.ID()]; ok {
-		rec, err = renamer.Apply(rec)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return f.shaper.Apply(rec)
 }
 

--- a/proc/fuse/ztests/dup.yaml
+++ b/proc/fuse/ztests/dup.yaml
@@ -5,5 +5,5 @@ input: |
   {a:"goodnight",b:123 (int32)} (=0)
 
 output: |
-  {a:"hello",b:"world",b_2:null (int32)} (=0)
-  {a:"goodnight",b:null,b_2:123} (0)
+  {a:"hello",b:"world" (0=((string,int32)))} (=1)
+  {a:"goodnight",b:123 (int32)} (1)

--- a/zio/parquetio/writer.go
+++ b/zio/parquetio/writer.go
@@ -1,9 +1,9 @@
 package parquetio
 
 import (
+	"errors"
 	"io"
 
-	"github.com/brimdata/zed/zio/csvio"
 	"github.com/brimdata/zed/zng"
 	goparquet "github.com/fraugster/parquet-go"
 )
@@ -31,17 +31,19 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) Write(rec *zng.Record) error {
+	recType := zng.AliasOf(rec.Type).(*zng.TypeRecord)
 	if w.typ == nil {
-		w.typ = zng.TypeRecordOf(rec.Type)
-		sd, err := newSchemaDefinition(w.typ)
+		w.typ = recType
+		sd, err := newSchemaDefinition(recType)
 		if err != nil {
 			return err
 		}
 		w.fw = goparquet.NewFileWriter(w.w, goparquet.WithSchemaDefinition(sd))
-	} else if w.typ != rec.Type {
-		return csvio.ErrNotDataFrame
+	} else if w.typ != recType {
+		return errors.New(
+			"Parquet output requires uniform records but multiple types encountered (consider 'fuse')")
 	}
-	data, err := newRecordData(zng.TypeRecordOf(rec.Type), rec.Bytes)
+	data, err := newRecordData(recType, rec.Bytes)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When records have a field with the same name but different types, the
fuse operator renames all but one uniquely by appending a suffix.
Remove this behavior and combine the different types in a union instead.

Closes #2855.

Part of #2852.

Depends on #2881.

