### PR TITLE
zfmt: fix ast.From formatting

### DIFF
--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -234,22 +234,22 @@ func (c *canon) proc(p ast.Proc) {
 		//XXX cleanup for len(Trunks) = 1
 		c.next()
 		c.open("from (")
-		c.open()
 		for _, trunk := range p.Trunks {
 			c.ret()
 			c.source(trunk.Source)
-			c.write(" => ")
-			c.open()
-			c.head = true
-			c.proc(trunk.Seq)
+			if trunk.Seq != nil {
+				c.write(" =>")
+				c.open()
+				c.head = true
+				c.proc(trunk.Seq)
+				c.close()
+			}
 			c.write(";")
-			c.close()
 		}
 		c.close()
 		c.ret()
 		c.flush()
 		c.write(")")
-		c.close()
 	case *ast.Const:
 		c.write("const %s=", p.Name)
 		c.expr(p.Expr, false)

--- a/zfmt/ztests/from.yaml
+++ b/zfmt/ztests/from.yaml
@@ -1,0 +1,40 @@
+script: |
+  zc -C 'file path'
+  echo ===
+  zc -C 'get http://host/path'
+  echo ===
+  zc -C 'from pool'
+  echo ===
+  zc -C 'from ( file path; get http://host/path; pool; )'
+  echo ===
+  zc -C 'from ( file path => head; get http://host/path => head; pool => head; )'
+
+outputs:
+  - name: stdout
+    data: |
+      from (
+        file path;
+      )
+      ===
+      from (
+        get http://host/path;
+      )
+      ===
+      from (
+        pool;
+      )
+      ===
+      from (
+        file path;
+        get http://host/path;
+        pool;
+      )
+      ===
+      from (
+        file path =>
+          head 1;
+        get http://host/path =>
+          head 1;
+        pool =>
+          head 1;
+      )


### PR DESCRIPTION
The AST function indents too deeply for ast.From, includes an
unnecessary space after an arrow (i.e., "=>"), and panics if an
ast.From.Trunks element has a nil Seq field.

Closes #2898.