### PR TITLE
ztest: pass temp dir to Bundle.RunScript, Ztest.RunScript

### DIFF
--- a/proc/sort/sort_test.go
+++ b/proc/sort/sort_test.go
@@ -135,7 +135,7 @@ func runTest(t *testing.T, cmd, input, output string) {
 		Zed:    cmd,
 		Input:  input,
 		Output: trim(output),
-	}).Run(t, "", "", "", "")
+	}).Run(t, "", "")
 }
 
 func TestSort(t *testing.T) {

--- a/zed_test.go
+++ b/zed_test.go
@@ -66,7 +66,7 @@ diff baseline.zson boomerang.zson
 		b := b
 		t.Run(b.TestName, func(t *testing.T) {
 			t.Parallel()
-			err := b.RunScript(shellPath, ".")
+			err := b.RunScript(shellPath, t.TempDir())
 			if err != nil {
 				err = &BoomerangError{
 					*b.Test.Inputs[0].Data,
@@ -159,7 +159,7 @@ diff baseline.parquet boomerang.parquet
 		b := b
 		t.Run(b.TestName, func(t *testing.T) {
 			t.Parallel()
-			err := b.RunScript(shellPath, ".")
+			err := b.RunScript(shellPath, t.TempDir())
 			if err != nil {
 				if s := err.Error(); strings.Contains(s, parquetio.ErrEmptyRecordType.Error()) ||
 					strings.Contains(s, parquetio.ErrNullType.Error()) ||

--- a/ztest/dir.go
+++ b/ztest/dir.go
@@ -8,19 +8,6 @@ import (
 // syntactic sugar for directory manipulations of a temp dir
 type Dir string
 
-func NewDir(name string) (*Dir, error) {
-	path, err := os.MkdirTemp("", name)
-	if err != nil {
-		return nil, err
-	}
-	d := Dir(path)
-	return &d, nil
-}
-
-func (d Dir) RemoveAll() {
-	os.RemoveAll(string(d))
-}
-
 func (d Dir) Path() string {
 	return string(d)
 }

--- a/ztest/shell.go
+++ b/ztest/shell.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 )
 
-func RunShell(dir *Dir, bindir, script string, stdin io.Reader, useenvs []string) (string, string, error) {
+func RunShell(dir Dir, bindir, script string, stdin io.Reader, useenvs []string) (string, string, error) {
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
 		cmd = exec.Command("cmd.exe", "/c", script)


### PR DESCRIPTION
Passing a temporary directory path to these methods makes them usable
with directories created by testing.T.TempDir, which have more
meaningful names than those created by ztest.NewDir.