### PR TITLE
ztest: Add input flags to zed tests

### DIFF
--- a/zio/anyio/reader.go
+++ b/zio/anyio/reader.go
@@ -22,6 +22,9 @@ type ReaderOpts struct {
 }
 
 func NewReaderWithOpts(r io.Reader, zctx *zson.Context, opts ReaderOpts) (zio.Reader, error) {
+	if opts.Format != "" && opts.Format != "auto" {
+		return lookupReader(r, zctx, opts)
+	}
 	recorder := NewRecorder(r)
 	track := NewTrack(recorder)
 

--- a/zio/csvio/ztests/issue-2332.yaml
+++ b/zio/csvio/ztests/issue-2332.yaml
@@ -1,14 +1,12 @@
-script: zq -i csv -z '*' -
+zed: '*'
 
-inputs:
-  - name: stdin
-    data: |
-      "Letter", "Frequency", "Percentage"
-        "A",  24373121,  8.1
-        "B",   4762938,  1.6
+input-flags: -i csv
 
-outputs:
-  - name: stdout
-    data: |
-      {Letter:"A",Frequency:24373121.,Percentage:8.1}
-      {Letter:"B",Frequency:4762938.,Percentage:1.6}
+input: |
+  "Letter", "Frequency", "Percentage"
+    "A",  24373121,  8.1
+    "B",   4762938,  1.6
+
+output: |
+  {Letter:"A",Frequency:24373121.,Percentage:8.1}
+  {Letter:"B",Frequency:4762938.,Percentage:1.6}

--- a/zio/csvio/ztests/reader.yaml
+++ b/zio/csvio/ztests/reader.yaml
@@ -1,14 +1,12 @@
-script: zq -i csv -z '*' -
+zed: '*'
 
-inputs:
-  - name: stdin
-    data: |
-      a,b,c
-      1,2,3
-      hello,world,4
+input-flags: -i csv
 
-outputs:
-  - name: stdout
-    data: |
-      {a:1.,b:2.,c:3.}
-      {a:"hello",b:"world",c:4.}
+input: |
+  a,b,c
+  1,2,3
+  hello,world,4
+
+output: |
+  {a:1.,b:2.,c:3.}
+  {a:"hello",b:"world",c:4.}

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -552,18 +552,22 @@ func runzq(path, zed, input string, outputFlags []string, inputFlags []string) (
 	if err != nil {
 		return "", "", err
 	}
-	var outflags outputflags.Flags
 	var inflags inputflags.Flags
 	var flags flag.FlagSet
-	outflags.SetFlags(&flags)
 	inflags.SetFlags(&flags)
-	if err := flags.Parse(append(outputFlags, inputFlags...)); err != nil {
+	if err := flags.Parse(inputFlags); err != nil {
 		return "", "", err
 	}
 	zctx := zson.NewContext()
 	zr, err := anyio.NewReaderWithOpts(anyio.GzipReader(strings.NewReader(input)), zctx, inflags.Options())
 	if err != nil {
 		return "", err.Error(), err
+	}
+	var outflags outputflags.Flags
+	flags = flag.FlagSet{}
+	outflags.SetFlags(&flags)
+	if err := flags.Parse(outputFlags); err != nil {
+		return "", "", err
 	}
 	zw, err := anyio.NewWriter(&nopCloser{&outbuf}, outflags.Options())
 	if err != nil {


### PR DESCRIPTION
This allows for zed tests to specify the input format. Useful when
testing zio Readers such as csv that do not working with auto detect.