### PR TITLE
Make "drop" test deterministic by sorting pool names returned by "zapi ls"

### DIFF
--- a/service/ztests/drop.yaml
+++ b/service/ztests/drop.yaml
@@ -5,7 +5,7 @@ script: |
   zapi create -q -p p3
   zapi drop -f -p p3
   echo ===
-  zapi ls -f zng | zq -f zson "pick name" -
+  zapi ls -f zng | zq -f zson "pick name | sort name" -
 
 inputs:
   - name: service.sh


### PR DESCRIPTION
When the test automation ran for my PR #2940, this unrelated test failed. In running it manually I observed that repeated runs of `zapi ls` can indeed return the pool names in different order. Maybe we'd want to change that to have it be automatically sorted, but for now I'm just proposing we sort the output via Zed to so the test passes consistently.