### PR TITLE
csvio.Reader: Remove extraneous quotes

### DIFF
--- a/zio/csvio/preprocess.go
+++ b/zio/csvio/preprocess.go
@@ -103,13 +103,12 @@ func minIndex(x, y int) int {
 func checkField(field []byte) []byte {
 	// Looking for the case where there's open and closed quotes and text to the
 	// left or right side of it. If we find this case remove the quotes.
-	quote := []byte(`"`)
 	for {
-		start := bytes.Index(field, quote)
+		start := bytes.IndexByte(field, '"')
 		if start == -1 {
 			return field
 		}
-		end := bytes.Index(field[start+1:], quote)
+		end := bytes.IndexByte(field[start+1:], '"')
 		if end == -1 {
 			return field
 		}

--- a/zio/csvio/preprocess.go
+++ b/zio/csvio/preprocess.go
@@ -1,0 +1,127 @@
+package csvio
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/brimdata/zed/pkg/skim"
+)
+
+const (
+	ReadSize    = 64 * 1024
+	MaxLineSize = 50 * 1024 * 1024
+)
+
+// preProcess is a reader, meant to sit in front of the go csv reader, that
+// looks for fields where quotes do not cover the entirety of a field. If such
+// a case is found the quotes are stripped from the field.
+//
+// For instance, the line:
+// field1,"field2" extra
+// Would get converted into:
+// field1,field2 extra
+type preProcess struct {
+	leftover []byte
+	scanner  *skim.Scanner
+}
+
+func newPreProcess(r io.Reader) *preProcess {
+	buffer := make([]byte, ReadSize)
+	return &preProcess{
+		scanner: skim.NewScanner(r, buffer, MaxLineSize),
+	}
+}
+
+func (p *preProcess) Read(b []byte) (int, error) {
+	n := len(p.leftover)
+	if n > 0 {
+		if cc := p.copy(b, p.leftover); cc < n {
+			return cc, nil
+		}
+	}
+	for {
+		line, err := p.scanner.Scan()
+		if len(line) > 0 {
+			line = checkLine(line)
+			cc := p.copy(b[n:], line)
+			n += cc
+			if cc < len(line) {
+				return n, err
+			}
+		}
+		if err != nil {
+			return n, err
+		}
+	}
+}
+
+func (p *preProcess) copy(dst []byte, src []byte) int {
+	cc := copy(dst, src)
+	p.leftover = append(p.leftover[0:], src[cc:]...)
+	return cc
+}
+
+func checkLine(line []byte) []byte {
+	var field []byte
+	var pos int
+	for {
+		comma := bytes.Index(line[pos:], []byte(","))
+		newline := bytes.Index(line[pos:], []byte("\n"))
+		if i := minIndex(comma, newline); i == -1 {
+			field = line[pos:]
+		} else {
+			field = line[pos : pos+i+1]
+		}
+		old := len(field)
+		if old == 0 {
+			return line
+		}
+		field = checkField(field)
+		n := len(field)
+		pos += n
+		if n != old {
+			diff := old - n
+			line = append(line[:pos], line[pos+diff:]...)
+		}
+	}
+}
+
+func minIndex(x, y int) int {
+	switch {
+	case x == -1 && y == -1:
+		return -1
+	case x == -1:
+		return y
+	case y == -1:
+		return x
+	case x < y:
+		return x
+	}
+	return y
+}
+
+func checkField(field []byte) []byte {
+	// Looking for the case where there's open and closed quotes and text to the
+	// left or right side of it. If we find this case remove the quotes.
+	quote := []byte(`"`)
+	for {
+		start := bytes.Index(field, quote)
+		if start == -1 {
+			return field
+		}
+		end := bytes.Index(field[start+1:], quote)
+		if end == -1 {
+			return field
+		}
+		end += start + 1
+		if start == 0 && end == len(field)-1 {
+			return field
+		}
+		// also ignore double quotes
+		if end == start+1 {
+			return field
+		}
+		field = append(field[:end], field[end+1:]...)
+		field = append(field[:start], field[start+1:]...)
+	}
+}

--- a/zio/csvio/preprocess_test.go
+++ b/zio/csvio/preprocess_test.go
@@ -1,0 +1,25 @@
+package csvio
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreprocess(t *testing.T) {
+	const input = `
+field1,"field"2,field"3" my friend
+field4,"field"5 with "multiple" quotes "to" escape,field6`
+	const expected = `
+field1,field2,field3 my friend
+field4,field5 with multiple quotes to escape,field6`
+	p := newPreProcess(strings.NewReader(input))
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, p)
+	require.NoError(t, err)
+	assert.Equal(t, expected, buf.String())
+}

--- a/zio/csvio/preprocess_test.go
+++ b/zio/csvio/preprocess_test.go
@@ -17,7 +17,7 @@ field4,"field"5 with "multiple" quotes "to" escape,field6`
 	const expected = `
 field1,field2,field3 my friend
 field4,field5 with multiple quotes to escape,field6`
-	p := newPreProcess(strings.NewReader(input))
+	p := newPreprocess(strings.NewReader(input))
 	var buf bytes.Buffer
 	_, err := io.Copy(&buf, p)
 	require.NoError(t, err)

--- a/zio/csvio/preprocess_test.go
+++ b/zio/csvio/preprocess_test.go
@@ -13,10 +13,17 @@ import (
 func TestPreprocess(t *testing.T) {
 	const input = `
 field1,"field"2,field"3" my friend
-field4,"field"5 with "multiple" quotes "to" escape,field6`
+field4,"field"5 with "multiple" quotes "to" escape,field6
+""",""",""" has a couple "" embedded quotes and a , comma",""" """
+x,"hello,
+"" world , " foo,y`
 	const expected = `
-field1,field2,field3 my friend
-field4,field5 with multiple quotes to escape,field6`
+field1,"field2","field3 my friend"
+field4,"field5 with multiple quotes to escape",field6
+""",""",""" has a couple "" embedded quotes and a , comma",""" """
+x,"hello,
+"" world ,  foo",y`
+
 	p := newPreprocess(strings.NewReader(input))
 	var buf bytes.Buffer
 	_, err := io.Copy(&buf, p)

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -29,7 +29,7 @@ type Reader struct {
 //}
 
 func NewReader(r io.Reader, zctx *zson.Context) *Reader {
-	preprocess := newPreProcess(r)
+	preprocess := newPreprocess(r)
 	reader := csv.NewReader(preprocess)
 	reader.ReuseRecord = true
 	reader.TrimLeadingSpace = true

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -29,7 +29,8 @@ type Reader struct {
 //}
 
 func NewReader(r io.Reader, zctx *zson.Context) *Reader {
-	reader := csv.NewReader(r)
+	preprocess := newPreProcess(r)
+	reader := csv.NewReader(preprocess)
 	reader.ReuseRecord = true
 	reader.TrimLeadingSpace = true
 	return &Reader{

--- a/zio/csvio/ztests/embedded-quotes.yaml
+++ b/zio/csvio/ztests/embedded-quotes.yaml
@@ -1,0 +1,16 @@
+script: zq -i csv -Z '*' -
+
+inputs:
+  - name: stdin
+    data: |
+      field1, field2, field3
+      """,""",""" has a couple "" embedded quotes and a , comma",""" """
+
+outputs:
+  - name: stdout
+    data: |
+      {
+          field1: "\",\"",
+          field2: "\" has a couple \" embedded quotes and a , comma",
+          field3: "\" \""
+      }

--- a/zio/csvio/ztests/extraneous-quotes.yaml
+++ b/zio/csvio/ztests/extraneous-quotes.yaml
@@ -1,0 +1,14 @@
+script: zq -i csv -z '*' -
+
+inputs:
+  - name: stdin
+    data: |
+      field1,field2,field"3"
+      value1,"value"2,value"3" my friend
+      value4,"value"5 with "multiple" quotes "to" escape,value6
+
+outputs:
+  - name: stdout
+    data: |
+      {field1:"value1",field2:"value2",field3:"value3 my friend"}
+      {field1:"value4",field2:"value5 with multiple quotes to escape",field3:"value6"}

--- a/ztest/shell.go
+++ b/ztest/shell.go
@@ -33,5 +33,6 @@ func RunShell(dir Dir, bindir, script string, stdin io.Reader, useenvs []string)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
+	fmt.Println("stderr", stderr.String())
 	return stdout.String(), stderr.String(), err
 }

--- a/ztest/shell.go
+++ b/ztest/shell.go
@@ -33,6 +33,5 @@ func RunShell(dir Dir, bindir, script string, stdin io.Reader, useenvs []string)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	fmt.Println("stderr", stderr.String())
 	return stdout.String(), stderr.String(), err
 }


### PR DESCRIPTION
Add a reader on top of the go csv reader that looks for fields where
quotes do not cover the entirety of a field. If such a case is found
the quotes are stripped from the field.

For instance, the line:
field1,"field2" extra
Would get converted into:
field1,field2 extra

Closes #2862