### PR TITLE
user better key names for cloud storage objects

### DIFF
--- a/docs/lake/design.md
+++ b/docs/lake/design.md
@@ -746,14 +746,22 @@ the configuration history.
 
 ```
 <lake-path>/
-  R/
+  pools/
     HEAD
     TAIL
     1.zng
     2.zng
     ...
+  index_rules/
+    HEAD
+    TAIL
+    1.zng
+    2.zng
+    ...
+  staging/
+    ...
   <pool-tag-1>/
-    J/
+    log/
       HEAD
       TAIL
       1.zng
@@ -764,7 +772,7 @@ the configuration history.
       20-seek.zng
       21.zng
       ...
-    D/
+    data/
       <tag1>.{zng,zst}
       <tag2>.{zng,zst}
       ...

--- a/lake/commit/log.go
+++ b/lake/commit/log.go
@@ -24,8 +24,7 @@ type Log struct {
 }
 
 const (
-	journalHandle = "J"
-	maxRetries    = 10
+	maxRetries = 10
 )
 
 var ErrRetriesExceeded = fmt.Errorf("commit journal unavailable after %d attempts", maxRetries)
@@ -41,7 +40,7 @@ func newLog(path *storage.URI, o order.Which) *Log {
 func Open(ctx context.Context, engine storage.Engine, path *storage.URI, o order.Which) (*Log, error) {
 	l := newLog(path, o)
 	var err error
-	l.journal, err = journal.Open(ctx, engine, l.path.AppendPath(journalHandle))
+	l.journal, err = journal.Open(ctx, engine, l.path)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +49,7 @@ func Open(ctx context.Context, engine storage.Engine, path *storage.URI, o order
 
 func Create(ctx context.Context, engine storage.Engine, path *storage.URI, o order.Which) (*Log, error) {
 	l := newLog(path, o)
-	j, err := journal.Create(ctx, engine, l.path.AppendPath(journalHandle))
+	j, err := journal.Create(ctx, engine, l.path)
 	if err != nil {
 		return nil, err
 	}

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -26,10 +26,10 @@ import (
 )
 
 const (
-	DataTag  = "D"
-	IndexTag = "I"
-	LogTag   = "L"
-	StageTag = "S"
+	DataTag  = "data"
+	IndexTag = "index"
+	LogTag   = "log"
+	StageTag = "staging"
 )
 
 var ErrStagingEmpty = errors.New("staging area empty")

--- a/lake/ztests/consecutive-ts.yaml
+++ b/lake/ztests/consecutive-ts.yaml
@@ -3,7 +3,7 @@ script: |
   zed lake init -q
   zed lake create -q -p logs -orderby ts:desc
   zed lake load -q -p logs -seekstride 11B in.zson
-  zq -z test/*/D/*-seek.zng
+  zq -z test/*/data/*-seek.zng
 
 inputs:
   - name: in.zson


### PR DESCRIPTION
This commit improves the key names for cloud storage objects to
make debugging and demo easier.  It will also help people new
to the lake design more easily understand the layout.

We also got rid of the superfulous "J" component in the commit log.