### PR TITLE
expr: limit intermediate type creation in shapers

### DIFF
--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -103,11 +103,10 @@ func (c *ConstShaper) Eval(in *zng.Record) (zng.Value, error) {
 	if err != nil {
 		return zng.Value{}, err
 	}
-	inType := zng.AliasOf(inVal.Type).(*zng.TypeRecord)
 	id := in.Type.ID()
 	s, ok := c.shapers[id]
 	if !ok {
-		s, err = createShaper(c.zctx, c.transforms, c.shapeTo, inType)
+		s, err = createShaper(c.zctx, c.transforms, c.shapeTo, inVal.Type)
 		if err != nil {
 			return zng.Value{}, err
 		}
@@ -135,118 +134,105 @@ type shaper struct {
 	step step
 }
 
-func createShaper(zctx *zson.Context, transforms ShaperTransform, shapeTo zng.Type, inType *zng.TypeRecord) (*shaper, error) {
-	var err error
-	spec := zng.TypeRecordOf(shapeTo)
-	typ := inType
-	if transforms&Cast > 0 {
-		typ, err = castRecordType(zctx, typ, spec)
-		if err != nil {
-			return nil, err
-		}
+func createShaper(zctx *zson.Context, tf ShaperTransform, spec, in zng.Type) (*shaper, error) {
+	typ, err := shaperType(zctx, tf, spec, in)
+	if err != nil {
+		return nil, err
 	}
-	if transforms&Crop > 0 {
-		typ, err = cropRecordType(zctx, typ, spec)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if transforms&Fill > 0 {
-		typ, err = fillRecordType(zctx, typ, spec)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if transforms&Order > 0 {
-		typ, err = orderRecordType(zctx, typ, spec)
-		if err != nil {
-			return nil, err
-		}
-	}
-	step, err := createStepRecord(inType, typ)
-	var final zng.Type
-	if typ.ID() == shapeTo.ID() {
-		// If the underlying records are the same, then use the
-		// spec record as it might be an alias and the intention
-		// would be to cast to the named type.
-		final = shapeTo
-	} else {
-		final = typ
-	}
-	return &shaper{final, step}, err
+	step, err := createStepRecord(zng.TypeRecordOf(in), zng.TypeRecordOf(typ))
+	return &shaper{typ, step}, err
 }
 
-// castRecordType applies a cast (as specified by the record type 'spec')
-// to a record type and returns the resulting record type.
-func castRecordType(zctx *zson.Context, input, spec *zng.TypeRecord) (*zng.TypeRecord, error) {
-	cols := make([]zng.Column, 0)
-	for _, inCol := range input.Columns {
-		// For each input column, check if we have a matching
-		// name in the cast spec.
-		ind, ok := spec.ColumnOfField(inCol.Name)
-		if !ok {
-			// 1. No match: output type unmodified.
-			cols = append(cols, inCol)
-			continue
+func shaperType(zctx *zson.Context, tf ShaperTransform, spec, in zng.Type) (zng.Type, error) {
+	inUnder, specUnder := zng.AliasOf(in), zng.AliasOf(spec)
+	if tf&Cast > 0 {
+		if inUnder == specUnder || inUnder == zng.TypeNull {
+			return spec, nil
 		}
-		specCol := spec.Columns[ind]
-		if inCol.Type.ID() == specCol.Type.ID() {
-			// Field has same type in cast: output type unmodified.
+		if isMap(specUnder) {
+			return nil, fmt.Errorf("cannot yet use maps in shaping functions (issue #2894)")
+		}
+		if zng.IsPrimitiveType(inUnder) && zng.IsPrimitiveType(specUnder) {
+			// Matching field is a primitive: output type is cast type.
+			if LookupPrimitiveCaster(specUnder) == nil {
+				return nil, fmt.Errorf("cast to %s not implemented", spec)
+			}
+			return spec, nil
+		}
+		if bestUnionSelector(in, specUnder) > -1 {
+			return spec, nil
+		}
+	} else if inUnder == specUnder {
+		return in, nil
+	}
+	if inRec, ok := inUnder.(*zng.TypeRecord); ok {
+		if specRec, ok := specUnder.(*zng.TypeRecord); ok {
+			cols, err := shaperColumns(zctx, tf, specRec, inRec)
+			if err != nil {
+				return nil, err
+			}
+			if tf&Cast > 0 {
+				if equalColumns(cols, specRec.Columns) {
+					return spec, nil
+				}
+			} else if equalColumns(cols, inRec.Columns) {
+				return in, nil
+			}
+			return zctx.LookupTypeRecord(cols)
+		}
+	}
+	inInner, specInner := zng.InnerType(inUnder), zng.InnerType(specUnder)
+	if inInner != nil && specInner != nil && (tf&Cast > 0 || isArray(inUnder) == isArray(specUnder)) {
+		t, err := shaperType(zctx, tf, specInner, inInner)
+		if err != nil {
+			return nil, err
+		}
+		if tf&Cast > 0 {
+			if t == specInner {
+				return spec, nil
+			}
+		} else if t == inInner {
+			return in, nil
+		}
+		if isArray(specUnder) {
+			return zctx.LookupTypeArray(t), nil
+		}
+		return zctx.LookupTypeSet(t), nil
+	}
+	return in, nil
+}
+
+func shaperColumns(zctx *zson.Context, tf ShaperTransform, specRec, inRec *zng.TypeRecord) ([]zng.Column, error) {
+	crop, fill := tf&Crop > 0, tf&Fill > 0
+	if tf&Order == 0 {
+		crop, fill = !fill, !crop
+		specRec, inRec = inRec, specRec
+	}
+	var cols []zng.Column
+	for _, specCol := range specRec.Columns {
+		if inColType, ok := inRec.TypeOfField(specCol.Name); ok {
+			specColType := specCol.Type
+			if tf&Order == 0 {
+				// Counteract the swap of specRec and inRec above.
+				specColType, inColType = inColType, specColType
+			}
+			t, err := shaperType(zctx, tf, specColType, inColType)
+			if err != nil {
+				return nil, err
+			}
+			cols = append(cols, zng.Column{Name: specCol.Name, Type: t})
+		} else if fill {
 			cols = append(cols, specCol)
-			continue
 		}
-		castType, err := castType(zctx, inCol.Type, specCol.Type)
-		if err != nil {
-			return nil, err
+	}
+	if !crop {
+		for _, inCol := range inRec.Columns {
+			if !specRec.HasField(inCol.Name) {
+				cols = append(cols, inCol)
+			}
 		}
-		cols = append(cols, zng.Column{inCol.Name, castType})
 	}
-	return zctx.LookupTypeRecord(cols)
-}
-
-func castType(zctx *zson.Context, inType, specType zng.Type) (zng.Type, error) {
-	if _, ok := specType.(*zng.TypeMap); ok {
-		return nil, fmt.Errorf("cannot yet use maps in shaping functions (issue #2894)")
-	}
-	switch {
-	case inType.ID() == zng.IDNull:
-		return specType, nil
-	case zng.IsRecordType(inType) && zng.IsRecordType(specType):
-		// Matching field is a record: recurse.
-		inRec := zng.AliasOf(inType).(*zng.TypeRecord)
-		castRec := zng.AliasOf(specType).(*zng.TypeRecord)
-		return castRecordType(zctx, inRec, castRec)
-	case zng.IsPrimitiveType(inType) && zng.IsPrimitiveType(specType):
-		// Matching field is a primitive: output type is cast type.
-		if LookupPrimitiveCaster(zng.AliasOf(specType)) == nil {
-			return nil, fmt.Errorf("cast to %s not implemented", specType)
-		}
-		return specType, nil
-	case isCollectionType(inType) && isCollectionType(specType):
-		out, err := castType(zctx, zng.InnerType(inType), zng.InnerType(specType))
-		if err != nil {
-			return nil, err
-		}
-		if _, ok := zng.AliasOf(specType).(*zng.TypeArray); ok {
-			return zctx.LookupTypeArray(out), nil
-		}
-		return zctx.LookupTypeSet(out), nil
-	}
-	if bestUnionSelector(inType, specType) > -1 {
-		return specType, nil
-	}
-	// Non-castable type pair with at least one
-	// (non-record) container: output column is left
-	// unchanged.
-	return inType, nil
-}
-
-func isCollectionType(t zng.Type) bool {
-	switch zng.AliasOf(t).(type) {
-	case *zng.TypeArray, *zng.TypeSet:
-		return true
-	}
-	return false
+	return cols, nil
 }
 
 // bestUnionSelector tries to return the most specific union selector for in
@@ -281,176 +267,31 @@ func bestUnionSelector(in, spec zng.Type) int {
 	return compatible
 }
 
-// cropRecordType applies a crop (as specified by the record type 'spec')
-// to a record type and returns the resulting record type.
-func cropRecordType(zctx *zson.Context, input, spec *zng.TypeRecord) (*zng.TypeRecord, error) {
-	cols := make([]zng.Column, 0)
-	for _, inCol := range input.Columns {
-		ind, ok := spec.ColumnOfField(inCol.Name)
-		if !ok {
-			// 1. Field not in crop: drop.
-			continue
-		}
-		inType := zng.AliasOf(inCol.Type)
-		specCol := spec.Columns[ind]
-		specType := zng.AliasOf(specCol.Type)
-		switch {
-		case zng.IsPrimitiveType(inType):
-			// 2. Field is non-record in input: keep (regardless of crop record-ness)
-			cols = append(cols, inCol)
-		case zng.IsRecordType(inType) && zng.IsRecordType(specType):
-			// 3. Both records: recurse
-			out, err := cropRecordType(zctx, inType.(*zng.TypeRecord), specType.(*zng.TypeRecord))
-			if err != nil {
-				return nil, err
-			}
-			cols = append(cols, zng.Column{inCol.Name, out})
-		case isCollectionType(inType) && isCollectionType(specType):
-			inInner := zng.AliasOf(zng.InnerType(inType))
-			specInner := zng.AliasOf(zng.InnerType(specType))
-			if zng.IsRecordType(inInner) && zng.IsRecordType(specInner) {
-				// 4. array/set of records
-				inner, err := cropRecordType(zctx, inInner.(*zng.TypeRecord), specInner.(*zng.TypeRecord))
-				if err != nil {
-					return nil, err
-				}
-				var t zng.Type
-				if _, ok := inCol.Type.(*zng.TypeArray); ok {
-					t, err = zctx.LookupTypeArray(inner), nil
-				} else {
-					t, err = zctx.LookupTypeSet(inner), nil
-				}
-				if err != nil {
-					return nil, err
-				}
-				cols = append(cols, zng.Column{inCol.Name, t})
-			} else {
-				cols = append(cols, inCol)
-			}
-		default:
-			// 5. container input but non-container in crop: keep crop
-			cols = append(cols, specCol)
-
+func equalColumns(a, b []zng.Column) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
 		}
 	}
-	return zctx.LookupTypeRecord(cols)
+	return true
 }
 
-// fillRecordType applies a fill (as specified by the record type 'spec')
-// to a record type and returns the resulting record type.
-func fillRecordType(zctx *zson.Context, input, spec *zng.TypeRecord) (*zng.TypeRecord, error) {
-	cols := make([]zng.Column, len(input.Columns), len(input.Columns)+len(spec.Columns))
-	copy(cols, input.Columns)
-	for _, specCol := range spec.Columns {
-		if i, ok := input.ColumnOfField(specCol.Name); ok {
-			specType := zng.AliasOf(specCol.Type)
-			inCol := input.Columns[i]
-			inType := zng.AliasOf(inCol.Type)
-			// Field is present both in input and spec: recurse if
-			// both records, or select appropriate type if not.
-			if specRecType, ok := specType.(*zng.TypeRecord); ok {
-				if inRecType, ok := inType.(*zng.TypeRecord); ok {
-					filled, err := fillRecordType(zctx, inRecType, specRecType)
-					if err != nil {
-						return nil, err
-					}
-					cols[i] = zng.Column{specCol.Name, filled}
-				} else {
-					cols[i] = specCol
-				}
-				continue
-			}
-			if isCollectionType(inType) && isCollectionType(specType) {
-				inInner := zng.AliasOf(zng.InnerType(inCol.Type))
-				specInner := zng.AliasOf(zng.InnerType(specCol.Type))
-				if zng.IsRecordType(inInner) && zng.IsRecordType(specInner) {
-					if inner, err := fillRecordType(zctx, inInner.(*zng.TypeRecord), specInner.(*zng.TypeRecord)); err != nil {
-						return nil, err
-					} else {
-						var err error
-						var t zng.Type
-						if _, ok := inCol.Type.(*zng.TypeArray); ok {
-							t, err = zctx.LookupTypeArray(inner), nil
-						} else {
-							t, err = zctx.LookupTypeSet(inner), nil
-						}
-						if err != nil {
-							return nil, err
-						}
-						cols[i] = zng.Column{specCol.Name, t}
-					}
-				}
-			}
-		} else {
-			cols = append(cols, specCol)
-		}
-	}
-	return zctx.LookupTypeRecord(cols)
+func isArray(t zng.Type) bool {
+	_, ok := t.(*zng.TypeArray)
+	return ok
 }
 
-// orderRecordType applies a field order (as specified by the record type 'spec')
-// to a record type and returns the resulting record type.
-func orderRecordType(zctx *zson.Context, input, spec *zng.TypeRecord) (*zng.TypeRecord, error) {
-	cols := make([]zng.Column, 0)
-	// Simple order algorithm creates a list with all specified
-	// 'order' fields present in input, followed by any other
-	// fields that were in input but not specified in order. Two
-	// examples:
-	//
-	// 1. (a b c d) order (c e b a) -> (c b a d)
-	//
-	// 2. (a b c d) order (d e c b) -> (d c b a)
-	//
-	// The second example with 'a' moving to the back suggests
-	// that we may want to use a different algorithm where
-	// unspecified fields "stay where they were". Specifically we
-	// might prefer that the result be (a d c b). We will learn
-	// with use, so starting with simpler algorithm for now.
-	//
-	for _, specCol := range spec.Columns {
-		if ind, ok := input.ColumnOfField(specCol.Name); ok {
-			inCol := input.Columns[ind]
-			inType := zng.AliasOf(inCol.Type)
-			specType := zng.AliasOf(specCol.Type)
-			if zng.IsRecordType(inType) && zng.IsRecordType(specType) {
-				if nested, err := orderRecordType(zctx, inType.(*zng.TypeRecord), specType.(*zng.TypeRecord)); err != nil {
-					return nil, err
-				} else {
-					cols = append(cols, zng.Column{specCol.Name, nested})
-				}
-				continue
-			}
-			if isCollectionType(inCol.Type) && isCollectionType(specCol.Type) &&
-				zng.IsRecordType(zng.InnerType(inCol.Type)) &&
-				zng.IsRecordType(zng.InnerType(specCol.Type)) {
-				inInner := zng.AliasOf(zng.InnerType(inCol.Type))
-				specInner := zng.AliasOf(zng.InnerType(specCol.Type))
-				if inner, err := orderRecordType(zctx, inInner.(*zng.TypeRecord), specInner.(*zng.TypeRecord)); err != nil {
-					return nil, err
-				} else {
-					var err error
-					var t zng.Type
-					if _, ok := inCol.Type.(*zng.TypeArray); ok {
-						t, err = zctx.LookupTypeArray(inner), nil
-					} else {
-						t, err = zctx.LookupTypeSet(inner), nil
-					}
-					if err != nil {
-						return nil, err
-					}
-					cols = append(cols, zng.Column{specCol.Name, t})
-				}
-				continue
-			}
-			cols = append(cols, inCol)
-		}
-	}
-	for _, inCol := range input.Columns {
-		if !spec.HasField(inCol.Name) {
-			cols = append(cols, inCol)
-		}
-	}
-	return zctx.LookupTypeRecord(cols)
+func isMap(t zng.Type) bool {
+	_, ok := t.(*zng.TypeMap)
+	return ok
+}
+
+func isSet(t zng.Type) bool {
+	_, ok := t.(*zng.TypeSet)
+	return ok
 }
 
 type op int
@@ -516,14 +357,14 @@ func createStep(in, out zng.Type) (step, error) {
 			return step{op: copyPrimitive}, nil
 		}
 	case zng.IsRecordType(in) && zng.IsRecordType(out):
-		return createStepRecord(in.(*zng.TypeRecord), out.(*zng.TypeRecord))
+		return createStepRecord(zng.TypeRecordOf(in), zng.TypeRecordOf(out))
 	case zng.IsPrimitiveType(in) && zng.IsPrimitiveType(out):
 		return step{op: castPrimitive, fromType: in, toType: out}, nil
 	case isCollectionType(in):
-		if _, ok := out.(*zng.TypeArray); ok {
+		if _, ok := zng.AliasOf(out).(*zng.TypeArray); ok {
 			return createStepArray(zng.InnerType(in), zng.InnerType(out))
 		}
-		if _, ok := out.(*zng.TypeSet); ok {
+		if _, ok := zng.AliasOf(out).(*zng.TypeSet); ok {
 			return createStepSet(zng.InnerType(in), zng.InnerType(out))
 		}
 	}
@@ -531,6 +372,14 @@ func createStep(in, out zng.Type) (step, error) {
 		return step{op: castUnion, fromType: in, toSelector: s}, nil
 	}
 	return step{}, fmt.Errorf("createStep: incompatible types %s and %s", in, out)
+}
+
+func isCollectionType(t zng.Type) bool {
+	switch zng.AliasOf(t).(type) {
+	case *zng.TypeArray, *zng.TypeSet:
+		return true
+	}
+	return false
 }
 
 func createStepArray(in, out zng.Type) (step, error) {

--- a/expr/ztests/shape-alias.yaml
+++ b/expr/ztests/shape-alias.yaml
@@ -5,4 +5,4 @@ input: |
   {a:{q:1(myport=(int16)), p: 2 (myport)}, b:[{q:1}],c:3 }
 
 output: |
-  {c:3 (=port),b:[{p:null (port),q:1 (port)} (=0)] (=1),a:{p:2,q:1} (0)} (=2)
+  {c:3 (=port),b:[{p:null (port),q:1 (port)} (=prec)] (=parr),a:{p:2,q:1} (prec)} (=0)

--- a/expr/ztests/shape-cast-alias.yaml
+++ b/expr/ztests/shape-cast-alias.yaml
@@ -6,5 +6,5 @@ input: |
   {a: 1, b:{p: 1}, c:[1]}
 
 output: |
-  {a:1 (=port),b:{p:1 (port)} (=0),c:[1 (port)] (=1)} (=2)
-  {a:1,b:{p:1},c:[1]} (2)
+  {a:1 (=port),b:{p:1 (port)} (=prec),c:[1 (port)] (=parr)} (=0)
+  {a:1,b:{p:1},c:[1]} (0)

--- a/expr/ztests/shape-crop-null.yaml
+++ b/expr/ztests/shape-crop-null.yaml
@@ -1,0 +1,10 @@
+zed: put this:=crop({f:null})
+
+input: &input |
+  {f:1 (=int64_alias)} (=int64_record_alias)
+  {f:[1 (int64_alias)] (=array_alias)} (=array_record_alias)
+  {f:{g:1 (int64_alias)} (=record_alias)} (=record_record_alias)
+  {f:|[1 (int64_alias)]| (=set_alias)} (=set_record_alias)
+  {f:1 (int64_alias) (union_alias=(0=((int64_alias,int64))))} (=union_record_alias)
+
+output: *input

--- a/expr/ztests/shape-fill-null.yaml
+++ b/expr/ztests/shape-fill-null.yaml
@@ -1,0 +1,10 @@
+zed: put this:=fill({f:null})
+
+input: &input |
+  {f:1 (=int64_alias)} (=int64_record_alias)
+  {f:[1 (int64_alias)] (=array_alias)} (=array_record_alias)
+  {f:{g:1 (int64_alias)} (=record_alias)} (=record_record_alias)
+  {f:|[1 (int64_alias)]| (=set_alias)} (=set_record_alias)
+  {f:1 (int64_alias) (union_alias=(0=((int64_alias,int64))))} (=union_record_alias)
+
+output: *input

--- a/expr/ztests/shape-order-null.yaml
+++ b/expr/ztests/shape-order-null.yaml
@@ -1,0 +1,10 @@
+zed: put this:=order({f:null})
+
+input: &input |
+  {f:1 (=int64_alias)} (=int64_record_alias)
+  {f:[1 (int64_alias)] (=array_alias)} (=array_record_alias)
+  {f:{g:1 (int64_alias)} (=record_alias)} (=record_record_alias)
+  {f:|[1 (int64_alias)]| (=set_alias)} (=set_record_alias)
+  {f:1 (int64_alias) (union_alias=(0=((int64_alias,int64))))} (=union_record_alias)
+
+output: *input

--- a/zeek/ztests/shape-zeek-ndjson.yaml
+++ b/zeek/ztests/shape-zeek-ndjson.yaml
@@ -20,11 +20,11 @@ outputs:
               orig_p: 49562 (port=(uint16)),
               resp_h: 23.217.103.245,
               resp_p: 80 (port)
-          } (=0),
+          } (=conn_id),
           name: "TCP_ack_underflow_or_misorder" (bstring),
           addl: null (bstring),
           notice: false,
           peer: "zeek" (bstring),
           source: null (bstring),
           _write_ts: 2018-03-24T17:15:20.600843Z
-      } (=1)
+      } (=weird)


### PR DESCRIPTION
A shaper computes an output type for each input type by computing types
that result from applying each of its transforms in turn.  If a shaper
has multiple transforms, this process can create intermediate types that
remain in the type context but never appear in the output.  For inputs
containing many types, creating these intermediate types can consume
substantial CPU and memory.  Rework shaper output type computation so it
does not create intermediate types.

This is part of the fix for #2874.