### PR TITLE
api, service: compress ZNG response from POST /query, /search

### DIFF
--- a/api/queryio/zng.go
+++ b/api/queryio/zng.go
@@ -21,7 +21,9 @@ func NewZNGWriter(w io.WriteCloser) *ZNGWriter {
 	m := zson.NewZNGMarshaler()
 	m.Decorate(zson.StyleSimple)
 	return &ZNGWriter{
-		Writer:    zngio.NewWriter(w, zngio.WriterOpts{}),
+		Writer: zngio.NewWriter(w, zngio.WriterOpts{
+			LZ4BlockSize: zngio.DefaultLZ4BlockSize,
+		}),
 		marshaler: m,
 	}
 }

--- a/service/ztests/curl-query-zng-noctrl.yaml
+++ b/service/ztests/curl-query-zng-noctrl.yaml
@@ -1,0 +1,23 @@
+script: |
+  source service.sh
+  zapi create -q -p test
+  zapi load -q -p test in.zson
+  curl -X POST \
+    -H "Accept: application/x-zng" \
+    -d '{"query": "from test"}' \
+    http://${ZED_LAKE_HOST}/query?noctrl=t
+
+inputs:
+  - name: service.sh
+  - name: in.zson
+    # This ZSON produces ZNG output containing a compressed value
+    # message block.
+    data: |
+      {a:"aaaaaaaaaaaaaaa",b:"aaaaaaaaaaaaaaa"}
+
+outputs:
+  - name: stdout
+    # Generated with
+    # `bash -c 'zq - <<<{a:\"aaaaaaaaaaaaaaa\",b:\"aaaaaaaaaaaaaaa\"} | base64'`.
+    data: !!binary |
+      9gIBYRABYhD9ACIXShcgIGEBAAAQAMBhYWFhYWFhYWFhYWH/


### PR DESCRIPTION
I didn't add a test for /search compression since that route is going
away, but I did verify it by hand.

This should address brimdata/brim#1778.