### PR TITLE
mdtest: strip "...\n" suffix for "mdtest-output head" only

### DIFF
--- a/mdtest/mdtest.go
+++ b/mdtest/mdtest.go
@@ -162,14 +162,16 @@ func parseMarkdown(source []byte) (map[string]string, []*Test, error) {
 			if words := fcbInfoWords(commandFCB, source); len(words) > 1 {
 				dir = words[1]
 			}
+			expected := fcbLines(fcb, source)
 			var head bool
 			if words := fcbInfoWords(fcb, source); len(words) > 1 && words[1] == "head" {
+				expected = strings.TrimSuffix(expected, "...\n")
 				head = true
 			}
 			tests = append(tests, &Test{
 				Command:  fcbLines(commandFCB, source),
 				Dir:      dir,
-				Expected: strings.TrimSuffix(fcbLines(fcb, source), "...\n"),
+				Expected: expected,
 				Head:     head,
 				Line:     fcbLineNumber(commandFCB, source),
 			})

--- a/mdtest/mdtest_test.go
+++ b/mdtest/mdtest_test.go
@@ -121,6 +121,21 @@ block 2
 				{Command: "block 1\n", Expected: "block 2\n", Line: 2, Head: true},
 			},
 		},
+		{
+			name: "non-headed output with trailing ellipsis",
+			markdown: `
+~~~mdtest-command
+block 1
+~~~
+~~~mdtest-output
+block 2
+...
+~~~
+`,
+			tests: []*Test{
+				{Command: "block 1\n", Expected: "block 2\n...\n", Line: 2},
+			},
+		},
 	}
 	for _, tc := range tests {
 		tc := tc


### PR DESCRIPTION
Surprisingly, any "...\n" suffix is stripped from the content of all
"mdtest-output" fenced code blocks.  Limit this to "mdtest-output head"
blocks only.