### PR TITLE
expr/agg: limit intermediate type creation in Schema

### DIFF
--- a/expr/agg/fuse.go
+++ b/expr/agg/fuse.go
@@ -33,10 +33,7 @@ func (f *fuse) Result(zctx *zson.Context) (zng.Value, error) {
 		// empty input
 		return zng.Value{zng.TypeNull, nil}, nil
 	}
-	schema, err := NewSchema(zctx)
-	if err != nil {
-		return zng.Value{}, err
-	}
+	schema := NewSchema(zctx)
 	for _, p := range f.partials {
 		typ, err := zctx.LookupByValue(p.Bytes)
 		if err != nil {
@@ -51,7 +48,11 @@ func (f *fuse) Result(zctx *zson.Context) (zng.Value, error) {
 	for typ := range f.shapes {
 		schema.Mixin(typ)
 	}
-	return zctx.LookupTypeValue(schema.Type), nil
+	typ, err := schema.Type()
+	if err != nil {
+		return zng.Value{}, err
+	}
+	return zctx.LookupTypeValue(typ), nil
 }
 
 func (f *fuse) ConsumeAsPartial(p zng.Value) error {


### PR DESCRIPTION
Each call to Schema.Mixin creates a new record type, but for current use
cases, all but the last are intermediate types that remain in the type
context but never appear in the input.  Creating these intermediate
types can consume substantial CPU and memory.  Rework Schema so it does
not create them.

This is part of the fix for #2874.

Depends on #2897.