### PR TITLE
cmd/zed: use root.Command.Init context everwhere

### DIFF
--- a/cmd/zed/index/lookup/command.go
+++ b/cmd/zed/index/lookup/command.go
@@ -1,7 +1,6 @@
 package lookup
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"strings"
@@ -51,7 +50,7 @@ func newLookupCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, err
 }
 
 func (c *LookupCommand) Run(args []string) error {
-	_, cleanup, err := c.Init(&c.outputFlags)
+	ctx, cleanup, err := c.Init(&c.outputFlags)
 	if err != nil {
 		return err
 	}
@@ -68,7 +67,7 @@ func (c *LookupCommand) Run(args []string) error {
 		return err
 	}
 	local := storage.NewLocalEngine()
-	finder, err := index.NewFinder(context.TODO(), zson.NewContext(), local, uri)
+	finder, err := index.NewFinder(ctx, zson.NewContext(), local, uri)
 	if err != nil {
 		return err
 	}
@@ -77,8 +76,6 @@ func (c *LookupCommand) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	hits := make(chan *zng.Record)
 	var searchErr error
 	go func() {

--- a/cmd/zed/index/section/command.go
+++ b/cmd/zed/index/section/command.go
@@ -1,7 +1,6 @@
 package section
 
 import (
-	"context"
 	"errors"
 	"flag"
 
@@ -48,7 +47,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
-	_, cleanup, err := c.Init(&c.outputFlags)
+	ctx, cleanup, err := c.Init(&c.outputFlags)
 	if err != nil {
 		return err
 	}
@@ -63,7 +62,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer reader.Close()
-	writer, err := c.outputFlags.Open(context.TODO(), local)
+	writer, err := c.outputFlags.Open(ctx, local)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/lake/find/command.go
+++ b/cmd/zed/lake/find/command.go
@@ -78,11 +78,11 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 func (c *Command) Run(args []string) error {
 	return errors.New("issue #2532")
 	/* NOT YET
-	defer c.Cleanup()
-	if err := c.Init(&c.outputFlags); err != nil {
+	ctx, cleanup, err := c.Init(&c.outputFlags)
+ 	if err != nil {
 		return err
 	}
-
+	defer cleanup()
 	lk, err := lake.OpenLake(c.root, nil)
 	if err != nil {
 		return err
@@ -100,9 +100,6 @@ func (c *Command) Run(args []string) error {
 	if c.skipMissing {
 		findOptions = append(findOptions, lake.SkipMissing())
 	}
-
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
 	outputFile := c.outputFlags.FileName()
 	if outputFile == "-" {
 		outputFile = ""

--- a/cmd/zed/lake/find/command.go
+++ b/cmd/zed/lake/find/command.go
@@ -78,58 +78,58 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 func (c *Command) Run(args []string) error {
 	return errors.New("issue #2532")
 	/* NOT YET
-	ctx, cleanup, err := c.Init(&c.outputFlags)
- 	if err != nil {
-		return err
-	}
-	defer cleanup()
-	lk, err := lake.OpenLake(c.root, nil)
-	if err != nil {
-		return err
-	}
-
-	query, err := index.ParseQuery(c.indexFile, args)
-	if err != nil {
-		return err
-	}
-
-	var findOptions []lake.FindOption
-	if c.pathField != "" {
-		findOptions = append(findOptions, lake.AddPath(c.pathField, !c.relativePaths))
-	}
-	if c.skipMissing {
-		findOptions = append(findOptions, lake.SkipMissing())
-	}
-	outputFile := c.outputFlags.FileName()
-	if outputFile == "-" {
-		outputFile = ""
-	}
-	writer, err := emitter.NewFile(ctx, outputFile, c.outputFlags.Options())
-	if err != nil {
-		return err
-	}
-	defer writer.Close()
-	hits := make(chan *zng.Record)
-	var searchErr error
-	go func() {
-		searchErr = lake.Find(ctx, zson.NewContext(), lk, query, hits, findOptions...)
-		close(hits)
-	}()
-	for hit := range hits {
-		var err error
-		if writer != nil {
-			err = writer.Write(hit)
-		} else {
-			var path string
-			path, err = hit.AccessString(c.pathField)
-			if err == nil {
-				fmt.Println(path)
-			}
+		ctx, cleanup, err := c.Init(&c.outputFlags)
+	 	if err != nil {
+			return err
 		}
+		defer cleanup()
+		lk, err := lake.OpenLake(c.root, nil)
 		if err != nil {
 			return err
 		}
-	}
-	return searchErr
+
+		query, err := index.ParseQuery(c.indexFile, args)
+		if err != nil {
+			return err
+		}
+
+		var findOptions []lake.FindOption
+		if c.pathField != "" {
+			findOptions = append(findOptions, lake.AddPath(c.pathField, !c.relativePaths))
+		}
+		if c.skipMissing {
+			findOptions = append(findOptions, lake.SkipMissing())
+		}
+		outputFile := c.outputFlags.FileName()
+		if outputFile == "-" {
+			outputFile = ""
+		}
+		writer, err := emitter.NewFile(ctx, outputFile, c.outputFlags.Options())
+		if err != nil {
+			return err
+		}
+		defer writer.Close()
+		hits := make(chan *zng.Record)
+		var searchErr error
+		go func() {
+			searchErr = lake.Find(ctx, zson.NewContext(), lk, query, hits, findOptions...)
+			close(hits)
+		}()
+		for hit := range hits {
+			var err error
+			if writer != nil {
+				err = writer.Write(hit)
+			} else {
+				var path string
+				path, err = hit.AccessString(c.pathField)
+				if err == nil {
+					fmt.Println(path)
+				}
+			}
+			if err != nil {
+				return err
+			}
+		}
+		return searchErr
 	*/
 }

--- a/cmd/zed/zst/create/command.go
+++ b/cmd/zed/zst/create/command.go
@@ -1,7 +1,6 @@
 package create
 
 import (
-	"context"
 	"errors"
 	"flag"
 
@@ -62,7 +61,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
-	_, cleanup, err := c.Init(&c.inputFlags, &c.outputFlags)
+	ctx, cleanup, err := c.Init(&c.inputFlags, &c.outputFlags)
 	if err != nil {
 		return err
 	}
@@ -77,11 +76,11 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer zio.CloseReaders(readers)
-	reader, err := zbuf.MergeReadersByTsAsReader(context.Background(), readers, order.Asc)
+	reader, err := zbuf.MergeReadersByTsAsReader(ctx, readers, order.Asc)
 	if err != nil {
 		return err
 	}
-	writer, err := c.outputFlags.Open(context.TODO(), local)
+	writer, err := c.outputFlags.Open(ctx, local)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/zst/cut/command.go
+++ b/cmd/zed/zst/cut/command.go
@@ -1,7 +1,6 @@
 package inspect
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"strings"
@@ -53,7 +52,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
-	_, cleanup, err := c.Init(&c.outputFlags)
+	ctx, cleanup, err := c.Init(&c.outputFlags)
 	if err != nil {
 		return err
 	}
@@ -65,8 +64,6 @@ func (c *Command) Run(args []string) error {
 		return errors.New("zst cut: must specify field to cut with -k")
 	}
 	fields := strings.Split(c.fieldExpr, ".")
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	path := args[0]
 	local := storage.NewLocalEngine()
 	cutter, err := zst.NewCutterFromPath(ctx, zson.NewContext(), local, path, fields)

--- a/cmd/zed/zst/inspect/command.go
+++ b/cmd/zed/zst/inspect/command.go
@@ -1,7 +1,6 @@
 package inspect
 
 import (
-	"context"
 	"errors"
 	"flag"
 
@@ -51,7 +50,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
-	_, cleanup, err := c.Init(&c.outputFlags)
+	ctx, cleanup, err := c.Init(&c.outputFlags)
 	if err != nil {
 		return err
 	}
@@ -59,8 +58,6 @@ func (c *Command) Run(args []string) error {
 	if len(args) != 1 {
 		return errors.New("zst inspect: must be run with a single file argument")
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	path := args[0]
 	local := storage.NewLocalEngine()
 	reader, err := zst.NewReaderFromPath(ctx, zson.NewContext(), local, path)


### PR DESCRIPTION
cmd/zed/root.Command.Init returns a context.Context, but it isn't always
used.  Use it everywhere it's available.