### PR TITLE
move zng serialization code out of package journal and into zngbytes

### DIFF
--- a/lake/commit/log.go
+++ b/lake/commit/log.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio/zngio"
+	"github.com/brimdata/zed/zngbytes"
 	"github.com/segmentio/ksuid"
 )
 
@@ -116,7 +117,7 @@ func (l *Log) Snapshot(ctx context.Context, at journal.ID) (*Snapshot, error) {
 		return nil, err
 	}
 	snapshot := newSnapshotAt(at)
-	reader := journal.NewDeserializer(r, actions.JournalTypes)
+	reader := zngbytes.NewDeserializer(r, actions.JournalTypes)
 	for {
 		entry, err := reader.Read()
 		if err != nil {
@@ -149,7 +150,7 @@ func (l *Log) SnapshotOfCommit(ctx context.Context, at journal.ID, commit ksuid.
 	}
 	var valid bool
 	snapshot := newSnapshotAt(at)
-	reader := journal.NewDeserializer(r, actions.JournalTypes)
+	reader := zngbytes.NewDeserializer(r, actions.JournalTypes)
 	for {
 		entry, err := reader.Read()
 		if err != nil {
@@ -190,7 +191,7 @@ func (l *Log) JournalIDOfCommit(ctx context.Context, at journal.ID, commit ksuid
 		if err != nil {
 			return journal.Nil, err
 		}
-		reader := journal.NewDeserializer(bytes.NewReader(b), actions.JournalTypes)
+		reader := zngbytes.NewDeserializer(bytes.NewReader(b), actions.JournalTypes)
 		entry, err := reader.Read()
 		if err != nil {
 			return journal.Nil, err

--- a/lake/commit/transaction.go
+++ b/lake/commit/transaction.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/brimdata/zed/lake/commit/actions"
 	"github.com/brimdata/zed/lake/index"
-	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/lake/segment"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zngbytes"
 	"github.com/segmentio/ksuid"
 )
 
@@ -94,7 +94,7 @@ func (t *Transaction) appendAddIndex(i *index.Reference) {
 }
 
 func (t Transaction) Serialize() ([]byte, error) {
-	writer := journal.NewSerializer()
+	writer := zngbytes.NewSerializer()
 	for _, action := range t.Actions {
 		if err := writer.Write(action); err != nil {
 			writer.Close()
@@ -112,7 +112,7 @@ func (t Transaction) Serialize() ([]byte, error) {
 }
 
 func (t *Transaction) Deserialize(r io.Reader) error {
-	reader := journal.NewDeserializer(r, actions.JournalTypes)
+	reader := zngbytes.NewDeserializer(r, actions.JournalTypes)
 	for {
 		entry, err := reader.Read()
 		if err != nil {

--- a/lake/index/store.go
+++ b/lake/index/store.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zngbytes"
 	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
 )
@@ -261,7 +262,7 @@ func (s *Store) IDs(ctx context.Context) ([]ksuid.KSUID, error) {
 }
 
 func serialize(r interface{}) ([]byte, error) {
-	serializer := journal.NewSerializer()
+	serializer := zngbytes.NewSerializer()
 	if err := serializer.Write(r); err != nil {
 		return nil, err
 	}

--- a/lake/journal/kvs/store.go
+++ b/lake/journal/kvs/store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zngbytes"
 	"github.com/brimdata/zed/zson"
 )
 
@@ -218,7 +219,7 @@ func (s *Store) Move(ctx context.Context, oldKey, newKey string, newVal interfac
 		Key:   newKey,
 		Value: newVal,
 	}
-	serializer := journal.NewSerializer()
+	serializer := zngbytes.NewSerializer()
 	if err := serializer.Write(&remove); err != nil {
 		return err
 	}
@@ -254,7 +255,7 @@ func (s *Store) Move(ctx context.Context, oldKey, newKey string, newVal interfac
 }
 
 func (e Entry) serialize() ([]byte, error) {
-	serializer := journal.NewSerializer()
+	serializer := zngbytes.NewSerializer()
 	if err := serializer.Write(&e); err != nil {
 		return nil, err
 	}

--- a/zngbytes/deserializer.go
+++ b/zngbytes/deserializer.go
@@ -1,4 +1,4 @@
-package journal
+package zngbytes
 
 import (
 	"io"

--- a/zngbytes/serializer.go
+++ b/zngbytes/serializer.go
@@ -1,4 +1,4 @@
-package journal
+package zngbytes
 
 import (
 	"bytes"


### PR DESCRIPTION
This commit moves the zng serialization code that was in package journal
into a new, top-level package called zngbytes.  There was no dependency
between the journal code and this serialization logic and after this
change, this functionality will be more obviously available without
reaching into package journal.