### PR TITLE
fix tzngio type value formatter

### DIFF
--- a/zio/tableio/ztests/type-value.yaml
+++ b/zio/tableio/ztests/type-value.yaml
@@ -1,0 +1,10 @@
+zed: 'cut typeof(this)'
+
+input: |
+  {a:1}
+
+output-flags: -f table
+
+output: |
+  TYPEOF
+  ({a:int64})

--- a/zio/tzngio/stringof.go
+++ b/zio/tzngio/stringof.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zng"
+	"github.com/brimdata/zed/zson"
 )
 
 // The fmt paramter passed to Type.StringOf() must be one of the following
@@ -91,7 +92,8 @@ func StringOf(zv zng.Value, out OutFmt, b bool) string {
 	case *zng.TypeOfTime:
 		return StringOfTime(t, zv.Bytes, out, b)
 	case *zng.TypeOfType:
-		return StringOfString(zng.TypeString, zv.Bytes, out, b)
+		s, _ := zson.FormatValue(zv)
+		return s
 	case *zng.TypeUnion:
 		return StringOfUnion(t, zv.Bytes, out, b)
 	default:


### PR DESCRIPTION
This commit fixes a bug in the table output that prints the new,
binary-encoded type value as a string.  For now, the fix here is
to update the tzngio printer though this should eventually go away
and the table writer should probably use package zson.