### PR TITLE
service: send 400 for POST /pool/{}/add with no records

### DIFF
--- a/lake/commit/transaction.go
+++ b/lake/commit/transaction.go
@@ -13,6 +13,10 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
+// ErrEmptyTransaction is the error returned by Transaction.Serialize when
+// Transaction.Actions is empty.
+var ErrEmptyTransaction = errors.New("empty transaction")
+
 type Transaction struct {
 	ID      ksuid.KSUID         `zng:"id"`
 	Actions []actions.Interface `zng:"actions"`
@@ -101,7 +105,7 @@ func (t Transaction) Serialize() ([]byte, error) {
 	}
 	b := writer.Bytes()
 	if len(b) == 0 {
-		return nil, errors.New("empty transaction")
+		return nil, ErrEmptyTransaction
 	}
 	return b, nil
 }

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -281,14 +281,17 @@ func handleAdd(c *Core, w *ResponseWriter, r *Request) {
 	}
 	warnings := warningCollector{}
 	zr = zio.NewWarningReader(zr, &warnings)
-	commit, err := pool.Add(r.Context(), zr)
+	kommit, err := pool.Add(r.Context(), zr)
 	if err != nil {
+		if errors.Is(err, commit.ErrEmptyTransaction) {
+			err = zqe.ErrInvalid("no records in request")
+		}
 		w.Error(err)
 		return
 	}
 	w.Respond(http.StatusOK, api.AddResponse{
 		Warnings: warnings,
-		Commit:   commit,
+		Commit:   kommit,
 	})
 }
 

--- a/service/ztests/add-empty.yaml
+++ b/service/ztests/add-empty.yaml
@@ -1,0 +1,14 @@
+script: |
+  source service.sh
+  zapi create -q -p test
+  zapi add -q -p test -
+
+inputs:
+  - name: stdin
+    data: ''
+  - name: service.sh
+
+outputs:
+  - name: stderr
+    data: |
+      status code 400: no records in request

--- a/service/ztests/add-garbage.yaml
+++ b/service/ztests/add-garbage.yaml
@@ -1,0 +1,25 @@
+script: |
+  source service.sh
+  zapi create -q -p test
+  zapi add -q -p test -
+
+inputs:
+  - name: stdin
+    data: |
+      This file contains no records.
+  - name: service.sh
+
+outputs:
+  - name: stderr
+    data: |
+      stdio:stdin: format detection error
+      	tzng: line 1: bad format
+      	zeek: line 1: bad types/fields definition in zeek header
+      	zjson: line 1: invalid character 'T' looking for beginning of value
+      	zson: identifier "This" must be enum and requires decorator
+      	zng: malformed zng record
+      	csv: auto-detection not supported
+      	json: auto-detection not supported
+      	parquet: auto-detection not supported
+      	zst: auto-detection not supported
+      status code 400: no records in request


### PR DESCRIPTION
A POST /pool/{pool}/add request whose body is empty or cannot be parsed
elicits a 500 response.  Change that to 400.

Closes #2883.