### PR TITLE
prepare some ztests for automatic formatting

### DIFF
--- a/compiler/parser/ztests/multi-line.yaml
+++ b/compiler/parser/ztests/multi-line.yaml
@@ -4,11 +4,9 @@ script: |
 inputs:
   - name: count.zql
     data: |
-
       c
         :=
           count()
-
   - name: in.zson
     data: |
       {s:"1"}

--- a/service/ztests/s3/ls.yaml
+++ b/service/ztests/s3/ls.yaml
@@ -2,7 +2,7 @@ skip: "issue #2651"
 
 script: |
   source services.sh s3://bucket/zedlake
-  zapi -host $LAKE_HOST new p1 
+  zapi -host $LAKE_HOST new p1
   zapi -host $LAKE_HOST new p2
   zapi -host $LAKE_HOST new p3
   echo ===

--- a/service/ztests/s3/postpath-s3.yaml
+++ b/service/ztests/s3/postpath-s3.yaml
@@ -1,7 +1,7 @@
 skip: "issue #2651"
 
 script: |
-  source services.sh 
+  source services.sh
   mkdir -p s3/bucket
   mv babble.zson s3/bucket
   zapi -host $LAKE_HOST -p test postpath -f s3://bucket/babble.zson >/dev/null


### PR DESCRIPTION
A few ztests contain white space that causes ugly output when those
tests are formatted by gopkg.in/yaml.v3.  Remove it.