### PR TITLE
Remove reference to zed/2849, since it's fixed

### DIFF
--- a/docs/language/README.md
+++ b/docs/language/README.md
@@ -220,9 +220,6 @@ from ... | switch color (
 ) | ...
 ```
 
-> **Note:** The syntax shown here for `switch` is still being
-> implemented ([zed/2849](https://github.com/brimdata/zed/issues/2849)).
-
 ## Operators
 
 Each operator is identified by name and performs a specific operation


### PR DESCRIPTION
Per [https://github.com/brimdata/zed/issues/2849#issuecomment-884413089,](https://github.com/brimdata/zed/issues/2849#issuecomment-884413089,) this link in the docs can be removed now. :tada: