### PR TITLE
replace references to union index with selector

### DIFF
--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -479,14 +479,14 @@ tend to be zero-filled for small integers.
 The body of a length-N container comprises zero or more tag-encoded values,
 where the values are encoded as follows:
 
-| Type     |          Value                            |
-|----------|-------------------------------------------|
-| `array`  | concatenation of elements                 |
-| `set`    | normalized concatenation of elements      |
-| `record` | concatenation of elements                 |
-| `union`  | concatenation of type position and value  |
-| `enum`   | position of enum element                  |
-| `map`    | concatenation of key and value elements   |
+| Type     |          Value                          |
+|----------|-----------------------------------------|
+| `array`  | concatenation of elements               |
+| `set`    | normalized concatenation of elements    |
+| `record` | concatenation of elements               |
+| `union`  | concatenation of selector and value     |
+| `enum`   | position of enum element                |
+| `map`    | concatenation of key and value elements |
 
 Since N, the byte length of any of these container values, is known,
 there is no need to encode a count of the
@@ -498,9 +498,10 @@ sequence of bytes encoding each element's tag-counted value is
 lexicographically greater than that of the preceding element.
 
 A union value is encoded as a container with two elements. The first
-element is the `uvarint` encoding of the positional index determining
-the type of the value in reference to the union's list of defined types,
-and the second element is the value encoded according to that type.
+element, called the selector, is the `uvarint` encoding of the
+positional index determining the type of the value in reference to the
+union's list of defined types, and the second element is the value
+encoded according to that type.
 
 An enumeration value is represented as the `uvarint` encoding of the
 positional index of that value's symbol in reference to the enum's

--- a/expr/shaper_test.go
+++ b/expr/shaper_test.go
@@ -25,7 +25,7 @@ func TestBestUnionSelector(t *testing.T) {
 	test := func(expected, needle zng.Type, haystack []zng.Type) {
 		t.Helper()
 		union := zctx.LookupTypeUnion(haystack)
-		typ, err := union.TypeIndex(bestUnionSelector(needle, union))
+		typ, err := union.Type(bestUnionSelector(needle, union))
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, typ)
 		}

--- a/zio/tzngio/parser.go
+++ b/zio/tzngio/parser.go
@@ -177,15 +177,15 @@ func parseUnion(u *zng.TypeUnion, in []byte) (zng.Type, int, []byte, error) {
 	if c < 0 {
 		return nil, -1, nil, ErrBadValue
 	}
-	index, err := strconv.Atoi(string(in[0:c]))
+	selector, err := strconv.Atoi(string(in[0:c]))
 	if err != nil {
 		return nil, -1, nil, err
 	}
-	typ, err := u.TypeIndex(index)
+	typ, err := u.Type(selector)
 	if err != nil {
 		return nil, -1, nil, err
 	}
-	return typ, index, in[c+1:], nil
+	return typ, selector, in[c+1:], nil
 }
 
 func ParseContainer(typ zng.Type, in []byte) (zcode.Bytes, error) {

--- a/zio/tzngio/stringof.go
+++ b/zio/tzngio/stringof.go
@@ -362,12 +362,12 @@ func StringOfTime(t *zng.TypeOfTime, zv zcode.Bytes, _ OutFmt, _ bool) string {
 }
 
 func StringOfUnion(t *zng.TypeUnion, zv zcode.Bytes, ofmt OutFmt, _ bool) string {
-	typ, index, iv, err := t.SplitZng(zv)
+	typ, selector, iv, err := t.SplitZng(zv)
 	if err != nil {
 		// this follows set and record StringOfs. Like there, XXX.
 		return "ERR"
 	}
 
-	s := strconv.FormatInt(index, 10) + ":"
+	s := strconv.FormatInt(selector, 10) + ":"
 	return s + StringOf(zng.Value{typ, iv}, ofmt, false)
 }

--- a/zio/tzngio/writer.go
+++ b/zio/tzngio/writer.go
@@ -122,11 +122,11 @@ func (w *Writer) write(s string) error {
 
 func (w *Writer) writeUnion(parent zng.Value) error {
 	utyp := zng.AliasOf(parent.Type).(*zng.TypeUnion)
-	inner, index, v, err := utyp.SplitZng(parent.Bytes)
+	inner, selector, v, err := utyp.SplitZng(parent.Bytes)
 	if err != nil {
 		return err
 	}
-	s := strconv.FormatInt(index, 10) + ":"
+	s := strconv.FormatInt(selector, 10) + ":"
 	if err := w.write(s); err != nil {
 		return err
 	}

--- a/zio/zjsonio/values.go
+++ b/zio/zjsonio/values.go
@@ -16,7 +16,7 @@ func encodeUnion(zctx *zson.Context, union *zng.TypeUnion, bytes zcode.Bytes) (i
 	if bytes == nil {
 		return nil, nil
 	}
-	inner, index, b, err := union.SplitZng(bytes)
+	inner, selector, b, err := union.SplitZng(bytes)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +24,7 @@ func encodeUnion(zctx *zson.Context, union *zng.TypeUnion, bytes zcode.Bytes) (i
 	if err != nil {
 		return nil, err
 	}
-	return []interface{}{strconv.Itoa(int(index)), val}, nil
+	return []interface{}{strconv.Itoa(int(selector)), val}, nil
 }
 
 func encodeMap(zctx *zson.Context, typ *zng.TypeMap, v zcode.Bytes) (interface{}, error) {
@@ -225,20 +225,20 @@ func decodeUnion(builder *zcode.Builder, typ *zng.TypeUnion, body interface{}) e
 	if len(tuple) != 2 {
 		return errors.New("ZJSON union value not an array of two elements")
 	}
-	istr, ok := tuple[0].(string)
+	selectorStr, ok := tuple[0].(string)
 	if !ok {
-		return errors.New("bad type index for ZJSON union value ")
+		return errors.New("bad selector for ZJSON union value")
 	}
-	index, err := strconv.Atoi(istr)
+	selector, err := strconv.Atoi(selectorStr)
 	if err != nil {
-		return fmt.Errorf("bad type index for ZJSON union value: %w", err)
+		return fmt.Errorf("bad selector for ZJSON union value: %w", err)
 	}
-	inner, err := typ.TypeIndex(index)
+	inner, err := typ.Type(selector)
 	if err != nil {
-		return fmt.Errorf("bad type index for ZJSON union value: %w", err)
+		return fmt.Errorf("bad selector for ZJSON union value: %w", err)
 	}
 	builder.BeginContainer()
-	builder.AppendPrimitive(zng.EncodeInt(int64(index)))
+	builder.AppendPrimitive(zng.EncodeInt(int64(selector)))
 	if err := decodeValue(builder, inner, tuple[1]); err != nil {
 		return err
 	}

--- a/zng/type.go
+++ b/zng/type.go
@@ -17,11 +17,11 @@ import (
 )
 
 var (
-	ErrLenUnset   = errors.New("len(unset) is undefined")
-	ErrNotArray   = errors.New("cannot index a non-array")
-	ErrIndex      = errors.New("array index out of bounds")
-	ErrUnionIndex = errors.New("union index out of bounds")
-	ErrEnumIndex  = errors.New("enum index out of bounds")
+	ErrLenUnset      = errors.New("len(unset) is undefined")
+	ErrNotArray      = errors.New("cannot index a non-array")
+	ErrIndex         = errors.New("array index out of bounds")
+	ErrUnionSelector = errors.New("union selector out of bounds")
+	ErrEnumIndex     = errors.New("enum index out of bounds")
 )
 
 // A Type is an interface presented by a zeek type.

--- a/zng/union.go
+++ b/zng/union.go
@@ -20,16 +20,16 @@ func (t *TypeUnion) ID() int {
 	return t.id
 }
 
-func (t *TypeUnion) TypeIndex(index int) (Type, error) {
-	if index < 0 || index >= len(t.Types) {
-		return nil, ErrUnionIndex
+// Type returns the type corresponding to selector.
+func (t *TypeUnion) Type(selector int) (Type, error) {
+	if selector < 0 || selector >= len(t.Types) {
+		return nil, ErrUnionSelector
 	}
-	return t.Types[index], nil
+	return t.Types[selector], nil
 }
 
 // SplitZng takes a zng encoding of a value of the receiver's union type and
-// returns the concrete type of the value, its index into the union
-// type, and the value encoding.
+// returns the concrete type of the value, its selector, and the value encoding.
 func (t *TypeUnion) SplitZng(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	it := zv.Iter()
 	v, container, err := it.Next()
@@ -39,11 +39,11 @@ func (t *TypeUnion) SplitZng(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	if container {
 		return nil, -1, nil, ErrBadValue
 	}
-	index, err := DecodeInt(v)
+	selector, err := DecodeInt(v)
 	if err != nil {
 		return nil, -1, nil, err
 	}
-	inner, err := t.TypeIndex(int(index))
+	inner, err := t.Type(int(selector))
 	if err != nil {
 		return nil, -1, nil, err
 	}
@@ -54,7 +54,7 @@ func (t *TypeUnion) SplitZng(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	if !it.Done() {
 		return nil, -1, nil, ErrBadValue
 	}
-	return inner, int64(index), v, nil
+	return inner, int64(selector), v, nil
 }
 
 func (t *TypeUnion) Marshal(zv zcode.Bytes) (interface{}, error) {

--- a/zng/walk.go
+++ b/zng/walk.go
@@ -118,11 +118,11 @@ func walkUnion(typ *TypeUnion, body zcode.Bytes, visit Visitor) error {
 	if container {
 		return ErrBadValue
 	}
-	index, err := DecodeInt(v)
+	selector, err := DecodeInt(v)
 	if err != nil {
 		return err
 	}
-	inner, err := typ.TypeIndex(int(index))
+	inner, err := typ.Type(int(selector))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Code sometimes refers to a union selector as an index.  Replace those
references with selector for consistency and introduce the term in the
ZNG specification.