### PR TITLE
replace zbuf.MergeReadersByTsAsReader with zio.ConcatReader

### DIFF
--- a/cmd/zed/lake/add/command.go
+++ b/cmd/zed/lake/add/command.go
@@ -15,7 +15,6 @@ import (
 	"github.com/brimdata/zed/pkg/rlimit"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/pkg/units"
-	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
 )
@@ -99,18 +98,13 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	// XXX See issue #2921.  Not clear we should merge by ts here.
-	reader, err := zbuf.MergeReadersByTsAsReader(ctx, readers, pool.Layout.Order)
-	if err != nil {
-		return err
-	}
 	action := "staged"
 	var commit *api.CommitRequest
 	if c.commit {
 		commit = c.CommitRequest()
 		action = "committed"
 	}
-	id, err := lake.Add(ctx, pool.ID, reader, commit)
+	id, err := lake.Add(ctx, pool.ID, zio.ConcatReader(readers...), commit)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/lake/load/command.go
+++ b/cmd/zed/lake/load/command.go
@@ -15,7 +15,6 @@ import (
 	"github.com/brimdata/zed/pkg/rlimit"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/pkg/units"
-	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
 )
@@ -87,11 +86,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	reader, err := zbuf.MergeReadersByTsAsReader(ctx, readers, pool.Layout.Order)
-	if err != nil {
-		return err
-	}
-	commitID, err := lake.Add(ctx, pool.ID, reader, c.CommitRequest())
+	commitID, err := lake.Add(ctx, pool.ID, zio.ConcatReader(readers...), c.CommitRequest())
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/zst/create/command.go
+++ b/cmd/zed/zst/create/command.go
@@ -7,10 +7,8 @@ import (
 	"github.com/brimdata/zed/cli/inputflags"
 	"github.com/brimdata/zed/cli/outputflags"
 	"github.com/brimdata/zed/cmd/zed/zst"
-	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
-	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
 )
@@ -76,15 +74,11 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer zio.CloseReaders(readers)
-	reader, err := zbuf.MergeReadersByTsAsReader(ctx, readers, order.Asc)
-	if err != nil {
-		return err
-	}
 	writer, err := c.outputFlags.Open(ctx, local)
 	if err != nil {
 		return err
 	}
-	if err := zio.Copy(writer, reader); err != nil {
+	if err := zio.Copy(writer, zio.ConcatReader(readers...)); err != nil {
 		return err
 	}
 	return writer.Close()

--- a/zbuf/merger.go
+++ b/zbuf/merger.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/brimdata/zed/expr"
 	"github.com/brimdata/zed/order"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zng"
 )
 
@@ -74,21 +73,6 @@ func NewMerger(ctx context.Context, pullers []Puller, cmp expr.CompareFn) *Merge
 		m.pullers = append(m.pullers, &mergerPuller{Puller: p, ch: make(chan batch)})
 	}
 	return m
-}
-
-func MergeReadersByTsAsReader(ctx context.Context, readers []zio.Reader, o order.Which) (zio.Reader, error) {
-	if len(readers) == 1 {
-		return readers[0], nil
-	}
-	return MergeReadersByTs(ctx, readers, o)
-}
-
-func MergeReadersByTs(ctx context.Context, readers []zio.Reader, o order.Which) (*Merger, error) {
-	pullers, err := ReadersToPullers(ctx, readers)
-	if err != nil {
-		return nil, err
-	}
-	return MergeByTs(ctx, pullers, o), nil
 }
 
 func MergeByTs(ctx context.Context, pullers []Puller, o order.Which) *Merger {

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -64,35 +64,6 @@ func (s *ScannerStats) Copy() ScannerStats {
 	}
 }
 
-func ReadersToScanners(ctx context.Context, readers []zio.Reader) ([]Scanner, error) {
-	scanners := make([]Scanner, 0, len(readers))
-	for _, reader := range readers {
-		s, err := NewScanner(ctx, reader, nil)
-		if err != nil {
-			return nil, err
-		}
-		scanners = append(scanners, s)
-	}
-	return scanners, nil
-}
-
-// ReadersToPullers returns a slice of Pullers that pull from the given
-// Readers.  If any or all of the readers implement Scannerable, then
-// a scanner will be created from the underlying Scannerable so that the
-// pulled Batches are more efficient, i.e., the zng scanner will arrange
-// for each Batch to be returned to a pool instead of being GC'd.
-func ReadersToPullers(ctx context.Context, readers []zio.Reader) ([]Puller, error) {
-	scanners, err := ReadersToScanners(ctx, readers)
-	if err != nil {
-		return nil, err
-	}
-	pullers := make([]Puller, 0, len(scanners))
-	for _, s := range scanners {
-		pullers = append(pullers, s)
-	}
-	return pullers, nil
-}
-
 var ScannerBatchSize = 100
 
 // NewScanner returns a Scanner for r that filters records by filterExpr and s.


### PR DESCRIPTION
Calls to zbuf.MergeReadersByTsAsReader assume the readers passed to it
are ordered by field ts, but that assumption is generally unwarranted.
Use zio.ConcatReader instead.

Closes #2921.