### PR TITLE
add meta-query to "from" operator and port instropection logic

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -195,13 +195,6 @@ func (c *Connection) ZedToAST(ctx context.Context, zprog string) ([]byte, error)
 	return resp.Body(), nil
 }
 
-func (c *Connection) ScanPools(ctx context.Context) (*Response, error) {
-	req := c.Request(ctx)
-	req.Method = http.MethodGet
-	req.URL = "/pool"
-	return c.stream(req)
-}
-
 // PoolGet retrieves information about the specified pool.
 func (c *Connection) PoolGet(ctx context.Context, id ksuid.KSUID) (*Response, error) {
 	req := c.Request(ctx)
@@ -265,26 +258,6 @@ func (c *Connection) ScanStaging(ctx context.Context, pool ksuid.KSUID, tags []k
 		SetQueryParamsFromValues(url.Values{"tag": t})
 	req.Method = http.MethodGet
 	req.URL = path.Join("/pool", pool.String(), "staging")
-	return c.stream(req)
-}
-
-func (c *Connection) ScanSegments(ctx context.Context, pool, at ksuid.KSUID, partitions bool) (*Response, error) {
-	req := c.Request(ctx)
-	if at != ksuid.Nil {
-		req.SetQueryParam("at", at.String())
-	}
-	if partitions {
-		req.SetQueryParam("partition", "T")
-	}
-	req.Method = http.MethodGet
-	req.URL = path.Join("/pool", pool.String(), "segments")
-	return c.stream(req)
-}
-
-func (c *Connection) ScanLog(ctx context.Context, pool ksuid.KSUID) (*Response, error) {
-	req := c.Request(ctx)
-	req.Method = http.MethodGet
-	req.URL = path.Join("/pool", pool.String(), "log")
 	return c.stream(req)
 }
 

--- a/cli/adaptor.go
+++ b/cli/adaptor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/storage"
@@ -28,15 +29,15 @@ func NewFileAdaptor(engine storage.Engine) *FileAdaptor {
 	}
 }
 
-func (f *FileAdaptor) Lookup(_ context.Context, _ string) (ksuid.KSUID, error) {
-	return ksuid.Nil, nil
+func (f *FileAdaptor) LookupIDs(context.Context, string, string) (ksuid.KSUID, ksuid.KSUID, error) {
+	return ksuid.Nil, ksuid.Nil, nil
 }
 
-func (f *FileAdaptor) Layout(_ context.Context, _ ksuid.KSUID) (order.Layout, error) {
-	return order.Nil, errors.New("pool scan not available when running on local file system")
+func (f *FileAdaptor) Layout(context.Context, dag.Source) order.Layout {
+	return order.Nil
 }
 
-func (f *FileAdaptor) NewScheduler(context.Context, *zson.Context, ksuid.KSUID, ksuid.KSUID, extent.Span, zbuf.Filter) (proc.Scheduler, error) {
+func (f *FileAdaptor) NewScheduler(context.Context, *zson.Context, dag.Source, extent.Span, zbuf.Filter) (proc.Scheduler, error) {
 	return nil, errors.New("pool scan not available when running on local file system")
 }
 

--- a/cli/lakeflags/flags.go
+++ b/cli/lakeflags/flags.go
@@ -1,11 +1,7 @@
 package lakeflags
 
 import (
-	"encoding/hex"
 	"flag"
-	"fmt"
-
-	"github.com/segmentio/ksuid"
 )
 
 type Flags struct {
@@ -16,39 +12,4 @@ type Flags struct {
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&f.Quiet, "q", false, "quiet mode")
 	fs.StringVar(&f.PoolName, "p", "", "name of pool")
-}
-
-func ParseID(s string) (ksuid.KSUID, error) {
-	// Check if this is a cut-and-paste from ZNG, which encodes
-	// the 20-byte KSUID as a 40 character hex string with 0x prefix.
-	var id ksuid.KSUID
-	if len(s) == 42 && s[0:2] == "0x" {
-		b, err := hex.DecodeString(s[2:])
-		if err != nil {
-			return ksuid.Nil, fmt.Errorf("illegal hex tag: %s", s)
-		}
-		id, err = ksuid.FromBytes(b)
-		if err != nil {
-			return ksuid.Nil, fmt.Errorf("illegal hex tag: %s", s)
-		}
-	} else {
-		var err error
-		id, err = ksuid.Parse(s)
-		if err != nil {
-			return ksuid.Nil, fmt.Errorf("%s: invalid commit ID", s)
-		}
-	}
-	return id, nil
-}
-
-func ParseIDs(ss []string) ([]ksuid.KSUID, error) {
-	ids := make([]ksuid.KSUID, 0, len(ss))
-	for _, s := range ss {
-		id, err := ParseID(s)
-		if err != nil {
-			return nil, err
-		}
-		ids = append(ids, id)
-	}
-	return ids, nil
 }

--- a/cmd/zed/lake/commit/command.go
+++ b/cmd/zed/lake/commit/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brimdata/zed/cli/lakeflags"
 	zedapi "github.com/brimdata/zed/cmd/zed/api"
 	zedlake "github.com/brimdata/zed/cmd/zed/lake"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/segmentio/ksuid"
 )
@@ -65,7 +66,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	ids, err := lakeflags.ParseIDs(args)
+	ids, err := parser.ParseIDs(args)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/lake/delete/command.go
+++ b/cmd/zed/lake/delete/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brimdata/zed/cli/lakeflags"
 	zedapi "github.com/brimdata/zed/cmd/zed/api"
 	zedlake "github.com/brimdata/zed/cmd/zed/lake"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/pkg/charm"
 )
 
@@ -74,7 +75,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	tags, err := lakeflags.ParseIDs(args)
+	tags, err := parser.ParseIDs(args)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/lake/index/apply.go
+++ b/cmd/zed/lake/index/apply.go
@@ -5,8 +5,8 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/brimdata/zed/cli/lakeflags"
 	zedlake "github.com/brimdata/zed/cmd/zed/lake"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/rlimit"
 	"github.com/segmentio/ksuid"
@@ -50,7 +50,7 @@ func (c *ApplyCommand) Run(args []string) error {
 		return errors.New("index apply command requires rule name and one or more object IDs")
 	}
 	ruleName := args[0]
-	tags, err := lakeflags.ParseIDs(args[1:])
+	tags, err := parser.ParseIDs(args[1:])
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/lake/index/create.go
+++ b/cmd/zed/lake/index/create.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/brimdata/zed/cli/outputflags"
 	"github.com/brimdata/zed/cli/procflags"
+	"github.com/brimdata/zed/driver"
 	"github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/pkg/charm"
@@ -69,7 +70,8 @@ func (c *CreateCommand) Run(args []string) error {
 		if err != nil {
 			return err
 		}
-		if err := lake.ScanIndexRules(ctx, w, nil); err != nil {
+		d := driver.NewCLI(w)
+		if err := api.ScanIndexRules(ctx, lake, d); err != nil {
 			return err
 		}
 		return w.Close()

--- a/cmd/zed/lake/index/drop.go
+++ b/cmd/zed/lake/index/drop.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/brimdata/zed/cli/lakeflags"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/rlimit"
 )
@@ -37,7 +37,7 @@ func (c *DropCommand) Run(args []string) error {
 	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
 		return err
 	}
-	ids, err := lakeflags.ParseIDs(args)
+	ids, err := parser.ParseIDs(args)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/lake/index/ls.go
+++ b/cmd/zed/lake/index/ls.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 
 	"github.com/brimdata/zed/cli/outputflags"
+	"github.com/brimdata/zed/driver"
+	"github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/rlimit"
 	"github.com/brimdata/zed/pkg/storage"
@@ -46,5 +48,5 @@ func (c *LsCommand) Run(args []string) error {
 		return err
 	}
 	defer w.Close()
-	return lake.ScanIndexRules(ctx, w, args)
+	return api.ScanIndexRules(ctx, lake, driver.NewCLI(w))
 }

--- a/cmd/zed/lake/squash/command.go
+++ b/cmd/zed/lake/squash/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brimdata/zed/cli/lakeflags"
 	zedapi "github.com/brimdata/zed/cmd/zed/api"
 	zedlake "github.com/brimdata/zed/cmd/zed/lake"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/pkg/charm"
 )
 
@@ -63,7 +64,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	ids, err := lakeflags.ParseIDs(args)
+	ids, err := parser.ParseIDs(args)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/lake/status/command.go
+++ b/cmd/zed/lake/status/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/zed/cli/outputflags"
 	zedapi "github.com/brimdata/zed/cmd/zed/api"
 	zedlake "github.com/brimdata/zed/cmd/zed/lake"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
@@ -52,7 +53,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer cleanup()
-	ids, err := lakeflags.ParseIDs(args)
+	ids, err := parser.ParseIDs(args)
 	if err != nil {
 		return err
 	}

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -369,11 +369,11 @@ type (
 		Layout *Layout `json:"layout"`
 	}
 	Pool struct {
-		Kind      string `json:"kind" unpack:""`
-		Name      string `json:"name"`
-		At        string `json:"at"`
-		Range     *Range `json:"range"`
-		ScanOrder string `json:"scan_order"` // asc, desc, or unknown
+		Kind      string   `json:"kind" unpack:""`
+		Spec      PoolSpec `json:"spec"`
+		At        string   `json:"at"`
+		Range     *Range   `json:"range"`
+		ScanOrder string   `json:"scan_order"` // asc, desc, or unknown
 	}
 	Explode struct {
 		Kind string   `json:"kind" unpack:""`
@@ -382,6 +382,12 @@ type (
 		As   Expr     `json:"as"`
 	}
 )
+
+type PoolSpec struct {
+	Pool   string `json:"pool"`
+	Branch string `json:"branch"`
+	Meta   string `json:"meta"`
+}
 
 type Range struct {
 	Kind  string `json:"kind" unpack:""`

--- a/compiler/ast/dag/operator.go
+++ b/compiler/ast/dag/operator.go
@@ -166,10 +166,35 @@ type (
 	Pool struct {
 		Kind      string      `json:"kind" unpack:""`
 		ID        ksuid.KSUID `json:"id"`
+		Branch    ksuid.KSUID `json:"branch"`
 		At        ksuid.KSUID `json:"at"`
 		ScanLower Expr        `json:"scan_lower"`
 		ScanUpper Expr        `json:"scan_upper"`
 		ScanOrder string      `json:"scan_order"`
+	}
+	PoolMeta struct {
+		Kind string      `json:"kind" unpack:""`
+		ID   ksuid.KSUID `json:"id"`
+		Meta string      `json:"meta"`
+		//XXX these will go away when we implement branches
+		At        ksuid.KSUID `json:"at"`
+		ScanLower Expr        `json:"scan_lower"`
+		ScanUpper Expr        `json:"scan_upper"`
+		ScanOrder string      `json:"scan_order"`
+	}
+	BranchMeta struct {
+		Kind      string      `json:"kind" unpack:""`
+		ID        ksuid.KSUID `json:"id"`
+		Branch    ksuid.KSUID `json:"branch"`
+		Meta      string      `json:"meta"`
+		At        ksuid.KSUID `json:"at"`
+		ScanLower Expr        `json:"scan_lower"`
+		ScanUpper Expr        `json:"scan_upper"`
+		ScanOrder string      `json:"scan_order"`
+	}
+	LakeMeta struct {
+		Kind string `json:"kind" unpack:""`
+		Meta string `json:"meta"`
 	}
 )
 
@@ -177,10 +202,13 @@ type Source interface {
 	Source()
 }
 
-func (*File) Source() {}
-func (*HTTP) Source() {}
-func (*Pool) Source() {}
-func (*Pass) Source() {}
+func (*File) Source()       {}
+func (*HTTP) Source()       {}
+func (*Pool) Source()       {}
+func (*LakeMeta) Source()   {}
+func (*PoolMeta) Source()   {}
+func (*BranchMeta) Source() {}
+func (*Pass) Source()       {}
 
 // A From node can be a DAG entrypoint or an operator.  When it appears
 // as an operator it mixes its single parent in with other Trunks to

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -183,8 +183,8 @@ func (o *Optimizer) getLayout(s dag.Source, parent order.Layout) (order.Layout, 
 		return s.Layout, nil
 	case *dag.HTTP:
 		return s.Layout, nil
-	case *dag.Pool:
-		return o.adaptor.Layout(o.ctx, s.ID)
+	case *dag.Pool, *dag.LakeMeta, *dag.PoolMeta, *dag.BranchMeta:
+		return o.adaptor.Layout(o.ctx, s), nil
 	case *dag.Pass:
 		return parent, nil
 	case *kernel.Reader:

--- a/compiler/parser/lake.go
+++ b/compiler/parser/lake.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/segmentio/ksuid"
+)
+
+func ParseID(s string) (ksuid.KSUID, error) {
+	// Check if this is a cut-and-paste from ZNG, which encodes
+	// the 20-byte KSUID as a 40 character hex string with 0x prefix.
+	var id ksuid.KSUID
+	if len(s) == 42 && s[0:2] == "0x" {
+		b, err := hex.DecodeString(s[2:])
+		if err != nil {
+			return ksuid.Nil, fmt.Errorf("illegal hex tag: %s", s)
+		}
+		id, err = ksuid.FromBytes(b)
+		if err != nil {
+			return ksuid.Nil, fmt.Errorf("illegal hex tag: %s", s)
+		}
+	} else {
+		var err error
+		id, err = ksuid.Parse(s)
+		if err != nil {
+			return ksuid.Nil, fmt.Errorf("%s: invalid commit ID", s)
+		}
+	}
+	return id, nil
+}
+
+func ParseIDs(ss []string) ([]ksuid.KSUID, error) {
+	ids := make([]ksuid.KSUID, 0, len(ss))
+	for _, s := range ss {
+		id, err := ParseID(s)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -656,8 +656,8 @@ function peg$parse(input, options) {
           },
       peg$c206 = peg$literalExpectation("from", true),
       peg$c207 = function(body) { return body },
-      peg$c208 = function(name, at, over, order) {
-            return {"kind": "Pool", "name": name, "at": at, "range": over, "scan_order": order}
+      peg$c208 = function(spec, at, over, order) {
+            return {"kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order}
           },
       peg$c209 = "get",
       peg$c210 = peg$literalExpectation("get", true),
@@ -682,38 +682,57 @@ function peg$parse(input, options) {
       peg$c227 = function(lower, upper) {
             return {"kind":"Range","lower": lower, "upper": upper}
           },
-      peg$c228 = function(name) { return name },
-      peg$c229 = "order",
-      peg$c230 = peg$literalExpectation("order", true),
-      peg$c231 = function(keys, order) {
+      peg$c228 = "/",
+      peg$c229 = peg$literalExpectation("/", false),
+      peg$c230 = "]",
+      peg$c231 = peg$literalExpectation("]", false),
+      peg$c232 = function(pool, branch, meta) {
+            return {"pool": pool, "branch": branch, "meta": meta}
+          },
+      peg$c233 = function(pool, meta) {
+            return {"pool": pool, "branch": null, "meta": meta}
+          },
+      peg$c234 = function(meta) {
+            return {"pool": null, "branch": null, "meta": meta}
+          },
+      peg$c235 = function(pool, branch) {
+            return {"pool": pool, "branch": branch, "meta": null}
+          },
+      peg$c236 = function(pool) {
+            return {"pool": pool, "branch": null, "meta": null}
+          },
+      peg$c237 = function(name) { return name },
+      peg$c240 = "order",
+      peg$c241 = peg$literalExpectation("order", true),
+      peg$c242 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c232 = "format",
-      peg$c233 = peg$literalExpectation("format", true),
-      peg$c234 = function(val) { return val },
-      peg$c235 = ":asc",
-      peg$c236 = peg$literalExpectation(":asc", true),
-      peg$c237 = function() { return "asc" },
-      peg$c238 = ":desc",
-      peg$c239 = peg$literalExpectation(":desc", true),
-      peg$c240 = function() { return "desc" },
-      peg$c241 = "asc",
-      peg$c242 = peg$literalExpectation("asc", true),
-      peg$c243 = "desc",
-      peg$c244 = peg$literalExpectation("desc", true),
-      peg$c245 = "pass",
-      peg$c246 = peg$literalExpectation("pass", true),
-      peg$c247 = function() {
+      peg$c243 = "format",
+      peg$c244 = peg$literalExpectation("format", true),
+      peg$c245 = function(val) { return val },
+      peg$c246 = ":asc",
+      peg$c247 = peg$literalExpectation(":asc", true),
+      peg$c248 = function() { return "asc" },
+      peg$c249 = ":desc",
+      peg$c250 = peg$literalExpectation(":desc", true),
+      peg$c251 = function() { return "desc" },
+      peg$c252 = "asc",
+      peg$c253 = peg$literalExpectation("asc", true),
+      peg$c254 = "desc",
+      peg$c255 = peg$literalExpectation("desc", true),
+      peg$c256 = "pass",
+      peg$c257 = peg$literalExpectation("pass", true),
+      peg$c258 = function() {
             return {"kind":"Pass"}
           },
-      peg$c248 = "explode",
-      peg$c249 = peg$literalExpectation("explode", true),
-      peg$c250 = function(args, typ, as) {
+      peg$c259 = "explode",
+      peg$c260 = peg$literalExpectation("explode", true),
+      peg$c261 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c251 = function(typ) { return typ},
-      peg$c252 = function(lhs) { return lhs },
-      peg$c254 = function(first, rest) {
+      peg$c262 = function(typ) { return typ},
+      peg$c263 = function(lhs) { return lhs },
+      peg$c265 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -722,53 +741,51 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c255 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c256 = "?",
-      peg$c257 = peg$literalExpectation("?", false),
-      peg$c258 = function(condition, thenClause, elseClause) {
+      peg$c266 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c267 = "?",
+      peg$c268 = peg$literalExpectation("?", false),
+      peg$c269 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c259 = function(first, op, expr) { return [op, expr] },
-      peg$c260 = function(first, rest) {
+      peg$c270 = function(first, op, expr) { return [op, expr] },
+      peg$c271 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c261 = function(first, comp, expr) { return [comp, expr] },
-      peg$c262 = function() { return "="},
-      peg$c263 = "+",
-      peg$c264 = peg$literalExpectation("+", false),
-      peg$c265 = "-",
-      peg$c266 = peg$literalExpectation("-", false),
-      peg$c267 = "/",
-      peg$c268 = peg$literalExpectation("/", false),
-      peg$c269 = function(e) {
+      peg$c272 = function(first, comp, expr) { return [comp, expr] },
+      peg$c273 = function() { return "="},
+      peg$c274 = "+",
+      peg$c275 = peg$literalExpectation("+", false),
+      peg$c276 = "-",
+      peg$c277 = peg$literalExpectation("-", false),
+      peg$c278 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c270 = function(typ) { return typ },
-      peg$c271 = "not",
-      peg$c272 = peg$literalExpectation("not", false),
-      peg$c273 = "match",
-      peg$c274 = peg$literalExpectation("match", false),
-      peg$c275 = "select",
-      peg$c276 = peg$literalExpectation("select", false),
-      peg$c277 = function(args, methods) {
+      peg$c279 = function(typ) { return typ },
+      peg$c280 = "not",
+      peg$c281 = peg$literalExpectation("not", false),
+      peg$c282 = "match",
+      peg$c283 = peg$literalExpectation("match", false),
+      peg$c284 = "select",
+      peg$c285 = peg$literalExpectation("select", false),
+      peg$c286 = function(args, methods) {
             return {"kind":"SelectExpr", "selectors":args, "methods": methods}
           },
-      peg$c278 = function(methods) { return methods },
-      peg$c279 = function(typ, expr) {
+      peg$c287 = function(methods) { return methods },
+      peg$c288 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c280 = function(fn, args) {
+      peg$c289 = function(fn, args) {
             return {"kind": "Call", "name": fn, "args": args}
           },
-      peg$c281 = function() { return [] },
-      peg$c282 = function(first, e) { return e },
-      peg$c283 = function(e) { return e },
-      peg$c284 = function() {
+      peg$c290 = function() { return [] },
+      peg$c291 = function(first, e) { return e },
+      peg$c292 = function(e) { return e },
+      peg$c293 = function() {
             return {"kind":"Root"}
           },
-      peg$c285 = "this",
-      peg$c286 = peg$literalExpectation("this", false),
-      peg$c287 = function(field) {
+      peg$c294 = "this",
+      peg$c295 = peg$literalExpectation("this", false),
+      peg$c296 = function(field) {
             return {"kind": "BinaryExpr", "op":".",
                            
             "lhs":{"kind":"Root"},
@@ -777,9 +794,7 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c288 = "]",
-      peg$c289 = peg$literalExpectation("]", false),
-      peg$c290 = function(expr) {
+      peg$c297 = function(expr) {
             return {"kind": "BinaryExpr", "op":"[",
                            
             "lhs":{"kind":"Root"},
@@ -788,58 +803,58 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c291 = function(from, to) {
+      peg$c298 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c292 = function(to) {
+      peg$c299 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c293 = function(from) {
+      peg$c300 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c294 = function(expr) { return ["[", expr] },
-      peg$c295 = function(id) { return [".", id] },
-      peg$c296 = "}",
-      peg$c297 = peg$literalExpectation("}", false),
-      peg$c298 = function(fields) {
+      peg$c301 = function(expr) { return ["[", expr] },
+      peg$c302 = function(id) { return [".", id] },
+      peg$c303 = "}",
+      peg$c304 = peg$literalExpectation("}", false),
+      peg$c305 = function(fields) {
             return {"kind":"RecordExpr", "fields":fields }
           },
-      peg$c299 = function(first, rest) {
+      peg$c306 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c300 = function(name, value) {
+      peg$c307 = function(name, value) {
             return {"name": name, "value": value}
           },
-      peg$c301 = function(exprs) {
+      peg$c308 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c302 = "|[",
-      peg$c303 = peg$literalExpectation("|[", false),
-      peg$c304 = "]|",
-      peg$c305 = peg$literalExpectation("]|", false),
-      peg$c306 = function(exprs) {
+      peg$c309 = "|[",
+      peg$c310 = peg$literalExpectation("|[", false),
+      peg$c311 = "]|",
+      peg$c312 = peg$literalExpectation("]|", false),
+      peg$c313 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c307 = "|{",
-      peg$c308 = peg$literalExpectation("|{", false),
-      peg$c309 = "}|",
-      peg$c310 = peg$literalExpectation("}|", false),
-      peg$c311 = function(exprs) {
+      peg$c314 = "|{",
+      peg$c315 = peg$literalExpectation("|{", false),
+      peg$c316 = "}|",
+      peg$c317 = peg$literalExpectation("}|", false),
+      peg$c318 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c312 = function(key, value) {
+      peg$c319 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c313 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c320 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -861,13 +876,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c314 = function(assignments) { return assignments },
-      peg$c315 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c316 = function(table, alias) {
+      peg$c321 = function(assignments) { return assignments },
+      peg$c322 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c323 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c317 = function(first, join) { return join },
-      peg$c318 = function(style, table, alias, leftKey, rightKey) {
+      peg$c324 = function(first, join) { return join },
+      peg$c325 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -885,274 +900,274 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c319 = function(style) { return style },
-      peg$c320 = function(keys, order) {
+      peg$c326 = function(style) { return style },
+      peg$c327 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c321 = function(dir) { return dir },
-      peg$c322 = function(count) { return count },
-      peg$c323 = peg$literalExpectation("select", true),
-      peg$c324 = function() { return "select" },
-      peg$c325 = "as",
-      peg$c326 = peg$literalExpectation("as", true),
-      peg$c327 = function() { return "as" },
-      peg$c328 = function() { return "from" },
-      peg$c329 = function() { return "join" },
-      peg$c330 = peg$literalExpectation("where", true),
-      peg$c331 = function() { return "where" },
-      peg$c332 = "group",
-      peg$c333 = peg$literalExpectation("group", true),
-      peg$c334 = function() { return "group" },
-      peg$c335 = "having",
-      peg$c336 = peg$literalExpectation("having", true),
-      peg$c337 = function() { return "having" },
-      peg$c338 = function() { return "order" },
-      peg$c339 = "on",
-      peg$c340 = peg$literalExpectation("on", true),
-      peg$c341 = function() { return "on" },
-      peg$c342 = "limit",
-      peg$c343 = peg$literalExpectation("limit", true),
-      peg$c344 = function() { return "limit" },
-      peg$c345 = function(v) {
+      peg$c328 = function(dir) { return dir },
+      peg$c329 = function(count) { return count },
+      peg$c330 = peg$literalExpectation("select", true),
+      peg$c331 = function() { return "select" },
+      peg$c332 = "as",
+      peg$c333 = peg$literalExpectation("as", true),
+      peg$c334 = function() { return "as" },
+      peg$c335 = function() { return "from" },
+      peg$c336 = function() { return "join" },
+      peg$c337 = peg$literalExpectation("where", true),
+      peg$c338 = function() { return "where" },
+      peg$c339 = "group",
+      peg$c340 = peg$literalExpectation("group", true),
+      peg$c341 = function() { return "group" },
+      peg$c342 = "having",
+      peg$c343 = peg$literalExpectation("having", true),
+      peg$c344 = function() { return "having" },
+      peg$c345 = function() { return "order" },
+      peg$c346 = "on",
+      peg$c347 = peg$literalExpectation("on", true),
+      peg$c348 = function() { return "on" },
+      peg$c349 = "limit",
+      peg$c350 = peg$literalExpectation("limit", true),
+      peg$c351 = function() { return "limit" },
+      peg$c352 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c346 = function(v) {
+      peg$c353 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c347 = function(v) {
+      peg$c354 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c348 = function(v) {
+      peg$c355 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c349 = "true",
-      peg$c350 = peg$literalExpectation("true", false),
-      peg$c351 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c352 = "false",
-      peg$c353 = peg$literalExpectation("false", false),
-      peg$c354 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c355 = "null",
-      peg$c356 = peg$literalExpectation("null", false),
-      peg$c357 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c358 = function(typ) {
+      peg$c356 = "true",
+      peg$c357 = peg$literalExpectation("true", false),
+      peg$c358 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c359 = "false",
+      peg$c360 = peg$literalExpectation("false", false),
+      peg$c361 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c362 = "null",
+      peg$c363 = peg$literalExpectation("null", false),
+      peg$c364 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c365 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c359 = function(name, typ) {
+      peg$c366 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c360 = function(name) {
+      peg$c367 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c361 = function(u) { return u },
-      peg$c362 = function(types) {
+      peg$c368 = function(u) { return u },
+      peg$c369 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c363 = function(fields) {
+      peg$c370 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c364 = function(typ) {
+      peg$c371 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c365 = function(typ) {
+      peg$c372 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c366 = function(keyType, valType) {
+      peg$c373 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c367 = "uint8",
-      peg$c368 = peg$literalExpectation("uint8", false),
-      peg$c369 = "uint16",
-      peg$c370 = peg$literalExpectation("uint16", false),
-      peg$c371 = "uint32",
-      peg$c372 = peg$literalExpectation("uint32", false),
-      peg$c373 = "uint64",
-      peg$c374 = peg$literalExpectation("uint64", false),
-      peg$c375 = "int8",
-      peg$c376 = peg$literalExpectation("int8", false),
-      peg$c377 = "int16",
-      peg$c378 = peg$literalExpectation("int16", false),
-      peg$c379 = "int32",
-      peg$c380 = peg$literalExpectation("int32", false),
-      peg$c381 = "int64",
-      peg$c382 = peg$literalExpectation("int64", false),
-      peg$c383 = "float64",
-      peg$c384 = peg$literalExpectation("float64", false),
-      peg$c385 = "bool",
-      peg$c386 = peg$literalExpectation("bool", false),
-      peg$c387 = "string",
-      peg$c388 = peg$literalExpectation("string", false),
-      peg$c389 = function() {
+      peg$c374 = "uint8",
+      peg$c375 = peg$literalExpectation("uint8", false),
+      peg$c376 = "uint16",
+      peg$c377 = peg$literalExpectation("uint16", false),
+      peg$c378 = "uint32",
+      peg$c379 = peg$literalExpectation("uint32", false),
+      peg$c380 = "uint64",
+      peg$c381 = peg$literalExpectation("uint64", false),
+      peg$c382 = "int8",
+      peg$c383 = peg$literalExpectation("int8", false),
+      peg$c384 = "int16",
+      peg$c385 = peg$literalExpectation("int16", false),
+      peg$c386 = "int32",
+      peg$c387 = peg$literalExpectation("int32", false),
+      peg$c388 = "int64",
+      peg$c389 = peg$literalExpectation("int64", false),
+      peg$c390 = "float64",
+      peg$c391 = peg$literalExpectation("float64", false),
+      peg$c392 = "bool",
+      peg$c393 = peg$literalExpectation("bool", false),
+      peg$c394 = "string",
+      peg$c395 = peg$literalExpectation("string", false),
+      peg$c396 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c390 = "duration",
-      peg$c391 = peg$literalExpectation("duration", false),
-      peg$c392 = "time",
-      peg$c393 = peg$literalExpectation("time", false),
-      peg$c394 = "bytes",
-      peg$c395 = peg$literalExpectation("bytes", false),
-      peg$c396 = "bstring",
-      peg$c397 = peg$literalExpectation("bstring", false),
-      peg$c398 = "ip",
-      peg$c399 = peg$literalExpectation("ip", false),
-      peg$c400 = "net",
-      peg$c401 = peg$literalExpectation("net", false),
-      peg$c402 = "error",
-      peg$c403 = peg$literalExpectation("error", false),
-      peg$c404 = function(name, typ) {
+      peg$c397 = "duration",
+      peg$c398 = peg$literalExpectation("duration", false),
+      peg$c399 = "time",
+      peg$c400 = peg$literalExpectation("time", false),
+      peg$c401 = "bytes",
+      peg$c402 = peg$literalExpectation("bytes", false),
+      peg$c403 = "bstring",
+      peg$c404 = peg$literalExpectation("bstring", false),
+      peg$c405 = "ip",
+      peg$c406 = peg$literalExpectation("ip", false),
+      peg$c407 = "net",
+      peg$c408 = peg$literalExpectation("net", false),
+      peg$c409 = "error",
+      peg$c410 = peg$literalExpectation("error", false),
+      peg$c411 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c405 = "and",
-      peg$c406 = peg$literalExpectation("and", true),
-      peg$c407 = function() { return "and" },
-      peg$c408 = "or",
-      peg$c409 = peg$literalExpectation("or", true),
-      peg$c410 = function() { return "or" },
-      peg$c411 = peg$literalExpectation("in", true),
-      peg$c412 = function() { return "in" },
-      peg$c413 = peg$literalExpectation("not", true),
-      peg$c414 = function() { return "not" },
-      peg$c415 = "by",
-      peg$c416 = peg$literalExpectation("by", true),
-      peg$c417 = function() { return "by" },
-      peg$c418 = /^[A-Za-z_$]/,
-      peg$c419 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c420 = /^[0-9]/,
-      peg$c421 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c422 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c423 = function() {  return text() },
-      peg$c424 = "$",
-      peg$c425 = peg$literalExpectation("$", false),
-      peg$c426 = "\\",
-      peg$c427 = peg$literalExpectation("\\", false),
-      peg$c428 = "T",
-      peg$c429 = peg$literalExpectation("T", false),
-      peg$c430 = function() {
+      peg$c412 = "and",
+      peg$c413 = peg$literalExpectation("and", true),
+      peg$c414 = function() { return "and" },
+      peg$c415 = "or",
+      peg$c416 = peg$literalExpectation("or", true),
+      peg$c417 = function() { return "or" },
+      peg$c418 = peg$literalExpectation("in", true),
+      peg$c419 = function() { return "in" },
+      peg$c420 = peg$literalExpectation("not", true),
+      peg$c421 = function() { return "not" },
+      peg$c422 = "by",
+      peg$c423 = peg$literalExpectation("by", true),
+      peg$c424 = function() { return "by" },
+      peg$c425 = /^[A-Za-z_$]/,
+      peg$c426 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c427 = /^[0-9]/,
+      peg$c428 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c429 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c430 = function() {  return text() },
+      peg$c431 = "$",
+      peg$c432 = peg$literalExpectation("$", false),
+      peg$c433 = "\\",
+      peg$c434 = peg$literalExpectation("\\", false),
+      peg$c435 = "T",
+      peg$c436 = peg$literalExpectation("T", false),
+      peg$c437 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c431 = "Z",
-      peg$c432 = peg$literalExpectation("Z", false),
-      peg$c433 = function() {
+      peg$c438 = "Z",
+      peg$c439 = peg$literalExpectation("Z", false),
+      peg$c440 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c434 = "ns",
-      peg$c435 = peg$literalExpectation("ns", true),
-      peg$c436 = "us",
-      peg$c437 = peg$literalExpectation("us", true),
-      peg$c438 = "ms",
-      peg$c439 = peg$literalExpectation("ms", true),
-      peg$c440 = "s",
-      peg$c441 = peg$literalExpectation("s", true),
-      peg$c442 = "m",
-      peg$c443 = peg$literalExpectation("m", true),
-      peg$c444 = "h",
-      peg$c445 = peg$literalExpectation("h", true),
-      peg$c446 = "d",
-      peg$c447 = peg$literalExpectation("d", true),
-      peg$c448 = "w",
-      peg$c449 = peg$literalExpectation("w", true),
-      peg$c450 = "y",
-      peg$c451 = peg$literalExpectation("y", true),
-      peg$c452 = function(a, b) {
+      peg$c441 = "ns",
+      peg$c442 = peg$literalExpectation("ns", true),
+      peg$c443 = "us",
+      peg$c444 = peg$literalExpectation("us", true),
+      peg$c445 = "ms",
+      peg$c446 = peg$literalExpectation("ms", true),
+      peg$c447 = "s",
+      peg$c448 = peg$literalExpectation("s", true),
+      peg$c449 = "m",
+      peg$c450 = peg$literalExpectation("m", true),
+      peg$c451 = "h",
+      peg$c452 = peg$literalExpectation("h", true),
+      peg$c453 = "d",
+      peg$c454 = peg$literalExpectation("d", true),
+      peg$c455 = "w",
+      peg$c456 = peg$literalExpectation("w", true),
+      peg$c457 = "y",
+      peg$c458 = peg$literalExpectation("y", true),
+      peg$c459 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c453 = "::",
-      peg$c454 = peg$literalExpectation("::", false),
-      peg$c455 = function(a, b, d, e) {
+      peg$c460 = "::",
+      peg$c461 = peg$literalExpectation("::", false),
+      peg$c462 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c456 = function(a, b) {
+      peg$c463 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c457 = function(a, b) {
+      peg$c464 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c458 = function() {
+      peg$c465 = function() {
             return "::"
           },
-      peg$c459 = function(v) { return ":" + v },
-      peg$c460 = function(v) { return v + ":" },
-      peg$c461 = function(a, m) {
+      peg$c466 = function(v) { return ":" + v },
+      peg$c467 = function(v) { return v + ":" },
+      peg$c468 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c462 = function(a, m) {
+      peg$c469 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c463 = function(s) { return parseInt(s) },
-      peg$c464 = function() {
+      peg$c470 = function(s) { return parseInt(s) },
+      peg$c471 = function() {
             return text()
           },
-      peg$c465 = "e",
-      peg$c466 = peg$literalExpectation("e", true),
-      peg$c467 = /^[+\-]/,
-      peg$c468 = peg$classExpectation(["+", "-"], false, false),
-      peg$c469 = /^[0-9a-fA-F]/,
-      peg$c470 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c471 = "\"",
-      peg$c472 = peg$literalExpectation("\"", false),
-      peg$c473 = function(v) { return joinChars(v) },
-      peg$c474 = "'",
-      peg$c475 = peg$literalExpectation("'", false),
-      peg$c476 = peg$anyExpectation(),
-      peg$c477 = function(head, tail) { return head + joinChars(tail) },
-      peg$c478 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c479 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c480 = function(head, tail) {
+      peg$c472 = "e",
+      peg$c473 = peg$literalExpectation("e", true),
+      peg$c474 = /^[+\-]/,
+      peg$c475 = peg$classExpectation(["+", "-"], false, false),
+      peg$c476 = /^[0-9a-fA-F]/,
+      peg$c477 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c478 = "\"",
+      peg$c479 = peg$literalExpectation("\"", false),
+      peg$c480 = function(v) { return joinChars(v) },
+      peg$c481 = "'",
+      peg$c482 = peg$literalExpectation("'", false),
+      peg$c483 = peg$anyExpectation(),
+      peg$c484 = function(head, tail) { return head + joinChars(tail) },
+      peg$c485 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c486 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c487 = function(head, tail) {
             return reglob$1.Reglob(head + joinChars(tail))
           },
-      peg$c481 = function() { return "*"},
-      peg$c482 = function() { return "=" },
-      peg$c483 = function() { return "\\*" },
-      peg$c484 = "x",
-      peg$c485 = peg$literalExpectation("x", false),
-      peg$c486 = function() { return "\\" + text() },
-      peg$c487 = "b",
-      peg$c488 = peg$literalExpectation("b", false),
-      peg$c489 = function() { return "\b" },
-      peg$c490 = "f",
-      peg$c491 = peg$literalExpectation("f", false),
-      peg$c492 = function() { return "\f" },
-      peg$c493 = "n",
-      peg$c494 = peg$literalExpectation("n", false),
-      peg$c495 = function() { return "\n" },
-      peg$c496 = "r",
-      peg$c497 = peg$literalExpectation("r", false),
-      peg$c498 = function() { return "\r" },
-      peg$c499 = "t",
-      peg$c500 = peg$literalExpectation("t", false),
-      peg$c501 = function() { return "\t" },
-      peg$c502 = "v",
-      peg$c503 = peg$literalExpectation("v", false),
-      peg$c504 = function() { return "\v" },
-      peg$c505 = function() { return "*" },
-      peg$c506 = "u",
-      peg$c507 = peg$literalExpectation("u", false),
-      peg$c508 = function(chars) {
+      peg$c488 = function() { return "*"},
+      peg$c489 = function() { return "=" },
+      peg$c490 = function() { return "\\*" },
+      peg$c491 = "x",
+      peg$c492 = peg$literalExpectation("x", false),
+      peg$c493 = function() { return "\\" + text() },
+      peg$c494 = "b",
+      peg$c495 = peg$literalExpectation("b", false),
+      peg$c496 = function() { return "\b" },
+      peg$c497 = "f",
+      peg$c498 = peg$literalExpectation("f", false),
+      peg$c499 = function() { return "\f" },
+      peg$c500 = "n",
+      peg$c501 = peg$literalExpectation("n", false),
+      peg$c502 = function() { return "\n" },
+      peg$c503 = "r",
+      peg$c504 = peg$literalExpectation("r", false),
+      peg$c505 = function() { return "\r" },
+      peg$c506 = "t",
+      peg$c507 = peg$literalExpectation("t", false),
+      peg$c508 = function() { return "\t" },
+      peg$c509 = "v",
+      peg$c510 = peg$literalExpectation("v", false),
+      peg$c511 = function() { return "\v" },
+      peg$c512 = function() { return "*" },
+      peg$c513 = "u",
+      peg$c514 = peg$literalExpectation("u", false),
+      peg$c515 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c509 = /^[^\/\\]/,
-      peg$c510 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c511 = "\\/",
-      peg$c512 = peg$literalExpectation("\\/", false),
-      peg$c513 = /^[\0-\x1F\\]/,
-      peg$c514 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c515 = peg$otherExpectation("whitespace"),
-      peg$c516 = "\t",
-      peg$c517 = peg$literalExpectation("\t", false),
-      peg$c518 = "\x0B",
-      peg$c519 = peg$literalExpectation("\x0B", false),
-      peg$c520 = "\f",
-      peg$c521 = peg$literalExpectation("\f", false),
-      peg$c522 = " ",
-      peg$c523 = peg$literalExpectation(" ", false),
-      peg$c524 = "\xA0",
-      peg$c525 = peg$literalExpectation("\xA0", false),
-      peg$c526 = "\uFEFF",
-      peg$c527 = peg$literalExpectation("\uFEFF", false),
-      peg$c528 = /^[\n\r\u2028\u2029]/,
-      peg$c529 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c530 = peg$otherExpectation("comment"),
-      peg$c535 = "//",
-      peg$c536 = peg$literalExpectation("//", false),
+      peg$c516 = /^[^\/\\]/,
+      peg$c517 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c518 = "\\/",
+      peg$c519 = peg$literalExpectation("\\/", false),
+      peg$c520 = /^[\0-\x1F\\]/,
+      peg$c521 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c522 = peg$otherExpectation("whitespace"),
+      peg$c523 = "\t",
+      peg$c524 = peg$literalExpectation("\t", false),
+      peg$c525 = "\x0B",
+      peg$c526 = peg$literalExpectation("\x0B", false),
+      peg$c527 = "\f",
+      peg$c528 = peg$literalExpectation("\f", false),
+      peg$c529 = " ",
+      peg$c530 = peg$literalExpectation(" ", false),
+      peg$c531 = "\xA0",
+      peg$c532 = peg$literalExpectation("\xA0", false),
+      peg$c533 = "\uFEFF",
+      peg$c534 = peg$literalExpectation("\uFEFF", false),
+      peg$c535 = /^[\n\r\u2028\u2029]/,
+      peg$c536 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c537 = peg$otherExpectation("comment"),
+      peg$c542 = "//",
+      peg$c543 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -5301,7 +5316,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parsePoolName();
+    s1 = peg$parsePoolSpec();
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePoolAt();
       if (s2 === peg$FAILED) {
@@ -5623,6 +5638,188 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsePoolSpec() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = peg$parsePoolName();
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 47) {
+        s2 = peg$c228;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parsePoolName();
+        if (s3 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 91) {
+            s4 = peg$c48;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseIdentifierName();
+            if (s5 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 93) {
+                s6 = peg$c230;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
+              }
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c232(s1, s3, s5);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parsePoolName();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 91) {
+          s2 = peg$c48;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseIdentifierName();
+          if (s3 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s4 = peg$c230;
+              peg$currPos++;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
+            }
+            if (s4 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c233(s1, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 91) {
+          s1 = peg$c48;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseIdentifierName();
+          if (s2 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s3 = peg$c230;
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
+            }
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c234(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsePoolName();
+          if (s1 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 47) {
+              s2 = peg$c228;
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c229); }
+            }
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parsePoolName();
+              if (s3 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c235(s1, s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parsePoolName();
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c236(s1);
+            }
+            s0 = s1;
+          }
+        }
+      }
+    }
+
+    return s0;
+  }
+
   function peg$parsePoolName() {
     var s0, s1;
 
@@ -5630,7 +5827,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c228(s1);
+      s1 = peg$c237(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5661,12 +5858,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c230); }
+        if (peg$silentFails === 0) { peg$fail(peg$c241); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5676,7 +5873,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c231(s4, s5);
+              s1 = peg$c242(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5708,12 +5905,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c232) {
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c243) {
         s2 = input.substr(peg$currPos, 6);
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c233); }
+        if (peg$silentFails === 0) { peg$fail(peg$c244); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5721,7 +5918,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c234(s4);
+            s1 = peg$c245(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5747,30 +5944,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c235) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c246) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
+      if (peg$silentFails === 0) { peg$fail(peg$c247); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c237();
+      s1 = peg$c248();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c238) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c249) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c239); }
+        if (peg$silentFails === 0) { peg$fail(peg$c250); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c240();
+        s1 = peg$c251();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -5778,7 +5975,7 @@ function peg$parse(input, options) {
         s1 = peg$c108;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c237();
+          s1 = peg$c248();
         }
         s0 = s1;
       }
@@ -5793,26 +5990,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c230); }
+        if (peg$silentFails === 0) { peg$fail(peg$c241); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c241) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c252) {
             s4 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c242); }
+            if (peg$silentFails === 0) { peg$fail(peg$c253); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c237();
+            s1 = peg$c248();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5834,26 +6031,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
           s2 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c230); }
+          if (peg$silentFails === 0) { peg$fail(peg$c241); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c243) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c254) {
               s4 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c244); }
+              if (peg$silentFails === 0) { peg$fail(peg$c255); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c240();
+              s1 = peg$c251();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5880,16 +6077,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c245) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c256) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c257); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c247();
+      s1 = peg$c258();
     }
     s0 = s1;
 
@@ -5900,12 +6097,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c248) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c259) {
       s1 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c260); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5920,7 +6117,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c250(s3, s4, s5);
+              s1 = peg$c261(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5959,7 +6156,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c251(s4);
+            s1 = peg$c262(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5994,7 +6191,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c252(s4);
+            s1 = peg$c263(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6094,7 +6291,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c254(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6129,7 +6326,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c255(s1, s5);
+              s1 = peg$c266(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6172,11 +6369,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c256;
+          s3 = peg$c267;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c257); }
+          if (peg$silentFails === 0) { peg$fail(peg$c268); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6198,7 +6395,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c258(s1, s5, s9);
+                      s1 = peg$c269(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6260,7 +6457,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6290,7 +6487,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6311,7 +6508,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6342,7 +6539,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6372,7 +6569,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6393,7 +6590,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6426,7 +6623,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c261(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6456,7 +6653,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRelativeExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s3;
-                  s4 = peg$c261(s1, s5, s7);
+                  s4 = peg$c272(s1, s5, s7);
                   s3 = s4;
                 } else {
                   peg$currPos = s3;
@@ -6477,7 +6674,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c260(s1, s2);
+          s1 = peg$c271(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6505,7 +6702,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c262();
+      s1 = peg$c273();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6567,7 +6764,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6597,7 +6794,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6618,7 +6815,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6696,7 +6893,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6726,7 +6923,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6747,7 +6944,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6766,19 +6963,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c263;
+      s1 = peg$c274;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c265;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -6807,7 +7004,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6837,7 +7034,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6858,7 +7055,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6885,11 +7082,11 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c267;
+        s1 = peg$c228;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -6918,7 +7115,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c269(s3);
+          s1 = peg$c278(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6981,7 +7178,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s1);
+            s1 = peg$c279(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7086,28 +7283,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c271) {
-      s0 = peg$c271;
+    if (input.substr(peg$currPos, 3) === peg$c280) {
+      s0 = peg$c280;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c273) {
-        s0 = peg$c273;
+      if (input.substr(peg$currPos, 5) === peg$c282) {
+        s0 = peg$c282;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c274); }
+        if (peg$silentFails === 0) { peg$fail(peg$c283); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c275) {
-          s0 = peg$c275;
+        if (input.substr(peg$currPos, 6) === peg$c284) {
+          s0 = peg$c284;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c276); }
+          if (peg$silentFails === 0) { peg$fail(peg$c285); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -7128,12 +7325,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c273) {
-      s1 = peg$c273;
+    if (input.substr(peg$currPos, 5) === peg$c282) {
+      s1 = peg$c282;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c283); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7187,12 +7384,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c275) {
-      s1 = peg$c275;
+    if (input.substr(peg$currPos, 6) === peg$c284) {
+      s1 = peg$c284;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7225,7 +7422,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c277(s5, s8);
+                    s1 = peg$c286(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7279,7 +7476,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c278(s1);
+      s1 = peg$c287(s1);
     }
     s0 = s1;
 
@@ -7358,7 +7555,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c279(s1, s5);
+                  s1 = peg$c288(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7434,7 +7631,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c280(s2, s6);
+                    s1 = peg$c289(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7481,7 +7678,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c281();
+        s1 = peg$c290();
       }
       s0 = s1;
     }
@@ -7512,7 +7709,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c282(s1, s7);
+              s4 = peg$c291(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7548,7 +7745,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c282(s1, s7);
+                s4 = peg$c291(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7601,7 +7798,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExprPattern();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c283(s2);
+        s1 = peg$c292(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7694,7 +7891,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c284();
+            s1 = peg$c293();
           }
           s0 = s1;
         }
@@ -7708,12 +7905,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c285) {
-      s1 = peg$c285;
+    if (input.substr(peg$currPos, 4) === peg$c294) {
+      s1 = peg$c294;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -7739,7 +7936,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c287(s2);
+        s1 = peg$c296(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7770,15 +7967,15 @@ function peg$parse(input, options) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c288;
+              s4 = peg$c230;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c289); }
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c290(s3);
+              s1 = peg$c297(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7830,15 +8027,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c288;
+                  s7 = peg$c230;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c231); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c291(s2, s6);
+                  s1 = peg$c298(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7893,15 +8090,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c288;
+                  s6 = peg$c230;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c231); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c292(s5);
+                  s1 = peg$c299(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7952,15 +8149,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c288;
+                    s6 = peg$c230;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c231); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c293(s2);
+                    s1 = peg$c300(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7999,15 +8196,15 @@ function peg$parse(input, options) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c288;
+                s3 = peg$c230;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c294(s2);
+                s1 = peg$c301(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8051,7 +8248,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c295(s3);
+                  s1 = peg$c302(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8160,15 +8357,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c296;
+              s5 = peg$c303;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c298(s3);
+              s1 = peg$c305(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8208,7 +8405,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8284,7 +8481,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c300(s1, s5);
+              s1 = peg$c307(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8329,15 +8526,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c288;
+              s5 = peg$c230;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c289); }
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c301(s3);
+              s1 = peg$c308(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8367,12 +8564,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c302) {
-      s1 = peg$c302;
+    if (input.substr(peg$currPos, 2) === peg$c309) {
+      s1 = peg$c309;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c303); }
+      if (peg$silentFails === 0) { peg$fail(peg$c310); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8381,16 +8578,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c304) {
-              s5 = peg$c304;
+            if (input.substr(peg$currPos, 2) === peg$c311) {
+              s5 = peg$c311;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c312); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c306(s3);
+              s1 = peg$c313(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8420,12 +8617,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c307) {
-      s1 = peg$c307;
+    if (input.substr(peg$currPos, 2) === peg$c314) {
+      s1 = peg$c314;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c308); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8434,16 +8631,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c309) {
-              s5 = peg$c309;
+            if (input.substr(peg$currPos, 2) === peg$c316) {
+              s5 = peg$c316;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c317); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s3);
+              s1 = peg$c318(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8483,7 +8680,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8498,7 +8695,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c281();
+        s1 = peg$c290();
       }
       s0 = s1;
     }
@@ -8525,7 +8722,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c283(s4);
+            s1 = peg$c292(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8568,7 +8765,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c312(s1, s5);
+              s1 = peg$c319(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8633,7 +8830,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c313(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c320(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8711,7 +8908,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c314(s3);
+            s1 = peg$c321(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8745,7 +8942,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s1, s5);
+              s1 = peg$c322(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8892,7 +9089,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c316(s4, s5);
+              s1 = peg$c323(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9018,7 +9215,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c317(s1, s4);
+        s4 = peg$c324(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9027,7 +9224,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c317(s1, s4);
+          s4 = peg$c324(s1, s4);
         }
         s3 = s4;
       }
@@ -9089,7 +9286,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c318(s1, s5, s6, s10, s14);
+                                s1 = peg$c325(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9166,7 +9363,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c319(s2);
+        s1 = peg$c326(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9325,7 +9522,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c320(s6, s7);
+                  s1 = peg$c327(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9371,7 +9568,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c321(s2);
+        s1 = peg$c328(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9386,7 +9583,7 @@ function peg$parse(input, options) {
       s1 = peg$c108;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c237();
+        s1 = peg$c248();
       }
       s0 = s1;
     }
@@ -9407,7 +9604,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c322(s4);
+            s1 = peg$c329(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9442,16 +9639,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c275) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c284) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c324();
+      s1 = peg$c331();
     }
     s0 = s1;
 
@@ -9462,16 +9659,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c325) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c332) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c326); }
+      if (peg$silentFails === 0) { peg$fail(peg$c333); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c327();
+      s1 = peg$c334();
     }
     s0 = s1;
 
@@ -9491,7 +9688,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328();
+      s1 = peg$c335();
     }
     s0 = s1;
 
@@ -9511,7 +9708,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c329();
+      s1 = peg$c336();
     }
     s0 = s1;
 
@@ -9527,67 +9724,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c331();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseGROUP() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c332) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c334();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseHAVING() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c335) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c337();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseORDER() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c230); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -9598,13 +9735,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseON() {
+  function peg$parseGROUP() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c339) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c339) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c340); }
@@ -9618,13 +9755,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLIMIT() {
+  function peg$parseHAVING() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c342) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c342) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c343); }
@@ -9638,20 +9775,80 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseORDER() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c345();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseON() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c346) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c348();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseLIMIT() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c351();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parseASC() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c252) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c242); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c237();
+      s1 = peg$c248();
     }
     s0 = s1;
 
@@ -9662,16 +9859,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c243) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c254) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c255); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c240();
+      s1 = peg$c251();
     }
     s0 = s1;
 
@@ -9840,7 +10037,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c345(s1);
+        s1 = peg$c352(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9855,7 +10052,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c345(s1);
+        s1 = peg$c352(s1);
       }
       s0 = s1;
     }
@@ -9881,7 +10078,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c346(s1);
+        s1 = peg$c353(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9896,7 +10093,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c346(s1);
+        s1 = peg$c353(s1);
       }
       s0 = s1;
     }
@@ -9911,7 +10108,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347(s1);
+      s1 = peg$c354(s1);
     }
     s0 = s1;
 
@@ -9925,7 +10122,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348(s1);
+      s1 = peg$c355(s1);
     }
     s0 = s1;
 
@@ -9936,30 +10133,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c349) {
-      s1 = peg$c349;
+    if (input.substr(peg$currPos, 4) === peg$c356) {
+      s1 = peg$c356;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c358();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c352) {
-        s1 = peg$c352;
+      if (input.substr(peg$currPos, 5) === peg$c359) {
+        s1 = peg$c359;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c353); }
+        if (peg$silentFails === 0) { peg$fail(peg$c360); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354();
+        s1 = peg$c361();
       }
       s0 = s1;
     }
@@ -9971,16 +10168,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c355) {
-      s1 = peg$c355;
+    if (input.substr(peg$currPos, 4) === peg$c362) {
+      s1 = peg$c362;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c357();
+      s1 = peg$c364();
     }
     s0 = s1;
 
@@ -10019,7 +10216,7 @@ function peg$parse(input, options) {
       s2 = peg$parseTypeExternal();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c358(s2);
+        s1 = peg$c365(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10066,7 +10263,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s1);
+            s1 = peg$c279(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10133,7 +10330,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c251(s5);
+                  s1 = peg$c262(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10198,7 +10395,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c270(s5);
+                    s1 = peg$c279(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10251,7 +10448,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c228(s1);
+        s1 = peg$c237(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10300,7 +10497,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c359(s1, s7);
+                        s1 = peg$c366(s1, s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10343,7 +10540,7 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c360(s1);
+          s1 = peg$c367(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10369,7 +10566,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c361(s3);
+                  s1 = peg$c368(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10401,7 +10598,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362(s1);
+      s1 = peg$c369(s1);
     }
     s0 = s1;
 
@@ -10426,7 +10623,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10459,7 +10656,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s4);
+            s1 = peg$c279(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10500,15 +10697,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c296;
+              s5 = peg$c303;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c363(s3);
+              s1 = peg$c370(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10547,15 +10744,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c288;
+                s5 = peg$c230;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c364(s3);
+                s1 = peg$c371(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10579,12 +10776,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c302) {
-          s1 = peg$c302;
+        if (input.substr(peg$currPos, 2) === peg$c309) {
+          s1 = peg$c309;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c303); }
+          if (peg$silentFails === 0) { peg$fail(peg$c310); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10593,16 +10790,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c304) {
-                  s5 = peg$c304;
+                if (input.substr(peg$currPos, 2) === peg$c311) {
+                  s5 = peg$c311;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c312); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c365(s3);
+                  s1 = peg$c372(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10626,12 +10823,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c307) {
-            s1 = peg$c307;
+          if (input.substr(peg$currPos, 2) === peg$c314) {
+            s1 = peg$c314;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c308); }
+            if (peg$silentFails === 0) { peg$fail(peg$c315); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10654,16 +10851,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c309) {
-                            s9 = peg$c309;
+                          if (input.substr(peg$currPos, 2) === peg$c316) {
+                            s9 = peg$c316;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c310); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c317); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c366(s3, s7);
+                            s1 = peg$c373(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10727,15 +10924,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c296;
+              s5 = peg$c303;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c363(s3);
+              s1 = peg$c370(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10774,15 +10971,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c288;
+                s5 = peg$c230;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c364(s3);
+                s1 = peg$c371(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10806,12 +11003,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c302) {
-          s1 = peg$c302;
+        if (input.substr(peg$currPos, 2) === peg$c309) {
+          s1 = peg$c309;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c303); }
+          if (peg$silentFails === 0) { peg$fail(peg$c310); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10820,16 +11017,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c304) {
-                  s5 = peg$c304;
+                if (input.substr(peg$currPos, 2) === peg$c311) {
+                  s5 = peg$c311;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c312); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c365(s3);
+                  s1 = peg$c372(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10853,12 +11050,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c307) {
-            s1 = peg$c307;
+          if (input.substr(peg$currPos, 2) === peg$c314) {
+            s1 = peg$c314;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c308); }
+            if (peg$silentFails === 0) { peg$fail(peg$c315); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10881,16 +11078,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c309) {
-                            s9 = peg$c309;
+                          if (input.substr(peg$currPos, 2) === peg$c316) {
+                            s9 = peg$c316;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c310); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c317); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c366(s3, s7);
+                            s1 = peg$c373(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10950,92 +11147,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c367) {
-      s1 = peg$c367;
+    if (input.substr(peg$currPos, 5) === peg$c374) {
+      s1 = peg$c374;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c375); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c369) {
-        s1 = peg$c369;
+      if (input.substr(peg$currPos, 6) === peg$c376) {
+        s1 = peg$c376;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c370); }
+        if (peg$silentFails === 0) { peg$fail(peg$c377); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c371) {
-          s1 = peg$c371;
+        if (input.substr(peg$currPos, 6) === peg$c378) {
+          s1 = peg$c378;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c372); }
+          if (peg$silentFails === 0) { peg$fail(peg$c379); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c373) {
-            s1 = peg$c373;
+          if (input.substr(peg$currPos, 6) === peg$c380) {
+            s1 = peg$c380;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c374); }
+            if (peg$silentFails === 0) { peg$fail(peg$c381); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c375) {
-              s1 = peg$c375;
+            if (input.substr(peg$currPos, 4) === peg$c382) {
+              s1 = peg$c382;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c376); }
+              if (peg$silentFails === 0) { peg$fail(peg$c383); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c377) {
-                s1 = peg$c377;
+              if (input.substr(peg$currPos, 5) === peg$c384) {
+                s1 = peg$c384;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c378); }
+                if (peg$silentFails === 0) { peg$fail(peg$c385); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c379) {
-                  s1 = peg$c379;
+                if (input.substr(peg$currPos, 5) === peg$c386) {
+                  s1 = peg$c386;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c380); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c387); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c381) {
-                    s1 = peg$c381;
+                  if (input.substr(peg$currPos, 5) === peg$c388) {
+                    s1 = peg$c388;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c382); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c389); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c383) {
-                      s1 = peg$c383;
+                    if (input.substr(peg$currPos, 7) === peg$c390) {
+                      s1 = peg$c390;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c384); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c391); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c385) {
-                        s1 = peg$c385;
+                      if (input.substr(peg$currPos, 4) === peg$c392) {
+                        s1 = peg$c392;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c393); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c387) {
-                          s1 = peg$c387;
+                        if (input.substr(peg$currPos, 6) === peg$c394) {
+                          s1 = peg$c394;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c388); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c395); }
                         }
                       }
                     }
@@ -11049,7 +11246,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c389();
+      s1 = peg$c396();
     }
     s0 = s1;
 
@@ -11060,52 +11257,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c390) {
-      s1 = peg$c390;
+    if (input.substr(peg$currPos, 8) === peg$c397) {
+      s1 = peg$c397;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c391); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c392) {
-        s1 = peg$c392;
+      if (input.substr(peg$currPos, 4) === peg$c399) {
+        s1 = peg$c399;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c400); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c394) {
-          s1 = peg$c394;
+        if (input.substr(peg$currPos, 5) === peg$c401) {
+          s1 = peg$c401;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c395); }
+          if (peg$silentFails === 0) { peg$fail(peg$c402); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c396) {
-            s1 = peg$c396;
+          if (input.substr(peg$currPos, 7) === peg$c403) {
+            s1 = peg$c403;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c397); }
+            if (peg$silentFails === 0) { peg$fail(peg$c404); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c398) {
-              s1 = peg$c398;
+            if (input.substr(peg$currPos, 2) === peg$c405) {
+              s1 = peg$c405;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c399); }
+              if (peg$silentFails === 0) { peg$fail(peg$c406); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c400) {
-                s1 = peg$c400;
+              if (input.substr(peg$currPos, 3) === peg$c407) {
+                s1 = peg$c407;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c401); }
+                if (peg$silentFails === 0) { peg$fail(peg$c408); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11116,20 +11313,20 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c402) {
-                    s1 = peg$c402;
+                  if (input.substr(peg$currPos, 5) === peg$c409) {
+                    s1 = peg$c409;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c403); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c410); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c355) {
-                      s1 = peg$c355;
+                    if (input.substr(peg$currPos, 4) === peg$c362) {
+                      s1 = peg$c362;
                       peg$currPos += 4;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c363); }
                     }
                   }
                 }
@@ -11141,7 +11338,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c389();
+      s1 = peg$c396();
     }
     s0 = s1;
 
@@ -11162,7 +11359,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11195,7 +11392,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s4);
+            s1 = peg$c279(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11238,7 +11435,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c404(s1, s5);
+              s1 = peg$c411(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11279,121 +11476,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c405) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c407();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseOrToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c408) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c410();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseInToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c412();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseNotToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c271) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c412) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
@@ -11427,7 +11510,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseByToken() {
+  function peg$parseOrToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -11465,15 +11548,129 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseInToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c418); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c419();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseNotToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c280) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c421();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseByToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c422) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c424();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c418.test(input.charAt(peg$currPos))) {
+    if (peg$c425.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c419); }
+      if (peg$silentFails === 0) { peg$fail(peg$c426); }
     }
 
     return s0;
@@ -11484,12 +11681,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
     }
 
@@ -11503,7 +11700,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c422(s1);
+      s1 = peg$c429(s1);
     }
     s0 = s1;
 
@@ -11558,7 +11755,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c423();
+          s1 = peg$c430();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11575,11 +11772,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c424;
+        s1 = peg$c431;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c432); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11589,11 +11786,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c426;
+          s1 = peg$c433;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c427); }
+          if (peg$silentFails === 0) { peg$fail(peg$c434); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -11701,17 +11898,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c428;
+        s2 = peg$c435;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c429); }
+        if (peg$silentFails === 0) { peg$fail(peg$c436); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c430();
+          s1 = peg$c437();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11736,21 +11933,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c265;
+        s2 = peg$c276;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c265;
+            s4 = peg$c276;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c266); }
+            if (peg$silentFails === 0) { peg$fail(peg$c277); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -11785,36 +11982,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c420.test(input.charAt(peg$currPos))) {
+    if (peg$c427.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c428); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c420.test(input.charAt(peg$currPos))) {
+        if (peg$c427.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c421); }
+          if (peg$silentFails === 0) { peg$fail(peg$c428); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c420.test(input.charAt(peg$currPos))) {
+          if (peg$c427.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c428); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -11843,20 +12040,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c420.test(input.charAt(peg$currPos))) {
+    if (peg$c427.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c428); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -11931,22 +12128,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c420.test(input.charAt(peg$currPos))) {
+                if (peg$c427.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c428); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c420.test(input.charAt(peg$currPos))) {
+                    if (peg$c427.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c428); }
                     }
                   }
                 } else {
@@ -12001,28 +12198,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c431;
+      s0 = peg$c438;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c432); }
+      if (peg$silentFails === 0) { peg$fail(peg$c439); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c263;
+        s1 = peg$c274;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c264); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c265;
+          s1 = peg$c276;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c266); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12048,22 +12245,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c420.test(input.charAt(peg$currPos))) {
+                if (peg$c427.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c428); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c420.test(input.charAt(peg$currPos))) {
+                    if (peg$c427.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c428); }
                     }
                   }
                 } else {
@@ -12116,11 +12313,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c265;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12166,7 +12363,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c433();
+        s1 = peg$c440();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12228,76 +12425,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c434) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c441) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c435); }
+      if (peg$silentFails === 0) { peg$fail(peg$c442); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c436) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c443) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c437); }
+        if (peg$silentFails === 0) { peg$fail(peg$c444); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c438) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c445) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c439); }
+          if (peg$silentFails === 0) { peg$fail(peg$c446); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c440) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c447) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c441); }
+            if (peg$silentFails === 0) { peg$fail(peg$c448); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c442) {
+            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c449) {
               s0 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c443); }
+              if (peg$silentFails === 0) { peg$fail(peg$c450); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c444) {
+              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c451) {
                 s0 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c445); }
+                if (peg$silentFails === 0) { peg$fail(peg$c452); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c446) {
+                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c453) {
                   s0 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c447); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c454); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c448) {
+                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c455) {
                     s0 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c449); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c456); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c450) {
+                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c457) {
                       s0 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c451); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c458); }
                     }
                   }
                 }
@@ -12482,7 +12679,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c452(s1, s2);
+        s1 = peg$c459(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12503,12 +12700,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c453) {
-            s3 = peg$c453;
+          if (input.substr(peg$currPos, 2) === peg$c460) {
+            s3 = peg$c460;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c454); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12521,7 +12718,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c455(s1, s2, s4, s5);
+                s1 = peg$c462(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12545,12 +12742,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c453) {
-          s1 = peg$c453;
+        if (input.substr(peg$currPos, 2) === peg$c460) {
+          s1 = peg$c460;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c454); }
+          if (peg$silentFails === 0) { peg$fail(peg$c461); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12563,7 +12760,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c456(s2, s3);
+              s1 = peg$c463(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12588,16 +12785,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c453) {
-                s3 = peg$c453;
+              if (input.substr(peg$currPos, 2) === peg$c460) {
+                s3 = peg$c460;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c454); }
+                if (peg$silentFails === 0) { peg$fail(peg$c461); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c457(s1, s2);
+                s1 = peg$c464(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12613,16 +12810,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c453) {
-              s1 = peg$c453;
+            if (input.substr(peg$currPos, 2) === peg$c460) {
+              s1 = peg$c460;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c454); }
+              if (peg$silentFails === 0) { peg$fail(peg$c461); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c458();
+              s1 = peg$c465();
             }
             s0 = s1;
           }
@@ -12659,7 +12856,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c459(s2);
+        s1 = peg$c466(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12688,7 +12885,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c460(s1);
+        s1 = peg$c467(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12709,17 +12906,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c267;
+        s2 = peg$c228;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c461(s1, s3);
+          s1 = peg$c468(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12744,17 +12941,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c267;
+        s2 = peg$c228;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c462(s1, s3);
+          s1 = peg$c469(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12779,7 +12976,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c463(s1);
+      s1 = peg$c470(s1);
     }
     s0 = s1;
 
@@ -12802,22 +12999,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c420.test(input.charAt(peg$currPos))) {
+    if (peg$c427.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c428); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c420.test(input.charAt(peg$currPos))) {
+        if (peg$c427.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c421); }
+          if (peg$silentFails === 0) { peg$fail(peg$c428); }
         }
       }
     } else {
@@ -12837,11 +13034,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c265;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -12866,33 +13063,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c265;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c420.test(input.charAt(peg$currPos))) {
+          if (peg$c427.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c428); }
           }
         }
       } else {
@@ -12908,22 +13105,22 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c420.test(input.charAt(peg$currPos))) {
+          if (peg$c427.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c428); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c420.test(input.charAt(peg$currPos))) {
+              if (peg$c427.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                if (peg$silentFails === 0) { peg$fail(peg$c428); }
               }
             }
           } else {
@@ -12936,7 +13133,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c464();
+              s1 = peg$c471();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12961,11 +13158,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c265;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -12980,22 +13177,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c420.test(input.charAt(peg$currPos))) {
+          if (peg$c427.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c428); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c420.test(input.charAt(peg$currPos))) {
+              if (peg$c427.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                if (peg$silentFails === 0) { peg$fail(peg$c428); }
               }
             }
           } else {
@@ -13008,7 +13205,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c464();
+              s1 = peg$c471();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13035,20 +13232,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c465) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c472) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c473); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c474.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c475); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13100,12 +13297,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c469.test(input.charAt(peg$currPos))) {
+    if (peg$c476.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c470); }
+      if (peg$silentFails === 0) { peg$fail(peg$c477); }
     }
 
     return s0;
@@ -13116,11 +13313,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c471;
+      s1 = peg$c478;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c479); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13131,15 +13328,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c471;
+          s3 = peg$c478;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c472); }
+          if (peg$silentFails === 0) { peg$fail(peg$c479); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c473(s2);
+          s1 = peg$c480(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13156,11 +13353,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c474;
+        s1 = peg$c481;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c475); }
+        if (peg$silentFails === 0) { peg$fail(peg$c482); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13171,15 +13368,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c474;
+            s3 = peg$c481;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c475); }
+            if (peg$silentFails === 0) { peg$fail(peg$c482); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c473(s2);
+            s1 = peg$c480(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13205,11 +13402,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c471;
+      s2 = peg$c478;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c479); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13227,7 +13424,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c476); }
+        if (peg$silentFails === 0) { peg$fail(peg$c483); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13244,11 +13441,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c426;
+        s1 = peg$c433;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c427); }
+        if (peg$silentFails === 0) { peg$fail(peg$c434); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13283,7 +13480,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c477(s1, s2);
+        s1 = peg$c484(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13312,12 +13509,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c478.test(input.charAt(peg$currPos))) {
+    if (peg$c485.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c479); }
+      if (peg$silentFails === 0) { peg$fail(peg$c486); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13333,12 +13530,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
     }
 
@@ -13350,11 +13547,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c426;
+      s1 = peg$c433;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c427); }
+      if (peg$silentFails === 0) { peg$fail(peg$c434); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13413,7 +13610,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c480(s3, s4);
+            s1 = peg$c487(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13524,7 +13721,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c481();
+          s1 = peg$c488();
         }
         s0 = s1;
       }
@@ -13538,12 +13735,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
     }
 
@@ -13555,11 +13752,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c426;
+      s1 = peg$c433;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c427); }
+      if (peg$silentFails === 0) { peg$fail(peg$c434); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -13595,7 +13792,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c482();
+      s1 = peg$c489();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -13609,16 +13806,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c483();
+        s1 = peg$c490();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c467.test(input.charAt(peg$currPos))) {
+        if (peg$c474.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c468); }
+          if (peg$silentFails === 0) { peg$fail(peg$c475); }
         }
       }
     }
@@ -13633,11 +13830,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c474;
+      s2 = peg$c481;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c482); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13655,7 +13852,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c476); }
+        if (peg$silentFails === 0) { peg$fail(peg$c483); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13672,11 +13869,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c426;
+        s1 = peg$c433;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c427); }
+        if (peg$silentFails === 0) { peg$fail(peg$c434); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13702,11 +13899,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c484;
+      s1 = peg$c491;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c485); }
+      if (peg$silentFails === 0) { peg$fail(peg$c492); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -13714,7 +13911,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c486();
+          s1 = peg$c493();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13742,20 +13939,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c474;
+      s0 = peg$c481;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c482); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c471;
+        s1 = peg$c478;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c472); }
+        if (peg$silentFails === 0) { peg$fail(peg$c479); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13764,94 +13961,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c426;
+          s0 = peg$c433;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c427); }
+          if (peg$silentFails === 0) { peg$fail(peg$c434); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c487;
+            s1 = peg$c494;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c488); }
+            if (peg$silentFails === 0) { peg$fail(peg$c495); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c489();
+            s1 = peg$c496();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c490;
+              s1 = peg$c497;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c491); }
+              if (peg$silentFails === 0) { peg$fail(peg$c498); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c492();
+              s1 = peg$c499();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c493;
+                s1 = peg$c500;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c494); }
+                if (peg$silentFails === 0) { peg$fail(peg$c501); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c495();
+                s1 = peg$c502();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c496;
+                  s1 = peg$c503;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c497); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c504); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c498();
+                  s1 = peg$c505();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c499;
+                    s1 = peg$c506;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c500); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c507); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c501();
+                    s1 = peg$c508();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c502;
+                      s1 = peg$c509;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c503); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c510); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c504();
+                      s1 = peg$c511();
                     }
                     s0 = s1;
                   }
@@ -13879,7 +14076,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c482();
+      s1 = peg$c489();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -13893,16 +14090,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c505();
+        s1 = peg$c512();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c467.test(input.charAt(peg$currPos))) {
+        if (peg$c474.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c468); }
+          if (peg$silentFails === 0) { peg$fail(peg$c475); }
         }
       }
     }
@@ -13915,11 +14112,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c506;
+      s1 = peg$c513;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c507); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -13951,7 +14148,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c508(s2);
+        s1 = peg$c515(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13964,11 +14161,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c506;
+        s1 = peg$c513;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c507); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14035,15 +14232,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c296;
+              s4 = peg$c303;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c508(s3);
+              s1 = peg$c515(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14071,21 +14268,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c267;
+      s1 = peg$c228;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c229); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c267;
+          s3 = peg$c228;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          if (peg$silentFails === 0) { peg$fail(peg$c229); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14127,39 +14324,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c509.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c510); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c511) {
-        s2 = peg$c511;
+      if (input.substr(peg$currPos, 2) === peg$c518) {
+        s2 = peg$c518;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c512); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c509.test(input.charAt(peg$currPos))) {
+        if (peg$c516.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c510); }
+          if (peg$silentFails === 0) { peg$fail(peg$c517); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c511) {
-            s2 = peg$c511;
+          if (input.substr(peg$currPos, 2) === peg$c518) {
+            s2 = peg$c518;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c512); }
+            if (peg$silentFails === 0) { peg$fail(peg$c519); }
           }
         }
       }
@@ -14178,12 +14375,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c513.test(input.charAt(peg$currPos))) {
+    if (peg$c520.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c521); }
     }
 
     return s0;
@@ -14241,7 +14438,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c483); }
     }
 
     return s0;
@@ -14252,51 +14449,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c516;
+      s0 = peg$c523;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c517); }
+      if (peg$silentFails === 0) { peg$fail(peg$c524); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c518;
+        s0 = peg$c525;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c526); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c520;
+          s0 = peg$c527;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c521); }
+          if (peg$silentFails === 0) { peg$fail(peg$c528); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c522;
+            s0 = peg$c529;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c523); }
+            if (peg$silentFails === 0) { peg$fail(peg$c530); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c524;
+              s0 = peg$c531;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c525); }
+              if (peg$silentFails === 0) { peg$fail(peg$c532); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c526;
+                s0 = peg$c533;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c527); }
+                if (peg$silentFails === 0) { peg$fail(peg$c534); }
               }
             }
           }
@@ -14305,7 +14502,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c515); }
+      if (peg$silentFails === 0) { peg$fail(peg$c522); }
     }
 
     return s0;
@@ -14314,12 +14511,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c528.test(input.charAt(peg$currPos))) {
+    if (peg$c535.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c529); }
+      if (peg$silentFails === 0) { peg$fail(peg$c536); }
     }
 
     return s0;
@@ -14332,7 +14529,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c530); }
+      if (peg$silentFails === 0) { peg$fail(peg$c537); }
     }
 
     return s0;
@@ -14342,12 +14539,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c535) {
-      s1 = peg$c535;
+    if (input.substr(peg$currPos, 2) === peg$c542) {
+      s1 = peg$c542;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c536); }
+      if (peg$silentFails === 0) { peg$fail(peg$c543); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14465,7 +14662,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c483); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -3541,10 +3541,10 @@ var g = &grammar{
 					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 501, col: 5, offset: 14867},
-							label: "name",
+							label: "spec",
 							expr: &ruleRefExpr{
 								pos:  position{line: 501, col: 10, offset: 14872},
-								name: "PoolName",
+								name: "PoolSpec",
 							},
 						},
 						&labeledExpr{
@@ -3812,43 +3812,204 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "PoolName",
+			name: "PoolSpec",
 			pos:  position{line: 526, col: 1, offset: 15680},
 			expr: &choiceExpr{
 				pos: position{line: 527, col: 5, offset: 15693},
 				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 527, col: 5, offset: 15693},
+						run: (*parser).callonPoolSpec2,
+						expr: &seqExpr{
+							pos: position{line: 527, col: 5, offset: 15693},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 527, col: 5, offset: 15693},
+									label: "pool",
+									expr: &ruleRefExpr{
+										pos:  position{line: 527, col: 10, offset: 15698},
+										name: "PoolName",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 527, col: 19, offset: 15707},
+									val:        "/",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 527, col: 23, offset: 15711},
+									label: "branch",
+									expr: &ruleRefExpr{
+										pos:  position{line: 527, col: 30, offset: 15718},
+										name: "PoolName",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 527, col: 39, offset: 15727},
+									val:        "[",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 527, col: 43, offset: 15731},
+									label: "meta",
+									expr: &ruleRefExpr{
+										pos:  position{line: 527, col: 48, offset: 15736},
+										name: "IdentifierName",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 527, col: 63, offset: 15751},
+									val:        "]",
+									ignoreCase: false,
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 530, col: 5, offset: 15854},
+						run: (*parser).callonPoolSpec13,
+						expr: &seqExpr{
+							pos: position{line: 530, col: 5, offset: 15854},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 530, col: 5, offset: 15854},
+									label: "pool",
+									expr: &ruleRefExpr{
+										pos:  position{line: 530, col: 10, offset: 15859},
+										name: "PoolName",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 530, col: 19, offset: 15868},
+									val:        "[",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 530, col: 23, offset: 15872},
+									label: "meta",
+									expr: &ruleRefExpr{
+										pos:  position{line: 530, col: 28, offset: 15877},
+										name: "IdentifierName",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 530, col: 43, offset: 15892},
+									val:        "]",
+									ignoreCase: false,
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 533, col: 5, offset: 15992},
+						run: (*parser).callonPoolSpec21,
+						expr: &seqExpr{
+							pos: position{line: 533, col: 5, offset: 15992},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 533, col: 5, offset: 15992},
+									val:        "[",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 533, col: 9, offset: 15996},
+									label: "meta",
+									expr: &ruleRefExpr{
+										pos:  position{line: 533, col: 14, offset: 16001},
+										name: "IdentifierName",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 533, col: 29, offset: 16016},
+									val:        "]",
+									ignoreCase: false,
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 536, col: 5, offset: 16115},
+						run: (*parser).callonPoolSpec27,
+						expr: &seqExpr{
+							pos: position{line: 536, col: 5, offset: 16115},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 536, col: 5, offset: 16115},
+									label: "pool",
+									expr: &ruleRefExpr{
+										pos:  position{line: 536, col: 10, offset: 16120},
+										name: "PoolName",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 536, col: 19, offset: 16129},
+									val:        "/",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 536, col: 23, offset: 16133},
+									label: "branch",
+									expr: &ruleRefExpr{
+										pos:  position{line: 536, col: 30, offset: 16140},
+										name: "PoolName",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 539, col: 5, offset: 16247},
+						run: (*parser).callonPoolSpec34,
+						expr: &labeledExpr{
+							pos:   position{line: 539, col: 5, offset: 16247},
+							label: "pool",
+							expr: &ruleRefExpr{
+								pos:  position{line: 539, col: 10, offset: 16252},
+								name: "PoolName",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "PoolName",
+			pos:  position{line: 543, col: 1, offset: 16353},
+			expr: &choiceExpr{
+				pos: position{line: 544, col: 5, offset: 16366},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 544, col: 5, offset: 16366},
 						run: (*parser).callonPoolName2,
 						expr: &labeledExpr{
-							pos:   position{line: 527, col: 5, offset: 15693},
+							pos:   position{line: 544, col: 5, offset: 16366},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 527, col: 10, offset: 15698},
+								pos:  position{line: 544, col: 10, offset: 16371},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 528, col: 5, offset: 15738},
+						pos: position{line: 545, col: 5, offset: 16411},
 						run: (*parser).callonPoolName5,
 						expr: &labeledExpr{
-							pos:   position{line: 528, col: 5, offset: 15738},
+							pos:   position{line: 545, col: 5, offset: 16411},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 8, offset: 15741},
+								pos:  position{line: 545, col: 8, offset: 16414},
 								name: "KSUID",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 529, col: 5, offset: 15770},
+						pos: position{line: 546, col: 5, offset: 16443},
 						run: (*parser).callonPoolName8,
 						expr: &labeledExpr{
-							pos:   position{line: 529, col: 5, offset: 15770},
+							pos:   position{line: 546, col: 5, offset: 16443},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 529, col: 7, offset: 15772},
+								pos:  position{line: 546, col: 7, offset: 16445},
 								name: "QuotedString",
 							},
 						},
@@ -3857,40 +4018,52 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "PoolNameChar",
+			pos:  position{line: 548, col: 1, offset: 16477},
+			expr: &charClassMatcher{
+				pos:        position{line: 548, col: 16, offset: 16492},
+				val:        "[A-Za-z0-9_$.[\\]]",
+				chars:      []rune{'_', '$', '.', '[', ']'},
+				ranges:     []rune{'A', 'Z', 'a', 'z', '0', '9'},
+				ignoreCase: false,
+				inverted:   false,
+			},
+		},
+		{
 			name: "LayoutArg",
-			pos:  position{line: 531, col: 1, offset: 15804},
+			pos:  position{line: 550, col: 1, offset: 16511},
 			expr: &actionExpr{
-				pos: position{line: 532, col: 5, offset: 15818},
+				pos: position{line: 551, col: 5, offset: 16525},
 				run: (*parser).callonLayoutArg1,
 				expr: &seqExpr{
-					pos: position{line: 532, col: 5, offset: 15818},
+					pos: position{line: 551, col: 5, offset: 16525},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 532, col: 5, offset: 15818},
+							pos:  position{line: 551, col: 5, offset: 16525},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 532, col: 7, offset: 15820},
+							pos:        position{line: 551, col: 7, offset: 16527},
 							val:        "order",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 532, col: 16, offset: 15829},
+							pos:  position{line: 551, col: 16, offset: 16536},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 532, col: 18, offset: 15831},
+							pos:   position{line: 551, col: 18, offset: 16538},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 532, col: 23, offset: 15836},
+								pos:  position{line: 551, col: 23, offset: 16543},
 								name: "FieldExprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 532, col: 34, offset: 15847},
+							pos:   position{line: 551, col: 34, offset: 16554},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 532, col: 40, offset: 15853},
+								pos:  position{line: 551, col: 40, offset: 16560},
 								name: "OrderSuffix",
 							},
 						},
@@ -3900,31 +4073,31 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 536, col: 1, offset: 15963},
+			pos:  position{line: 555, col: 1, offset: 16670},
 			expr: &actionExpr{
-				pos: position{line: 537, col: 5, offset: 15977},
+				pos: position{line: 556, col: 5, offset: 16684},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 537, col: 5, offset: 15977},
+					pos: position{line: 556, col: 5, offset: 16684},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 537, col: 5, offset: 15977},
+							pos:  position{line: 556, col: 5, offset: 16684},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 537, col: 7, offset: 15979},
+							pos:        position{line: 556, col: 7, offset: 16686},
 							val:        "format",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 537, col: 17, offset: 15989},
+							pos:  position{line: 556, col: 17, offset: 16696},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 537, col: 19, offset: 15991},
+							pos:   position{line: 556, col: 19, offset: 16698},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 537, col: 23, offset: 15995},
+								pos:  position{line: 556, col: 23, offset: 16702},
 								name: "IdentifierName",
 							},
 						},
@@ -3934,33 +4107,33 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 539, col: 1, offset: 16031},
+			pos:  position{line: 558, col: 1, offset: 16738},
 			expr: &choiceExpr{
-				pos: position{line: 540, col: 5, offset: 16047},
+				pos: position{line: 559, col: 5, offset: 16754},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 540, col: 5, offset: 16047},
+						pos: position{line: 559, col: 5, offset: 16754},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 540, col: 5, offset: 16047},
+							pos:        position{line: 559, col: 5, offset: 16754},
 							val:        ":asc",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 16082},
+						pos: position{line: 560, col: 5, offset: 16789},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 541, col: 5, offset: 16082},
+							pos:        position{line: 560, col: 5, offset: 16789},
 							val:        ":desc",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 542, col: 5, offset: 16119},
+						pos: position{line: 561, col: 5, offset: 16826},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 542, col: 5, offset: 16119},
+							pos:        position{line: 561, col: 5, offset: 16826},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3970,31 +4143,31 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 544, col: 1, offset: 16145},
+			pos:  position{line: 563, col: 1, offset: 16852},
 			expr: &choiceExpr{
-				pos: position{line: 545, col: 5, offset: 16158},
+				pos: position{line: 564, col: 5, offset: 16865},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 545, col: 5, offset: 16158},
+						pos: position{line: 564, col: 5, offset: 16865},
 						run: (*parser).callonOrderArg2,
 						expr: &seqExpr{
-							pos: position{line: 545, col: 5, offset: 16158},
+							pos: position{line: 564, col: 5, offset: 16865},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 5, offset: 16158},
+									pos:  position{line: 564, col: 5, offset: 16865},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 545, col: 7, offset: 16160},
+									pos:        position{line: 564, col: 7, offset: 16867},
 									val:        "order",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 16, offset: 16169},
+									pos:  position{line: 564, col: 16, offset: 16876},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 545, col: 18, offset: 16171},
+									pos:        position{line: 564, col: 18, offset: 16878},
 									val:        "asc",
 									ignoreCase: true,
 								},
@@ -4002,26 +4175,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 546, col: 5, offset: 16205},
+						pos: position{line: 565, col: 5, offset: 16912},
 						run: (*parser).callonOrderArg8,
 						expr: &seqExpr{
-							pos: position{line: 546, col: 5, offset: 16205},
+							pos: position{line: 565, col: 5, offset: 16912},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 5, offset: 16205},
+									pos:  position{line: 565, col: 5, offset: 16912},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 546, col: 7, offset: 16207},
+									pos:        position{line: 565, col: 7, offset: 16914},
 									val:        "order",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 16, offset: 16216},
+									pos:  position{line: 565, col: 16, offset: 16923},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 546, col: 18, offset: 16218},
+									pos:        position{line: 565, col: 18, offset: 16925},
 									val:        "desc",
 									ignoreCase: true,
 								},
@@ -4033,12 +4206,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassProc",
-			pos:  position{line: 548, col: 1, offset: 16251},
+			pos:  position{line: 567, col: 1, offset: 16958},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 5, offset: 16264},
+				pos: position{line: 568, col: 5, offset: 16971},
 				run: (*parser).callonPassProc1,
 				expr: &litMatcher{
-					pos:        position{line: 549, col: 5, offset: 16264},
+					pos:        position{line: 568, col: 5, offset: 16971},
 					val:        "pass",
 					ignoreCase: true,
 				},
@@ -4046,45 +4219,45 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeProc",
-			pos:  position{line: 555, col: 1, offset: 16459},
+			pos:  position{line: 574, col: 1, offset: 17166},
 			expr: &actionExpr{
-				pos: position{line: 556, col: 5, offset: 16475},
+				pos: position{line: 575, col: 5, offset: 17182},
 				run: (*parser).callonExplodeProc1,
 				expr: &seqExpr{
-					pos: position{line: 556, col: 5, offset: 16475},
+					pos: position{line: 575, col: 5, offset: 17182},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 556, col: 5, offset: 16475},
+							pos:        position{line: 575, col: 5, offset: 17182},
 							val:        "explode",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 556, col: 16, offset: 16486},
+							pos:  position{line: 575, col: 16, offset: 17193},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 556, col: 18, offset: 16488},
+							pos:   position{line: 575, col: 18, offset: 17195},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 556, col: 23, offset: 16493},
+								pos:  position{line: 575, col: 23, offset: 17200},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 556, col: 29, offset: 16499},
+							pos:   position{line: 575, col: 29, offset: 17206},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 556, col: 33, offset: 16503},
+								pos:  position{line: 575, col: 33, offset: 17210},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 556, col: 41, offset: 16511},
+							pos:   position{line: 575, col: 41, offset: 17218},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 556, col: 44, offset: 16514},
+								pos: position{line: 575, col: 44, offset: 17221},
 								expr: &ruleRefExpr{
-									pos:  position{line: 556, col: 44, offset: 16514},
+									pos:  position{line: 575, col: 44, offset: 17221},
 									name: "AsArg",
 								},
 							},
@@ -4095,30 +4268,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 560, col: 1, offset: 16626},
+			pos:  position{line: 579, col: 1, offset: 17333},
 			expr: &actionExpr{
-				pos: position{line: 561, col: 5, offset: 16638},
+				pos: position{line: 580, col: 5, offset: 17345},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 561, col: 5, offset: 16638},
+					pos: position{line: 580, col: 5, offset: 17345},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 561, col: 5, offset: 16638},
+							pos:  position{line: 580, col: 5, offset: 17345},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 561, col: 7, offset: 16640},
+							pos:  position{line: 580, col: 7, offset: 17347},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 561, col: 10, offset: 16643},
+							pos:  position{line: 580, col: 10, offset: 17350},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 561, col: 12, offset: 16645},
+							pos:   position{line: 580, col: 12, offset: 17352},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 16, offset: 16649},
+								pos:  position{line: 580, col: 16, offset: 17356},
 								name: "Type",
 							},
 						},
@@ -4128,30 +4301,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 563, col: 1, offset: 16674},
+			pos:  position{line: 582, col: 1, offset: 17381},
 			expr: &actionExpr{
-				pos: position{line: 564, col: 5, offset: 16684},
+				pos: position{line: 583, col: 5, offset: 17391},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 564, col: 5, offset: 16684},
+					pos: position{line: 583, col: 5, offset: 17391},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 564, col: 5, offset: 16684},
+							pos:  position{line: 583, col: 5, offset: 17391},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 564, col: 7, offset: 16686},
+							pos:  position{line: 583, col: 7, offset: 17393},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 564, col: 10, offset: 16689},
+							pos:  position{line: 583, col: 10, offset: 17396},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 564, col: 12, offset: 16691},
+							pos:   position{line: 583, col: 12, offset: 17398},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 564, col: 16, offset: 16695},
+								pos:  position{line: 583, col: 16, offset: 17402},
 								name: "Lval",
 							},
 						},
@@ -4161,58 +4334,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 568, col: 1, offset: 16746},
+			pos:  position{line: 587, col: 1, offset: 17453},
 			expr: &ruleRefExpr{
-				pos:  position{line: 568, col: 8, offset: 16753},
+				pos:  position{line: 587, col: 8, offset: 17460},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 570, col: 1, offset: 16764},
+			pos:  position{line: 589, col: 1, offset: 17471},
 			expr: &actionExpr{
-				pos: position{line: 571, col: 5, offset: 16774},
+				pos: position{line: 590, col: 5, offset: 17481},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 571, col: 5, offset: 16774},
+					pos: position{line: 590, col: 5, offset: 17481},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 571, col: 5, offset: 16774},
+							pos:   position{line: 590, col: 5, offset: 17481},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 571, col: 11, offset: 16780},
+								pos:  position{line: 590, col: 11, offset: 17487},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 571, col: 16, offset: 16785},
+							pos:   position{line: 590, col: 16, offset: 17492},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 571, col: 21, offset: 16790},
+								pos: position{line: 590, col: 21, offset: 17497},
 								expr: &actionExpr{
-									pos: position{line: 571, col: 22, offset: 16791},
+									pos: position{line: 590, col: 22, offset: 17498},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 571, col: 22, offset: 16791},
+										pos: position{line: 590, col: 22, offset: 17498},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 571, col: 22, offset: 16791},
+												pos:  position{line: 590, col: 22, offset: 17498},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 571, col: 25, offset: 16794},
+												pos:        position{line: 590, col: 25, offset: 17501},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 571, col: 29, offset: 16798},
+												pos:  position{line: 590, col: 29, offset: 17505},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 571, col: 32, offset: 16801},
+												pos:   position{line: 590, col: 32, offset: 17508},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 571, col: 37, offset: 16806},
+													pos:  position{line: 590, col: 37, offset: 17513},
 													name: "Lval",
 												},
 											},
@@ -4227,52 +4400,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 575, col: 1, offset: 16918},
+			pos:  position{line: 594, col: 1, offset: 17625},
 			expr: &ruleRefExpr{
-				pos:  position{line: 575, col: 13, offset: 16930},
+				pos:  position{line: 594, col: 13, offset: 17637},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 577, col: 1, offset: 16936},
+			pos:  position{line: 596, col: 1, offset: 17643},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 5, offset: 16951},
+				pos: position{line: 597, col: 5, offset: 17658},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 5, offset: 16951},
+					pos: position{line: 597, col: 5, offset: 17658},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 578, col: 5, offset: 16951},
+							pos:   position{line: 597, col: 5, offset: 17658},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 578, col: 11, offset: 16957},
+								pos:  position{line: 597, col: 11, offset: 17664},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 578, col: 21, offset: 16967},
+							pos:   position{line: 597, col: 21, offset: 17674},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 578, col: 26, offset: 16972},
+								pos: position{line: 597, col: 26, offset: 17679},
 								expr: &seqExpr{
-									pos: position{line: 578, col: 27, offset: 16973},
+									pos: position{line: 597, col: 27, offset: 17680},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 578, col: 27, offset: 16973},
+											pos:  position{line: 597, col: 27, offset: 17680},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 578, col: 30, offset: 16976},
+											pos:        position{line: 597, col: 30, offset: 17683},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 578, col: 34, offset: 16980},
+											pos:  position{line: 597, col: 34, offset: 17687},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 578, col: 37, offset: 16983},
+											pos:  position{line: 597, col: 37, offset: 17690},
 											name: "FieldExpr",
 										},
 									},
@@ -4285,39 +4458,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 588, col: 1, offset: 17182},
+			pos:  position{line: 607, col: 1, offset: 17889},
 			expr: &actionExpr{
-				pos: position{line: 589, col: 5, offset: 17197},
+				pos: position{line: 608, col: 5, offset: 17904},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 589, col: 5, offset: 17197},
+					pos: position{line: 608, col: 5, offset: 17904},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 589, col: 5, offset: 17197},
+							pos:   position{line: 608, col: 5, offset: 17904},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 589, col: 9, offset: 17201},
+								pos:  position{line: 608, col: 9, offset: 17908},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 589, col: 14, offset: 17206},
+							pos:  position{line: 608, col: 14, offset: 17913},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 589, col: 17, offset: 17209},
+							pos:        position{line: 608, col: 17, offset: 17916},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 589, col: 22, offset: 17214},
+							pos:  position{line: 608, col: 22, offset: 17921},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 589, col: 25, offset: 17217},
+							pos:   position{line: 608, col: 25, offset: 17924},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 589, col: 29, offset: 17221},
+								pos:  position{line: 608, col: 29, offset: 17928},
 								name: "Expr",
 							},
 						},
@@ -4327,71 +4500,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 591, col: 1, offset: 17312},
+			pos:  position{line: 610, col: 1, offset: 18019},
 			expr: &ruleRefExpr{
-				pos:  position{line: 591, col: 8, offset: 17319},
+				pos:  position{line: 610, col: 8, offset: 18026},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 593, col: 1, offset: 17336},
+			pos:  position{line: 612, col: 1, offset: 18043},
 			expr: &choiceExpr{
-				pos: position{line: 594, col: 5, offset: 17356},
+				pos: position{line: 613, col: 5, offset: 18063},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 594, col: 5, offset: 17356},
+						pos: position{line: 613, col: 5, offset: 18063},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 594, col: 5, offset: 17356},
+							pos: position{line: 613, col: 5, offset: 18063},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 594, col: 5, offset: 17356},
+									pos:   position{line: 613, col: 5, offset: 18063},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 594, col: 15, offset: 17366},
+										pos:  position{line: 613, col: 15, offset: 18073},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 594, col: 29, offset: 17380},
+									pos:  position{line: 613, col: 29, offset: 18087},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 594, col: 32, offset: 17383},
+									pos:        position{line: 613, col: 32, offset: 18090},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 594, col: 36, offset: 17387},
+									pos:  position{line: 613, col: 36, offset: 18094},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 594, col: 39, offset: 17390},
+									pos:   position{line: 613, col: 39, offset: 18097},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 594, col: 50, offset: 17401},
+										pos:  position{line: 613, col: 50, offset: 18108},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 594, col: 55, offset: 17406},
+									pos:  position{line: 613, col: 55, offset: 18113},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 594, col: 58, offset: 17409},
+									pos:        position{line: 613, col: 58, offset: 18116},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 594, col: 62, offset: 17413},
+									pos:  position{line: 613, col: 62, offset: 18120},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 594, col: 65, offset: 17416},
+									pos:   position{line: 613, col: 65, offset: 18123},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 594, col: 76, offset: 17427},
+										pos:  position{line: 613, col: 76, offset: 18134},
 										name: "Expr",
 									},
 								},
@@ -4399,7 +4572,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 597, col: 5, offset: 17567},
+						pos:  position{line: 616, col: 5, offset: 18274},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4407,53 +4580,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 599, col: 1, offset: 17582},
+			pos:  position{line: 618, col: 1, offset: 18289},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 5, offset: 17600},
+				pos: position{line: 619, col: 5, offset: 18307},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 5, offset: 17600},
+					pos: position{line: 619, col: 5, offset: 18307},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 600, col: 5, offset: 17600},
+							pos:   position{line: 619, col: 5, offset: 18307},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 600, col: 11, offset: 17606},
+								pos:  position{line: 619, col: 11, offset: 18313},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 601, col: 5, offset: 17625},
+							pos:   position{line: 620, col: 5, offset: 18332},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 601, col: 10, offset: 17630},
+								pos: position{line: 620, col: 10, offset: 18337},
 								expr: &actionExpr{
-									pos: position{line: 601, col: 11, offset: 17631},
+									pos: position{line: 620, col: 11, offset: 18338},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 601, col: 11, offset: 17631},
+										pos: position{line: 620, col: 11, offset: 18338},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 601, col: 11, offset: 17631},
+												pos:  position{line: 620, col: 11, offset: 18338},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 601, col: 14, offset: 17634},
+												pos:   position{line: 620, col: 14, offset: 18341},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 601, col: 17, offset: 17637},
+													pos:  position{line: 620, col: 17, offset: 18344},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 601, col: 25, offset: 17645},
+												pos:  position{line: 620, col: 25, offset: 18352},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 601, col: 28, offset: 17648},
+												pos:   position{line: 620, col: 28, offset: 18355},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 601, col: 33, offset: 17653},
+													pos:  position{line: 620, col: 33, offset: 18360},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4468,53 +4641,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 605, col: 1, offset: 17771},
+			pos:  position{line: 624, col: 1, offset: 18478},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 5, offset: 17790},
+				pos: position{line: 625, col: 5, offset: 18497},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 5, offset: 17790},
+					pos: position{line: 625, col: 5, offset: 18497},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 606, col: 5, offset: 17790},
+							pos:   position{line: 625, col: 5, offset: 18497},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 11, offset: 17796},
+								pos:  position{line: 625, col: 11, offset: 18503},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 607, col: 5, offset: 17820},
+							pos:   position{line: 626, col: 5, offset: 18527},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 607, col: 10, offset: 17825},
+								pos: position{line: 626, col: 10, offset: 18532},
 								expr: &actionExpr{
-									pos: position{line: 607, col: 11, offset: 17826},
+									pos: position{line: 626, col: 11, offset: 18533},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 607, col: 11, offset: 17826},
+										pos: position{line: 626, col: 11, offset: 18533},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 607, col: 11, offset: 17826},
+												pos:  position{line: 626, col: 11, offset: 18533},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 607, col: 14, offset: 17829},
+												pos:   position{line: 626, col: 14, offset: 18536},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 607, col: 17, offset: 17832},
+													pos:  position{line: 626, col: 17, offset: 18539},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 607, col: 26, offset: 17841},
+												pos:  position{line: 626, col: 26, offset: 18548},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 607, col: 29, offset: 17844},
+												pos:   position{line: 626, col: 29, offset: 18551},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 607, col: 34, offset: 17849},
+													pos:  position{line: 626, col: 34, offset: 18556},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -4529,60 +4702,60 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 611, col: 1, offset: 17972},
+			pos:  position{line: 630, col: 1, offset: 18679},
 			expr: &choiceExpr{
-				pos: position{line: 612, col: 5, offset: 17996},
+				pos: position{line: 631, col: 5, offset: 18703},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 612, col: 5, offset: 17996},
+						pos:  position{line: 631, col: 5, offset: 18703},
 						name: "PatternMatch",
 					},
 					&actionExpr{
-						pos: position{line: 613, col: 5, offset: 18013},
+						pos: position{line: 632, col: 5, offset: 18720},
 						run: (*parser).callonEqualityCompareExpr3,
 						expr: &seqExpr{
-							pos: position{line: 613, col: 5, offset: 18013},
+							pos: position{line: 632, col: 5, offset: 18720},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 613, col: 5, offset: 18013},
+									pos:   position{line: 632, col: 5, offset: 18720},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 11, offset: 18019},
+										pos:  position{line: 632, col: 11, offset: 18726},
 										name: "RelativeExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 614, col: 5, offset: 18036},
+									pos:   position{line: 633, col: 5, offset: 18743},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 614, col: 10, offset: 18041},
+										pos: position{line: 633, col: 10, offset: 18748},
 										expr: &actionExpr{
-											pos: position{line: 614, col: 11, offset: 18042},
+											pos: position{line: 633, col: 11, offset: 18749},
 											run: (*parser).callonEqualityCompareExpr9,
 											expr: &seqExpr{
-												pos: position{line: 614, col: 11, offset: 18042},
+												pos: position{line: 633, col: 11, offset: 18749},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 614, col: 11, offset: 18042},
+														pos:  position{line: 633, col: 11, offset: 18749},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 614, col: 14, offset: 18045},
+														pos:   position{line: 633, col: 14, offset: 18752},
 														label: "comp",
 														expr: &ruleRefExpr{
-															pos:  position{line: 614, col: 19, offset: 18050},
+															pos:  position{line: 633, col: 19, offset: 18757},
 															name: "EqualityComparator",
 														},
 													},
 													&ruleRefExpr{
-														pos:  position{line: 614, col: 38, offset: 18069},
+														pos:  position{line: 633, col: 38, offset: 18776},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 614, col: 41, offset: 18072},
+														pos:   position{line: 633, col: 41, offset: 18779},
 														label: "expr",
 														expr: &ruleRefExpr{
-															pos:  position{line: 614, col: 46, offset: 18077},
+															pos:  position{line: 633, col: 46, offset: 18784},
 															name: "RelativeExpr",
 														},
 													},
@@ -4599,24 +4772,24 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 618, col: 1, offset: 18195},
+			pos:  position{line: 637, col: 1, offset: 18902},
 			expr: &choiceExpr{
-				pos: position{line: 619, col: 5, offset: 18216},
+				pos: position{line: 638, col: 5, offset: 18923},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 619, col: 5, offset: 18216},
+						pos: position{line: 638, col: 5, offset: 18923},
 						run: (*parser).callonEqualityOperator2,
 						expr: &litMatcher{
-							pos:        position{line: 619, col: 5, offset: 18216},
+							pos:        position{line: 638, col: 5, offset: 18923},
 							val:        "==",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 620, col: 5, offset: 18245},
+						pos: position{line: 639, col: 5, offset: 18952},
 						run: (*parser).callonEqualityOperator4,
 						expr: &litMatcher{
-							pos:        position{line: 620, col: 5, offset: 18245},
+							pos:        position{line: 639, col: 5, offset: 18952},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -4626,19 +4799,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 622, col: 1, offset: 18282},
+			pos:  position{line: 641, col: 1, offset: 18989},
 			expr: &choiceExpr{
-				pos: position{line: 623, col: 5, offset: 18305},
+				pos: position{line: 642, col: 5, offset: 19012},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 623, col: 5, offset: 18305},
+						pos:  position{line: 642, col: 5, offset: 19012},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 624, col: 5, offset: 18326},
+						pos: position{line: 643, col: 5, offset: 19033},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 624, col: 5, offset: 18326},
+							pos:        position{line: 643, col: 5, offset: 19033},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -4648,53 +4821,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 626, col: 1, offset: 18363},
+			pos:  position{line: 645, col: 1, offset: 19070},
 			expr: &actionExpr{
-				pos: position{line: 627, col: 5, offset: 18380},
+				pos: position{line: 646, col: 5, offset: 19087},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 627, col: 5, offset: 18380},
+					pos: position{line: 646, col: 5, offset: 19087},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 627, col: 5, offset: 18380},
+							pos:   position{line: 646, col: 5, offset: 19087},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 627, col: 11, offset: 18386},
+								pos:  position{line: 646, col: 11, offset: 19093},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 628, col: 5, offset: 18403},
+							pos:   position{line: 647, col: 5, offset: 19110},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 628, col: 10, offset: 18408},
+								pos: position{line: 647, col: 10, offset: 19115},
 								expr: &actionExpr{
-									pos: position{line: 628, col: 11, offset: 18409},
+									pos: position{line: 647, col: 11, offset: 19116},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 628, col: 11, offset: 18409},
+										pos: position{line: 647, col: 11, offset: 19116},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 628, col: 11, offset: 18409},
+												pos:  position{line: 647, col: 11, offset: 19116},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 628, col: 14, offset: 18412},
+												pos:   position{line: 647, col: 14, offset: 19119},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 628, col: 17, offset: 18415},
+													pos:  position{line: 647, col: 17, offset: 19122},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 628, col: 34, offset: 18432},
+												pos:  position{line: 647, col: 34, offset: 19139},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 628, col: 37, offset: 18435},
+												pos:   position{line: 647, col: 37, offset: 19142},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 628, col: 42, offset: 18440},
+													pos:  position{line: 647, col: 42, offset: 19147},
 													name: "AdditiveExpr",
 												},
 											},
@@ -4709,30 +4882,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 632, col: 1, offset: 18556},
+			pos:  position{line: 651, col: 1, offset: 19263},
 			expr: &actionExpr{
-				pos: position{line: 632, col: 20, offset: 18575},
+				pos: position{line: 651, col: 20, offset: 19282},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 632, col: 21, offset: 18576},
+					pos: position{line: 651, col: 21, offset: 19283},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 632, col: 21, offset: 18576},
+							pos:        position{line: 651, col: 21, offset: 19283},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 632, col: 28, offset: 18583},
+							pos:        position{line: 651, col: 28, offset: 19290},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 632, col: 34, offset: 18589},
+							pos:        position{line: 651, col: 34, offset: 19296},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 632, col: 41, offset: 18596},
+							pos:        position{line: 651, col: 41, offset: 19303},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -4742,53 +4915,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 634, col: 1, offset: 18633},
+			pos:  position{line: 653, col: 1, offset: 19340},
 			expr: &actionExpr{
-				pos: position{line: 635, col: 5, offset: 18650},
+				pos: position{line: 654, col: 5, offset: 19357},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 635, col: 5, offset: 18650},
+					pos: position{line: 654, col: 5, offset: 19357},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 635, col: 5, offset: 18650},
+							pos:   position{line: 654, col: 5, offset: 19357},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 11, offset: 18656},
+								pos:  position{line: 654, col: 11, offset: 19363},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 5, offset: 18679},
+							pos:   position{line: 655, col: 5, offset: 19386},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 636, col: 10, offset: 18684},
+								pos: position{line: 655, col: 10, offset: 19391},
 								expr: &actionExpr{
-									pos: position{line: 636, col: 11, offset: 18685},
+									pos: position{line: 655, col: 11, offset: 19392},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 636, col: 11, offset: 18685},
+										pos: position{line: 655, col: 11, offset: 19392},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 636, col: 11, offset: 18685},
+												pos:  position{line: 655, col: 11, offset: 19392},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 636, col: 14, offset: 18688},
+												pos:   position{line: 655, col: 14, offset: 19395},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 636, col: 17, offset: 18691},
+													pos:  position{line: 655, col: 17, offset: 19398},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 636, col: 34, offset: 18708},
+												pos:  position{line: 655, col: 34, offset: 19415},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 636, col: 37, offset: 18711},
+												pos:   position{line: 655, col: 37, offset: 19418},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 636, col: 42, offset: 18716},
+													pos:  position{line: 655, col: 42, offset: 19423},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -4803,20 +4976,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 640, col: 1, offset: 18838},
+			pos:  position{line: 659, col: 1, offset: 19545},
 			expr: &actionExpr{
-				pos: position{line: 640, col: 20, offset: 18857},
+				pos: position{line: 659, col: 20, offset: 19564},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 640, col: 21, offset: 18858},
+					pos: position{line: 659, col: 21, offset: 19565},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 640, col: 21, offset: 18858},
+							pos:        position{line: 659, col: 21, offset: 19565},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 640, col: 27, offset: 18864},
+							pos:        position{line: 659, col: 27, offset: 19571},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -4826,53 +4999,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 642, col: 1, offset: 18901},
+			pos:  position{line: 661, col: 1, offset: 19608},
 			expr: &actionExpr{
-				pos: position{line: 643, col: 5, offset: 18924},
+				pos: position{line: 662, col: 5, offset: 19631},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 643, col: 5, offset: 18924},
+					pos: position{line: 662, col: 5, offset: 19631},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 643, col: 5, offset: 18924},
+							pos:   position{line: 662, col: 5, offset: 19631},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 643, col: 11, offset: 18930},
+								pos:  position{line: 662, col: 11, offset: 19637},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 644, col: 5, offset: 18942},
+							pos:   position{line: 663, col: 5, offset: 19649},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 644, col: 10, offset: 18947},
+								pos: position{line: 663, col: 10, offset: 19654},
 								expr: &actionExpr{
-									pos: position{line: 644, col: 11, offset: 18948},
+									pos: position{line: 663, col: 11, offset: 19655},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 644, col: 11, offset: 18948},
+										pos: position{line: 663, col: 11, offset: 19655},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 644, col: 11, offset: 18948},
+												pos:  position{line: 663, col: 11, offset: 19655},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 644, col: 14, offset: 18951},
+												pos:   position{line: 663, col: 14, offset: 19658},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 644, col: 17, offset: 18954},
+													pos:  position{line: 663, col: 17, offset: 19661},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 644, col: 40, offset: 18977},
+												pos:  position{line: 663, col: 40, offset: 19684},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 644, col: 43, offset: 18980},
+												pos:   position{line: 663, col: 43, offset: 19687},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 644, col: 48, offset: 18985},
+													pos:  position{line: 663, col: 48, offset: 19692},
 													name: "NotExpr",
 												},
 											},
@@ -4887,20 +5060,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 648, col: 1, offset: 19096},
+			pos:  position{line: 667, col: 1, offset: 19803},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 26, offset: 19121},
+				pos: position{line: 667, col: 26, offset: 19828},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 648, col: 27, offset: 19122},
+					pos: position{line: 667, col: 27, offset: 19829},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 648, col: 27, offset: 19122},
+							pos:        position{line: 667, col: 27, offset: 19829},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 648, col: 33, offset: 19128},
+							pos:        position{line: 667, col: 33, offset: 19835},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -4910,30 +5083,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 650, col: 1, offset: 19165},
+			pos:  position{line: 669, col: 1, offset: 19872},
 			expr: &choiceExpr{
-				pos: position{line: 651, col: 5, offset: 19177},
+				pos: position{line: 670, col: 5, offset: 19884},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 651, col: 5, offset: 19177},
+						pos: position{line: 670, col: 5, offset: 19884},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 651, col: 5, offset: 19177},
+							pos: position{line: 670, col: 5, offset: 19884},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 651, col: 5, offset: 19177},
+									pos:        position{line: 670, col: 5, offset: 19884},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 651, col: 9, offset: 19181},
+									pos:  position{line: 670, col: 9, offset: 19888},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 651, col: 12, offset: 19184},
+									pos:   position{line: 670, col: 12, offset: 19891},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 651, col: 14, offset: 19186},
+										pos:  position{line: 670, col: 14, offset: 19893},
 										name: "NotExpr",
 									},
 								},
@@ -4941,7 +5114,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 654, col: 5, offset: 19295},
+						pos:  position{line: 673, col: 5, offset: 20002},
 						name: "FuncExpr",
 					},
 				},
@@ -4949,43 +5122,43 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 656, col: 1, offset: 19305},
+			pos:  position{line: 675, col: 1, offset: 20012},
 			expr: &choiceExpr{
-				pos: position{line: 657, col: 5, offset: 19318},
+				pos: position{line: 676, col: 5, offset: 20025},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 657, col: 5, offset: 19318},
+						pos:  position{line: 676, col: 5, offset: 20025},
 						name: "SelectExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 658, col: 5, offset: 19333},
+						pos:  position{line: 677, col: 5, offset: 20040},
 						name: "MatchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19347},
+						pos: position{line: 678, col: 5, offset: 20054},
 						run: (*parser).callonFuncExpr4,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 19347},
+							pos: position{line: 678, col: 5, offset: 20054},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 659, col: 5, offset: 19347},
+									pos:   position{line: 678, col: 5, offset: 20054},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 9, offset: 19351},
+										pos:  position{line: 678, col: 9, offset: 20058},
 										name: "TypeLiteral",
 									},
 								},
 								&notExpr{
-									pos: position{line: 659, col: 21, offset: 19363},
+									pos: position{line: 678, col: 21, offset: 20070},
 									expr: &seqExpr{
-										pos: position{line: 659, col: 23, offset: 19365},
+										pos: position{line: 678, col: 23, offset: 20072},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 659, col: 23, offset: 19365},
+												pos:  position{line: 678, col: 23, offset: 20072},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 659, col: 26, offset: 19368},
+												pos:        position{line: 678, col: 26, offset: 20075},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -4996,26 +5169,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 19397},
+						pos: position{line: 679, col: 5, offset: 20104},
 						run: (*parser).callonFuncExpr12,
 						expr: &seqExpr{
-							pos: position{line: 660, col: 5, offset: 19397},
+							pos: position{line: 679, col: 5, offset: 20104},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 660, col: 5, offset: 19397},
+									pos:   position{line: 679, col: 5, offset: 20104},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 660, col: 11, offset: 19403},
+										pos:  position{line: 679, col: 11, offset: 20110},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 660, col: 16, offset: 19408},
+									pos:   position{line: 679, col: 16, offset: 20115},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 660, col: 21, offset: 19413},
+										pos: position{line: 679, col: 21, offset: 20120},
 										expr: &ruleRefExpr{
-											pos:  position{line: 660, col: 22, offset: 19414},
+											pos:  position{line: 679, col: 22, offset: 20121},
 											name: "Deref",
 										},
 									},
@@ -5024,26 +5197,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 19485},
+						pos: position{line: 682, col: 5, offset: 20192},
 						run: (*parser).callonFuncExpr19,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 19485},
+							pos: position{line: 682, col: 5, offset: 20192},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 663, col: 5, offset: 19485},
+									pos:   position{line: 682, col: 5, offset: 20192},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 663, col: 11, offset: 19491},
+										pos:  position{line: 682, col: 11, offset: 20198},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 663, col: 20, offset: 19500},
+									pos:   position{line: 682, col: 20, offset: 20207},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 663, col: 25, offset: 19505},
+										pos: position{line: 682, col: 25, offset: 20212},
 										expr: &ruleRefExpr{
-											pos:  position{line: 663, col: 26, offset: 19506},
+											pos:  position{line: 682, col: 26, offset: 20213},
 											name: "Deref",
 										},
 									},
@@ -5052,11 +5225,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 666, col: 5, offset: 19577},
+						pos:  position{line: 685, col: 5, offset: 20284},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 19591},
+						pos:  position{line: 686, col: 5, offset: 20298},
 						name: "Primary",
 					},
 				},
@@ -5064,20 +5237,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 669, col: 1, offset: 19600},
+			pos:  position{line: 688, col: 1, offset: 20307},
 			expr: &seqExpr{
-				pos: position{line: 669, col: 13, offset: 19612},
+				pos: position{line: 688, col: 13, offset: 20319},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 669, col: 13, offset: 19612},
+						pos:  position{line: 688, col: 13, offset: 20319},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 669, col: 22, offset: 19621},
+						pos:  position{line: 688, col: 22, offset: 20328},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 669, col: 25, offset: 19624},
+						pos:        position{line: 688, col: 25, offset: 20331},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5086,27 +5259,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 671, col: 1, offset: 19629},
+			pos:  position{line: 690, col: 1, offset: 20336},
 			expr: &choiceExpr{
-				pos: position{line: 672, col: 5, offset: 19642},
+				pos: position{line: 691, col: 5, offset: 20349},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 672, col: 5, offset: 19642},
+						pos:        position{line: 691, col: 5, offset: 20349},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 673, col: 5, offset: 19652},
+						pos:        position{line: 692, col: 5, offset: 20359},
 						val:        "match",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 674, col: 5, offset: 19664},
+						pos:        position{line: 693, col: 5, offset: 20371},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 675, col: 5, offset: 19677},
+						pos:        position{line: 694, col: 5, offset: 20384},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -5115,37 +5288,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 677, col: 1, offset: 19685},
+			pos:  position{line: 696, col: 1, offset: 20392},
 			expr: &actionExpr{
-				pos: position{line: 678, col: 5, offset: 19699},
+				pos: position{line: 697, col: 5, offset: 20406},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 678, col: 5, offset: 19699},
+					pos: position{line: 697, col: 5, offset: 20406},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 678, col: 5, offset: 19699},
+							pos:        position{line: 697, col: 5, offset: 20406},
 							val:        "match",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 678, col: 13, offset: 19707},
+							pos:  position{line: 697, col: 13, offset: 20414},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 678, col: 16, offset: 19710},
+							pos:        position{line: 697, col: 16, offset: 20417},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 678, col: 20, offset: 19714},
+							pos:   position{line: 697, col: 20, offset: 20421},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 678, col: 25, offset: 19719},
+								pos:  position{line: 697, col: 25, offset: 20426},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 678, col: 39, offset: 19733},
+							pos:        position{line: 697, col: 39, offset: 20440},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5155,55 +5328,55 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 680, col: 1, offset: 19759},
+			pos:  position{line: 699, col: 1, offset: 20466},
 			expr: &actionExpr{
-				pos: position{line: 681, col: 5, offset: 19774},
+				pos: position{line: 700, col: 5, offset: 20481},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 681, col: 5, offset: 19774},
+					pos: position{line: 700, col: 5, offset: 20481},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 681, col: 5, offset: 19774},
+							pos:        position{line: 700, col: 5, offset: 20481},
 							val:        "select",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 681, col: 14, offset: 19783},
+							pos:  position{line: 700, col: 14, offset: 20490},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 681, col: 17, offset: 19786},
+							pos:        position{line: 700, col: 17, offset: 20493},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 681, col: 21, offset: 19790},
+							pos:  position{line: 700, col: 21, offset: 20497},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 681, col: 24, offset: 19793},
+							pos:   position{line: 700, col: 24, offset: 20500},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 681, col: 29, offset: 19798},
+								pos:  position{line: 700, col: 29, offset: 20505},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 681, col: 35, offset: 19804},
+							pos:  position{line: 700, col: 35, offset: 20511},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 681, col: 38, offset: 19807},
+							pos:        position{line: 700, col: 38, offset: 20514},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 681, col: 42, offset: 19811},
+							pos:   position{line: 700, col: 42, offset: 20518},
 							label: "methods",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 681, col: 50, offset: 19819},
+								pos: position{line: 700, col: 50, offset: 20526},
 								expr: &ruleRefExpr{
-									pos:  position{line: 681, col: 50, offset: 19819},
+									pos:  position{line: 700, col: 50, offset: 20526},
 									name: "Methods",
 								},
 							},
@@ -5214,17 +5387,17 @@ var g = &grammar{
 		},
 		{
 			name: "Methods",
-			pos:  position{line: 689, col: 1, offset: 20218},
+			pos:  position{line: 708, col: 1, offset: 20925},
 			expr: &actionExpr{
-				pos: position{line: 690, col: 5, offset: 20230},
+				pos: position{line: 709, col: 5, offset: 20937},
 				run: (*parser).callonMethods1,
 				expr: &labeledExpr{
-					pos:   position{line: 690, col: 5, offset: 20230},
+					pos:   position{line: 709, col: 5, offset: 20937},
 					label: "methods",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 690, col: 13, offset: 20238},
+						pos: position{line: 709, col: 13, offset: 20945},
 						expr: &ruleRefExpr{
-							pos:  position{line: 690, col: 13, offset: 20238},
+							pos:  position{line: 709, col: 13, offset: 20945},
 							name: "Method",
 						},
 					},
@@ -5233,31 +5406,31 @@ var g = &grammar{
 		},
 		{
 			name: "Method",
-			pos:  position{line: 692, col: 1, offset: 20271},
+			pos:  position{line: 711, col: 1, offset: 20978},
 			expr: &actionExpr{
-				pos: position{line: 693, col: 5, offset: 20282},
+				pos: position{line: 712, col: 5, offset: 20989},
 				run: (*parser).callonMethod1,
 				expr: &seqExpr{
-					pos: position{line: 693, col: 5, offset: 20282},
+					pos: position{line: 712, col: 5, offset: 20989},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 693, col: 5, offset: 20282},
+							pos:  position{line: 712, col: 5, offset: 20989},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 693, col: 8, offset: 20285},
+							pos:        position{line: 712, col: 8, offset: 20992},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 693, col: 12, offset: 20289},
+							pos:  position{line: 712, col: 12, offset: 20996},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 693, col: 15, offset: 20292},
+							pos:   position{line: 712, col: 15, offset: 20999},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 693, col: 17, offset: 20294},
+								pos:  position{line: 712, col: 17, offset: 21001},
 								name: "Function",
 							},
 						},
@@ -5267,48 +5440,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 695, col: 1, offset: 20322},
+			pos:  position{line: 714, col: 1, offset: 21029},
 			expr: &actionExpr{
-				pos: position{line: 696, col: 5, offset: 20331},
+				pos: position{line: 715, col: 5, offset: 21038},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 696, col: 5, offset: 20331},
+					pos: position{line: 715, col: 5, offset: 21038},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 696, col: 5, offset: 20331},
+							pos:   position{line: 715, col: 5, offset: 21038},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 696, col: 9, offset: 20335},
+								pos:  position{line: 715, col: 9, offset: 21042},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 696, col: 18, offset: 20344},
+							pos:  position{line: 715, col: 18, offset: 21051},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 696, col: 21, offset: 20347},
+							pos:        position{line: 715, col: 21, offset: 21054},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 696, col: 25, offset: 20351},
+							pos:  position{line: 715, col: 25, offset: 21058},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 696, col: 28, offset: 20354},
+							pos:   position{line: 715, col: 28, offset: 21061},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 696, col: 33, offset: 20359},
+								pos:  position{line: 715, col: 33, offset: 21066},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 696, col: 38, offset: 20364},
+							pos:  position{line: 715, col: 38, offset: 21071},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 696, col: 41, offset: 20367},
+							pos:        position{line: 715, col: 41, offset: 21074},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5318,55 +5491,55 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 700, col: 1, offset: 20464},
+			pos:  position{line: 719, col: 1, offset: 21171},
 			expr: &actionExpr{
-				pos: position{line: 701, col: 5, offset: 20477},
+				pos: position{line: 720, col: 5, offset: 21184},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 701, col: 5, offset: 20477},
+					pos: position{line: 720, col: 5, offset: 21184},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 701, col: 5, offset: 20477},
+							pos: position{line: 720, col: 5, offset: 21184},
 							expr: &ruleRefExpr{
-								pos:  position{line: 701, col: 6, offset: 20478},
+								pos:  position{line: 720, col: 6, offset: 21185},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 701, col: 16, offset: 20488},
+							pos:   position{line: 720, col: 16, offset: 21195},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 701, col: 19, offset: 20491},
+								pos:  position{line: 720, col: 19, offset: 21198},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 701, col: 34, offset: 20506},
+							pos:  position{line: 720, col: 34, offset: 21213},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 701, col: 37, offset: 20509},
+							pos:        position{line: 720, col: 37, offset: 21216},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 701, col: 41, offset: 20513},
+							pos:  position{line: 720, col: 41, offset: 21220},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 701, col: 44, offset: 20516},
+							pos:   position{line: 720, col: 44, offset: 21223},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 701, col: 49, offset: 20521},
+								pos:  position{line: 720, col: 49, offset: 21228},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 701, col: 63, offset: 20535},
+							pos:  position{line: 720, col: 63, offset: 21242},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 701, col: 66, offset: 20538},
+							pos:        position{line: 720, col: 66, offset: 21245},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5376,19 +5549,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 705, col: 1, offset: 20634},
+			pos:  position{line: 724, col: 1, offset: 21341},
 			expr: &choiceExpr{
-				pos: position{line: 706, col: 5, offset: 20652},
+				pos: position{line: 725, col: 5, offset: 21359},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 706, col: 5, offset: 20652},
+						pos:  position{line: 725, col: 5, offset: 21359},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 707, col: 5, offset: 20662},
+						pos: position{line: 726, col: 5, offset: 21369},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 707, col: 5, offset: 20662},
+							pos:  position{line: 726, col: 5, offset: 21369},
 							name: "__",
 						},
 					},
@@ -5397,50 +5570,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 709, col: 1, offset: 20698},
+			pos:  position{line: 728, col: 1, offset: 21405},
 			expr: &actionExpr{
-				pos: position{line: 710, col: 5, offset: 20708},
+				pos: position{line: 729, col: 5, offset: 21415},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 710, col: 5, offset: 20708},
+					pos: position{line: 729, col: 5, offset: 21415},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 710, col: 5, offset: 20708},
+							pos:   position{line: 729, col: 5, offset: 21415},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 710, col: 11, offset: 20714},
+								pos:  position{line: 729, col: 11, offset: 21421},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 710, col: 16, offset: 20719},
+							pos:   position{line: 729, col: 16, offset: 21426},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 710, col: 21, offset: 20724},
+								pos: position{line: 729, col: 21, offset: 21431},
 								expr: &actionExpr{
-									pos: position{line: 710, col: 22, offset: 20725},
+									pos: position{line: 729, col: 22, offset: 21432},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 710, col: 22, offset: 20725},
+										pos: position{line: 729, col: 22, offset: 21432},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 710, col: 22, offset: 20725},
+												pos:  position{line: 729, col: 22, offset: 21432},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 710, col: 25, offset: 20728},
+												pos:        position{line: 729, col: 25, offset: 21435},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 710, col: 29, offset: 20732},
+												pos:  position{line: 729, col: 29, offset: 21439},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 710, col: 32, offset: 20735},
+												pos:   position{line: 729, col: 32, offset: 21442},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 710, col: 34, offset: 20737},
+													pos:  position{line: 729, col: 34, offset: 21444},
 													name: "Expr",
 												},
 											},
@@ -5455,25 +5628,25 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 714, col: 1, offset: 20846},
+			pos:  position{line: 733, col: 1, offset: 21553},
 			expr: &actionExpr{
-				pos: position{line: 714, col: 13, offset: 20858},
+				pos: position{line: 733, col: 13, offset: 21565},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 714, col: 13, offset: 20858},
+					pos: position{line: 733, col: 13, offset: 21565},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 714, col: 13, offset: 20858},
+							pos: position{line: 733, col: 13, offset: 21565},
 							expr: &ruleRefExpr{
-								pos:  position{line: 714, col: 14, offset: 20859},
+								pos:  position{line: 733, col: 14, offset: 21566},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 714, col: 18, offset: 20863},
+							pos:   position{line: 733, col: 18, offset: 21570},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 714, col: 20, offset: 20865},
+								pos:  position{line: 733, col: 20, offset: 21572},
 								name: "DerefExprPattern",
 							},
 						},
@@ -5483,31 +5656,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExprPattern",
-			pos:  position{line: 716, col: 1, offset: 20901},
+			pos:  position{line: 735, col: 1, offset: 21608},
 			expr: &choiceExpr{
-				pos: position{line: 717, col: 5, offset: 20922},
+				pos: position{line: 736, col: 5, offset: 21629},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 717, col: 5, offset: 20922},
+						pos: position{line: 736, col: 5, offset: 21629},
 						run: (*parser).callonDerefExprPattern2,
 						expr: &seqExpr{
-							pos: position{line: 717, col: 5, offset: 20922},
+							pos: position{line: 736, col: 5, offset: 21629},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 717, col: 5, offset: 20922},
+									pos:   position{line: 736, col: 5, offset: 21629},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 717, col: 11, offset: 20928},
+										pos:  position{line: 736, col: 11, offset: 21635},
 										name: "DotID",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 717, col: 17, offset: 20934},
+									pos:   position{line: 736, col: 17, offset: 21641},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 717, col: 22, offset: 20939},
+										pos: position{line: 736, col: 22, offset: 21646},
 										expr: &ruleRefExpr{
-											pos:  position{line: 717, col: 23, offset: 20940},
+											pos:  position{line: 736, col: 23, offset: 21647},
 											name: "Deref",
 										},
 									},
@@ -5516,26 +5689,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 720, col: 5, offset: 21011},
+						pos: position{line: 739, col: 5, offset: 21718},
 						run: (*parser).callonDerefExprPattern9,
 						expr: &seqExpr{
-							pos: position{line: 720, col: 5, offset: 21011},
+							pos: position{line: 739, col: 5, offset: 21718},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 720, col: 5, offset: 21011},
+									pos:   position{line: 739, col: 5, offset: 21718},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 720, col: 11, offset: 21017},
+										pos:  position{line: 739, col: 11, offset: 21724},
 										name: "RootRecord",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 720, col: 22, offset: 21028},
+									pos:   position{line: 739, col: 22, offset: 21735},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 720, col: 27, offset: 21033},
+										pos: position{line: 739, col: 27, offset: 21740},
 										expr: &ruleRefExpr{
-											pos:  position{line: 720, col: 28, offset: 21034},
+											pos:  position{line: 739, col: 28, offset: 21741},
 											name: "Deref",
 										},
 									},
@@ -5544,26 +5717,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 723, col: 5, offset: 21105},
+						pos: position{line: 742, col: 5, offset: 21812},
 						run: (*parser).callonDerefExprPattern16,
 						expr: &seqExpr{
-							pos: position{line: 723, col: 5, offset: 21105},
+							pos: position{line: 742, col: 5, offset: 21812},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 723, col: 5, offset: 21105},
+									pos:   position{line: 742, col: 5, offset: 21812},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 723, col: 11, offset: 21111},
+										pos:  position{line: 742, col: 11, offset: 21818},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 723, col: 22, offset: 21122},
+									pos:   position{line: 742, col: 22, offset: 21829},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 723, col: 27, offset: 21127},
+										pos: position{line: 742, col: 27, offset: 21834},
 										expr: &ruleRefExpr{
-											pos:  position{line: 723, col: 28, offset: 21128},
+											pos:  position{line: 742, col: 28, offset: 21835},
 											name: "Deref",
 										},
 									},
@@ -5572,10 +5745,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 726, col: 5, offset: 21199},
+						pos: position{line: 745, col: 5, offset: 21906},
 						run: (*parser).callonDerefExprPattern23,
 						expr: &litMatcher{
-							pos:        position{line: 726, col: 5, offset: 21199},
+							pos:        position{line: 745, col: 5, offset: 21906},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -5585,12 +5758,12 @@ var g = &grammar{
 		},
 		{
 			name: "RootRecord",
-			pos:  position{line: 730, col: 1, offset: 21268},
+			pos:  position{line: 749, col: 1, offset: 21975},
 			expr: &actionExpr{
-				pos: position{line: 730, col: 14, offset: 21281},
+				pos: position{line: 749, col: 14, offset: 21988},
 				run: (*parser).callonRootRecord1,
 				expr: &litMatcher{
-					pos:        position{line: 730, col: 14, offset: 21281},
+					pos:        position{line: 749, col: 14, offset: 21988},
 					val:        "this",
 					ignoreCase: false,
 				},
@@ -5598,26 +5771,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotID",
-			pos:  position{line: 732, col: 1, offset: 21343},
+			pos:  position{line: 751, col: 1, offset: 22050},
 			expr: &choiceExpr{
-				pos: position{line: 733, col: 5, offset: 21353},
+				pos: position{line: 752, col: 5, offset: 22060},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 733, col: 5, offset: 21353},
+						pos: position{line: 752, col: 5, offset: 22060},
 						run: (*parser).callonDotID2,
 						expr: &seqExpr{
-							pos: position{line: 733, col: 5, offset: 21353},
+							pos: position{line: 752, col: 5, offset: 22060},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 733, col: 5, offset: 21353},
+									pos:        position{line: 752, col: 5, offset: 22060},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 733, col: 9, offset: 21357},
+									pos:   position{line: 752, col: 9, offset: 22064},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 733, col: 15, offset: 21363},
+										pos:  position{line: 752, col: 15, offset: 22070},
 										name: "Identifier",
 									},
 								},
@@ -5625,31 +5798,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 742, col: 5, offset: 21579},
+						pos: position{line: 761, col: 5, offset: 22286},
 						run: (*parser).callonDotID7,
 						expr: &seqExpr{
-							pos: position{line: 742, col: 5, offset: 21579},
+							pos: position{line: 761, col: 5, offset: 22286},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 742, col: 5, offset: 21579},
+									pos:        position{line: 761, col: 5, offset: 22286},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 742, col: 9, offset: 21583},
+									pos:        position{line: 761, col: 9, offset: 22290},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 742, col: 13, offset: 21587},
+									pos:   position{line: 761, col: 13, offset: 22294},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 18, offset: 21592},
+										pos:  position{line: 761, col: 18, offset: 22299},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 742, col: 23, offset: 21597},
+									pos:        position{line: 761, col: 23, offset: 22304},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5661,52 +5834,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 752, col: 1, offset: 21802},
+			pos:  position{line: 771, col: 1, offset: 22509},
 			expr: &choiceExpr{
-				pos: position{line: 753, col: 5, offset: 21812},
+				pos: position{line: 772, col: 5, offset: 22519},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 753, col: 5, offset: 21812},
+						pos: position{line: 772, col: 5, offset: 22519},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 753, col: 5, offset: 21812},
+							pos: position{line: 772, col: 5, offset: 22519},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 753, col: 5, offset: 21812},
+									pos:        position{line: 772, col: 5, offset: 22519},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 753, col: 9, offset: 21816},
+									pos:   position{line: 772, col: 9, offset: 22523},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 753, col: 14, offset: 21821},
+										pos:  position{line: 772, col: 14, offset: 22528},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 753, col: 27, offset: 21834},
+									pos:  position{line: 772, col: 27, offset: 22541},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 753, col: 30, offset: 21837},
+									pos:        position{line: 772, col: 30, offset: 22544},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 753, col: 34, offset: 21841},
+									pos:  position{line: 772, col: 34, offset: 22548},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 753, col: 37, offset: 21844},
+									pos:   position{line: 772, col: 37, offset: 22551},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 753, col: 40, offset: 21847},
+										pos:  position{line: 772, col: 40, offset: 22554},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 753, col: 53, offset: 21860},
+									pos:        position{line: 772, col: 53, offset: 22567},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5714,39 +5887,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 759, col: 5, offset: 22031},
+						pos: position{line: 778, col: 5, offset: 22738},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 759, col: 5, offset: 22031},
+							pos: position{line: 778, col: 5, offset: 22738},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 759, col: 5, offset: 22031},
+									pos:        position{line: 778, col: 5, offset: 22738},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 759, col: 9, offset: 22035},
+									pos:  position{line: 778, col: 9, offset: 22742},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 759, col: 12, offset: 22038},
+									pos:        position{line: 778, col: 12, offset: 22745},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 759, col: 16, offset: 22042},
+									pos:  position{line: 778, col: 16, offset: 22749},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 759, col: 19, offset: 22045},
+									pos:   position{line: 778, col: 19, offset: 22752},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 759, col: 22, offset: 22048},
+										pos:  position{line: 778, col: 22, offset: 22755},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 759, col: 35, offset: 22061},
+									pos:        position{line: 778, col: 35, offset: 22768},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5754,39 +5927,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 765, col: 5, offset: 22232},
+						pos: position{line: 784, col: 5, offset: 22939},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 765, col: 5, offset: 22232},
+							pos: position{line: 784, col: 5, offset: 22939},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 765, col: 5, offset: 22232},
+									pos:        position{line: 784, col: 5, offset: 22939},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 765, col: 9, offset: 22236},
+									pos:   position{line: 784, col: 9, offset: 22943},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 765, col: 14, offset: 22241},
+										pos:  position{line: 784, col: 14, offset: 22948},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 765, col: 27, offset: 22254},
+									pos:  position{line: 784, col: 27, offset: 22961},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 765, col: 30, offset: 22257},
+									pos:        position{line: 784, col: 30, offset: 22964},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 765, col: 34, offset: 22261},
+									pos:  position{line: 784, col: 34, offset: 22968},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 765, col: 37, offset: 22264},
+									pos:        position{line: 784, col: 37, offset: 22971},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5794,26 +5967,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 771, col: 5, offset: 22437},
+						pos: position{line: 790, col: 5, offset: 23144},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 771, col: 5, offset: 22437},
+							pos: position{line: 790, col: 5, offset: 23144},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 771, col: 5, offset: 22437},
+									pos:        position{line: 790, col: 5, offset: 23144},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 771, col: 9, offset: 22441},
+									pos:   position{line: 790, col: 9, offset: 23148},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 771, col: 14, offset: 22446},
+										pos:  position{line: 790, col: 14, offset: 23153},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 771, col: 19, offset: 22451},
+									pos:        position{line: 790, col: 19, offset: 23158},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5821,29 +5994,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 772, col: 5, offset: 22500},
+						pos: position{line: 791, col: 5, offset: 23207},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 772, col: 5, offset: 22500},
+							pos: position{line: 791, col: 5, offset: 23207},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 772, col: 5, offset: 22500},
+									pos:        position{line: 791, col: 5, offset: 23207},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 772, col: 9, offset: 22504},
+									pos: position{line: 791, col: 9, offset: 23211},
 									expr: &litMatcher{
-										pos:        position{line: 772, col: 11, offset: 22506},
+										pos:        position{line: 791, col: 11, offset: 23213},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 772, col: 16, offset: 22511},
+									pos:   position{line: 791, col: 16, offset: 23218},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 772, col: 19, offset: 22514},
+										pos:  position{line: 791, col: 19, offset: 23221},
 										name: "Identifier",
 									},
 								},
@@ -5855,59 +6028,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 774, col: 1, offset: 22565},
+			pos:  position{line: 793, col: 1, offset: 23272},
 			expr: &choiceExpr{
-				pos: position{line: 775, col: 5, offset: 22577},
+				pos: position{line: 794, col: 5, offset: 23284},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 775, col: 5, offset: 22577},
+						pos:  position{line: 794, col: 5, offset: 23284},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 776, col: 5, offset: 22589},
+						pos:  position{line: 795, col: 5, offset: 23296},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 777, col: 5, offset: 22600},
+						pos:  position{line: 796, col: 5, offset: 23307},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 778, col: 5, offset: 22610},
+						pos:  position{line: 797, col: 5, offset: 23317},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 779, col: 5, offset: 22618},
+						pos:  position{line: 798, col: 5, offset: 23325},
 						name: "Map",
 					},
 					&actionExpr{
-						pos: position{line: 780, col: 5, offset: 22626},
+						pos: position{line: 799, col: 5, offset: 23333},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 780, col: 5, offset: 22626},
+							pos: position{line: 799, col: 5, offset: 23333},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 780, col: 5, offset: 22626},
+									pos:        position{line: 799, col: 5, offset: 23333},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 780, col: 9, offset: 22630},
+									pos:  position{line: 799, col: 9, offset: 23337},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 780, col: 12, offset: 22633},
+									pos:   position{line: 799, col: 12, offset: 23340},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 780, col: 17, offset: 22638},
+										pos:  position{line: 799, col: 17, offset: 23345},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 780, col: 22, offset: 22643},
+									pos:  position{line: 799, col: 22, offset: 23350},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 780, col: 25, offset: 22646},
+									pos:        position{line: 799, col: 25, offset: 23353},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5919,36 +6092,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 782, col: 1, offset: 22672},
+			pos:  position{line: 801, col: 1, offset: 23379},
 			expr: &actionExpr{
-				pos: position{line: 783, col: 5, offset: 22683},
+				pos: position{line: 802, col: 5, offset: 23390},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 783, col: 5, offset: 22683},
+					pos: position{line: 802, col: 5, offset: 23390},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 783, col: 5, offset: 22683},
+							pos:        position{line: 802, col: 5, offset: 23390},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 783, col: 9, offset: 22687},
+							pos:  position{line: 802, col: 9, offset: 23394},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 783, col: 12, offset: 22690},
+							pos:   position{line: 802, col: 12, offset: 23397},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 783, col: 19, offset: 22697},
+								pos:  position{line: 802, col: 19, offset: 23404},
 								name: "Fields",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 783, col: 26, offset: 22704},
+							pos:  position{line: 802, col: 26, offset: 23411},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 783, col: 29, offset: 22707},
+							pos:        position{line: 802, col: 29, offset: 23414},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -5958,28 +6131,28 @@ var g = &grammar{
 		},
 		{
 			name: "Fields",
-			pos:  position{line: 787, col: 1, offset: 22800},
+			pos:  position{line: 806, col: 1, offset: 23507},
 			expr: &actionExpr{
-				pos: position{line: 788, col: 5, offset: 22811},
+				pos: position{line: 807, col: 5, offset: 23518},
 				run: (*parser).callonFields1,
 				expr: &seqExpr{
-					pos: position{line: 788, col: 5, offset: 22811},
+					pos: position{line: 807, col: 5, offset: 23518},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 788, col: 5, offset: 22811},
+							pos:   position{line: 807, col: 5, offset: 23518},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 788, col: 11, offset: 22817},
+								pos:  position{line: 807, col: 11, offset: 23524},
 								name: "Field",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 788, col: 17, offset: 22823},
+							pos:   position{line: 807, col: 17, offset: 23530},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 788, col: 22, offset: 22828},
+								pos: position{line: 807, col: 22, offset: 23535},
 								expr: &ruleRefExpr{
-									pos:  position{line: 788, col: 22, offset: 22828},
+									pos:  position{line: 807, col: 22, offset: 23535},
 									name: "FieldTail",
 								},
 							},
@@ -5990,31 +6163,31 @@ var g = &grammar{
 		},
 		{
 			name: "FieldTail",
-			pos:  position{line: 792, col: 1, offset: 22919},
+			pos:  position{line: 811, col: 1, offset: 23626},
 			expr: &actionExpr{
-				pos: position{line: 792, col: 13, offset: 22931},
+				pos: position{line: 811, col: 13, offset: 23638},
 				run: (*parser).callonFieldTail1,
 				expr: &seqExpr{
-					pos: position{line: 792, col: 13, offset: 22931},
+					pos: position{line: 811, col: 13, offset: 23638},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 13, offset: 22931},
+							pos:  position{line: 811, col: 13, offset: 23638},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 792, col: 16, offset: 22934},
+							pos:        position{line: 811, col: 16, offset: 23641},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 20, offset: 22938},
+							pos:  position{line: 811, col: 20, offset: 23645},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 792, col: 23, offset: 22941},
+							pos:   position{line: 811, col: 23, offset: 23648},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 792, col: 25, offset: 22943},
+								pos:  position{line: 811, col: 25, offset: 23650},
 								name: "Field",
 							},
 						},
@@ -6024,39 +6197,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 794, col: 1, offset: 22968},
+			pos:  position{line: 813, col: 1, offset: 23675},
 			expr: &actionExpr{
-				pos: position{line: 795, col: 5, offset: 22978},
+				pos: position{line: 814, col: 5, offset: 23685},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 795, col: 5, offset: 22978},
+					pos: position{line: 814, col: 5, offset: 23685},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 795, col: 5, offset: 22978},
+							pos:   position{line: 814, col: 5, offset: 23685},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 10, offset: 22983},
+								pos:  position{line: 814, col: 10, offset: 23690},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 20, offset: 22993},
+							pos:  position{line: 814, col: 20, offset: 23700},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 795, col: 23, offset: 22996},
+							pos:        position{line: 814, col: 23, offset: 23703},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 27, offset: 23000},
+							pos:  position{line: 814, col: 27, offset: 23707},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 30, offset: 23003},
+							pos:   position{line: 814, col: 30, offset: 23710},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 36, offset: 23009},
+								pos:  position{line: 814, col: 36, offset: 23716},
 								name: "Expr",
 							},
 						},
@@ -6066,36 +6239,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 799, col: 1, offset: 23094},
+			pos:  position{line: 818, col: 1, offset: 23801},
 			expr: &actionExpr{
-				pos: position{line: 800, col: 5, offset: 23104},
+				pos: position{line: 819, col: 5, offset: 23811},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 800, col: 5, offset: 23104},
+					pos: position{line: 819, col: 5, offset: 23811},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 800, col: 5, offset: 23104},
+							pos:        position{line: 819, col: 5, offset: 23811},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 800, col: 9, offset: 23108},
+							pos:  position{line: 819, col: 9, offset: 23815},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 800, col: 12, offset: 23111},
+							pos:   position{line: 819, col: 12, offset: 23818},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 800, col: 18, offset: 23117},
+								pos:  position{line: 819, col: 18, offset: 23824},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 800, col: 32, offset: 23131},
+							pos:  position{line: 819, col: 32, offset: 23838},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 800, col: 35, offset: 23134},
+							pos:        position{line: 819, col: 35, offset: 23841},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6105,36 +6278,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 804, col: 1, offset: 23224},
+			pos:  position{line: 823, col: 1, offset: 23931},
 			expr: &actionExpr{
-				pos: position{line: 805, col: 5, offset: 23232},
+				pos: position{line: 824, col: 5, offset: 23939},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 805, col: 5, offset: 23232},
+					pos: position{line: 824, col: 5, offset: 23939},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 805, col: 5, offset: 23232},
+							pos:        position{line: 824, col: 5, offset: 23939},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 10, offset: 23237},
+							pos:  position{line: 824, col: 10, offset: 23944},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 805, col: 13, offset: 23240},
+							pos:   position{line: 824, col: 13, offset: 23947},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 805, col: 19, offset: 23246},
+								pos:  position{line: 824, col: 19, offset: 23953},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 33, offset: 23260},
+							pos:  position{line: 824, col: 33, offset: 23967},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 805, col: 36, offset: 23263},
+							pos:        position{line: 824, col: 36, offset: 23970},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6144,36 +6317,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 809, col: 1, offset: 23352},
+			pos:  position{line: 828, col: 1, offset: 24059},
 			expr: &actionExpr{
-				pos: position{line: 810, col: 5, offset: 23360},
+				pos: position{line: 829, col: 5, offset: 24067},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 810, col: 5, offset: 23360},
+					pos: position{line: 829, col: 5, offset: 24067},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 810, col: 5, offset: 23360},
+							pos:        position{line: 829, col: 5, offset: 24067},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 810, col: 10, offset: 23365},
+							pos:  position{line: 829, col: 10, offset: 24072},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 810, col: 13, offset: 23368},
+							pos:   position{line: 829, col: 13, offset: 24075},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 810, col: 19, offset: 23374},
+								pos:  position{line: 829, col: 19, offset: 24081},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 810, col: 27, offset: 23382},
+							pos:  position{line: 829, col: 27, offset: 24089},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 810, col: 30, offset: 23385},
+							pos:        position{line: 829, col: 30, offset: 24092},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6183,31 +6356,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 814, col: 1, offset: 23476},
+			pos:  position{line: 833, col: 1, offset: 24183},
 			expr: &choiceExpr{
-				pos: position{line: 815, col: 5, offset: 23488},
+				pos: position{line: 834, col: 5, offset: 24195},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 815, col: 5, offset: 23488},
+						pos: position{line: 834, col: 5, offset: 24195},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 815, col: 5, offset: 23488},
+							pos: position{line: 834, col: 5, offset: 24195},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 815, col: 5, offset: 23488},
+									pos:   position{line: 834, col: 5, offset: 24195},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 815, col: 11, offset: 23494},
+										pos:  position{line: 834, col: 11, offset: 24201},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 815, col: 17, offset: 23500},
+									pos:   position{line: 834, col: 17, offset: 24207},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 815, col: 22, offset: 23505},
+										pos: position{line: 834, col: 22, offset: 24212},
 										expr: &ruleRefExpr{
-											pos:  position{line: 815, col: 22, offset: 23505},
+											pos:  position{line: 834, col: 22, offset: 24212},
 											name: "EntryTail",
 										},
 									},
@@ -6216,10 +6389,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 818, col: 5, offset: 23599},
+						pos: position{line: 837, col: 5, offset: 24306},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 818, col: 5, offset: 23599},
+							pos:  position{line: 837, col: 5, offset: 24306},
 							name: "__",
 						},
 					},
@@ -6228,31 +6401,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 821, col: 1, offset: 23636},
+			pos:  position{line: 840, col: 1, offset: 24343},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 13, offset: 23648},
+				pos: position{line: 840, col: 13, offset: 24355},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 821, col: 13, offset: 23648},
+					pos: position{line: 840, col: 13, offset: 24355},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 13, offset: 23648},
+							pos:  position{line: 840, col: 13, offset: 24355},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 821, col: 16, offset: 23651},
+							pos:        position{line: 840, col: 16, offset: 24358},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 20, offset: 23655},
+							pos:  position{line: 840, col: 20, offset: 24362},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 23, offset: 23658},
+							pos:   position{line: 840, col: 23, offset: 24365},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 821, col: 25, offset: 23660},
+								pos:  position{line: 840, col: 25, offset: 24367},
 								name: "Entry",
 							},
 						},
@@ -6262,39 +6435,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 823, col: 1, offset: 23685},
+			pos:  position{line: 842, col: 1, offset: 24392},
 			expr: &actionExpr{
-				pos: position{line: 824, col: 5, offset: 23695},
+				pos: position{line: 843, col: 5, offset: 24402},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 824, col: 5, offset: 23695},
+					pos: position{line: 843, col: 5, offset: 24402},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 824, col: 5, offset: 23695},
+							pos:   position{line: 843, col: 5, offset: 24402},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 824, col: 9, offset: 23699},
+								pos:  position{line: 843, col: 9, offset: 24406},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 824, col: 14, offset: 23704},
+							pos:  position{line: 843, col: 14, offset: 24411},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 824, col: 17, offset: 23707},
+							pos:        position{line: 843, col: 17, offset: 24414},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 824, col: 21, offset: 23711},
+							pos:  position{line: 843, col: 21, offset: 24418},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 824, col: 24, offset: 23714},
+							pos:   position{line: 843, col: 24, offset: 24421},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 824, col: 30, offset: 23720},
+								pos:  position{line: 843, col: 30, offset: 24427},
 								name: "Expr",
 							},
 						},
@@ -6304,92 +6477,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLProc",
-			pos:  position{line: 830, col: 1, offset: 23827},
+			pos:  position{line: 849, col: 1, offset: 24534},
 			expr: &actionExpr{
-				pos: position{line: 831, col: 5, offset: 23839},
+				pos: position{line: 850, col: 5, offset: 24546},
 				run: (*parser).callonSQLProc1,
 				expr: &seqExpr{
-					pos: position{line: 831, col: 5, offset: 23839},
+					pos: position{line: 850, col: 5, offset: 24546},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 831, col: 5, offset: 23839},
+							pos:   position{line: 850, col: 5, offset: 24546},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 831, col: 15, offset: 23849},
+								pos:  position{line: 850, col: 15, offset: 24556},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 5, offset: 23863},
+							pos:   position{line: 851, col: 5, offset: 24570},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 832, col: 10, offset: 23868},
+								pos: position{line: 851, col: 10, offset: 24575},
 								expr: &ruleRefExpr{
-									pos:  position{line: 832, col: 10, offset: 23868},
+									pos:  position{line: 851, col: 10, offset: 24575},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 833, col: 5, offset: 23881},
+							pos:   position{line: 852, col: 5, offset: 24588},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 833, col: 11, offset: 23887},
+								pos: position{line: 852, col: 11, offset: 24594},
 								expr: &ruleRefExpr{
-									pos:  position{line: 833, col: 11, offset: 23887},
+									pos:  position{line: 852, col: 11, offset: 24594},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 834, col: 5, offset: 23901},
+							pos:   position{line: 853, col: 5, offset: 24608},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 834, col: 11, offset: 23907},
+								pos: position{line: 853, col: 11, offset: 24614},
 								expr: &ruleRefExpr{
-									pos:  position{line: 834, col: 11, offset: 23907},
+									pos:  position{line: 853, col: 11, offset: 24614},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 835, col: 5, offset: 23921},
+							pos:   position{line: 854, col: 5, offset: 24628},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 835, col: 13, offset: 23929},
+								pos: position{line: 854, col: 13, offset: 24636},
 								expr: &ruleRefExpr{
-									pos:  position{line: 835, col: 13, offset: 23929},
+									pos:  position{line: 854, col: 13, offset: 24636},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 836, col: 5, offset: 23945},
+							pos:   position{line: 855, col: 5, offset: 24652},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 836, col: 12, offset: 23952},
+								pos: position{line: 855, col: 12, offset: 24659},
 								expr: &ruleRefExpr{
-									pos:  position{line: 836, col: 12, offset: 23952},
+									pos:  position{line: 855, col: 12, offset: 24659},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 837, col: 5, offset: 23967},
+							pos:   position{line: 856, col: 5, offset: 24674},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 837, col: 13, offset: 23975},
+								pos: position{line: 856, col: 13, offset: 24682},
 								expr: &ruleRefExpr{
-									pos:  position{line: 837, col: 13, offset: 23975},
+									pos:  position{line: 856, col: 13, offset: 24682},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 838, col: 5, offset: 23991},
+							pos:   position{line: 857, col: 5, offset: 24698},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 838, col: 11, offset: 23997},
+								pos:  position{line: 857, col: 11, offset: 24704},
 								name: "SQLLimit",
 							},
 						},
@@ -6399,26 +6572,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 862, col: 1, offset: 24364},
+			pos:  position{line: 881, col: 1, offset: 25071},
 			expr: &choiceExpr{
-				pos: position{line: 863, col: 5, offset: 24378},
+				pos: position{line: 882, col: 5, offset: 25085},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 863, col: 5, offset: 24378},
+						pos: position{line: 882, col: 5, offset: 25085},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 863, col: 5, offset: 24378},
+							pos: position{line: 882, col: 5, offset: 25085},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 5, offset: 24378},
+									pos:  position{line: 882, col: 5, offset: 25085},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 12, offset: 24385},
+									pos:  position{line: 882, col: 12, offset: 25092},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 863, col: 14, offset: 24387},
+									pos:        position{line: 882, col: 14, offset: 25094},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6426,24 +6599,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 864, col: 5, offset: 24415},
+						pos: position{line: 883, col: 5, offset: 25122},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 864, col: 5, offset: 24415},
+							pos: position{line: 883, col: 5, offset: 25122},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 5, offset: 24415},
+									pos:  position{line: 883, col: 5, offset: 25122},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 12, offset: 24422},
+									pos:  position{line: 883, col: 12, offset: 25129},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 864, col: 14, offset: 24424},
+									pos:   position{line: 883, col: 14, offset: 25131},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 864, col: 26, offset: 24436},
+										pos:  position{line: 883, col: 26, offset: 25143},
 										name: "SQLAssignments",
 									},
 								},
@@ -6455,41 +6628,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 866, col: 1, offset: 24480},
+			pos:  position{line: 885, col: 1, offset: 25187},
 			expr: &choiceExpr{
-				pos: position{line: 867, col: 5, offset: 24498},
+				pos: position{line: 886, col: 5, offset: 25205},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 867, col: 5, offset: 24498},
+						pos: position{line: 886, col: 5, offset: 25205},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 867, col: 5, offset: 24498},
+							pos: position{line: 886, col: 5, offset: 25205},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 867, col: 5, offset: 24498},
+									pos:   position{line: 886, col: 5, offset: 25205},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 867, col: 9, offset: 24502},
+										pos:  position{line: 886, col: 9, offset: 25209},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 867, col: 14, offset: 24507},
+									pos:  position{line: 886, col: 14, offset: 25214},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 867, col: 16, offset: 24509},
+									pos:  position{line: 886, col: 16, offset: 25216},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 867, col: 19, offset: 24512},
+									pos:  position{line: 886, col: 19, offset: 25219},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 867, col: 21, offset: 24514},
+									pos:   position{line: 886, col: 21, offset: 25221},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 867, col: 25, offset: 24518},
+										pos:  position{line: 886, col: 25, offset: 25225},
 										name: "Lval",
 									},
 								},
@@ -6497,13 +6670,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 868, col: 5, offset: 24612},
+						pos: position{line: 887, col: 5, offset: 25319},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 868, col: 5, offset: 24612},
+							pos:   position{line: 887, col: 5, offset: 25319},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 868, col: 10, offset: 24617},
+								pos:  position{line: 887, col: 10, offset: 25324},
 								name: "Expr",
 							},
 						},
@@ -6513,50 +6686,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 870, col: 1, offset: 24709},
+			pos:  position{line: 889, col: 1, offset: 25416},
 			expr: &actionExpr{
-				pos: position{line: 871, col: 5, offset: 24728},
+				pos: position{line: 890, col: 5, offset: 25435},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 871, col: 5, offset: 24728},
+					pos: position{line: 890, col: 5, offset: 25435},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 871, col: 5, offset: 24728},
+							pos:   position{line: 890, col: 5, offset: 25435},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 871, col: 11, offset: 24734},
+								pos:  position{line: 890, col: 11, offset: 25441},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 871, col: 25, offset: 24748},
+							pos:   position{line: 890, col: 25, offset: 25455},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 871, col: 30, offset: 24753},
+								pos: position{line: 890, col: 30, offset: 25460},
 								expr: &actionExpr{
-									pos: position{line: 871, col: 31, offset: 24754},
+									pos: position{line: 890, col: 31, offset: 25461},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 871, col: 31, offset: 24754},
+										pos: position{line: 890, col: 31, offset: 25461},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 871, col: 31, offset: 24754},
+												pos:  position{line: 890, col: 31, offset: 25461},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 871, col: 34, offset: 24757},
+												pos:        position{line: 890, col: 34, offset: 25464},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 871, col: 38, offset: 24761},
+												pos:  position{line: 890, col: 38, offset: 25468},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 871, col: 41, offset: 24764},
+												pos:   position{line: 890, col: 41, offset: 25471},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 871, col: 46, offset: 24769},
+													pos:  position{line: 890, col: 46, offset: 25476},
 													name: "SQLAssignment",
 												},
 											},
@@ -6571,43 +6744,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 875, col: 1, offset: 24890},
+			pos:  position{line: 894, col: 1, offset: 25597},
 			expr: &choiceExpr{
-				pos: position{line: 876, col: 5, offset: 24902},
+				pos: position{line: 895, col: 5, offset: 25609},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 876, col: 5, offset: 24902},
+						pos: position{line: 895, col: 5, offset: 25609},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 876, col: 5, offset: 24902},
+							pos: position{line: 895, col: 5, offset: 25609},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 876, col: 5, offset: 24902},
+									pos:  position{line: 895, col: 5, offset: 25609},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 876, col: 7, offset: 24904},
+									pos:  position{line: 895, col: 7, offset: 25611},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 876, col: 12, offset: 24909},
+									pos:  position{line: 895, col: 12, offset: 25616},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 876, col: 14, offset: 24911},
+									pos:   position{line: 895, col: 14, offset: 25618},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 876, col: 20, offset: 24917},
+										pos:  position{line: 895, col: 20, offset: 25624},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 876, col: 29, offset: 24926},
+									pos:   position{line: 895, col: 29, offset: 25633},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 876, col: 35, offset: 24932},
+										pos: position{line: 895, col: 35, offset: 25639},
 										expr: &ruleRefExpr{
-											pos:  position{line: 876, col: 35, offset: 24932},
+											pos:  position{line: 895, col: 35, offset: 25639},
 											name: "SQLAlias",
 										},
 									},
@@ -6616,25 +6789,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 879, col: 5, offset: 25027},
+						pos: position{line: 898, col: 5, offset: 25734},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 879, col: 5, offset: 25027},
+							pos: position{line: 898, col: 5, offset: 25734},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 5, offset: 25027},
+									pos:  position{line: 898, col: 5, offset: 25734},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 7, offset: 25029},
+									pos:  position{line: 898, col: 7, offset: 25736},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 12, offset: 25034},
+									pos:  position{line: 898, col: 12, offset: 25741},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 879, col: 14, offset: 25036},
+									pos:        position{line: 898, col: 14, offset: 25743},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6646,33 +6819,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 881, col: 1, offset: 25061},
+			pos:  position{line: 900, col: 1, offset: 25768},
 			expr: &choiceExpr{
-				pos: position{line: 882, col: 5, offset: 25074},
+				pos: position{line: 901, col: 5, offset: 25781},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 882, col: 5, offset: 25074},
+						pos: position{line: 901, col: 5, offset: 25781},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 882, col: 5, offset: 25074},
+							pos: position{line: 901, col: 5, offset: 25781},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 882, col: 5, offset: 25074},
+									pos:  position{line: 901, col: 5, offset: 25781},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 882, col: 7, offset: 25076},
+									pos:  position{line: 901, col: 7, offset: 25783},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 882, col: 10, offset: 25079},
+									pos:  position{line: 901, col: 10, offset: 25786},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 882, col: 12, offset: 25081},
+									pos:   position{line: 901, col: 12, offset: 25788},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 882, col: 15, offset: 25084},
+										pos:  position{line: 901, col: 15, offset: 25791},
 										name: "Lval",
 									},
 								},
@@ -6680,20 +6853,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 883, col: 5, offset: 25112},
+						pos: position{line: 902, col: 5, offset: 25819},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 883, col: 5, offset: 25112},
+							pos: position{line: 902, col: 5, offset: 25819},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 883, col: 5, offset: 25112},
+									pos:  position{line: 902, col: 5, offset: 25819},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 883, col: 7, offset: 25114},
+									pos:   position{line: 902, col: 7, offset: 25821},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 883, col: 10, offset: 25117},
+										pos:  position{line: 902, col: 10, offset: 25824},
 										name: "Lval",
 									},
 								},
@@ -6705,42 +6878,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 885, col: 1, offset: 25142},
+			pos:  position{line: 904, col: 1, offset: 25849},
 			expr: &ruleRefExpr{
-				pos:  position{line: 886, col: 5, offset: 25155},
+				pos:  position{line: 905, col: 5, offset: 25862},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 888, col: 1, offset: 25161},
+			pos:  position{line: 907, col: 1, offset: 25868},
 			expr: &actionExpr{
-				pos: position{line: 889, col: 5, offset: 25174},
+				pos: position{line: 908, col: 5, offset: 25881},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 889, col: 5, offset: 25174},
+					pos: position{line: 908, col: 5, offset: 25881},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 889, col: 5, offset: 25174},
+							pos:   position{line: 908, col: 5, offset: 25881},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 889, col: 11, offset: 25180},
+								pos:  position{line: 908, col: 11, offset: 25887},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 889, col: 19, offset: 25188},
+							pos:   position{line: 908, col: 19, offset: 25895},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 889, col: 24, offset: 25193},
+								pos: position{line: 908, col: 24, offset: 25900},
 								expr: &actionExpr{
-									pos: position{line: 889, col: 25, offset: 25194},
+									pos: position{line: 908, col: 25, offset: 25901},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 889, col: 25, offset: 25194},
+										pos:   position{line: 908, col: 25, offset: 25901},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 889, col: 30, offset: 25199},
+											pos:  position{line: 908, col: 30, offset: 25906},
 											name: "SQLJoin",
 										},
 									},
@@ -6753,90 +6926,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 893, col: 1, offset: 25314},
+			pos:  position{line: 912, col: 1, offset: 26021},
 			expr: &actionExpr{
-				pos: position{line: 894, col: 5, offset: 25326},
+				pos: position{line: 913, col: 5, offset: 26033},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 894, col: 5, offset: 25326},
+					pos: position{line: 913, col: 5, offset: 26033},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 894, col: 5, offset: 25326},
+							pos:   position{line: 913, col: 5, offset: 26033},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 894, col: 11, offset: 25332},
+								pos:  position{line: 913, col: 11, offset: 26039},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 894, col: 24, offset: 25345},
+							pos:  position{line: 913, col: 24, offset: 26052},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 894, col: 26, offset: 25347},
+							pos:  position{line: 913, col: 26, offset: 26054},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 894, col: 31, offset: 25352},
+							pos:  position{line: 913, col: 31, offset: 26059},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 894, col: 33, offset: 25354},
+							pos:   position{line: 913, col: 33, offset: 26061},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 894, col: 39, offset: 25360},
+								pos:  position{line: 913, col: 39, offset: 26067},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 894, col: 48, offset: 25369},
+							pos:   position{line: 913, col: 48, offset: 26076},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 894, col: 54, offset: 25375},
+								pos: position{line: 913, col: 54, offset: 26082},
 								expr: &ruleRefExpr{
-									pos:  position{line: 894, col: 54, offset: 25375},
+									pos:  position{line: 913, col: 54, offset: 26082},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 894, col: 64, offset: 25385},
+							pos:  position{line: 913, col: 64, offset: 26092},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 894, col: 66, offset: 25387},
+							pos:  position{line: 913, col: 66, offset: 26094},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 894, col: 69, offset: 25390},
+							pos:  position{line: 913, col: 69, offset: 26097},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 894, col: 71, offset: 25392},
+							pos:   position{line: 913, col: 71, offset: 26099},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 894, col: 79, offset: 25400},
+								pos:  position{line: 913, col: 79, offset: 26107},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 894, col: 87, offset: 25408},
+							pos:  position{line: 913, col: 87, offset: 26115},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 894, col: 90, offset: 25411},
+							pos:        position{line: 913, col: 90, offset: 26118},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 894, col: 94, offset: 25415},
+							pos:  position{line: 913, col: 94, offset: 26122},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 894, col: 97, offset: 25418},
+							pos:   position{line: 913, col: 97, offset: 26125},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 894, col: 106, offset: 25427},
+								pos:  position{line: 913, col: 106, offset: 26134},
 								name: "JoinKey",
 							},
 						},
@@ -6846,36 +7019,36 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 913, col: 1, offset: 25662},
+			pos:  position{line: 932, col: 1, offset: 26369},
 			expr: &choiceExpr{
-				pos: position{line: 914, col: 5, offset: 25679},
+				pos: position{line: 933, col: 5, offset: 26386},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 914, col: 5, offset: 25679},
+						pos: position{line: 933, col: 5, offset: 26386},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 914, col: 5, offset: 25679},
+							pos: position{line: 933, col: 5, offset: 26386},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 914, col: 5, offset: 25679},
+									pos:  position{line: 933, col: 5, offset: 26386},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 914, col: 7, offset: 25681},
+									pos:   position{line: 933, col: 7, offset: 26388},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 914, col: 14, offset: 25688},
+										pos: position{line: 933, col: 14, offset: 26395},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 914, col: 14, offset: 25688},
+												pos:  position{line: 933, col: 14, offset: 26395},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 914, col: 21, offset: 25695},
+												pos:  position{line: 933, col: 21, offset: 26402},
 												name: "RIGHT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 914, col: 29, offset: 25703},
+												pos:  position{line: 933, col: 29, offset: 26410},
 												name: "INNER",
 											},
 										},
@@ -6885,10 +7058,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 915, col: 5, offset: 25736},
+						pos: position{line: 934, col: 5, offset: 26443},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &litMatcher{
-							pos:        position{line: 915, col: 5, offset: 25736},
+							pos:        position{line: 934, col: 5, offset: 26443},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -6898,30 +7071,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 917, col: 1, offset: 25772},
+			pos:  position{line: 936, col: 1, offset: 26479},
 			expr: &actionExpr{
-				pos: position{line: 918, col: 5, offset: 25785},
+				pos: position{line: 937, col: 5, offset: 26492},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 918, col: 5, offset: 25785},
+					pos: position{line: 937, col: 5, offset: 26492},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 918, col: 5, offset: 25785},
+							pos:  position{line: 937, col: 5, offset: 26492},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 918, col: 7, offset: 25787},
+							pos:  position{line: 937, col: 7, offset: 26494},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 918, col: 13, offset: 25793},
+							pos:  position{line: 937, col: 13, offset: 26500},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 918, col: 15, offset: 25795},
+							pos:   position{line: 937, col: 15, offset: 26502},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 918, col: 20, offset: 25800},
+								pos:  position{line: 937, col: 20, offset: 26507},
 								name: "SearchBoolean",
 							},
 						},
@@ -6931,38 +7104,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 920, col: 1, offset: 25836},
+			pos:  position{line: 939, col: 1, offset: 26543},
 			expr: &actionExpr{
-				pos: position{line: 921, col: 5, offset: 25851},
+				pos: position{line: 940, col: 5, offset: 26558},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 921, col: 5, offset: 25851},
+					pos: position{line: 940, col: 5, offset: 26558},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 5, offset: 25851},
+							pos:  position{line: 940, col: 5, offset: 26558},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 7, offset: 25853},
+							pos:  position{line: 940, col: 7, offset: 26560},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 13, offset: 25859},
+							pos:  position{line: 940, col: 13, offset: 26566},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 15, offset: 25861},
+							pos:  position{line: 940, col: 15, offset: 26568},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 18, offset: 25864},
+							pos:  position{line: 940, col: 18, offset: 26571},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 921, col: 20, offset: 25866},
+							pos:   position{line: 940, col: 20, offset: 26573},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 921, col: 28, offset: 25874},
+								pos:  position{line: 940, col: 28, offset: 26581},
 								name: "FieldExprs",
 							},
 						},
@@ -6972,30 +7145,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 923, col: 1, offset: 25910},
+			pos:  position{line: 942, col: 1, offset: 26617},
 			expr: &actionExpr{
-				pos: position{line: 924, col: 5, offset: 25924},
+				pos: position{line: 943, col: 5, offset: 26631},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 924, col: 5, offset: 25924},
+					pos: position{line: 943, col: 5, offset: 26631},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 924, col: 5, offset: 25924},
+							pos:  position{line: 943, col: 5, offset: 26631},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 924, col: 7, offset: 25926},
+							pos:  position{line: 943, col: 7, offset: 26633},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 924, col: 14, offset: 25933},
+							pos:  position{line: 943, col: 14, offset: 26640},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 924, col: 16, offset: 25935},
+							pos:   position{line: 943, col: 16, offset: 26642},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 924, col: 21, offset: 25940},
+								pos:  position{line: 943, col: 21, offset: 26647},
 								name: "SearchBoolean",
 							},
 						},
@@ -7005,46 +7178,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 926, col: 1, offset: 25976},
+			pos:  position{line: 945, col: 1, offset: 26683},
 			expr: &actionExpr{
-				pos: position{line: 927, col: 5, offset: 25991},
+				pos: position{line: 946, col: 5, offset: 26698},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 927, col: 5, offset: 25991},
+					pos: position{line: 946, col: 5, offset: 26698},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 927, col: 5, offset: 25991},
+							pos:  position{line: 946, col: 5, offset: 26698},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 927, col: 7, offset: 25993},
+							pos:  position{line: 946, col: 7, offset: 26700},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 927, col: 13, offset: 25999},
+							pos:  position{line: 946, col: 13, offset: 26706},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 927, col: 15, offset: 26001},
+							pos:  position{line: 946, col: 15, offset: 26708},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 927, col: 18, offset: 26004},
+							pos:  position{line: 946, col: 18, offset: 26711},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 927, col: 20, offset: 26006},
+							pos:   position{line: 946, col: 20, offset: 26713},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 927, col: 25, offset: 26011},
+								pos:  position{line: 946, col: 25, offset: 26718},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 927, col: 31, offset: 26017},
+							pos:   position{line: 946, col: 31, offset: 26724},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 927, col: 37, offset: 26023},
+								pos:  position{line: 946, col: 37, offset: 26730},
 								name: "SQLOrder",
 							},
 						},
@@ -7054,32 +7227,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 931, col: 1, offset: 26133},
+			pos:  position{line: 950, col: 1, offset: 26840},
 			expr: &choiceExpr{
-				pos: position{line: 932, col: 5, offset: 26146},
+				pos: position{line: 951, col: 5, offset: 26853},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 932, col: 5, offset: 26146},
+						pos: position{line: 951, col: 5, offset: 26853},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 932, col: 5, offset: 26146},
+							pos: position{line: 951, col: 5, offset: 26853},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 932, col: 5, offset: 26146},
+									pos:  position{line: 951, col: 5, offset: 26853},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 932, col: 7, offset: 26148},
+									pos:   position{line: 951, col: 7, offset: 26855},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 932, col: 12, offset: 26153},
+										pos: position{line: 951, col: 12, offset: 26860},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 932, col: 12, offset: 26153},
+												pos:  position{line: 951, col: 12, offset: 26860},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 932, col: 18, offset: 26159},
+												pos:  position{line: 951, col: 18, offset: 26866},
 												name: "DESC",
 											},
 										},
@@ -7089,10 +7262,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 933, col: 5, offset: 26189},
+						pos: position{line: 952, col: 5, offset: 26896},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 933, col: 5, offset: 26189},
+							pos:        position{line: 952, col: 5, offset: 26896},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7102,33 +7275,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 935, col: 1, offset: 26215},
+			pos:  position{line: 954, col: 1, offset: 26922},
 			expr: &choiceExpr{
-				pos: position{line: 936, col: 5, offset: 26228},
+				pos: position{line: 955, col: 5, offset: 26935},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 936, col: 5, offset: 26228},
+						pos: position{line: 955, col: 5, offset: 26935},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 936, col: 5, offset: 26228},
+							pos: position{line: 955, col: 5, offset: 26935},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 5, offset: 26228},
+									pos:  position{line: 955, col: 5, offset: 26935},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 7, offset: 26230},
+									pos:  position{line: 955, col: 7, offset: 26937},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 13, offset: 26236},
+									pos:  position{line: 955, col: 13, offset: 26943},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 936, col: 15, offset: 26238},
+									pos:   position{line: 955, col: 15, offset: 26945},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 936, col: 21, offset: 26244},
+										pos:  position{line: 955, col: 21, offset: 26951},
 										name: "UInt",
 									},
 								},
@@ -7136,10 +7309,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 937, col: 5, offset: 26275},
+						pos: position{line: 956, col: 5, offset: 26982},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 937, col: 5, offset: 26275},
+							pos:        position{line: 956, col: 5, offset: 26982},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7149,12 +7322,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 939, col: 1, offset: 26297},
+			pos:  position{line: 958, col: 1, offset: 27004},
 			expr: &actionExpr{
-				pos: position{line: 939, col: 10, offset: 26306},
+				pos: position{line: 958, col: 10, offset: 27013},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 939, col: 10, offset: 26306},
+					pos:        position{line: 958, col: 10, offset: 27013},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7162,12 +7335,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 940, col: 1, offset: 26341},
+			pos:  position{line: 959, col: 1, offset: 27048},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 6, offset: 26346},
+				pos: position{line: 959, col: 6, offset: 27053},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 940, col: 6, offset: 26346},
+					pos:        position{line: 959, col: 6, offset: 27053},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7175,12 +7348,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 941, col: 1, offset: 26373},
+			pos:  position{line: 960, col: 1, offset: 27080},
 			expr: &actionExpr{
-				pos: position{line: 941, col: 8, offset: 26380},
+				pos: position{line: 960, col: 8, offset: 27087},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 941, col: 8, offset: 26380},
+					pos:        position{line: 960, col: 8, offset: 27087},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7188,12 +7361,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 942, col: 1, offset: 26411},
+			pos:  position{line: 961, col: 1, offset: 27118},
 			expr: &actionExpr{
-				pos: position{line: 942, col: 8, offset: 26418},
+				pos: position{line: 961, col: 8, offset: 27125},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 942, col: 8, offset: 26418},
+					pos:        position{line: 961, col: 8, offset: 27125},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7201,12 +7374,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 943, col: 1, offset: 26449},
+			pos:  position{line: 962, col: 1, offset: 27156},
 			expr: &actionExpr{
-				pos: position{line: 943, col: 9, offset: 26457},
+				pos: position{line: 962, col: 9, offset: 27164},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 943, col: 9, offset: 26457},
+					pos:        position{line: 962, col: 9, offset: 27164},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7214,12 +7387,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 944, col: 1, offset: 26490},
+			pos:  position{line: 963, col: 1, offset: 27197},
 			expr: &actionExpr{
-				pos: position{line: 944, col: 9, offset: 26498},
+				pos: position{line: 963, col: 9, offset: 27205},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 944, col: 9, offset: 26498},
+					pos:        position{line: 963, col: 9, offset: 27205},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7227,20 +7400,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 945, col: 1, offset: 26531},
+			pos:  position{line: 964, col: 1, offset: 27238},
 			expr: &ruleRefExpr{
-				pos:  position{line: 945, col: 6, offset: 26536},
+				pos:  position{line: 964, col: 6, offset: 27243},
 				name: "ByToken",
 			},
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 946, col: 1, offset: 26544},
+			pos:  position{line: 965, col: 1, offset: 27251},
 			expr: &actionExpr{
-				pos: position{line: 946, col: 10, offset: 26553},
+				pos: position{line: 965, col: 10, offset: 27260},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 946, col: 10, offset: 26553},
+					pos:        position{line: 965, col: 10, offset: 27260},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7248,12 +7421,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 947, col: 1, offset: 26588},
+			pos:  position{line: 966, col: 1, offset: 27295},
 			expr: &actionExpr{
-				pos: position{line: 947, col: 9, offset: 26596},
+				pos: position{line: 966, col: 9, offset: 27303},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 947, col: 9, offset: 26596},
+					pos:        position{line: 966, col: 9, offset: 27303},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7261,12 +7434,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 948, col: 1, offset: 26629},
+			pos:  position{line: 967, col: 1, offset: 27336},
 			expr: &actionExpr{
-				pos: position{line: 948, col: 6, offset: 26634},
+				pos: position{line: 967, col: 6, offset: 27341},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 948, col: 6, offset: 26634},
+					pos:        position{line: 967, col: 6, offset: 27341},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7274,12 +7447,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 949, col: 1, offset: 26661},
+			pos:  position{line: 968, col: 1, offset: 27368},
 			expr: &actionExpr{
-				pos: position{line: 949, col: 9, offset: 26669},
+				pos: position{line: 968, col: 9, offset: 27376},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 949, col: 9, offset: 26669},
+					pos:        position{line: 968, col: 9, offset: 27376},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7287,12 +7460,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 950, col: 1, offset: 26702},
+			pos:  position{line: 969, col: 1, offset: 27409},
 			expr: &actionExpr{
-				pos: position{line: 950, col: 7, offset: 26708},
+				pos: position{line: 969, col: 7, offset: 27415},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 950, col: 7, offset: 26708},
+					pos:        position{line: 969, col: 7, offset: 27415},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7300,12 +7473,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 951, col: 1, offset: 26737},
+			pos:  position{line: 970, col: 1, offset: 27444},
 			expr: &actionExpr{
-				pos: position{line: 951, col: 8, offset: 26744},
+				pos: position{line: 970, col: 8, offset: 27451},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 951, col: 8, offset: 26744},
+					pos:        position{line: 970, col: 8, offset: 27451},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7313,12 +7486,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 952, col: 1, offset: 26775},
+			pos:  position{line: 971, col: 1, offset: 27482},
 			expr: &actionExpr{
-				pos: position{line: 952, col: 8, offset: 26782},
+				pos: position{line: 971, col: 8, offset: 27489},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 952, col: 8, offset: 26782},
+					pos:        position{line: 971, col: 8, offset: 27489},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7326,12 +7499,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 953, col: 1, offset: 26813},
+			pos:  position{line: 972, col: 1, offset: 27520},
 			expr: &actionExpr{
-				pos: position{line: 953, col: 9, offset: 26821},
+				pos: position{line: 972, col: 9, offset: 27528},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 953, col: 9, offset: 26821},
+					pos:        position{line: 972, col: 9, offset: 27528},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7339,12 +7512,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 954, col: 1, offset: 26854},
+			pos:  position{line: 973, col: 1, offset: 27561},
 			expr: &actionExpr{
-				pos: position{line: 954, col: 9, offset: 26862},
+				pos: position{line: 973, col: 9, offset: 27569},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 954, col: 9, offset: 26862},
+					pos:        position{line: 973, col: 9, offset: 27569},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7352,48 +7525,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 956, col: 1, offset: 26896},
+			pos:  position{line: 975, col: 1, offset: 27603},
 			expr: &choiceExpr{
-				pos: position{line: 957, col: 5, offset: 26918},
+				pos: position{line: 976, col: 5, offset: 27625},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 5, offset: 26918},
+						pos:  position{line: 976, col: 5, offset: 27625},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 14, offset: 26927},
+						pos:  position{line: 976, col: 14, offset: 27634},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 19, offset: 26932},
+						pos:  position{line: 976, col: 19, offset: 27639},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 27, offset: 26940},
+						pos:  position{line: 976, col: 27, offset: 27647},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 34, offset: 26947},
+						pos:  position{line: 976, col: 34, offset: 27654},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 42, offset: 26955},
+						pos:  position{line: 976, col: 42, offset: 27662},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 50, offset: 26963},
+						pos:  position{line: 976, col: 50, offset: 27670},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 59, offset: 26972},
+						pos:  position{line: 976, col: 59, offset: 27679},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 67, offset: 26980},
+						pos:  position{line: 976, col: 67, offset: 27687},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 75, offset: 26988},
+						pos:  position{line: 976, col: 75, offset: 27695},
 						name: "ON",
 					},
 				},
@@ -7401,48 +7574,48 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 961, col: 1, offset: 27014},
+			pos:  position{line: 980, col: 1, offset: 27721},
 			expr: &choiceExpr{
-				pos: position{line: 962, col: 5, offset: 27026},
+				pos: position{line: 981, col: 5, offset: 27733},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 962, col: 5, offset: 27026},
+						pos:  position{line: 981, col: 5, offset: 27733},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 963, col: 5, offset: 27042},
+						pos:  position{line: 982, col: 5, offset: 27749},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 964, col: 5, offset: 27060},
+						pos:  position{line: 983, col: 5, offset: 27767},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 965, col: 5, offset: 27078},
+						pos:  position{line: 984, col: 5, offset: 27785},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 966, col: 5, offset: 27097},
+						pos:  position{line: 985, col: 5, offset: 27804},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 967, col: 5, offset: 27110},
+						pos:  position{line: 986, col: 5, offset: 27817},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 968, col: 5, offset: 27119},
+						pos:  position{line: 987, col: 5, offset: 27826},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 969, col: 5, offset: 27136},
+						pos:  position{line: 988, col: 5, offset: 27843},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 970, col: 5, offset: 27155},
+						pos:  position{line: 989, col: 5, offset: 27862},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 971, col: 5, offset: 27174},
+						pos:  position{line: 990, col: 5, offset: 27881},
 						name: "NullLiteral",
 					},
 				},
@@ -7450,15 +7623,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 973, col: 1, offset: 27187},
+			pos:  position{line: 992, col: 1, offset: 27894},
 			expr: &actionExpr{
-				pos: position{line: 974, col: 5, offset: 27205},
+				pos: position{line: 993, col: 5, offset: 27912},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 974, col: 5, offset: 27205},
+					pos:   position{line: 993, col: 5, offset: 27912},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 974, col: 7, offset: 27207},
+						pos:  position{line: 993, col: 7, offset: 27914},
 						name: "QuotedString",
 					},
 				},
@@ -7466,28 +7639,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 978, col: 1, offset: 27320},
+			pos:  position{line: 997, col: 1, offset: 28027},
 			expr: &choiceExpr{
-				pos: position{line: 979, col: 5, offset: 27338},
+				pos: position{line: 998, col: 5, offset: 28045},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 979, col: 5, offset: 27338},
+						pos: position{line: 998, col: 5, offset: 28045},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 979, col: 5, offset: 27338},
+							pos: position{line: 998, col: 5, offset: 28045},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 979, col: 5, offset: 27338},
+									pos:   position{line: 998, col: 5, offset: 28045},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 979, col: 7, offset: 27340},
+										pos:  position{line: 998, col: 7, offset: 28047},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 979, col: 14, offset: 27347},
+									pos: position{line: 998, col: 14, offset: 28054},
 									expr: &ruleRefExpr{
-										pos:  position{line: 979, col: 15, offset: 27348},
+										pos:  position{line: 998, col: 15, offset: 28055},
 										name: "IdentifierRest",
 									},
 								},
@@ -7495,13 +7668,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 982, col: 5, offset: 27463},
+						pos: position{line: 1001, col: 5, offset: 28170},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 982, col: 5, offset: 27463},
+							pos:   position{line: 1001, col: 5, offset: 28170},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 982, col: 7, offset: 27465},
+								pos:  position{line: 1001, col: 7, offset: 28172},
 								name: "IP4Net",
 							},
 						},
@@ -7511,28 +7684,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 986, col: 1, offset: 27569},
+			pos:  position{line: 1005, col: 1, offset: 28276},
 			expr: &choiceExpr{
-				pos: position{line: 987, col: 5, offset: 27588},
+				pos: position{line: 1006, col: 5, offset: 28295},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 987, col: 5, offset: 27588},
+						pos: position{line: 1006, col: 5, offset: 28295},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 987, col: 5, offset: 27588},
+							pos: position{line: 1006, col: 5, offset: 28295},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 987, col: 5, offset: 27588},
+									pos:   position{line: 1006, col: 5, offset: 28295},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 987, col: 7, offset: 27590},
+										pos:  position{line: 1006, col: 7, offset: 28297},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 987, col: 11, offset: 27594},
+									pos: position{line: 1006, col: 11, offset: 28301},
 									expr: &ruleRefExpr{
-										pos:  position{line: 987, col: 12, offset: 27595},
+										pos:  position{line: 1006, col: 12, offset: 28302},
 										name: "IdentifierRest",
 									},
 								},
@@ -7540,13 +7713,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 990, col: 5, offset: 27709},
+						pos: position{line: 1009, col: 5, offset: 28416},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 990, col: 5, offset: 27709},
+							pos:   position{line: 1009, col: 5, offset: 28416},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 990, col: 7, offset: 27711},
+								pos:  position{line: 1009, col: 7, offset: 28418},
 								name: "IP",
 							},
 						},
@@ -7556,15 +7729,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 994, col: 1, offset: 27810},
+			pos:  position{line: 1013, col: 1, offset: 28517},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 5, offset: 27827},
+				pos: position{line: 1014, col: 5, offset: 28534},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 995, col: 5, offset: 27827},
+					pos:   position{line: 1014, col: 5, offset: 28534},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 995, col: 7, offset: 27829},
+						pos:  position{line: 1014, col: 7, offset: 28536},
 						name: "FloatString",
 					},
 				},
@@ -7572,15 +7745,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 999, col: 1, offset: 27942},
+			pos:  position{line: 1018, col: 1, offset: 28649},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 5, offset: 27961},
+				pos: position{line: 1019, col: 5, offset: 28668},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1000, col: 5, offset: 27961},
+					pos:   position{line: 1019, col: 5, offset: 28668},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1000, col: 7, offset: 27963},
+						pos:  position{line: 1019, col: 7, offset: 28670},
 						name: "IntString",
 					},
 				},
@@ -7588,24 +7761,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1004, col: 1, offset: 28072},
+			pos:  position{line: 1023, col: 1, offset: 28779},
 			expr: &choiceExpr{
-				pos: position{line: 1005, col: 5, offset: 28091},
+				pos: position{line: 1024, col: 5, offset: 28798},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1005, col: 5, offset: 28091},
+						pos: position{line: 1024, col: 5, offset: 28798},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 1005, col: 5, offset: 28091},
+							pos:        position{line: 1024, col: 5, offset: 28798},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1006, col: 5, offset: 28204},
+						pos: position{line: 1025, col: 5, offset: 28911},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 1006, col: 5, offset: 28204},
+							pos:        position{line: 1025, col: 5, offset: 28911},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7615,12 +7788,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1008, col: 1, offset: 28315},
+			pos:  position{line: 1027, col: 1, offset: 29022},
 			expr: &actionExpr{
-				pos: position{line: 1009, col: 5, offset: 28331},
+				pos: position{line: 1028, col: 5, offset: 29038},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 1009, col: 5, offset: 28331},
+					pos:        position{line: 1028, col: 5, offset: 29038},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7628,34 +7801,34 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1011, col: 1, offset: 28437},
+			pos:  position{line: 1030, col: 1, offset: 29144},
 			expr: &actionExpr{
-				pos: position{line: 1012, col: 5, offset: 28453},
+				pos: position{line: 1031, col: 5, offset: 29160},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1012, col: 5, offset: 28453},
+					pos: position{line: 1031, col: 5, offset: 29160},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1012, col: 5, offset: 28453},
+							pos: position{line: 1031, col: 5, offset: 29160},
 							expr: &seqExpr{
-								pos: position{line: 1012, col: 7, offset: 28455},
+								pos: position{line: 1031, col: 7, offset: 29162},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1012, col: 7, offset: 28455},
+										pos:  position{line: 1031, col: 7, offset: 29162},
 										name: "SQLTokenSentinels",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1012, col: 25, offset: 28473},
+										pos:  position{line: 1031, col: 25, offset: 29180},
 										name: "EOT",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1012, col: 30, offset: 28478},
+							pos:   position{line: 1031, col: 30, offset: 29185},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1012, col: 34, offset: 28482},
+								pos:  position{line: 1031, col: 34, offset: 29189},
 								name: "TypeExternal",
 							},
 						},
@@ -7665,16 +7838,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1016, col: 1, offset: 28580},
+			pos:  position{line: 1035, col: 1, offset: 29287},
 			expr: &choiceExpr{
-				pos: position{line: 1017, col: 5, offset: 28593},
+				pos: position{line: 1036, col: 5, offset: 29300},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1017, col: 5, offset: 28593},
+						pos:  position{line: 1036, col: 5, offset: 29300},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1018, col: 5, offset: 28610},
+						pos:  position{line: 1037, col: 5, offset: 29317},
 						name: "PrimitiveType",
 					},
 				},
@@ -7682,36 +7855,36 @@ var g = &grammar{
 		},
 		{
 			name: "TypeExternal",
-			pos:  position{line: 1020, col: 1, offset: 28625},
+			pos:  position{line: 1039, col: 1, offset: 29332},
 			expr: &choiceExpr{
-				pos: position{line: 1021, col: 5, offset: 28642},
+				pos: position{line: 1040, col: 5, offset: 29349},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1021, col: 5, offset: 28642},
+						pos:  position{line: 1040, col: 5, offset: 29349},
 						name: "ExplicitType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1022, col: 5, offset: 28659},
+						pos:  position{line: 1041, col: 5, offset: 29366},
 						name: "ComplexTypeExternal",
 					},
 					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 28683},
+						pos: position{line: 1042, col: 5, offset: 29390},
 						run: (*parser).callonTypeExternal4,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 28683},
+							pos: position{line: 1042, col: 5, offset: 29390},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1023, col: 5, offset: 28683},
+									pos:   position{line: 1042, col: 5, offset: 29390},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 9, offset: 28687},
+										pos:  position{line: 1042, col: 9, offset: 29394},
 										name: "PrimitiveTypeExternal",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1023, col: 31, offset: 28709},
+									pos: position{line: 1042, col: 31, offset: 29416},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 32, offset: 28710},
+										pos:  position{line: 1042, col: 32, offset: 29417},
 										name: "IdentifierRest",
 									},
 								},
@@ -7723,20 +7896,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1025, col: 1, offset: 28746},
+			pos:  position{line: 1044, col: 1, offset: 29453},
 			expr: &choiceExpr{
-				pos: position{line: 1026, col: 5, offset: 28755},
+				pos: position{line: 1045, col: 5, offset: 29462},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1026, col: 5, offset: 28755},
+						pos:  position{line: 1045, col: 5, offset: 29462},
 						name: "ExplicitType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1027, col: 5, offset: 28772},
+						pos:  position{line: 1046, col: 5, offset: 29479},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1028, col: 5, offset: 28790},
+						pos:  position{line: 1047, col: 5, offset: 29497},
 						name: "ComplexType",
 					},
 				},
@@ -7744,48 +7917,48 @@ var g = &grammar{
 		},
 		{
 			name: "ExplicitType",
-			pos:  position{line: 1030, col: 1, offset: 28803},
+			pos:  position{line: 1049, col: 1, offset: 29510},
 			expr: &choiceExpr{
-				pos: position{line: 1031, col: 5, offset: 28820},
+				pos: position{line: 1050, col: 5, offset: 29527},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1031, col: 5, offset: 28820},
+						pos: position{line: 1050, col: 5, offset: 29527},
 						run: (*parser).callonExplicitType2,
 						expr: &seqExpr{
-							pos: position{line: 1031, col: 5, offset: 28820},
+							pos: position{line: 1050, col: 5, offset: 29527},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1031, col: 5, offset: 28820},
+									pos:        position{line: 1050, col: 5, offset: 29527},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1031, col: 12, offset: 28827},
+									pos:  position{line: 1050, col: 12, offset: 29534},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1031, col: 15, offset: 28830},
+									pos:        position{line: 1050, col: 15, offset: 29537},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1031, col: 19, offset: 28834},
+									pos:  position{line: 1050, col: 19, offset: 29541},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1031, col: 22, offset: 28837},
+									pos:   position{line: 1050, col: 22, offset: 29544},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1031, col: 26, offset: 28841},
+										pos:  position{line: 1050, col: 26, offset: 29548},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1031, col: 31, offset: 28846},
+									pos:  position{line: 1050, col: 31, offset: 29553},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1031, col: 34, offset: 28849},
+									pos:        position{line: 1050, col: 34, offset: 29556},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -7793,43 +7966,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1032, col: 5, offset: 28876},
+						pos: position{line: 1051, col: 5, offset: 29583},
 						run: (*parser).callonExplicitType12,
 						expr: &seqExpr{
-							pos: position{line: 1032, col: 5, offset: 28876},
+							pos: position{line: 1051, col: 5, offset: 29583},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1032, col: 5, offset: 28876},
+									pos:        position{line: 1051, col: 5, offset: 29583},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1032, col: 12, offset: 28883},
+									pos:  position{line: 1051, col: 12, offset: 29590},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1032, col: 15, offset: 28886},
+									pos:        position{line: 1051, col: 15, offset: 29593},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1032, col: 19, offset: 28890},
+									pos:  position{line: 1051, col: 19, offset: 29597},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1032, col: 22, offset: 28893},
+									pos:   position{line: 1051, col: 22, offset: 29600},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1032, col: 26, offset: 28897},
+										pos:  position{line: 1051, col: 26, offset: 29604},
 										name: "TypeUnion",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1032, col: 36, offset: 28907},
+									pos:  position{line: 1051, col: 36, offset: 29614},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1032, col: 39, offset: 28910},
+									pos:        position{line: 1051, col: 39, offset: 29617},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -7841,28 +8014,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1034, col: 1, offset: 28935},
+			pos:  position{line: 1053, col: 1, offset: 29642},
 			expr: &choiceExpr{
-				pos: position{line: 1035, col: 5, offset: 28953},
+				pos: position{line: 1054, col: 5, offset: 29660},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1035, col: 5, offset: 28953},
+						pos: position{line: 1054, col: 5, offset: 29660},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1035, col: 5, offset: 28953},
+							pos: position{line: 1054, col: 5, offset: 29660},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1035, col: 5, offset: 28953},
+									pos:   position{line: 1054, col: 5, offset: 29660},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1035, col: 10, offset: 28958},
+										pos:  position{line: 1054, col: 10, offset: 29665},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1035, col: 24, offset: 28972},
+									pos: position{line: 1054, col: 24, offset: 29679},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1035, col: 25, offset: 28973},
+										pos:  position{line: 1054, col: 25, offset: 29680},
 										name: "IdentifierRest",
 									},
 								},
@@ -7870,55 +8043,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1036, col: 5, offset: 29013},
+						pos: position{line: 1055, col: 5, offset: 29720},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1036, col: 5, offset: 29013},
+							pos: position{line: 1055, col: 5, offset: 29720},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1036, col: 5, offset: 29013},
+									pos:   position{line: 1055, col: 5, offset: 29720},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1036, col: 10, offset: 29018},
+										pos:  position{line: 1055, col: 10, offset: 29725},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1036, col: 25, offset: 29033},
+									pos:  position{line: 1055, col: 25, offset: 29740},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1036, col: 28, offset: 29036},
+									pos:        position{line: 1055, col: 28, offset: 29743},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1036, col: 32, offset: 29040},
+									pos:  position{line: 1055, col: 32, offset: 29747},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1036, col: 35, offset: 29043},
+									pos:        position{line: 1055, col: 35, offset: 29750},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1036, col: 39, offset: 29047},
+									pos:  position{line: 1055, col: 39, offset: 29754},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1036, col: 42, offset: 29050},
+									pos:   position{line: 1055, col: 42, offset: 29757},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1036, col: 46, offset: 29054},
+										pos:  position{line: 1055, col: 46, offset: 29761},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1036, col: 51, offset: 29059},
+									pos:  position{line: 1055, col: 51, offset: 29766},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1036, col: 54, offset: 29062},
+									pos:        position{line: 1055, col: 54, offset: 29769},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -7926,42 +8099,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1039, col: 5, offset: 29163},
+						pos: position{line: 1058, col: 5, offset: 29870},
 						run: (*parser).callonAmbiguousType21,
 						expr: &labeledExpr{
-							pos:   position{line: 1039, col: 5, offset: 29163},
+							pos:   position{line: 1058, col: 5, offset: 29870},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1039, col: 10, offset: 29168},
+								pos:  position{line: 1058, col: 10, offset: 29875},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1042, col: 5, offset: 29270},
+						pos: position{line: 1061, col: 5, offset: 29977},
 						run: (*parser).callonAmbiguousType24,
 						expr: &seqExpr{
-							pos: position{line: 1042, col: 5, offset: 29270},
+							pos: position{line: 1061, col: 5, offset: 29977},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1042, col: 5, offset: 29270},
+									pos:        position{line: 1061, col: 5, offset: 29977},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1042, col: 9, offset: 29274},
+									pos:  position{line: 1061, col: 9, offset: 29981},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1042, col: 12, offset: 29277},
+									pos:   position{line: 1061, col: 12, offset: 29984},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1042, col: 14, offset: 29279},
+										pos:  position{line: 1061, col: 14, offset: 29986},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1042, col: 25, offset: 29290},
+									pos:        position{line: 1061, col: 25, offset: 29997},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -7973,15 +8146,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1044, col: 1, offset: 29313},
+			pos:  position{line: 1063, col: 1, offset: 30020},
 			expr: &actionExpr{
-				pos: position{line: 1045, col: 5, offset: 29327},
+				pos: position{line: 1064, col: 5, offset: 30034},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1045, col: 5, offset: 29327},
+					pos:   position{line: 1064, col: 5, offset: 30034},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1045, col: 11, offset: 29333},
+						pos:  position{line: 1064, col: 11, offset: 30040},
 						name: "TypeList",
 					},
 				},
@@ -7989,28 +8162,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1049, col: 1, offset: 29429},
+			pos:  position{line: 1068, col: 1, offset: 30136},
 			expr: &actionExpr{
-				pos: position{line: 1050, col: 5, offset: 29442},
+				pos: position{line: 1069, col: 5, offset: 30149},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1050, col: 5, offset: 29442},
+					pos: position{line: 1069, col: 5, offset: 30149},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1050, col: 5, offset: 29442},
+							pos:   position{line: 1069, col: 5, offset: 30149},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1050, col: 11, offset: 29448},
+								pos:  position{line: 1069, col: 11, offset: 30155},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1050, col: 16, offset: 29453},
+							pos:   position{line: 1069, col: 16, offset: 30160},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1050, col: 21, offset: 29458},
+								pos: position{line: 1069, col: 21, offset: 30165},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1050, col: 21, offset: 29458},
+									pos:  position{line: 1069, col: 21, offset: 30165},
 									name: "TypeListTail",
 								},
 							},
@@ -8021,31 +8194,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1054, col: 1, offset: 29552},
+			pos:  position{line: 1073, col: 1, offset: 30259},
 			expr: &actionExpr{
-				pos: position{line: 1054, col: 16, offset: 29567},
+				pos: position{line: 1073, col: 16, offset: 30274},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1054, col: 16, offset: 29567},
+					pos: position{line: 1073, col: 16, offset: 30274},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1054, col: 16, offset: 29567},
+							pos:  position{line: 1073, col: 16, offset: 30274},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1054, col: 19, offset: 29570},
+							pos:        position{line: 1073, col: 19, offset: 30277},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1054, col: 23, offset: 29574},
+							pos:  position{line: 1073, col: 23, offset: 30281},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1054, col: 26, offset: 29577},
+							pos:   position{line: 1073, col: 26, offset: 30284},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1054, col: 30, offset: 29581},
+								pos:  position{line: 1073, col: 30, offset: 30288},
 								name: "Type",
 							},
 						},
@@ -8055,39 +8228,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1056, col: 1, offset: 29607},
+			pos:  position{line: 1075, col: 1, offset: 30314},
 			expr: &choiceExpr{
-				pos: position{line: 1057, col: 5, offset: 29623},
+				pos: position{line: 1076, col: 5, offset: 30330},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 29623},
+						pos: position{line: 1076, col: 5, offset: 30330},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 29623},
+							pos: position{line: 1076, col: 5, offset: 30330},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1057, col: 5, offset: 29623},
+									pos:        position{line: 1076, col: 5, offset: 30330},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 9, offset: 29627},
+									pos:  position{line: 1076, col: 9, offset: 30334},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 12, offset: 29630},
+									pos:   position{line: 1076, col: 12, offset: 30337},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1057, col: 19, offset: 29637},
+										pos:  position{line: 1076, col: 19, offset: 30344},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 33, offset: 29651},
+									pos:  position{line: 1076, col: 33, offset: 30358},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 36, offset: 29654},
+									pos:        position{line: 1076, col: 36, offset: 30361},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8095,34 +8268,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1060, col: 5, offset: 29749},
+						pos: position{line: 1079, col: 5, offset: 30456},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1060, col: 5, offset: 29749},
+							pos: position{line: 1079, col: 5, offset: 30456},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1060, col: 5, offset: 29749},
+									pos:        position{line: 1079, col: 5, offset: 30456},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1060, col: 9, offset: 29753},
+									pos:  position{line: 1079, col: 9, offset: 30460},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1060, col: 12, offset: 29756},
+									pos:   position{line: 1079, col: 12, offset: 30463},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1060, col: 16, offset: 29760},
+										pos:  position{line: 1079, col: 16, offset: 30467},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1060, col: 21, offset: 29765},
+									pos:  position{line: 1079, col: 21, offset: 30472},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1060, col: 24, offset: 29768},
+									pos:        position{line: 1079, col: 24, offset: 30475},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8130,34 +8303,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1063, col: 5, offset: 29857},
+						pos: position{line: 1082, col: 5, offset: 30564},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1063, col: 5, offset: 29857},
+							pos: position{line: 1082, col: 5, offset: 30564},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1063, col: 5, offset: 29857},
+									pos:        position{line: 1082, col: 5, offset: 30564},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 10, offset: 29862},
+									pos:  position{line: 1082, col: 10, offset: 30569},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1063, col: 14, offset: 29866},
+									pos:   position{line: 1082, col: 14, offset: 30573},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1063, col: 18, offset: 29870},
+										pos:  position{line: 1082, col: 18, offset: 30577},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 23, offset: 29875},
+									pos:  position{line: 1082, col: 23, offset: 30582},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1063, col: 26, offset: 29878},
+									pos:        position{line: 1082, col: 26, offset: 30585},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8165,55 +8338,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 29966},
+						pos: position{line: 1085, col: 5, offset: 30673},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1066, col: 5, offset: 29966},
+							pos: position{line: 1085, col: 5, offset: 30673},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1066, col: 5, offset: 29966},
+									pos:        position{line: 1085, col: 5, offset: 30673},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 10, offset: 29971},
+									pos:  position{line: 1085, col: 10, offset: 30678},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 13, offset: 29974},
+									pos:   position{line: 1085, col: 13, offset: 30681},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1066, col: 21, offset: 29982},
+										pos:  position{line: 1085, col: 21, offset: 30689},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 26, offset: 29987},
+									pos:  position{line: 1085, col: 26, offset: 30694},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1066, col: 29, offset: 29990},
+									pos:        position{line: 1085, col: 29, offset: 30697},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 33, offset: 29994},
+									pos:  position{line: 1085, col: 33, offset: 30701},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 36, offset: 29997},
+									pos:   position{line: 1085, col: 36, offset: 30704},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1066, col: 44, offset: 30005},
+										pos:  position{line: 1085, col: 44, offset: 30712},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 49, offset: 30010},
+									pos:  position{line: 1085, col: 49, offset: 30717},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1066, col: 52, offset: 30013},
+									pos:        position{line: 1085, col: 52, offset: 30720},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8225,39 +8398,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexTypeExternal",
-			pos:  position{line: 1070, col: 1, offset: 30127},
+			pos:  position{line: 1089, col: 1, offset: 30834},
 			expr: &choiceExpr{
-				pos: position{line: 1071, col: 5, offset: 30151},
+				pos: position{line: 1090, col: 5, offset: 30858},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 30151},
+						pos: position{line: 1090, col: 5, offset: 30858},
 						run: (*parser).callonComplexTypeExternal2,
 						expr: &seqExpr{
-							pos: position{line: 1071, col: 5, offset: 30151},
+							pos: position{line: 1090, col: 5, offset: 30858},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1071, col: 5, offset: 30151},
+									pos:        position{line: 1090, col: 5, offset: 30858},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1071, col: 9, offset: 30155},
+									pos:  position{line: 1090, col: 9, offset: 30862},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1071, col: 12, offset: 30158},
+									pos:   position{line: 1090, col: 12, offset: 30865},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1071, col: 19, offset: 30165},
+										pos:  position{line: 1090, col: 19, offset: 30872},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1071, col: 33, offset: 30179},
+									pos:  position{line: 1090, col: 33, offset: 30886},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1071, col: 36, offset: 30182},
+									pos:        position{line: 1090, col: 36, offset: 30889},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8265,34 +8438,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1074, col: 5, offset: 30277},
+						pos: position{line: 1093, col: 5, offset: 30984},
 						run: (*parser).callonComplexTypeExternal10,
 						expr: &seqExpr{
-							pos: position{line: 1074, col: 5, offset: 30277},
+							pos: position{line: 1093, col: 5, offset: 30984},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1074, col: 5, offset: 30277},
+									pos:        position{line: 1093, col: 5, offset: 30984},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1074, col: 9, offset: 30281},
+									pos:  position{line: 1093, col: 9, offset: 30988},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1074, col: 12, offset: 30284},
+									pos:   position{line: 1093, col: 12, offset: 30991},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1074, col: 16, offset: 30288},
+										pos:  position{line: 1093, col: 16, offset: 30995},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1074, col: 29, offset: 30301},
+									pos:  position{line: 1093, col: 29, offset: 31008},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1074, col: 32, offset: 30304},
+									pos:        position{line: 1093, col: 32, offset: 31011},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8300,34 +8473,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 30393},
+						pos: position{line: 1096, col: 5, offset: 31100},
 						run: (*parser).callonComplexTypeExternal18,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 30393},
+							pos: position{line: 1096, col: 5, offset: 31100},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1077, col: 5, offset: 30393},
+									pos:        position{line: 1096, col: 5, offset: 31100},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1077, col: 10, offset: 30398},
+									pos:  position{line: 1096, col: 10, offset: 31105},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 13, offset: 30401},
+									pos:   position{line: 1096, col: 13, offset: 31108},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 17, offset: 30405},
+										pos:  position{line: 1096, col: 17, offset: 31112},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1077, col: 30, offset: 30418},
+									pos:  position{line: 1096, col: 30, offset: 31125},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1077, col: 33, offset: 30421},
+									pos:        position{line: 1096, col: 33, offset: 31128},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8335,55 +8508,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 30509},
+						pos: position{line: 1099, col: 5, offset: 31216},
 						run: (*parser).callonComplexTypeExternal26,
 						expr: &seqExpr{
-							pos: position{line: 1080, col: 5, offset: 30509},
+							pos: position{line: 1099, col: 5, offset: 31216},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1080, col: 5, offset: 30509},
+									pos:        position{line: 1099, col: 5, offset: 31216},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 10, offset: 30514},
+									pos:  position{line: 1099, col: 10, offset: 31221},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 13, offset: 30517},
+									pos:   position{line: 1099, col: 13, offset: 31224},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1080, col: 21, offset: 30525},
+										pos:  position{line: 1099, col: 21, offset: 31232},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 34, offset: 30538},
+									pos:  position{line: 1099, col: 34, offset: 31245},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1080, col: 37, offset: 30541},
+									pos:        position{line: 1099, col: 37, offset: 31248},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 41, offset: 30545},
+									pos:  position{line: 1099, col: 41, offset: 31252},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 44, offset: 30548},
+									pos:   position{line: 1099, col: 44, offset: 31255},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1080, col: 52, offset: 30556},
+										pos:  position{line: 1099, col: 52, offset: 31263},
 										name: "TypeExternal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 65, offset: 30569},
+									pos:  position{line: 1099, col: 65, offset: 31276},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1080, col: 68, offset: 30572},
+									pos:        position{line: 1099, col: 68, offset: 31279},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8395,16 +8568,16 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1084, col: 1, offset: 30686},
+			pos:  position{line: 1103, col: 1, offset: 31393},
 			expr: &choiceExpr{
-				pos: position{line: 1085, col: 5, offset: 30704},
+				pos: position{line: 1104, col: 5, offset: 31411},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1085, col: 5, offset: 30704},
+						pos:  position{line: 1104, col: 5, offset: 31411},
 						name: "PrimitiveTypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1086, col: 5, offset: 30730},
+						pos:  position{line: 1105, col: 5, offset: 31437},
 						name: "PrimitiveTypeInternal",
 					},
 				},
@@ -8412,65 +8585,65 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeExternal",
-			pos:  position{line: 1092, col: 1, offset: 30989},
+			pos:  position{line: 1111, col: 1, offset: 31696},
 			expr: &actionExpr{
-				pos: position{line: 1093, col: 5, offset: 31015},
+				pos: position{line: 1112, col: 5, offset: 31722},
 				run: (*parser).callonPrimitiveTypeExternal1,
 				expr: &choiceExpr{
-					pos: position{line: 1093, col: 9, offset: 31019},
+					pos: position{line: 1112, col: 9, offset: 31726},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1093, col: 9, offset: 31019},
+							pos:        position{line: 1112, col: 9, offset: 31726},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 19, offset: 31029},
+							pos:        position{line: 1112, col: 19, offset: 31736},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 30, offset: 31040},
+							pos:        position{line: 1112, col: 30, offset: 31747},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 41, offset: 31051},
+							pos:        position{line: 1112, col: 41, offset: 31758},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 9, offset: 31068},
+							pos:        position{line: 1113, col: 9, offset: 31775},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 18, offset: 31077},
+							pos:        position{line: 1113, col: 18, offset: 31784},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 28, offset: 31087},
+							pos:        position{line: 1113, col: 28, offset: 31794},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 38, offset: 31097},
+							pos:        position{line: 1113, col: 38, offset: 31804},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1095, col: 9, offset: 31113},
+							pos:        position{line: 1114, col: 9, offset: 31820},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1096, col: 9, offset: 31131},
+							pos:        position{line: 1115, col: 9, offset: 31838},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1096, col: 18, offset: 31140},
+							pos:        position{line: 1115, col: 18, offset: 31847},
 							val:        "string",
 							ignoreCase: false,
 						},
@@ -8480,55 +8653,55 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeInternal",
-			pos:  position{line: 1107, col: 1, offset: 31781},
+			pos:  position{line: 1126, col: 1, offset: 32488},
 			expr: &actionExpr{
-				pos: position{line: 1108, col: 5, offset: 31807},
+				pos: position{line: 1127, col: 5, offset: 32514},
 				run: (*parser).callonPrimitiveTypeInternal1,
 				expr: &choiceExpr{
-					pos: position{line: 1108, col: 9, offset: 31811},
+					pos: position{line: 1127, col: 9, offset: 32518},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1108, col: 9, offset: 31811},
+							pos:        position{line: 1127, col: 9, offset: 32518},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1108, col: 22, offset: 31824},
+							pos:        position{line: 1127, col: 22, offset: 32531},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1109, col: 9, offset: 31839},
+							pos:        position{line: 1128, col: 9, offset: 32546},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1110, col: 9, offset: 31855},
+							pos:        position{line: 1129, col: 9, offset: 32562},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1111, col: 9, offset: 31873},
+							pos:        position{line: 1130, col: 9, offset: 32580},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1111, col: 16, offset: 31880},
+							pos:        position{line: 1130, col: 16, offset: 32587},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1112, col: 9, offset: 31894},
+							pos:        position{line: 1131, col: 9, offset: 32601},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1112, col: 18, offset: 31903},
+							pos:        position{line: 1131, col: 18, offset: 32610},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1112, col: 28, offset: 31913},
+							pos:        position{line: 1131, col: 28, offset: 32620},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8538,28 +8711,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1116, col: 1, offset: 32029},
+			pos:  position{line: 1135, col: 1, offset: 32736},
 			expr: &actionExpr{
-				pos: position{line: 1117, col: 5, offset: 32047},
+				pos: position{line: 1136, col: 5, offset: 32754},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1117, col: 5, offset: 32047},
+					pos: position{line: 1136, col: 5, offset: 32754},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1117, col: 5, offset: 32047},
+							pos:   position{line: 1136, col: 5, offset: 32754},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1117, col: 11, offset: 32053},
+								pos:  position{line: 1136, col: 11, offset: 32760},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1117, col: 21, offset: 32063},
+							pos:   position{line: 1136, col: 21, offset: 32770},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1117, col: 26, offset: 32068},
+								pos: position{line: 1136, col: 26, offset: 32775},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1117, col: 26, offset: 32068},
+									pos:  position{line: 1136, col: 26, offset: 32775},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -8570,31 +8743,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1121, col: 1, offset: 32167},
+			pos:  position{line: 1140, col: 1, offset: 32874},
 			expr: &actionExpr{
-				pos: position{line: 1121, col: 21, offset: 32187},
+				pos: position{line: 1140, col: 21, offset: 32894},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1121, col: 21, offset: 32187},
+					pos: position{line: 1140, col: 21, offset: 32894},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1121, col: 21, offset: 32187},
+							pos:  position{line: 1140, col: 21, offset: 32894},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1121, col: 24, offset: 32190},
+							pos:        position{line: 1140, col: 24, offset: 32897},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1121, col: 28, offset: 32194},
+							pos:  position{line: 1140, col: 28, offset: 32901},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1121, col: 31, offset: 32197},
+							pos:   position{line: 1140, col: 31, offset: 32904},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1121, col: 35, offset: 32201},
+								pos:  position{line: 1140, col: 35, offset: 32908},
 								name: "TypeField",
 							},
 						},
@@ -8604,39 +8777,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1123, col: 1, offset: 32232},
+			pos:  position{line: 1142, col: 1, offset: 32939},
 			expr: &actionExpr{
-				pos: position{line: 1124, col: 5, offset: 32246},
+				pos: position{line: 1143, col: 5, offset: 32953},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1124, col: 5, offset: 32246},
+					pos: position{line: 1143, col: 5, offset: 32953},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1124, col: 5, offset: 32246},
+							pos:   position{line: 1143, col: 5, offset: 32953},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1124, col: 10, offset: 32251},
+								pos:  position{line: 1143, col: 10, offset: 32958},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1124, col: 20, offset: 32261},
+							pos:  position{line: 1143, col: 20, offset: 32968},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1124, col: 23, offset: 32264},
+							pos:        position{line: 1143, col: 23, offset: 32971},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1124, col: 27, offset: 32268},
+							pos:  position{line: 1143, col: 27, offset: 32975},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1124, col: 30, offset: 32271},
+							pos:   position{line: 1143, col: 30, offset: 32978},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1124, col: 34, offset: 32275},
+								pos:  position{line: 1143, col: 34, offset: 32982},
 								name: "Type",
 							},
 						},
@@ -8646,28 +8819,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListExternal",
-			pos:  position{line: 1128, col: 1, offset: 32357},
+			pos:  position{line: 1147, col: 1, offset: 33064},
 			expr: &actionExpr{
-				pos: position{line: 1129, col: 5, offset: 32383},
+				pos: position{line: 1148, col: 5, offset: 33090},
 				run: (*parser).callonTypeFieldListExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1129, col: 5, offset: 32383},
+					pos: position{line: 1148, col: 5, offset: 33090},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1129, col: 5, offset: 32383},
+							pos:   position{line: 1148, col: 5, offset: 33090},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1129, col: 11, offset: 32389},
+								pos:  position{line: 1148, col: 11, offset: 33096},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1129, col: 21, offset: 32399},
+							pos:   position{line: 1148, col: 21, offset: 33106},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1129, col: 26, offset: 32404},
+								pos: position{line: 1148, col: 26, offset: 33111},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1129, col: 26, offset: 32404},
+									pos:  position{line: 1148, col: 26, offset: 33111},
 									name: "TypeFieldListTailExternal",
 								},
 							},
@@ -8678,31 +8851,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTailExternal",
-			pos:  position{line: 1133, col: 1, offset: 32511},
+			pos:  position{line: 1152, col: 1, offset: 33218},
 			expr: &actionExpr{
-				pos: position{line: 1133, col: 29, offset: 32539},
+				pos: position{line: 1152, col: 29, offset: 33246},
 				run: (*parser).callonTypeFieldListTailExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1133, col: 29, offset: 32539},
+					pos: position{line: 1152, col: 29, offset: 33246},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1133, col: 29, offset: 32539},
+							pos:  position{line: 1152, col: 29, offset: 33246},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1133, col: 32, offset: 32542},
+							pos:        position{line: 1152, col: 32, offset: 33249},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1133, col: 36, offset: 32546},
+							pos:  position{line: 1152, col: 36, offset: 33253},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1133, col: 39, offset: 32549},
+							pos:   position{line: 1152, col: 39, offset: 33256},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1133, col: 43, offset: 32553},
+								pos:  position{line: 1152, col: 43, offset: 33260},
 								name: "TypeFieldExternal",
 							},
 						},
@@ -8712,39 +8885,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldExternal",
-			pos:  position{line: 1135, col: 1, offset: 32592},
+			pos:  position{line: 1154, col: 1, offset: 33299},
 			expr: &actionExpr{
-				pos: position{line: 1136, col: 5, offset: 32614},
+				pos: position{line: 1155, col: 5, offset: 33321},
 				run: (*parser).callonTypeFieldExternal1,
 				expr: &seqExpr{
-					pos: position{line: 1136, col: 5, offset: 32614},
+					pos: position{line: 1155, col: 5, offset: 33321},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1136, col: 5, offset: 32614},
+							pos:   position{line: 1155, col: 5, offset: 33321},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1136, col: 10, offset: 32619},
+								pos:  position{line: 1155, col: 10, offset: 33326},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1136, col: 20, offset: 32629},
+							pos:  position{line: 1155, col: 20, offset: 33336},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1136, col: 23, offset: 32632},
+							pos:        position{line: 1155, col: 23, offset: 33339},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1136, col: 27, offset: 32636},
+							pos:  position{line: 1155, col: 27, offset: 33343},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1136, col: 30, offset: 32639},
+							pos:   position{line: 1155, col: 30, offset: 33346},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1136, col: 34, offset: 32643},
+								pos:  position{line: 1155, col: 34, offset: 33350},
 								name: "TypeExternal",
 							},
 						},
@@ -8754,16 +8927,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1140, col: 1, offset: 32733},
+			pos:  position{line: 1159, col: 1, offset: 33440},
 			expr: &choiceExpr{
-				pos: position{line: 1141, col: 5, offset: 32747},
+				pos: position{line: 1160, col: 5, offset: 33454},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1141, col: 5, offset: 32747},
+						pos:  position{line: 1160, col: 5, offset: 33454},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1142, col: 5, offset: 32766},
+						pos:  position{line: 1161, col: 5, offset: 33473},
 						name: "QuotedString",
 					},
 				},
@@ -8771,16 +8944,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 1144, col: 1, offset: 32780},
+			pos:  position{line: 1163, col: 1, offset: 33487},
 			expr: &choiceExpr{
-				pos: position{line: 1145, col: 5, offset: 32798},
+				pos: position{line: 1164, col: 5, offset: 33505},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1145, col: 5, offset: 32798},
+						pos:  position{line: 1164, col: 5, offset: 33505},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1145, col: 24, offset: 32817},
+						pos:  position{line: 1164, col: 24, offset: 33524},
 						name: "RelativeOperator",
 					},
 				},
@@ -8788,22 +8961,22 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1147, col: 1, offset: 32835},
+			pos:  position{line: 1166, col: 1, offset: 33542},
 			expr: &actionExpr{
-				pos: position{line: 1147, col: 12, offset: 32846},
+				pos: position{line: 1166, col: 12, offset: 33553},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1147, col: 12, offset: 32846},
+					pos: position{line: 1166, col: 12, offset: 33553},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1147, col: 12, offset: 32846},
+							pos:        position{line: 1166, col: 12, offset: 33553},
 							val:        "and",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1147, col: 19, offset: 32853},
+							pos: position{line: 1166, col: 19, offset: 33560},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1147, col: 20, offset: 32854},
+								pos:  position{line: 1166, col: 20, offset: 33561},
 								name: "IdentifierRest",
 							},
 						},
@@ -8813,22 +8986,22 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1148, col: 1, offset: 32891},
+			pos:  position{line: 1167, col: 1, offset: 33598},
 			expr: &actionExpr{
-				pos: position{line: 1148, col: 11, offset: 32901},
+				pos: position{line: 1167, col: 11, offset: 33608},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1148, col: 11, offset: 32901},
+					pos: position{line: 1167, col: 11, offset: 33608},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1148, col: 11, offset: 32901},
+							pos:        position{line: 1167, col: 11, offset: 33608},
 							val:        "or",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1148, col: 17, offset: 32907},
+							pos: position{line: 1167, col: 17, offset: 33614},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1148, col: 18, offset: 32908},
+								pos:  position{line: 1167, col: 18, offset: 33615},
 								name: "IdentifierRest",
 							},
 						},
@@ -8838,22 +9011,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1149, col: 1, offset: 32944},
+			pos:  position{line: 1168, col: 1, offset: 33651},
 			expr: &actionExpr{
-				pos: position{line: 1149, col: 11, offset: 32954},
+				pos: position{line: 1168, col: 11, offset: 33661},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1149, col: 11, offset: 32954},
+					pos: position{line: 1168, col: 11, offset: 33661},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1149, col: 11, offset: 32954},
+							pos:        position{line: 1168, col: 11, offset: 33661},
 							val:        "in",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1149, col: 17, offset: 32960},
+							pos: position{line: 1168, col: 17, offset: 33667},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1149, col: 18, offset: 32961},
+								pos:  position{line: 1168, col: 18, offset: 33668},
 								name: "IdentifierRest",
 							},
 						},
@@ -8863,22 +9036,22 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1150, col: 1, offset: 32997},
+			pos:  position{line: 1169, col: 1, offset: 33704},
 			expr: &actionExpr{
-				pos: position{line: 1150, col: 12, offset: 33008},
+				pos: position{line: 1169, col: 12, offset: 33715},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1150, col: 12, offset: 33008},
+					pos: position{line: 1169, col: 12, offset: 33715},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1150, col: 12, offset: 33008},
+							pos:        position{line: 1169, col: 12, offset: 33715},
 							val:        "not",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1150, col: 19, offset: 33015},
+							pos: position{line: 1169, col: 19, offset: 33722},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1150, col: 20, offset: 33016},
+								pos:  position{line: 1169, col: 20, offset: 33723},
 								name: "IdentifierRest",
 							},
 						},
@@ -8888,22 +9061,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1151, col: 1, offset: 33053},
+			pos:  position{line: 1170, col: 1, offset: 33760},
 			expr: &actionExpr{
-				pos: position{line: 1151, col: 11, offset: 33063},
+				pos: position{line: 1170, col: 11, offset: 33770},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1151, col: 11, offset: 33063},
+					pos: position{line: 1170, col: 11, offset: 33770},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1151, col: 11, offset: 33063},
+							pos:        position{line: 1170, col: 11, offset: 33770},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1151, col: 17, offset: 33069},
+							pos: position{line: 1170, col: 17, offset: 33776},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1151, col: 18, offset: 33070},
+								pos:  position{line: 1170, col: 18, offset: 33777},
 								name: "IdentifierRest",
 							},
 						},
@@ -8913,9 +9086,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1153, col: 1, offset: 33107},
+			pos:  position{line: 1172, col: 1, offset: 33814},
 			expr: &charClassMatcher{
-				pos:        position{line: 1153, col: 19, offset: 33125},
+				pos:        position{line: 1172, col: 19, offset: 33832},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -8925,16 +9098,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1155, col: 1, offset: 33137},
+			pos:  position{line: 1174, col: 1, offset: 33844},
 			expr: &choiceExpr{
-				pos: position{line: 1155, col: 18, offset: 33154},
+				pos: position{line: 1174, col: 18, offset: 33861},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1155, col: 18, offset: 33154},
+						pos:  position{line: 1174, col: 18, offset: 33861},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1155, col: 36, offset: 33172},
+						pos:        position{line: 1174, col: 36, offset: 33879},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -8945,15 +9118,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1157, col: 1, offset: 33179},
+			pos:  position{line: 1176, col: 1, offset: 33886},
 			expr: &actionExpr{
-				pos: position{line: 1158, col: 5, offset: 33194},
+				pos: position{line: 1177, col: 5, offset: 33901},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1158, col: 5, offset: 33194},
+					pos:   position{line: 1177, col: 5, offset: 33901},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1158, col: 8, offset: 33197},
+						pos:  position{line: 1177, col: 8, offset: 33904},
 						name: "IdentifierName",
 					},
 				},
@@ -8961,29 +9134,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1160, col: 1, offset: 33278},
+			pos:  position{line: 1179, col: 1, offset: 33985},
 			expr: &choiceExpr{
-				pos: position{line: 1161, col: 5, offset: 33297},
+				pos: position{line: 1180, col: 5, offset: 34004},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1161, col: 5, offset: 33297},
+						pos: position{line: 1180, col: 5, offset: 34004},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1161, col: 5, offset: 33297},
+							pos: position{line: 1180, col: 5, offset: 34004},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1161, col: 5, offset: 33297},
+									pos: position{line: 1180, col: 5, offset: 34004},
 									expr: &seqExpr{
-										pos: position{line: 1161, col: 7, offset: 33299},
+										pos: position{line: 1180, col: 7, offset: 34006},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1161, col: 7, offset: 33299},
+												pos:  position{line: 1180, col: 7, offset: 34006},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1161, col: 15, offset: 33307},
+												pos: position{line: 1180, col: 15, offset: 34014},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1161, col: 16, offset: 33308},
+													pos:  position{line: 1180, col: 16, offset: 34015},
 													name: "IdentifierRest",
 												},
 											},
@@ -8991,13 +9164,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1161, col: 32, offset: 33324},
+									pos:  position{line: 1180, col: 32, offset: 34031},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1161, col: 48, offset: 33340},
+									pos: position{line: 1180, col: 48, offset: 34047},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1161, col: 48, offset: 33340},
+										pos:  position{line: 1180, col: 48, offset: 34047},
 										name: "IdentifierRest",
 									},
 								},
@@ -9005,30 +9178,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1162, col: 5, offset: 33392},
+						pos: position{line: 1181, col: 5, offset: 34099},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1162, col: 5, offset: 33392},
+							pos:        position{line: 1181, col: 5, offset: 34099},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1163, col: 5, offset: 33431},
+						pos: position{line: 1182, col: 5, offset: 34138},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1163, col: 5, offset: 33431},
+							pos: position{line: 1182, col: 5, offset: 34138},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1163, col: 5, offset: 33431},
+									pos:        position{line: 1182, col: 5, offset: 34138},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1163, col: 10, offset: 33436},
+									pos:   position{line: 1182, col: 10, offset: 34143},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1163, col: 13, offset: 33439},
+										pos:  position{line: 1182, col: 13, offset: 34146},
 										name: "IDGuard",
 									},
 								},
@@ -9036,39 +9209,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1165, col: 5, offset: 33530},
+						pos: position{line: 1184, col: 5, offset: 34237},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1165, col: 5, offset: 33530},
+							pos:        position{line: 1184, col: 5, offset: 34237},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1166, col: 5, offset: 33572},
+						pos: position{line: 1185, col: 5, offset: 34279},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1166, col: 5, offset: 33572},
+							pos: position{line: 1185, col: 5, offset: 34279},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1166, col: 5, offset: 33572},
+									pos:   position{line: 1185, col: 5, offset: 34279},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1166, col: 8, offset: 33575},
+										pos:  position{line: 1185, col: 8, offset: 34282},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1166, col: 26, offset: 33593},
+									pos: position{line: 1185, col: 26, offset: 34300},
 									expr: &seqExpr{
-										pos: position{line: 1166, col: 28, offset: 33595},
+										pos: position{line: 1185, col: 28, offset: 34302},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1166, col: 28, offset: 33595},
+												pos:  position{line: 1185, col: 28, offset: 34302},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1166, col: 31, offset: 33598},
+												pos:        position{line: 1185, col: 31, offset: 34305},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9083,24 +9256,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1168, col: 1, offset: 33623},
+			pos:  position{line: 1187, col: 1, offset: 34330},
 			expr: &choiceExpr{
-				pos: position{line: 1169, col: 5, offset: 33635},
+				pos: position{line: 1188, col: 5, offset: 34342},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1169, col: 5, offset: 33635},
+						pos:  position{line: 1188, col: 5, offset: 34342},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1170, col: 5, offset: 33654},
+						pos:  position{line: 1189, col: 5, offset: 34361},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1171, col: 5, offset: 33670},
+						pos:  position{line: 1190, col: 5, offset: 34377},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1172, col: 5, offset: 33687},
+						pos:  position{line: 1191, col: 5, offset: 34394},
 						name: "SearchGuard",
 					},
 				},
@@ -9108,24 +9281,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1174, col: 1, offset: 33700},
+			pos:  position{line: 1193, col: 1, offset: 34407},
 			expr: &actionExpr{
-				pos: position{line: 1175, col: 5, offset: 33709},
+				pos: position{line: 1194, col: 5, offset: 34416},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1175, col: 5, offset: 33709},
+					pos: position{line: 1194, col: 5, offset: 34416},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1175, col: 5, offset: 33709},
+							pos:  position{line: 1194, col: 5, offset: 34416},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1175, col: 14, offset: 33718},
+							pos:        position{line: 1194, col: 14, offset: 34425},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1175, col: 18, offset: 33722},
+							pos:  position{line: 1194, col: 18, offset: 34429},
 							name: "FullTime",
 						},
 					},
@@ -9134,30 +9307,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1179, col: 1, offset: 33842},
+			pos:  position{line: 1198, col: 1, offset: 34549},
 			expr: &seqExpr{
-				pos: position{line: 1179, col: 12, offset: 33853},
+				pos: position{line: 1198, col: 12, offset: 34560},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1179, col: 12, offset: 33853},
+						pos:  position{line: 1198, col: 12, offset: 34560},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1179, col: 15, offset: 33856},
+						pos:        position{line: 1198, col: 15, offset: 34563},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1179, col: 19, offset: 33860},
+						pos:  position{line: 1198, col: 19, offset: 34567},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1179, col: 22, offset: 33863},
+						pos:        position{line: 1198, col: 22, offset: 34570},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1179, col: 26, offset: 33867},
+						pos:  position{line: 1198, col: 26, offset: 34574},
 						name: "D2",
 					},
 				},
@@ -9165,33 +9338,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1181, col: 1, offset: 33871},
+			pos:  position{line: 1200, col: 1, offset: 34578},
 			expr: &seqExpr{
-				pos: position{line: 1181, col: 6, offset: 33876},
+				pos: position{line: 1200, col: 6, offset: 34583},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1181, col: 6, offset: 33876},
+						pos:        position{line: 1200, col: 6, offset: 34583},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1181, col: 11, offset: 33881},
+						pos:        position{line: 1200, col: 11, offset: 34588},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1181, col: 16, offset: 33886},
+						pos:        position{line: 1200, col: 16, offset: 34593},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1181, col: 21, offset: 33891},
+						pos:        position{line: 1200, col: 21, offset: 34598},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9202,19 +9375,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1182, col: 1, offset: 33897},
+			pos:  position{line: 1201, col: 1, offset: 34604},
 			expr: &seqExpr{
-				pos: position{line: 1182, col: 6, offset: 33902},
+				pos: position{line: 1201, col: 6, offset: 34609},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1182, col: 6, offset: 33902},
+						pos:        position{line: 1201, col: 6, offset: 34609},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1182, col: 11, offset: 33907},
+						pos:        position{line: 1201, col: 11, offset: 34614},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9225,16 +9398,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1184, col: 1, offset: 33914},
+			pos:  position{line: 1203, col: 1, offset: 34621},
 			expr: &seqExpr{
-				pos: position{line: 1184, col: 12, offset: 33925},
+				pos: position{line: 1203, col: 12, offset: 34632},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 12, offset: 33925},
+						pos:  position{line: 1203, col: 12, offset: 34632},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 24, offset: 33937},
+						pos:  position{line: 1203, col: 24, offset: 34644},
 						name: "TimeOffset",
 					},
 				},
@@ -9242,46 +9415,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1186, col: 1, offset: 33949},
+			pos:  position{line: 1205, col: 1, offset: 34656},
 			expr: &seqExpr{
-				pos: position{line: 1186, col: 15, offset: 33963},
+				pos: position{line: 1205, col: 15, offset: 34670},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 15, offset: 33963},
+						pos:  position{line: 1205, col: 15, offset: 34670},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1186, col: 18, offset: 33966},
+						pos:        position{line: 1205, col: 18, offset: 34673},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 22, offset: 33970},
+						pos:  position{line: 1205, col: 22, offset: 34677},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1186, col: 25, offset: 33973},
+						pos:        position{line: 1205, col: 25, offset: 34680},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 29, offset: 33977},
+						pos:  position{line: 1205, col: 29, offset: 34684},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1186, col: 32, offset: 33980},
+						pos: position{line: 1205, col: 32, offset: 34687},
 						expr: &seqExpr{
-							pos: position{line: 1186, col: 33, offset: 33981},
+							pos: position{line: 1205, col: 33, offset: 34688},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1186, col: 33, offset: 33981},
+									pos:        position{line: 1205, col: 33, offset: 34688},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1186, col: 37, offset: 33985},
+									pos: position{line: 1205, col: 37, offset: 34692},
 									expr: &charClassMatcher{
-										pos:        position{line: 1186, col: 37, offset: 33985},
+										pos:        position{line: 1205, col: 37, offset: 34692},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9296,60 +9469,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1188, col: 1, offset: 33995},
+			pos:  position{line: 1207, col: 1, offset: 34702},
 			expr: &choiceExpr{
-				pos: position{line: 1189, col: 5, offset: 34010},
+				pos: position{line: 1208, col: 5, offset: 34717},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1189, col: 5, offset: 34010},
+						pos:        position{line: 1208, col: 5, offset: 34717},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1190, col: 5, offset: 34018},
+						pos: position{line: 1209, col: 5, offset: 34725},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1190, col: 6, offset: 34019},
+								pos: position{line: 1209, col: 6, offset: 34726},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1190, col: 6, offset: 34019},
+										pos:        position{line: 1209, col: 6, offset: 34726},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1190, col: 12, offset: 34025},
+										pos:        position{line: 1209, col: 12, offset: 34732},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1190, col: 17, offset: 34030},
+								pos:  position{line: 1209, col: 17, offset: 34737},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1190, col: 20, offset: 34033},
+								pos:        position{line: 1209, col: 20, offset: 34740},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1190, col: 24, offset: 34037},
+								pos:  position{line: 1209, col: 24, offset: 34744},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1190, col: 27, offset: 34040},
+								pos: position{line: 1209, col: 27, offset: 34747},
 								expr: &seqExpr{
-									pos: position{line: 1190, col: 28, offset: 34041},
+									pos: position{line: 1209, col: 28, offset: 34748},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1190, col: 28, offset: 34041},
+											pos:        position{line: 1209, col: 28, offset: 34748},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1190, col: 32, offset: 34045},
+											pos: position{line: 1209, col: 32, offset: 34752},
 											expr: &charClassMatcher{
-												pos:        position{line: 1190, col: 32, offset: 34045},
+												pos:        position{line: 1209, col: 32, offset: 34752},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9366,32 +9539,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1192, col: 1, offset: 34055},
+			pos:  position{line: 1211, col: 1, offset: 34762},
 			expr: &actionExpr{
-				pos: position{line: 1193, col: 5, offset: 34068},
+				pos: position{line: 1212, col: 5, offset: 34775},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1193, col: 5, offset: 34068},
+					pos: position{line: 1212, col: 5, offset: 34775},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1193, col: 5, offset: 34068},
+							pos: position{line: 1212, col: 5, offset: 34775},
 							expr: &litMatcher{
-								pos:        position{line: 1193, col: 5, offset: 34068},
+								pos:        position{line: 1212, col: 5, offset: 34775},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1193, col: 10, offset: 34073},
+							pos: position{line: 1212, col: 10, offset: 34780},
 							expr: &seqExpr{
-								pos: position{line: 1193, col: 11, offset: 34074},
+								pos: position{line: 1212, col: 11, offset: 34781},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1193, col: 11, offset: 34074},
+										pos:  position{line: 1212, col: 11, offset: 34781},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1193, col: 19, offset: 34082},
+										pos:  position{line: 1212, col: 19, offset: 34789},
 										name: "TimeUnit",
 									},
 								},
@@ -9403,26 +9576,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1197, col: 1, offset: 34208},
+			pos:  position{line: 1216, col: 1, offset: 34915},
 			expr: &seqExpr{
-				pos: position{line: 1197, col: 11, offset: 34218},
+				pos: position{line: 1216, col: 11, offset: 34925},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1197, col: 11, offset: 34218},
+						pos:  position{line: 1216, col: 11, offset: 34925},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1197, col: 16, offset: 34223},
+						pos: position{line: 1216, col: 16, offset: 34930},
 						expr: &seqExpr{
-							pos: position{line: 1197, col: 17, offset: 34224},
+							pos: position{line: 1216, col: 17, offset: 34931},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1197, col: 17, offset: 34224},
+									pos:        position{line: 1216, col: 17, offset: 34931},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1197, col: 21, offset: 34228},
+									pos:  position{line: 1216, col: 21, offset: 34935},
 									name: "UInt",
 								},
 							},
@@ -9433,52 +9606,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1199, col: 1, offset: 34236},
+			pos:  position{line: 1218, col: 1, offset: 34943},
 			expr: &choiceExpr{
-				pos: position{line: 1200, col: 5, offset: 34249},
+				pos: position{line: 1219, col: 5, offset: 34956},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1200, col: 5, offset: 34249},
+						pos:        position{line: 1219, col: 5, offset: 34956},
 						val:        "ns",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1201, col: 5, offset: 34259},
+						pos:        position{line: 1220, col: 5, offset: 34966},
 						val:        "us",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1202, col: 5, offset: 34269},
+						pos:        position{line: 1221, col: 5, offset: 34976},
 						val:        "ms",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1203, col: 5, offset: 34279},
+						pos:        position{line: 1222, col: 5, offset: 34986},
 						val:        "s",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1204, col: 5, offset: 34288},
+						pos:        position{line: 1223, col: 5, offset: 34995},
 						val:        "m",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1205, col: 5, offset: 34297},
+						pos:        position{line: 1224, col: 5, offset: 35004},
 						val:        "h",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1206, col: 5, offset: 34306},
+						pos:        position{line: 1225, col: 5, offset: 35013},
 						val:        "d",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1207, col: 5, offset: 34315},
+						pos:        position{line: 1226, col: 5, offset: 35022},
 						val:        "w",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1208, col: 5, offset: 34324},
+						pos:        position{line: 1227, col: 5, offset: 35031},
 						val:        "y",
 						ignoreCase: true,
 					},
@@ -9487,42 +9660,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1210, col: 1, offset: 34330},
+			pos:  position{line: 1229, col: 1, offset: 35037},
 			expr: &actionExpr{
-				pos: position{line: 1211, col: 5, offset: 34337},
+				pos: position{line: 1230, col: 5, offset: 35044},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1211, col: 5, offset: 34337},
+					pos: position{line: 1230, col: 5, offset: 35044},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1211, col: 5, offset: 34337},
+							pos:  position{line: 1230, col: 5, offset: 35044},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1211, col: 10, offset: 34342},
+							pos:        position{line: 1230, col: 10, offset: 35049},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1211, col: 14, offset: 34346},
+							pos:  position{line: 1230, col: 14, offset: 35053},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1211, col: 19, offset: 34351},
+							pos:        position{line: 1230, col: 19, offset: 35058},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1211, col: 23, offset: 34355},
+							pos:  position{line: 1230, col: 23, offset: 35062},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1211, col: 28, offset: 34360},
+							pos:        position{line: 1230, col: 28, offset: 35067},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1211, col: 32, offset: 34364},
+							pos:  position{line: 1230, col: 32, offset: 35071},
 							name: "UInt",
 						},
 					},
@@ -9531,42 +9704,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1213, col: 1, offset: 34401},
+			pos:  position{line: 1232, col: 1, offset: 35108},
 			expr: &actionExpr{
-				pos: position{line: 1214, col: 5, offset: 34409},
+				pos: position{line: 1233, col: 5, offset: 35116},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1214, col: 5, offset: 34409},
+					pos: position{line: 1233, col: 5, offset: 35116},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1214, col: 5, offset: 34409},
+							pos: position{line: 1233, col: 5, offset: 35116},
 							expr: &seqExpr{
-								pos: position{line: 1214, col: 8, offset: 34412},
+								pos: position{line: 1233, col: 8, offset: 35119},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1214, col: 8, offset: 34412},
+										pos:  position{line: 1233, col: 8, offset: 35119},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1214, col: 12, offset: 34416},
+										pos:        position{line: 1233, col: 12, offset: 35123},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1214, col: 16, offset: 34420},
+										pos:  position{line: 1233, col: 16, offset: 35127},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1214, col: 20, offset: 34424},
+										pos: position{line: 1233, col: 20, offset: 35131},
 										expr: &choiceExpr{
-											pos: position{line: 1214, col: 22, offset: 34426},
+											pos: position{line: 1233, col: 22, offset: 35133},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1214, col: 22, offset: 34426},
+													pos:  position{line: 1233, col: 22, offset: 35133},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1214, col: 33, offset: 34437},
+													pos:        position{line: 1233, col: 33, offset: 35144},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9577,10 +9750,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1214, col: 39, offset: 34443},
+							pos:   position{line: 1233, col: 39, offset: 35150},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1214, col: 41, offset: 34445},
+								pos:  position{line: 1233, col: 41, offset: 35152},
 								name: "IP6Variations",
 							},
 						},
@@ -9590,32 +9763,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1218, col: 1, offset: 34609},
+			pos:  position{line: 1237, col: 1, offset: 35316},
 			expr: &choiceExpr{
-				pos: position{line: 1219, col: 5, offset: 34627},
+				pos: position{line: 1238, col: 5, offset: 35334},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1219, col: 5, offset: 34627},
+						pos: position{line: 1238, col: 5, offset: 35334},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1219, col: 5, offset: 34627},
+							pos: position{line: 1238, col: 5, offset: 35334},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1219, col: 5, offset: 34627},
+									pos:   position{line: 1238, col: 5, offset: 35334},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1219, col: 7, offset: 34629},
+										pos: position{line: 1238, col: 7, offset: 35336},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1219, col: 7, offset: 34629},
+											pos:  position{line: 1238, col: 7, offset: 35336},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1219, col: 17, offset: 34639},
+									pos:   position{line: 1238, col: 17, offset: 35346},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1219, col: 19, offset: 34641},
+										pos:  position{line: 1238, col: 19, offset: 35348},
 										name: "IP6Tail",
 									},
 								},
@@ -9623,51 +9796,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1222, col: 5, offset: 34705},
+						pos: position{line: 1241, col: 5, offset: 35412},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1222, col: 5, offset: 34705},
+							pos: position{line: 1241, col: 5, offset: 35412},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1222, col: 5, offset: 34705},
+									pos:   position{line: 1241, col: 5, offset: 35412},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1222, col: 7, offset: 34707},
+										pos:  position{line: 1241, col: 7, offset: 35414},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1222, col: 11, offset: 34711},
+									pos:   position{line: 1241, col: 11, offset: 35418},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1222, col: 13, offset: 34713},
+										pos: position{line: 1241, col: 13, offset: 35420},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1222, col: 13, offset: 34713},
+											pos:  position{line: 1241, col: 13, offset: 35420},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1222, col: 23, offset: 34723},
+									pos:        position{line: 1241, col: 23, offset: 35430},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1222, col: 28, offset: 34728},
+									pos:   position{line: 1241, col: 28, offset: 35435},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1222, col: 30, offset: 34730},
+										pos: position{line: 1241, col: 30, offset: 35437},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1222, col: 30, offset: 34730},
+											pos:  position{line: 1241, col: 30, offset: 35437},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1222, col: 40, offset: 34740},
+									pos:   position{line: 1241, col: 40, offset: 35447},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1222, col: 42, offset: 34742},
+										pos:  position{line: 1241, col: 42, offset: 35449},
 										name: "IP6Tail",
 									},
 								},
@@ -9675,32 +9848,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1225, col: 5, offset: 34841},
+						pos: position{line: 1244, col: 5, offset: 35548},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1225, col: 5, offset: 34841},
+							pos: position{line: 1244, col: 5, offset: 35548},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1225, col: 5, offset: 34841},
+									pos:        position{line: 1244, col: 5, offset: 35548},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1225, col: 10, offset: 34846},
+									pos:   position{line: 1244, col: 10, offset: 35553},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1225, col: 12, offset: 34848},
+										pos: position{line: 1244, col: 12, offset: 35555},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1225, col: 12, offset: 34848},
+											pos:  position{line: 1244, col: 12, offset: 35555},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1225, col: 22, offset: 34858},
+									pos:   position{line: 1244, col: 22, offset: 35565},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1225, col: 24, offset: 34860},
+										pos:  position{line: 1244, col: 24, offset: 35567},
 										name: "IP6Tail",
 									},
 								},
@@ -9708,32 +9881,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1228, col: 5, offset: 34931},
+						pos: position{line: 1247, col: 5, offset: 35638},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1228, col: 5, offset: 34931},
+							pos: position{line: 1247, col: 5, offset: 35638},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1228, col: 5, offset: 34931},
+									pos:   position{line: 1247, col: 5, offset: 35638},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1228, col: 7, offset: 34933},
+										pos:  position{line: 1247, col: 7, offset: 35640},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1228, col: 11, offset: 34937},
+									pos:   position{line: 1247, col: 11, offset: 35644},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1228, col: 13, offset: 34939},
+										pos: position{line: 1247, col: 13, offset: 35646},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1228, col: 13, offset: 34939},
+											pos:  position{line: 1247, col: 13, offset: 35646},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1228, col: 23, offset: 34949},
+									pos:        position{line: 1247, col: 23, offset: 35656},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -9741,10 +9914,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1231, col: 5, offset: 35017},
+						pos: position{line: 1250, col: 5, offset: 35724},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1231, col: 5, offset: 35017},
+							pos:        position{line: 1250, col: 5, offset: 35724},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -9754,16 +9927,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1235, col: 1, offset: 35054},
+			pos:  position{line: 1254, col: 1, offset: 35761},
 			expr: &choiceExpr{
-				pos: position{line: 1236, col: 5, offset: 35066},
+				pos: position{line: 1255, col: 5, offset: 35773},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1236, col: 5, offset: 35066},
+						pos:  position{line: 1255, col: 5, offset: 35773},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1237, col: 5, offset: 35073},
+						pos:  position{line: 1256, col: 5, offset: 35780},
 						name: "Hex",
 					},
 				},
@@ -9771,23 +9944,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1239, col: 1, offset: 35078},
+			pos:  position{line: 1258, col: 1, offset: 35785},
 			expr: &actionExpr{
-				pos: position{line: 1239, col: 12, offset: 35089},
+				pos: position{line: 1258, col: 12, offset: 35796},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1239, col: 12, offset: 35089},
+					pos: position{line: 1258, col: 12, offset: 35796},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1239, col: 12, offset: 35089},
+							pos:        position{line: 1258, col: 12, offset: 35796},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1239, col: 16, offset: 35093},
+							pos:   position{line: 1258, col: 16, offset: 35800},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1239, col: 18, offset: 35095},
+								pos:  position{line: 1258, col: 18, offset: 35802},
 								name: "Hex",
 							},
 						},
@@ -9797,23 +9970,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1241, col: 1, offset: 35133},
+			pos:  position{line: 1260, col: 1, offset: 35840},
 			expr: &actionExpr{
-				pos: position{line: 1241, col: 12, offset: 35144},
+				pos: position{line: 1260, col: 12, offset: 35851},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1241, col: 12, offset: 35144},
+					pos: position{line: 1260, col: 12, offset: 35851},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1241, col: 12, offset: 35144},
+							pos:   position{line: 1260, col: 12, offset: 35851},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1241, col: 14, offset: 35146},
+								pos:  position{line: 1260, col: 14, offset: 35853},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1241, col: 18, offset: 35150},
+							pos:        position{line: 1260, col: 18, offset: 35857},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -9823,31 +9996,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1243, col: 1, offset: 35188},
+			pos:  position{line: 1262, col: 1, offset: 35895},
 			expr: &actionExpr{
-				pos: position{line: 1244, col: 5, offset: 35199},
+				pos: position{line: 1263, col: 5, offset: 35906},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1244, col: 5, offset: 35199},
+					pos: position{line: 1263, col: 5, offset: 35906},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1244, col: 5, offset: 35199},
+							pos:   position{line: 1263, col: 5, offset: 35906},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1244, col: 7, offset: 35201},
+								pos:  position{line: 1263, col: 7, offset: 35908},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1244, col: 10, offset: 35204},
+							pos:        position{line: 1263, col: 10, offset: 35911},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1244, col: 14, offset: 35208},
+							pos:   position{line: 1263, col: 14, offset: 35915},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1244, col: 16, offset: 35210},
+								pos:  position{line: 1263, col: 16, offset: 35917},
 								name: "UInt",
 							},
 						},
@@ -9857,31 +10030,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1248, col: 1, offset: 35283},
+			pos:  position{line: 1267, col: 1, offset: 35990},
 			expr: &actionExpr{
-				pos: position{line: 1249, col: 5, offset: 35294},
+				pos: position{line: 1268, col: 5, offset: 36001},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1249, col: 5, offset: 35294},
+					pos: position{line: 1268, col: 5, offset: 36001},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1249, col: 5, offset: 35294},
+							pos:   position{line: 1268, col: 5, offset: 36001},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1249, col: 7, offset: 35296},
+								pos:  position{line: 1268, col: 7, offset: 36003},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1249, col: 11, offset: 35300},
+							pos:        position{line: 1268, col: 11, offset: 36007},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1249, col: 15, offset: 35304},
+							pos:   position{line: 1268, col: 15, offset: 36011},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1249, col: 17, offset: 35306},
+								pos:  position{line: 1268, col: 17, offset: 36013},
 								name: "UInt",
 							},
 						},
@@ -9891,15 +10064,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1253, col: 1, offset: 35369},
+			pos:  position{line: 1272, col: 1, offset: 36076},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 4, offset: 35377},
+				pos: position{line: 1273, col: 4, offset: 36084},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1254, col: 4, offset: 35377},
+					pos:   position{line: 1273, col: 4, offset: 36084},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1254, col: 6, offset: 35379},
+						pos:  position{line: 1273, col: 6, offset: 36086},
 						name: "UIntString",
 					},
 				},
@@ -9907,16 +10080,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1256, col: 1, offset: 35419},
+			pos:  position{line: 1275, col: 1, offset: 36126},
 			expr: &choiceExpr{
-				pos: position{line: 1257, col: 5, offset: 35433},
+				pos: position{line: 1276, col: 5, offset: 36140},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1257, col: 5, offset: 35433},
+						pos:  position{line: 1276, col: 5, offset: 36140},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1258, col: 5, offset: 35448},
+						pos:  position{line: 1277, col: 5, offset: 36155},
 						name: "MinusIntString",
 					},
 				},
@@ -9924,14 +10097,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1260, col: 1, offset: 35464},
+			pos:  position{line: 1279, col: 1, offset: 36171},
 			expr: &actionExpr{
-				pos: position{line: 1260, col: 14, offset: 35477},
+				pos: position{line: 1279, col: 14, offset: 36184},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1260, col: 14, offset: 35477},
+					pos: position{line: 1279, col: 14, offset: 36184},
 					expr: &charClassMatcher{
-						pos:        position{line: 1260, col: 14, offset: 35477},
+						pos:        position{line: 1279, col: 14, offset: 36184},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9942,20 +10115,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1262, col: 1, offset: 35516},
+			pos:  position{line: 1281, col: 1, offset: 36223},
 			expr: &actionExpr{
-				pos: position{line: 1263, col: 5, offset: 35535},
+				pos: position{line: 1282, col: 5, offset: 36242},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1263, col: 5, offset: 35535},
+					pos: position{line: 1282, col: 5, offset: 36242},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1263, col: 5, offset: 35535},
+							pos:        position{line: 1282, col: 5, offset: 36242},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1263, col: 9, offset: 35539},
+							pos:  position{line: 1282, col: 9, offset: 36246},
 							name: "UIntString",
 						},
 					},
@@ -9964,28 +10137,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1265, col: 1, offset: 35582},
+			pos:  position{line: 1284, col: 1, offset: 36289},
 			expr: &choiceExpr{
-				pos: position{line: 1266, col: 5, offset: 35598},
+				pos: position{line: 1285, col: 5, offset: 36305},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1266, col: 5, offset: 35598},
+						pos: position{line: 1285, col: 5, offset: 36305},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1266, col: 5, offset: 35598},
+							pos: position{line: 1285, col: 5, offset: 36305},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1266, col: 5, offset: 35598},
+									pos: position{line: 1285, col: 5, offset: 36305},
 									expr: &litMatcher{
-										pos:        position{line: 1266, col: 5, offset: 35598},
+										pos:        position{line: 1285, col: 5, offset: 36305},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1266, col: 10, offset: 35603},
+									pos: position{line: 1285, col: 10, offset: 36310},
 									expr: &charClassMatcher{
-										pos:        position{line: 1266, col: 10, offset: 35603},
+										pos:        position{line: 1285, col: 10, offset: 36310},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9993,14 +10166,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1266, col: 17, offset: 35610},
+									pos:        position{line: 1285, col: 17, offset: 36317},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1266, col: 21, offset: 35614},
+									pos: position{line: 1285, col: 21, offset: 36321},
 									expr: &charClassMatcher{
-										pos:        position{line: 1266, col: 21, offset: 35614},
+										pos:        position{line: 1285, col: 21, offset: 36321},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10008,9 +10181,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1266, col: 28, offset: 35621},
+									pos: position{line: 1285, col: 28, offset: 36328},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1266, col: 28, offset: 35621},
+										pos:  position{line: 1285, col: 28, offset: 36328},
 										name: "ExponentPart",
 									},
 								},
@@ -10018,28 +10191,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1269, col: 5, offset: 35680},
+						pos: position{line: 1288, col: 5, offset: 36387},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1269, col: 5, offset: 35680},
+							pos: position{line: 1288, col: 5, offset: 36387},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1269, col: 5, offset: 35680},
+									pos: position{line: 1288, col: 5, offset: 36387},
 									expr: &litMatcher{
-										pos:        position{line: 1269, col: 5, offset: 35680},
+										pos:        position{line: 1288, col: 5, offset: 36387},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1269, col: 10, offset: 35685},
+									pos:        position{line: 1288, col: 10, offset: 36392},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1269, col: 14, offset: 35689},
+									pos: position{line: 1288, col: 14, offset: 36396},
 									expr: &charClassMatcher{
-										pos:        position{line: 1269, col: 14, offset: 35689},
+										pos:        position{line: 1288, col: 14, offset: 36396},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10047,9 +10220,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1269, col: 21, offset: 35696},
+									pos: position{line: 1288, col: 21, offset: 36403},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1269, col: 21, offset: 35696},
+										pos:  position{line: 1288, col: 21, offset: 36403},
 										name: "ExponentPart",
 									},
 								},
@@ -10061,19 +10234,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1273, col: 1, offset: 35752},
+			pos:  position{line: 1292, col: 1, offset: 36459},
 			expr: &seqExpr{
-				pos: position{line: 1273, col: 16, offset: 35767},
+				pos: position{line: 1292, col: 16, offset: 36474},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1273, col: 16, offset: 35767},
+						pos:        position{line: 1292, col: 16, offset: 36474},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1273, col: 21, offset: 35772},
+						pos: position{line: 1292, col: 21, offset: 36479},
 						expr: &charClassMatcher{
-							pos:        position{line: 1273, col: 21, offset: 35772},
+							pos:        position{line: 1292, col: 21, offset: 36479},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10081,7 +10254,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 27, offset: 35778},
+						pos:  position{line: 1292, col: 27, offset: 36485},
 						name: "UIntString",
 					},
 				},
@@ -10089,14 +10262,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1275, col: 1, offset: 35790},
+			pos:  position{line: 1294, col: 1, offset: 36497},
 			expr: &actionExpr{
-				pos: position{line: 1275, col: 7, offset: 35796},
+				pos: position{line: 1294, col: 7, offset: 36503},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1275, col: 7, offset: 35796},
+					pos: position{line: 1294, col: 7, offset: 36503},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1275, col: 7, offset: 35796},
+						pos:  position{line: 1294, col: 7, offset: 36503},
 						name: "HexDigit",
 					},
 				},
@@ -10104,9 +10277,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1277, col: 1, offset: 35838},
+			pos:  position{line: 1296, col: 1, offset: 36545},
 			expr: &charClassMatcher{
-				pos:        position{line: 1277, col: 12, offset: 35849},
+				pos:        position{line: 1296, col: 12, offset: 36556},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10115,34 +10288,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1280, col: 1, offset: 35863},
+			pos:  position{line: 1299, col: 1, offset: 36570},
 			expr: &choiceExpr{
-				pos: position{line: 1281, col: 5, offset: 35880},
+				pos: position{line: 1300, col: 5, offset: 36587},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1281, col: 5, offset: 35880},
+						pos: position{line: 1300, col: 5, offset: 36587},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1281, col: 5, offset: 35880},
+							pos: position{line: 1300, col: 5, offset: 36587},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1281, col: 5, offset: 35880},
+									pos:        position{line: 1300, col: 5, offset: 36587},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1281, col: 9, offset: 35884},
+									pos:   position{line: 1300, col: 9, offset: 36591},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1281, col: 11, offset: 35886},
+										pos: position{line: 1300, col: 11, offset: 36593},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1281, col: 11, offset: 35886},
+											pos:  position{line: 1300, col: 11, offset: 36593},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1281, col: 29, offset: 35904},
+									pos:        position{line: 1300, col: 29, offset: 36611},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10150,29 +10323,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1282, col: 5, offset: 35941},
+						pos: position{line: 1301, col: 5, offset: 36648},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1282, col: 5, offset: 35941},
+							pos: position{line: 1301, col: 5, offset: 36648},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1282, col: 5, offset: 35941},
+									pos:        position{line: 1301, col: 5, offset: 36648},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1282, col: 9, offset: 35945},
+									pos:   position{line: 1301, col: 9, offset: 36652},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1282, col: 11, offset: 35947},
+										pos: position{line: 1301, col: 11, offset: 36654},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1282, col: 11, offset: 35947},
+											pos:  position{line: 1301, col: 11, offset: 36654},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1282, col: 29, offset: 35965},
+									pos:        position{line: 1301, col: 29, offset: 36672},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10184,55 +10357,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1284, col: 1, offset: 35999},
+			pos:  position{line: 1303, col: 1, offset: 36706},
 			expr: &choiceExpr{
-				pos: position{line: 1285, col: 5, offset: 36020},
+				pos: position{line: 1304, col: 5, offset: 36727},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1285, col: 5, offset: 36020},
+						pos: position{line: 1304, col: 5, offset: 36727},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1285, col: 5, offset: 36020},
+							pos: position{line: 1304, col: 5, offset: 36727},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1285, col: 5, offset: 36020},
+									pos: position{line: 1304, col: 5, offset: 36727},
 									expr: &choiceExpr{
-										pos: position{line: 1285, col: 7, offset: 36022},
+										pos: position{line: 1304, col: 7, offset: 36729},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1285, col: 7, offset: 36022},
+												pos:        position{line: 1304, col: 7, offset: 36729},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1285, col: 13, offset: 36028},
+												pos:  position{line: 1304, col: 13, offset: 36735},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1285, col: 26, offset: 36041,
+									line: 1304, col: 26, offset: 36748,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1286, col: 5, offset: 36078},
+						pos: position{line: 1305, col: 5, offset: 36785},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1286, col: 5, offset: 36078},
+							pos: position{line: 1305, col: 5, offset: 36785},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1286, col: 5, offset: 36078},
+									pos:        position{line: 1305, col: 5, offset: 36785},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1286, col: 10, offset: 36083},
+									pos:   position{line: 1305, col: 10, offset: 36790},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1286, col: 12, offset: 36085},
+										pos:  position{line: 1305, col: 12, offset: 36792},
 										name: "EscapeSequence",
 									},
 								},
@@ -10244,28 +10417,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1288, col: 1, offset: 36119},
+			pos:  position{line: 1307, col: 1, offset: 36826},
 			expr: &actionExpr{
-				pos: position{line: 1289, col: 5, offset: 36131},
+				pos: position{line: 1308, col: 5, offset: 36838},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1289, col: 5, offset: 36131},
+					pos: position{line: 1308, col: 5, offset: 36838},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1289, col: 5, offset: 36131},
+							pos:   position{line: 1308, col: 5, offset: 36838},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 10, offset: 36136},
+								pos:  position{line: 1308, col: 10, offset: 36843},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 23, offset: 36149},
+							pos:   position{line: 1308, col: 23, offset: 36856},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1289, col: 28, offset: 36154},
+								pos: position{line: 1308, col: 28, offset: 36861},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1289, col: 28, offset: 36154},
+									pos:  position{line: 1308, col: 28, offset: 36861},
 									name: "KeyWordRest",
 								},
 							},
@@ -10276,16 +10449,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1291, col: 1, offset: 36216},
+			pos:  position{line: 1310, col: 1, offset: 36923},
 			expr: &choiceExpr{
-				pos: position{line: 1292, col: 5, offset: 36233},
+				pos: position{line: 1311, col: 5, offset: 36940},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1292, col: 5, offset: 36233},
+						pos:  position{line: 1311, col: 5, offset: 36940},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1293, col: 5, offset: 36250},
+						pos:  position{line: 1312, col: 5, offset: 36957},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10293,12 +10466,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1295, col: 1, offset: 36262},
+			pos:  position{line: 1314, col: 1, offset: 36969},
 			expr: &actionExpr{
-				pos: position{line: 1295, col: 16, offset: 36277},
+				pos: position{line: 1314, col: 16, offset: 36984},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1295, col: 16, offset: 36277},
+					pos:        position{line: 1314, col: 16, offset: 36984},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10309,16 +10482,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1297, col: 1, offset: 36326},
+			pos:  position{line: 1316, col: 1, offset: 37033},
 			expr: &choiceExpr{
-				pos: position{line: 1298, col: 5, offset: 36342},
+				pos: position{line: 1317, col: 5, offset: 37049},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1298, col: 5, offset: 36342},
+						pos:  position{line: 1317, col: 5, offset: 37049},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1299, col: 5, offset: 36359},
+						pos:        position{line: 1318, col: 5, offset: 37066},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10329,30 +10502,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1301, col: 1, offset: 36366},
+			pos:  position{line: 1320, col: 1, offset: 37073},
 			expr: &actionExpr{
-				pos: position{line: 1301, col: 14, offset: 36379},
+				pos: position{line: 1320, col: 14, offset: 37086},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1301, col: 14, offset: 36379},
+					pos: position{line: 1320, col: 14, offset: 37086},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1301, col: 14, offset: 36379},
+							pos:        position{line: 1320, col: 14, offset: 37086},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1301, col: 19, offset: 36384},
+							pos:   position{line: 1320, col: 19, offset: 37091},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1301, col: 22, offset: 36387},
+								pos: position{line: 1320, col: 22, offset: 37094},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1301, col: 22, offset: 36387},
+										pos:  position{line: 1320, col: 22, offset: 37094},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1301, col: 38, offset: 36403},
+										pos:  position{line: 1320, col: 38, offset: 37110},
 										name: "EscapeSequence",
 									},
 								},
@@ -10364,42 +10537,42 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 1303, col: 1, offset: 36439},
+			pos:  position{line: 1322, col: 1, offset: 37146},
 			expr: &actionExpr{
-				pos: position{line: 1304, col: 5, offset: 36448},
+				pos: position{line: 1323, col: 5, offset: 37155},
 				run: (*parser).callonGlob1,
 				expr: &seqExpr{
-					pos: position{line: 1304, col: 5, offset: 36448},
+					pos: position{line: 1323, col: 5, offset: 37155},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1304, col: 5, offset: 36448},
+							pos: position{line: 1323, col: 5, offset: 37155},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1304, col: 6, offset: 36449},
+								pos:  position{line: 1323, col: 6, offset: 37156},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1304, col: 22, offset: 36465},
+							pos: position{line: 1323, col: 22, offset: 37172},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1304, col: 23, offset: 36466},
+								pos:  position{line: 1323, col: 23, offset: 37173},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1304, col: 35, offset: 36478},
+							pos:   position{line: 1323, col: 35, offset: 37185},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1304, col: 40, offset: 36483},
+								pos:  position{line: 1323, col: 40, offset: 37190},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1304, col: 50, offset: 36493},
+							pos:   position{line: 1323, col: 50, offset: 37200},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1304, col: 55, offset: 36498},
+								pos: position{line: 1323, col: 55, offset: 37205},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1304, col: 55, offset: 36498},
+									pos:  position{line: 1323, col: 55, offset: 37205},
 									name: "GlobRest",
 								},
 							},
@@ -10410,20 +10583,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1308, col: 1, offset: 36582},
+			pos:  position{line: 1327, col: 1, offset: 37289},
 			expr: &seqExpr{
-				pos: position{line: 1308, col: 19, offset: 36600},
+				pos: position{line: 1327, col: 19, offset: 37307},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1308, col: 19, offset: 36600},
+						pos: position{line: 1327, col: 19, offset: 37307},
 						expr: &litMatcher{
-							pos:        position{line: 1308, col: 19, offset: 36600},
+							pos:        position{line: 1327, col: 19, offset: 37307},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1308, col: 24, offset: 36605},
+						pos:  position{line: 1327, col: 24, offset: 37312},
 						name: "KeyWordStart",
 					},
 				},
@@ -10431,19 +10604,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1309, col: 1, offset: 36618},
+			pos:  position{line: 1328, col: 1, offset: 37325},
 			expr: &seqExpr{
-				pos: position{line: 1309, col: 15, offset: 36632},
+				pos: position{line: 1328, col: 15, offset: 37339},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1309, col: 15, offset: 36632},
+						pos: position{line: 1328, col: 15, offset: 37339},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1309, col: 15, offset: 36632},
+							pos:  position{line: 1328, col: 15, offset: 37339},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1309, col: 28, offset: 36645},
+						pos:        position{line: 1328, col: 28, offset: 37352},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10452,23 +10625,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1311, col: 1, offset: 36650},
+			pos:  position{line: 1330, col: 1, offset: 37357},
 			expr: &choiceExpr{
-				pos: position{line: 1312, col: 5, offset: 36664},
+				pos: position{line: 1331, col: 5, offset: 37371},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 5, offset: 36664},
+						pos:  position{line: 1331, col: 5, offset: 37371},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1313, col: 5, offset: 36681},
+						pos:  position{line: 1332, col: 5, offset: 37388},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 36693},
+						pos: position{line: 1333, col: 5, offset: 37400},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1314, col: 5, offset: 36693},
+							pos:        position{line: 1333, col: 5, offset: 37400},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10478,16 +10651,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1316, col: 1, offset: 36717},
+			pos:  position{line: 1335, col: 1, offset: 37424},
 			expr: &choiceExpr{
-				pos: position{line: 1317, col: 5, offset: 36730},
+				pos: position{line: 1336, col: 5, offset: 37437},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1317, col: 5, offset: 36730},
+						pos:  position{line: 1336, col: 5, offset: 37437},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1318, col: 5, offset: 36744},
+						pos:        position{line: 1337, col: 5, offset: 37451},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10498,30 +10671,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1320, col: 1, offset: 36751},
+			pos:  position{line: 1339, col: 1, offset: 37458},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 11, offset: 36761},
+				pos: position{line: 1339, col: 11, offset: 37468},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1320, col: 11, offset: 36761},
+					pos: position{line: 1339, col: 11, offset: 37468},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1320, col: 11, offset: 36761},
+							pos:        position{line: 1339, col: 11, offset: 37468},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1320, col: 16, offset: 36766},
+							pos:   position{line: 1339, col: 16, offset: 37473},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1320, col: 19, offset: 36769},
+								pos: position{line: 1339, col: 19, offset: 37476},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1320, col: 19, offset: 36769},
+										pos:  position{line: 1339, col: 19, offset: 37476},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1320, col: 32, offset: 36782},
+										pos:  position{line: 1339, col: 32, offset: 37489},
 										name: "EscapeSequence",
 									},
 								},
@@ -10533,30 +10706,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1322, col: 1, offset: 36818},
+			pos:  position{line: 1341, col: 1, offset: 37525},
 			expr: &choiceExpr{
-				pos: position{line: 1323, col: 5, offset: 36833},
+				pos: position{line: 1342, col: 5, offset: 37540},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1323, col: 5, offset: 36833},
+						pos: position{line: 1342, col: 5, offset: 37540},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1323, col: 5, offset: 36833},
+							pos:        position{line: 1342, col: 5, offset: 37540},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1324, col: 5, offset: 36861},
+						pos: position{line: 1343, col: 5, offset: 37568},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1324, col: 5, offset: 36861},
+							pos:        position{line: 1343, col: 5, offset: 37568},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1325, col: 5, offset: 36891},
+						pos:        position{line: 1344, col: 5, offset: 37598},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10567,55 +10740,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1328, col: 1, offset: 36898},
+			pos:  position{line: 1347, col: 1, offset: 37605},
 			expr: &choiceExpr{
-				pos: position{line: 1329, col: 5, offset: 36919},
+				pos: position{line: 1348, col: 5, offset: 37626},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 36919},
+						pos: position{line: 1348, col: 5, offset: 37626},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1329, col: 5, offset: 36919},
+							pos: position{line: 1348, col: 5, offset: 37626},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1329, col: 5, offset: 36919},
+									pos: position{line: 1348, col: 5, offset: 37626},
 									expr: &choiceExpr{
-										pos: position{line: 1329, col: 7, offset: 36921},
+										pos: position{line: 1348, col: 7, offset: 37628},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1329, col: 7, offset: 36921},
+												pos:        position{line: 1348, col: 7, offset: 37628},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1329, col: 13, offset: 36927},
+												pos:  position{line: 1348, col: 13, offset: 37634},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1329, col: 26, offset: 36940,
+									line: 1348, col: 26, offset: 37647,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1330, col: 5, offset: 36977},
+						pos: position{line: 1349, col: 5, offset: 37684},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1330, col: 5, offset: 36977},
+							pos: position{line: 1349, col: 5, offset: 37684},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1330, col: 5, offset: 36977},
+									pos:        position{line: 1349, col: 5, offset: 37684},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1330, col: 10, offset: 36982},
+									pos:   position{line: 1349, col: 10, offset: 37689},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1330, col: 12, offset: 36984},
+										pos:  position{line: 1349, col: 12, offset: 37691},
 										name: "EscapeSequence",
 									},
 								},
@@ -10627,38 +10800,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1332, col: 1, offset: 37018},
+			pos:  position{line: 1351, col: 1, offset: 37725},
 			expr: &choiceExpr{
-				pos: position{line: 1333, col: 5, offset: 37037},
+				pos: position{line: 1352, col: 5, offset: 37744},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1333, col: 5, offset: 37037},
+						pos: position{line: 1352, col: 5, offset: 37744},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 1333, col: 5, offset: 37037},
+							pos: position{line: 1352, col: 5, offset: 37744},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1333, col: 5, offset: 37037},
+									pos:        position{line: 1352, col: 5, offset: 37744},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1333, col: 9, offset: 37041},
+									pos:  position{line: 1352, col: 9, offset: 37748},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1333, col: 18, offset: 37050},
+									pos:  position{line: 1352, col: 18, offset: 37757},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1334, col: 5, offset: 37101},
+						pos:  position{line: 1353, col: 5, offset: 37808},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1335, col: 5, offset: 37122},
+						pos:  position{line: 1354, col: 5, offset: 37829},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10666,79 +10839,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1337, col: 1, offset: 37137},
+			pos:  position{line: 1356, col: 1, offset: 37844},
 			expr: &choiceExpr{
-				pos: position{line: 1338, col: 5, offset: 37158},
+				pos: position{line: 1357, col: 5, offset: 37865},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1338, col: 5, offset: 37158},
+						pos:        position{line: 1357, col: 5, offset: 37865},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1339, col: 5, offset: 37166},
+						pos: position{line: 1358, col: 5, offset: 37873},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1339, col: 5, offset: 37166},
+							pos:        position{line: 1358, col: 5, offset: 37873},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1340, col: 5, offset: 37206},
+						pos:        position{line: 1359, col: 5, offset: 37913},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1341, col: 5, offset: 37215},
+						pos: position{line: 1360, col: 5, offset: 37922},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1341, col: 5, offset: 37215},
+							pos:        position{line: 1360, col: 5, offset: 37922},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 37244},
+						pos: position{line: 1361, col: 5, offset: 37951},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1342, col: 5, offset: 37244},
+							pos:        position{line: 1361, col: 5, offset: 37951},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1343, col: 5, offset: 37273},
+						pos: position{line: 1362, col: 5, offset: 37980},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1343, col: 5, offset: 37273},
+							pos:        position{line: 1362, col: 5, offset: 37980},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1344, col: 5, offset: 37302},
+						pos: position{line: 1363, col: 5, offset: 38009},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1344, col: 5, offset: 37302},
+							pos:        position{line: 1363, col: 5, offset: 38009},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1345, col: 5, offset: 37331},
+						pos: position{line: 1364, col: 5, offset: 38038},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1345, col: 5, offset: 37331},
+							pos:        position{line: 1364, col: 5, offset: 38038},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1346, col: 5, offset: 37360},
+						pos: position{line: 1365, col: 5, offset: 38067},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1346, col: 5, offset: 37360},
+							pos:        position{line: 1365, col: 5, offset: 38067},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -10748,30 +10921,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1348, col: 1, offset: 37386},
+			pos:  position{line: 1367, col: 1, offset: 38093},
 			expr: &choiceExpr{
-				pos: position{line: 1349, col: 5, offset: 37404},
+				pos: position{line: 1368, col: 5, offset: 38111},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1349, col: 5, offset: 37404},
+						pos: position{line: 1368, col: 5, offset: 38111},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1349, col: 5, offset: 37404},
+							pos:        position{line: 1368, col: 5, offset: 38111},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1350, col: 5, offset: 37432},
+						pos: position{line: 1369, col: 5, offset: 38139},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1350, col: 5, offset: 37432},
+							pos:        position{line: 1369, col: 5, offset: 38139},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1351, col: 5, offset: 37460},
+						pos:        position{line: 1370, col: 5, offset: 38167},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10782,41 +10955,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1353, col: 1, offset: 37466},
+			pos:  position{line: 1372, col: 1, offset: 38173},
 			expr: &choiceExpr{
-				pos: position{line: 1354, col: 5, offset: 37484},
+				pos: position{line: 1373, col: 5, offset: 38191},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1354, col: 5, offset: 37484},
+						pos: position{line: 1373, col: 5, offset: 38191},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1354, col: 5, offset: 37484},
+							pos: position{line: 1373, col: 5, offset: 38191},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1354, col: 5, offset: 37484},
+									pos:        position{line: 1373, col: 5, offset: 38191},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1354, col: 9, offset: 37488},
+									pos:   position{line: 1373, col: 9, offset: 38195},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1354, col: 16, offset: 37495},
+										pos: position{line: 1373, col: 16, offset: 38202},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1354, col: 16, offset: 37495},
+												pos:  position{line: 1373, col: 16, offset: 38202},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1354, col: 25, offset: 37504},
+												pos:  position{line: 1373, col: 25, offset: 38211},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1354, col: 34, offset: 37513},
+												pos:  position{line: 1373, col: 34, offset: 38220},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1354, col: 43, offset: 37522},
+												pos:  position{line: 1373, col: 43, offset: 38229},
 												name: "HexDigit",
 											},
 										},
@@ -10826,63 +10999,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1357, col: 5, offset: 37585},
+						pos: position{line: 1376, col: 5, offset: 38292},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1357, col: 5, offset: 37585},
+							pos: position{line: 1376, col: 5, offset: 38292},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1357, col: 5, offset: 37585},
+									pos:        position{line: 1376, col: 5, offset: 38292},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1357, col: 9, offset: 37589},
+									pos:        position{line: 1376, col: 9, offset: 38296},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1357, col: 13, offset: 37593},
+									pos:   position{line: 1376, col: 13, offset: 38300},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1357, col: 20, offset: 37600},
+										pos: position{line: 1376, col: 20, offset: 38307},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1357, col: 20, offset: 37600},
+												pos:  position{line: 1376, col: 20, offset: 38307},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1357, col: 29, offset: 37609},
+												pos: position{line: 1376, col: 29, offset: 38316},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1357, col: 29, offset: 37609},
+													pos:  position{line: 1376, col: 29, offset: 38316},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1357, col: 39, offset: 37619},
+												pos: position{line: 1376, col: 39, offset: 38326},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1357, col: 39, offset: 37619},
+													pos:  position{line: 1376, col: 39, offset: 38326},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1357, col: 49, offset: 37629},
+												pos: position{line: 1376, col: 49, offset: 38336},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1357, col: 49, offset: 37629},
+													pos:  position{line: 1376, col: 49, offset: 38336},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1357, col: 59, offset: 37639},
+												pos: position{line: 1376, col: 59, offset: 38346},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1357, col: 59, offset: 37639},
+													pos:  position{line: 1376, col: 59, offset: 38346},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1357, col: 69, offset: 37649},
+												pos: position{line: 1376, col: 69, offset: 38356},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1357, col: 69, offset: 37649},
+													pos:  position{line: 1376, col: 69, offset: 38356},
 													name: "HexDigit",
 												},
 											},
@@ -10890,7 +11063,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1357, col: 80, offset: 37660},
+									pos:        position{line: 1376, col: 80, offset: 38367},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -10902,35 +11075,35 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1361, col: 1, offset: 37714},
+			pos:  position{line: 1380, col: 1, offset: 38421},
 			expr: &actionExpr{
-				pos: position{line: 1362, col: 5, offset: 37725},
+				pos: position{line: 1381, col: 5, offset: 38432},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1362, col: 5, offset: 37725},
+					pos: position{line: 1381, col: 5, offset: 38432},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1362, col: 5, offset: 37725},
+							pos:        position{line: 1381, col: 5, offset: 38432},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1362, col: 9, offset: 37729},
+							pos:   position{line: 1381, col: 9, offset: 38436},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1362, col: 14, offset: 37734},
+								pos:  position{line: 1381, col: 14, offset: 38441},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1362, col: 25, offset: 37745},
+							pos:        position{line: 1381, col: 25, offset: 38452},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1362, col: 29, offset: 37749},
+							pos: position{line: 1381, col: 29, offset: 38456},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1362, col: 30, offset: 37750},
+								pos:  position{line: 1381, col: 30, offset: 38457},
 								name: "KeyWordStart",
 							},
 						},
@@ -10940,24 +11113,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1364, col: 1, offset: 37785},
+			pos:  position{line: 1383, col: 1, offset: 38492},
 			expr: &actionExpr{
-				pos: position{line: 1365, col: 5, offset: 37800},
+				pos: position{line: 1384, col: 5, offset: 38507},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1365, col: 5, offset: 37800},
+					pos: position{line: 1384, col: 5, offset: 38507},
 					expr: &choiceExpr{
-						pos: position{line: 1365, col: 6, offset: 37801},
+						pos: position{line: 1384, col: 6, offset: 38508},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1365, col: 6, offset: 37801},
+								pos:        position{line: 1384, col: 6, offset: 38508},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 1365, col: 13, offset: 37808},
+								pos:        position{line: 1384, col: 13, offset: 38515},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -10968,9 +11141,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1367, col: 1, offset: 37848},
+			pos:  position{line: 1386, col: 1, offset: 38555},
 			expr: &charClassMatcher{
-				pos:        position{line: 1368, col: 5, offset: 37864},
+				pos:        position{line: 1387, col: 5, offset: 38571},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -10980,42 +11153,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1370, col: 1, offset: 37879},
+			pos:  position{line: 1389, col: 1, offset: 38586},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1370, col: 6, offset: 37884},
+				pos: position{line: 1389, col: 6, offset: 38591},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1370, col: 6, offset: 37884},
+					pos:  position{line: 1389, col: 6, offset: 38591},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1372, col: 1, offset: 37895},
+			pos:  position{line: 1391, col: 1, offset: 38602},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1372, col: 6, offset: 37900},
+				pos: position{line: 1391, col: 6, offset: 38607},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1372, col: 6, offset: 37900},
+					pos:  position{line: 1391, col: 6, offset: 38607},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1374, col: 1, offset: 37911},
+			pos:  position{line: 1393, col: 1, offset: 38618},
 			expr: &choiceExpr{
-				pos: position{line: 1375, col: 5, offset: 37924},
+				pos: position{line: 1394, col: 5, offset: 38631},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 5, offset: 37924},
+						pos:  position{line: 1394, col: 5, offset: 38631},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1376, col: 5, offset: 37939},
+						pos:  position{line: 1395, col: 5, offset: 38646},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1377, col: 5, offset: 37958},
+						pos:  position{line: 1396, col: 5, offset: 38665},
 						name: "Comment",
 					},
 				},
@@ -11023,45 +11196,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1379, col: 1, offset: 37967},
+			pos:  position{line: 1398, col: 1, offset: 38674},
 			expr: &anyMatcher{
-				line: 1380, col: 5, offset: 37987,
+				line: 1399, col: 5, offset: 38694,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1382, col: 1, offset: 37990},
+			pos:         position{line: 1401, col: 1, offset: 38697},
 			expr: &choiceExpr{
-				pos: position{line: 1383, col: 5, offset: 38018},
+				pos: position{line: 1402, col: 5, offset: 38725},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1383, col: 5, offset: 38018},
+						pos:        position{line: 1402, col: 5, offset: 38725},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1384, col: 5, offset: 38027},
+						pos:        position{line: 1403, col: 5, offset: 38734},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1385, col: 5, offset: 38036},
+						pos:        position{line: 1404, col: 5, offset: 38743},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1386, col: 5, offset: 38045},
+						pos:        position{line: 1405, col: 5, offset: 38752},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1387, col: 5, offset: 38053},
+						pos:        position{line: 1406, col: 5, offset: 38760},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1388, col: 5, offset: 38066},
+						pos:        position{line: 1407, col: 5, offset: 38773},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11070,9 +11243,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1390, col: 1, offset: 38076},
+			pos:  position{line: 1409, col: 1, offset: 38783},
 			expr: &charClassMatcher{
-				pos:        position{line: 1391, col: 5, offset: 38095},
+				pos:        position{line: 1410, col: 5, offset: 38802},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11082,45 +11255,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1397, col: 1, offset: 38425},
+			pos:         position{line: 1416, col: 1, offset: 39132},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1400, col: 5, offset: 38496},
+				pos:  position{line: 1419, col: 5, offset: 39203},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1402, col: 1, offset: 38515},
+			pos:  position{line: 1421, col: 1, offset: 39222},
 			expr: &seqExpr{
-				pos: position{line: 1403, col: 5, offset: 38536},
+				pos: position{line: 1422, col: 5, offset: 39243},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1403, col: 5, offset: 38536},
+						pos:        position{line: 1422, col: 5, offset: 39243},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1403, col: 10, offset: 38541},
+						pos: position{line: 1422, col: 10, offset: 39248},
 						expr: &seqExpr{
-							pos: position{line: 1403, col: 11, offset: 38542},
+							pos: position{line: 1422, col: 11, offset: 39249},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1403, col: 11, offset: 38542},
+									pos: position{line: 1422, col: 11, offset: 39249},
 									expr: &litMatcher{
-										pos:        position{line: 1403, col: 12, offset: 38543},
+										pos:        position{line: 1422, col: 12, offset: 39250},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1403, col: 17, offset: 38548},
+									pos:  position{line: 1422, col: 17, offset: 39255},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1403, col: 35, offset: 38566},
+						pos:        position{line: 1422, col: 35, offset: 39273},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11129,29 +11302,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1405, col: 1, offset: 38572},
+			pos:  position{line: 1424, col: 1, offset: 39279},
 			expr: &seqExpr{
-				pos: position{line: 1406, col: 5, offset: 38594},
+				pos: position{line: 1425, col: 5, offset: 39301},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1406, col: 5, offset: 38594},
+						pos:        position{line: 1425, col: 5, offset: 39301},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1406, col: 10, offset: 38599},
+						pos: position{line: 1425, col: 10, offset: 39306},
 						expr: &seqExpr{
-							pos: position{line: 1406, col: 11, offset: 38600},
+							pos: position{line: 1425, col: 11, offset: 39307},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1406, col: 11, offset: 38600},
+									pos: position{line: 1425, col: 11, offset: 39307},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1406, col: 12, offset: 38601},
+										pos:  position{line: 1425, col: 12, offset: 39308},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1406, col: 27, offset: 38616},
+									pos:  position{line: 1425, col: 27, offset: 39323},
 									name: "SourceCharacter",
 								},
 							},
@@ -11162,19 +11335,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1408, col: 1, offset: 38635},
+			pos:  position{line: 1427, col: 1, offset: 39342},
 			expr: &seqExpr{
-				pos: position{line: 1408, col: 7, offset: 38641},
+				pos: position{line: 1427, col: 7, offset: 39348},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1408, col: 7, offset: 38641},
+						pos: position{line: 1427, col: 7, offset: 39348},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1408, col: 7, offset: 38641},
+							pos:  position{line: 1427, col: 7, offset: 39348},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1408, col: 19, offset: 38653},
+						pos:  position{line: 1427, col: 19, offset: 39360},
 						name: "LineTerminator",
 					},
 				},
@@ -11182,16 +11355,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1410, col: 1, offset: 38669},
+			pos:  position{line: 1429, col: 1, offset: 39376},
 			expr: &choiceExpr{
-				pos: position{line: 1410, col: 7, offset: 38675},
+				pos: position{line: 1429, col: 7, offset: 39382},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1410, col: 7, offset: 38675},
+						pos:  position{line: 1429, col: 7, offset: 39382},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1410, col: 11, offset: 38679},
+						pos:  position{line: 1429, col: 11, offset: 39386},
 						name: "EOF",
 					},
 				},
@@ -11199,11 +11372,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1412, col: 1, offset: 38684},
+			pos:  position{line: 1431, col: 1, offset: 39391},
 			expr: &notExpr{
-				pos: position{line: 1412, col: 7, offset: 38690},
+				pos: position{line: 1431, col: 7, offset: 39397},
 				expr: &anyMatcher{
-					line: 1412, col: 8, offset: 38691,
+					line: 1431, col: 8, offset: 39398,
 				},
 			},
 		},
@@ -12267,15 +12440,15 @@ func (p *parser) callonPoolProc1() (interface{}, error) {
 	return p.cur.onPoolProc1(stack["body"])
 }
 
-func (c *current) onPoolBody1(name, at, over, order interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Pool", "name": name, "at": at, "range": over, "scan_order": order}, nil
+func (c *current) onPoolBody1(spec, at, over, order interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order}, nil
 
 }
 
 func (p *parser) callonPoolBody1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPoolBody1(stack["name"], stack["at"], stack["over"], stack["order"])
+	return p.cur.onPoolBody1(stack["spec"], stack["at"], stack["over"], stack["order"])
 }
 
 func (c *current) onHTTPProc1(url, format, layout interface{}) (interface{}, error) {
@@ -12348,6 +12521,61 @@ func (p *parser) callonPoolRange1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPoolRange1(stack["lower"], stack["upper"])
+}
+
+func (c *current) onPoolSpec2(pool, branch, meta interface{}) (interface{}, error) {
+	return map[string]interface{}{"pool": pool, "branch": branch, "meta": meta}, nil
+
+}
+
+func (p *parser) callonPoolSpec2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPoolSpec2(stack["pool"], stack["branch"], stack["meta"])
+}
+
+func (c *current) onPoolSpec13(pool, meta interface{}) (interface{}, error) {
+	return map[string]interface{}{"pool": pool, "branch": nil, "meta": meta}, nil
+
+}
+
+func (p *parser) callonPoolSpec13() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPoolSpec13(stack["pool"], stack["meta"])
+}
+
+func (c *current) onPoolSpec21(meta interface{}) (interface{}, error) {
+	return map[string]interface{}{"pool": nil, "branch": nil, "meta": meta}, nil
+
+}
+
+func (p *parser) callonPoolSpec21() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPoolSpec21(stack["meta"])
+}
+
+func (c *current) onPoolSpec27(pool, branch interface{}) (interface{}, error) {
+	return map[string]interface{}{"pool": pool, "branch": branch, "meta": nil}, nil
+
+}
+
+func (p *parser) callonPoolSpec27() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPoolSpec27(stack["pool"], stack["branch"])
+}
+
+func (c *current) onPoolSpec34(pool interface{}) (interface{}, error) {
+	return map[string]interface{}{"pool": pool, "branch": nil, "meta": nil}, nil
+
+}
+
+func (p *parser) callonPoolSpec34() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPoolSpec34(stack["pool"])
 }
 
 func (c *current) onPoolName2(name interface{}) (interface{}, error) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -567,8 +567,8 @@ function peg$parse(input, options) {
           },
       peg$c206 = peg$literalExpectation("from", true),
       peg$c207 = function(body) { return body },
-      peg$c208 = function(name, at, over, order) {
-            return {"kind": "Pool", "name": name, "at": at, "range": over, "scan_order": order}
+      peg$c208 = function(spec, at, over, order) {
+            return {"kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order}
           },
       peg$c209 = "get",
       peg$c210 = peg$literalExpectation("get", true),
@@ -593,39 +593,60 @@ function peg$parse(input, options) {
       peg$c227 = function(lower, upper) {
             return {"kind":"Range","lower": lower, "upper": upper}
           },
-      peg$c228 = function(name) { return name },
-      peg$c229 = "order",
-      peg$c230 = peg$literalExpectation("order", true),
-      peg$c231 = function(keys, order) {
+      peg$c228 = "/",
+      peg$c229 = peg$literalExpectation("/", false),
+      peg$c230 = "]",
+      peg$c231 = peg$literalExpectation("]", false),
+      peg$c232 = function(pool, branch, meta) {
+            return {"pool": pool, "branch": branch, "meta": meta}
+          },
+      peg$c233 = function(pool, meta) {
+            return {"pool": pool, "branch": null, "meta": meta}
+          },
+      peg$c234 = function(meta) {
+            return {"pool": null, "branch": null, "meta": meta}
+          },
+      peg$c235 = function(pool, branch) {
+            return {"pool": pool, "branch": branch, "meta": null}
+          },
+      peg$c236 = function(pool) {
+            return {"pool": pool, "branch": null, "meta": null}
+          },
+      peg$c237 = function(name) { return name },
+      peg$c238 = /^[A-Za-z0-9_$.[\]]/,
+      peg$c239 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", "$", ".", "[", "]"], false, false),
+      peg$c240 = "order",
+      peg$c241 = peg$literalExpectation("order", true),
+      peg$c242 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c232 = "format",
-      peg$c233 = peg$literalExpectation("format", true),
-      peg$c234 = function(val) { return val },
-      peg$c235 = ":asc",
-      peg$c236 = peg$literalExpectation(":asc", true),
-      peg$c237 = function() { return "asc" },
-      peg$c238 = ":desc",
-      peg$c239 = peg$literalExpectation(":desc", true),
-      peg$c240 = function() { return "desc" },
-      peg$c241 = "asc",
-      peg$c242 = peg$literalExpectation("asc", true),
-      peg$c243 = "desc",
-      peg$c244 = peg$literalExpectation("desc", true),
-      peg$c245 = "pass",
-      peg$c246 = peg$literalExpectation("pass", true),
-      peg$c247 = function() {
+      peg$c243 = "format",
+      peg$c244 = peg$literalExpectation("format", true),
+      peg$c245 = function(val) { return val },
+      peg$c246 = ":asc",
+      peg$c247 = peg$literalExpectation(":asc", true),
+      peg$c248 = function() { return "asc" },
+      peg$c249 = ":desc",
+      peg$c250 = peg$literalExpectation(":desc", true),
+      peg$c251 = function() { return "desc" },
+      peg$c252 = "asc",
+      peg$c253 = peg$literalExpectation("asc", true),
+      peg$c254 = "desc",
+      peg$c255 = peg$literalExpectation("desc", true),
+      peg$c256 = "pass",
+      peg$c257 = peg$literalExpectation("pass", true),
+      peg$c258 = function() {
             return {"kind":"Pass"}
           },
-      peg$c248 = "explode",
-      peg$c249 = peg$literalExpectation("explode", true),
-      peg$c250 = function(args, typ, as) {
+      peg$c259 = "explode",
+      peg$c260 = peg$literalExpectation("explode", true),
+      peg$c261 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c251 = function(typ) { return typ},
-      peg$c252 = function(lhs) { return lhs },
-      peg$c253 = function(first, lval) { return lval },
-      peg$c254 = function(first, rest) {
+      peg$c262 = function(typ) { return typ},
+      peg$c263 = function(lhs) { return lhs },
+      peg$c264 = function(first, lval) { return lval },
+      peg$c265 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -634,53 +655,51 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c255 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c256 = "?",
-      peg$c257 = peg$literalExpectation("?", false),
-      peg$c258 = function(condition, thenClause, elseClause) {
+      peg$c266 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c267 = "?",
+      peg$c268 = peg$literalExpectation("?", false),
+      peg$c269 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c259 = function(first, op, expr) { return [op, expr] },
-      peg$c260 = function(first, rest) {
+      peg$c270 = function(first, op, expr) { return [op, expr] },
+      peg$c271 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c261 = function(first, comp, expr) { return [comp, expr] },
-      peg$c262 = function() { return "="},
-      peg$c263 = "+",
-      peg$c264 = peg$literalExpectation("+", false),
-      peg$c265 = "-",
-      peg$c266 = peg$literalExpectation("-", false),
-      peg$c267 = "/",
-      peg$c268 = peg$literalExpectation("/", false),
-      peg$c269 = function(e) {
+      peg$c272 = function(first, comp, expr) { return [comp, expr] },
+      peg$c273 = function() { return "="},
+      peg$c274 = "+",
+      peg$c275 = peg$literalExpectation("+", false),
+      peg$c276 = "-",
+      peg$c277 = peg$literalExpectation("-", false),
+      peg$c278 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c270 = function(typ) { return typ },
-      peg$c271 = "not",
-      peg$c272 = peg$literalExpectation("not", false),
-      peg$c273 = "match",
-      peg$c274 = peg$literalExpectation("match", false),
-      peg$c275 = "select",
-      peg$c276 = peg$literalExpectation("select", false),
-      peg$c277 = function(args, methods) {
+      peg$c279 = function(typ) { return typ },
+      peg$c280 = "not",
+      peg$c281 = peg$literalExpectation("not", false),
+      peg$c282 = "match",
+      peg$c283 = peg$literalExpectation("match", false),
+      peg$c284 = "select",
+      peg$c285 = peg$literalExpectation("select", false),
+      peg$c286 = function(args, methods) {
             return {"kind":"SelectExpr", "selectors":args, "methods": methods}
           },
-      peg$c278 = function(methods) { return methods },
-      peg$c279 = function(typ, expr) {
+      peg$c287 = function(methods) { return methods },
+      peg$c288 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c280 = function(fn, args) {
+      peg$c289 = function(fn, args) {
             return {"kind": "Call", "name": fn, "args": args}
           },
-      peg$c281 = function() { return [] },
-      peg$c282 = function(first, e) { return e },
-      peg$c283 = function(e) { return e },
-      peg$c284 = function() {
+      peg$c290 = function() { return [] },
+      peg$c291 = function(first, e) { return e },
+      peg$c292 = function(e) { return e },
+      peg$c293 = function() {
             return {"kind":"Root"}
           },
-      peg$c285 = "this",
-      peg$c286 = peg$literalExpectation("this", false),
-      peg$c287 = function(field) {
+      peg$c294 = "this",
+      peg$c295 = peg$literalExpectation("this", false),
+      peg$c296 = function(field) {
             return {"kind": "BinaryExpr", "op":".",
                            
             "lhs":{"kind":"Root"},
@@ -689,9 +708,7 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c288 = "]",
-      peg$c289 = peg$literalExpectation("]", false),
-      peg$c290 = function(expr) {
+      peg$c297 = function(expr) {
             return {"kind": "BinaryExpr", "op":"[",
                            
             "lhs":{"kind":"Root"},
@@ -700,58 +717,58 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c291 = function(from, to) {
+      peg$c298 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c292 = function(to) {
+      peg$c299 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c293 = function(from) {
+      peg$c300 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c294 = function(expr) { return ["[", expr] },
-      peg$c295 = function(id) { return [".", id] },
-      peg$c296 = "}",
-      peg$c297 = peg$literalExpectation("}", false),
-      peg$c298 = function(fields) {
+      peg$c301 = function(expr) { return ["[", expr] },
+      peg$c302 = function(id) { return [".", id] },
+      peg$c303 = "}",
+      peg$c304 = peg$literalExpectation("}", false),
+      peg$c305 = function(fields) {
             return {"kind":"RecordExpr", "fields":fields }
           },
-      peg$c299 = function(first, rest) {
+      peg$c306 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c300 = function(name, value) {
+      peg$c307 = function(name, value) {
             return {"name": name, "value": value}
           },
-      peg$c301 = function(exprs) {
+      peg$c308 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c302 = "|[",
-      peg$c303 = peg$literalExpectation("|[", false),
-      peg$c304 = "]|",
-      peg$c305 = peg$literalExpectation("]|", false),
-      peg$c306 = function(exprs) {
+      peg$c309 = "|[",
+      peg$c310 = peg$literalExpectation("|[", false),
+      peg$c311 = "]|",
+      peg$c312 = peg$literalExpectation("]|", false),
+      peg$c313 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c307 = "|{",
-      peg$c308 = peg$literalExpectation("|{", false),
-      peg$c309 = "}|",
-      peg$c310 = peg$literalExpectation("}|", false),
-      peg$c311 = function(exprs) {
+      peg$c314 = "|{",
+      peg$c315 = peg$literalExpectation("|{", false),
+      peg$c316 = "}|",
+      peg$c317 = peg$literalExpectation("}|", false),
+      peg$c318 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c312 = function(key, value) {
+      peg$c319 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c313 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c320 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -773,13 +790,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c314 = function(assignments) { return assignments },
-      peg$c315 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c316 = function(table, alias) {
+      peg$c321 = function(assignments) { return assignments },
+      peg$c322 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c323 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c317 = function(first, join) { return join },
-      peg$c318 = function(style, table, alias, leftKey, rightKey) {
+      peg$c324 = function(first, join) { return join },
+      peg$c325 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -797,278 +814,278 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c319 = function(style) { return style },
-      peg$c320 = function(keys, order) {
+      peg$c326 = function(style) { return style },
+      peg$c327 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c321 = function(dir) { return dir },
-      peg$c322 = function(count) { return count },
-      peg$c323 = peg$literalExpectation("select", true),
-      peg$c324 = function() { return "select" },
-      peg$c325 = "as",
-      peg$c326 = peg$literalExpectation("as", true),
-      peg$c327 = function() { return "as" },
-      peg$c328 = function() { return "from" },
-      peg$c329 = function() { return "join" },
-      peg$c330 = peg$literalExpectation("where", true),
-      peg$c331 = function() { return "where" },
-      peg$c332 = "group",
-      peg$c333 = peg$literalExpectation("group", true),
-      peg$c334 = function() { return "group" },
-      peg$c335 = "having",
-      peg$c336 = peg$literalExpectation("having", true),
-      peg$c337 = function() { return "having" },
-      peg$c338 = function() { return "order" },
-      peg$c339 = "on",
-      peg$c340 = peg$literalExpectation("on", true),
-      peg$c341 = function() { return "on" },
-      peg$c342 = "limit",
-      peg$c343 = peg$literalExpectation("limit", true),
-      peg$c344 = function() { return "limit" },
-      peg$c345 = function(v) {
+      peg$c328 = function(dir) { return dir },
+      peg$c329 = function(count) { return count },
+      peg$c330 = peg$literalExpectation("select", true),
+      peg$c331 = function() { return "select" },
+      peg$c332 = "as",
+      peg$c333 = peg$literalExpectation("as", true),
+      peg$c334 = function() { return "as" },
+      peg$c335 = function() { return "from" },
+      peg$c336 = function() { return "join" },
+      peg$c337 = peg$literalExpectation("where", true),
+      peg$c338 = function() { return "where" },
+      peg$c339 = "group",
+      peg$c340 = peg$literalExpectation("group", true),
+      peg$c341 = function() { return "group" },
+      peg$c342 = "having",
+      peg$c343 = peg$literalExpectation("having", true),
+      peg$c344 = function() { return "having" },
+      peg$c345 = function() { return "order" },
+      peg$c346 = "on",
+      peg$c347 = peg$literalExpectation("on", true),
+      peg$c348 = function() { return "on" },
+      peg$c349 = "limit",
+      peg$c350 = peg$literalExpectation("limit", true),
+      peg$c351 = function() { return "limit" },
+      peg$c352 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c346 = function(v) {
+      peg$c353 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c347 = function(v) {
+      peg$c354 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c348 = function(v) {
+      peg$c355 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c349 = "true",
-      peg$c350 = peg$literalExpectation("true", false),
-      peg$c351 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c352 = "false",
-      peg$c353 = peg$literalExpectation("false", false),
-      peg$c354 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c355 = "null",
-      peg$c356 = peg$literalExpectation("null", false),
-      peg$c357 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c358 = function(typ) {
+      peg$c356 = "true",
+      peg$c357 = peg$literalExpectation("true", false),
+      peg$c358 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c359 = "false",
+      peg$c360 = peg$literalExpectation("false", false),
+      peg$c361 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c362 = "null",
+      peg$c363 = peg$literalExpectation("null", false),
+      peg$c364 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c365 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c359 = function(name, typ) {
+      peg$c366 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c360 = function(name) {
+      peg$c367 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c361 = function(u) { return u },
-      peg$c362 = function(types) {
+      peg$c368 = function(u) { return u },
+      peg$c369 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c363 = function(fields) {
+      peg$c370 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c364 = function(typ) {
+      peg$c371 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c365 = function(typ) {
+      peg$c372 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c366 = function(keyType, valType) {
+      peg$c373 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c367 = "uint8",
-      peg$c368 = peg$literalExpectation("uint8", false),
-      peg$c369 = "uint16",
-      peg$c370 = peg$literalExpectation("uint16", false),
-      peg$c371 = "uint32",
-      peg$c372 = peg$literalExpectation("uint32", false),
-      peg$c373 = "uint64",
-      peg$c374 = peg$literalExpectation("uint64", false),
-      peg$c375 = "int8",
-      peg$c376 = peg$literalExpectation("int8", false),
-      peg$c377 = "int16",
-      peg$c378 = peg$literalExpectation("int16", false),
-      peg$c379 = "int32",
-      peg$c380 = peg$literalExpectation("int32", false),
-      peg$c381 = "int64",
-      peg$c382 = peg$literalExpectation("int64", false),
-      peg$c383 = "float64",
-      peg$c384 = peg$literalExpectation("float64", false),
-      peg$c385 = "bool",
-      peg$c386 = peg$literalExpectation("bool", false),
-      peg$c387 = "string",
-      peg$c388 = peg$literalExpectation("string", false),
-      peg$c389 = function() {
+      peg$c374 = "uint8",
+      peg$c375 = peg$literalExpectation("uint8", false),
+      peg$c376 = "uint16",
+      peg$c377 = peg$literalExpectation("uint16", false),
+      peg$c378 = "uint32",
+      peg$c379 = peg$literalExpectation("uint32", false),
+      peg$c380 = "uint64",
+      peg$c381 = peg$literalExpectation("uint64", false),
+      peg$c382 = "int8",
+      peg$c383 = peg$literalExpectation("int8", false),
+      peg$c384 = "int16",
+      peg$c385 = peg$literalExpectation("int16", false),
+      peg$c386 = "int32",
+      peg$c387 = peg$literalExpectation("int32", false),
+      peg$c388 = "int64",
+      peg$c389 = peg$literalExpectation("int64", false),
+      peg$c390 = "float64",
+      peg$c391 = peg$literalExpectation("float64", false),
+      peg$c392 = "bool",
+      peg$c393 = peg$literalExpectation("bool", false),
+      peg$c394 = "string",
+      peg$c395 = peg$literalExpectation("string", false),
+      peg$c396 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c390 = "duration",
-      peg$c391 = peg$literalExpectation("duration", false),
-      peg$c392 = "time",
-      peg$c393 = peg$literalExpectation("time", false),
-      peg$c394 = "bytes",
-      peg$c395 = peg$literalExpectation("bytes", false),
-      peg$c396 = "bstring",
-      peg$c397 = peg$literalExpectation("bstring", false),
-      peg$c398 = "ip",
-      peg$c399 = peg$literalExpectation("ip", false),
-      peg$c400 = "net",
-      peg$c401 = peg$literalExpectation("net", false),
-      peg$c402 = "error",
-      peg$c403 = peg$literalExpectation("error", false),
-      peg$c404 = function(name, typ) {
+      peg$c397 = "duration",
+      peg$c398 = peg$literalExpectation("duration", false),
+      peg$c399 = "time",
+      peg$c400 = peg$literalExpectation("time", false),
+      peg$c401 = "bytes",
+      peg$c402 = peg$literalExpectation("bytes", false),
+      peg$c403 = "bstring",
+      peg$c404 = peg$literalExpectation("bstring", false),
+      peg$c405 = "ip",
+      peg$c406 = peg$literalExpectation("ip", false),
+      peg$c407 = "net",
+      peg$c408 = peg$literalExpectation("net", false),
+      peg$c409 = "error",
+      peg$c410 = peg$literalExpectation("error", false),
+      peg$c411 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c405 = "and",
-      peg$c406 = peg$literalExpectation("and", true),
-      peg$c407 = function() { return "and" },
-      peg$c408 = "or",
-      peg$c409 = peg$literalExpectation("or", true),
-      peg$c410 = function() { return "or" },
-      peg$c411 = peg$literalExpectation("in", true),
-      peg$c412 = function() { return "in" },
-      peg$c413 = peg$literalExpectation("not", true),
-      peg$c414 = function() { return "not" },
-      peg$c415 = "by",
-      peg$c416 = peg$literalExpectation("by", true),
-      peg$c417 = function() { return "by" },
-      peg$c418 = /^[A-Za-z_$]/,
-      peg$c419 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c420 = /^[0-9]/,
-      peg$c421 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c422 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c423 = function() {  return text() },
-      peg$c424 = "$",
-      peg$c425 = peg$literalExpectation("$", false),
-      peg$c426 = "\\",
-      peg$c427 = peg$literalExpectation("\\", false),
-      peg$c428 = "T",
-      peg$c429 = peg$literalExpectation("T", false),
-      peg$c430 = function() {
+      peg$c412 = "and",
+      peg$c413 = peg$literalExpectation("and", true),
+      peg$c414 = function() { return "and" },
+      peg$c415 = "or",
+      peg$c416 = peg$literalExpectation("or", true),
+      peg$c417 = function() { return "or" },
+      peg$c418 = peg$literalExpectation("in", true),
+      peg$c419 = function() { return "in" },
+      peg$c420 = peg$literalExpectation("not", true),
+      peg$c421 = function() { return "not" },
+      peg$c422 = "by",
+      peg$c423 = peg$literalExpectation("by", true),
+      peg$c424 = function() { return "by" },
+      peg$c425 = /^[A-Za-z_$]/,
+      peg$c426 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c427 = /^[0-9]/,
+      peg$c428 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c429 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c430 = function() {  return text() },
+      peg$c431 = "$",
+      peg$c432 = peg$literalExpectation("$", false),
+      peg$c433 = "\\",
+      peg$c434 = peg$literalExpectation("\\", false),
+      peg$c435 = "T",
+      peg$c436 = peg$literalExpectation("T", false),
+      peg$c437 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c431 = "Z",
-      peg$c432 = peg$literalExpectation("Z", false),
-      peg$c433 = function() {
+      peg$c438 = "Z",
+      peg$c439 = peg$literalExpectation("Z", false),
+      peg$c440 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c434 = "ns",
-      peg$c435 = peg$literalExpectation("ns", true),
-      peg$c436 = "us",
-      peg$c437 = peg$literalExpectation("us", true),
-      peg$c438 = "ms",
-      peg$c439 = peg$literalExpectation("ms", true),
-      peg$c440 = "s",
-      peg$c441 = peg$literalExpectation("s", true),
-      peg$c442 = "m",
-      peg$c443 = peg$literalExpectation("m", true),
-      peg$c444 = "h",
-      peg$c445 = peg$literalExpectation("h", true),
-      peg$c446 = "d",
-      peg$c447 = peg$literalExpectation("d", true),
-      peg$c448 = "w",
-      peg$c449 = peg$literalExpectation("w", true),
-      peg$c450 = "y",
-      peg$c451 = peg$literalExpectation("y", true),
-      peg$c452 = function(a, b) {
+      peg$c441 = "ns",
+      peg$c442 = peg$literalExpectation("ns", true),
+      peg$c443 = "us",
+      peg$c444 = peg$literalExpectation("us", true),
+      peg$c445 = "ms",
+      peg$c446 = peg$literalExpectation("ms", true),
+      peg$c447 = "s",
+      peg$c448 = peg$literalExpectation("s", true),
+      peg$c449 = "m",
+      peg$c450 = peg$literalExpectation("m", true),
+      peg$c451 = "h",
+      peg$c452 = peg$literalExpectation("h", true),
+      peg$c453 = "d",
+      peg$c454 = peg$literalExpectation("d", true),
+      peg$c455 = "w",
+      peg$c456 = peg$literalExpectation("w", true),
+      peg$c457 = "y",
+      peg$c458 = peg$literalExpectation("y", true),
+      peg$c459 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c453 = "::",
-      peg$c454 = peg$literalExpectation("::", false),
-      peg$c455 = function(a, b, d, e) {
+      peg$c460 = "::",
+      peg$c461 = peg$literalExpectation("::", false),
+      peg$c462 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c456 = function(a, b) {
+      peg$c463 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c457 = function(a, b) {
+      peg$c464 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c458 = function() {
+      peg$c465 = function() {
             return "::"
           },
-      peg$c459 = function(v) { return ":" + v },
-      peg$c460 = function(v) { return v + ":" },
-      peg$c461 = function(a, m) {
+      peg$c466 = function(v) { return ":" + v },
+      peg$c467 = function(v) { return v + ":" },
+      peg$c468 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c462 = function(a, m) {
+      peg$c469 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c463 = function(s) { return parseInt(s) },
-      peg$c464 = function() {
+      peg$c470 = function(s) { return parseInt(s) },
+      peg$c471 = function() {
             return text()
           },
-      peg$c465 = "e",
-      peg$c466 = peg$literalExpectation("e", true),
-      peg$c467 = /^[+\-]/,
-      peg$c468 = peg$classExpectation(["+", "-"], false, false),
-      peg$c469 = /^[0-9a-fA-F]/,
-      peg$c470 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c471 = "\"",
-      peg$c472 = peg$literalExpectation("\"", false),
-      peg$c473 = function(v) { return joinChars(v) },
-      peg$c474 = "'",
-      peg$c475 = peg$literalExpectation("'", false),
-      peg$c476 = peg$anyExpectation(),
-      peg$c477 = function(head, tail) { return head + joinChars(tail) },
-      peg$c478 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c479 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c480 = function(head, tail) {
+      peg$c472 = "e",
+      peg$c473 = peg$literalExpectation("e", true),
+      peg$c474 = /^[+\-]/,
+      peg$c475 = peg$classExpectation(["+", "-"], false, false),
+      peg$c476 = /^[0-9a-fA-F]/,
+      peg$c477 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c478 = "\"",
+      peg$c479 = peg$literalExpectation("\"", false),
+      peg$c480 = function(v) { return joinChars(v) },
+      peg$c481 = "'",
+      peg$c482 = peg$literalExpectation("'", false),
+      peg$c483 = peg$anyExpectation(),
+      peg$c484 = function(head, tail) { return head + joinChars(tail) },
+      peg$c485 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c486 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c487 = function(head, tail) {
             return reglob.Reglob(head + joinChars(tail))
           },
-      peg$c481 = function() { return "*"},
-      peg$c482 = function() { return "=" },
-      peg$c483 = function() { return "\\*" },
-      peg$c484 = "x",
-      peg$c485 = peg$literalExpectation("x", false),
-      peg$c486 = function() { return "\\" + text() },
-      peg$c487 = "b",
-      peg$c488 = peg$literalExpectation("b", false),
-      peg$c489 = function() { return "\b" },
-      peg$c490 = "f",
-      peg$c491 = peg$literalExpectation("f", false),
-      peg$c492 = function() { return "\f" },
-      peg$c493 = "n",
-      peg$c494 = peg$literalExpectation("n", false),
-      peg$c495 = function() { return "\n" },
-      peg$c496 = "r",
-      peg$c497 = peg$literalExpectation("r", false),
-      peg$c498 = function() { return "\r" },
-      peg$c499 = "t",
-      peg$c500 = peg$literalExpectation("t", false),
-      peg$c501 = function() { return "\t" },
-      peg$c502 = "v",
-      peg$c503 = peg$literalExpectation("v", false),
-      peg$c504 = function() { return "\v" },
-      peg$c505 = function() { return "*" },
-      peg$c506 = "u",
-      peg$c507 = peg$literalExpectation("u", false),
-      peg$c508 = function(chars) {
+      peg$c488 = function() { return "*"},
+      peg$c489 = function() { return "=" },
+      peg$c490 = function() { return "\\*" },
+      peg$c491 = "x",
+      peg$c492 = peg$literalExpectation("x", false),
+      peg$c493 = function() { return "\\" + text() },
+      peg$c494 = "b",
+      peg$c495 = peg$literalExpectation("b", false),
+      peg$c496 = function() { return "\b" },
+      peg$c497 = "f",
+      peg$c498 = peg$literalExpectation("f", false),
+      peg$c499 = function() { return "\f" },
+      peg$c500 = "n",
+      peg$c501 = peg$literalExpectation("n", false),
+      peg$c502 = function() { return "\n" },
+      peg$c503 = "r",
+      peg$c504 = peg$literalExpectation("r", false),
+      peg$c505 = function() { return "\r" },
+      peg$c506 = "t",
+      peg$c507 = peg$literalExpectation("t", false),
+      peg$c508 = function() { return "\t" },
+      peg$c509 = "v",
+      peg$c510 = peg$literalExpectation("v", false),
+      peg$c511 = function() { return "\v" },
+      peg$c512 = function() { return "*" },
+      peg$c513 = "u",
+      peg$c514 = peg$literalExpectation("u", false),
+      peg$c515 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c509 = /^[^\/\\]/,
-      peg$c510 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c511 = "\\/",
-      peg$c512 = peg$literalExpectation("\\/", false),
-      peg$c513 = /^[\0-\x1F\\]/,
-      peg$c514 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c515 = peg$otherExpectation("whitespace"),
-      peg$c516 = "\t",
-      peg$c517 = peg$literalExpectation("\t", false),
-      peg$c518 = "\x0B",
-      peg$c519 = peg$literalExpectation("\x0B", false),
-      peg$c520 = "\f",
-      peg$c521 = peg$literalExpectation("\f", false),
-      peg$c522 = " ",
-      peg$c523 = peg$literalExpectation(" ", false),
-      peg$c524 = "\xA0",
-      peg$c525 = peg$literalExpectation("\xA0", false),
-      peg$c526 = "\uFEFF",
-      peg$c527 = peg$literalExpectation("\uFEFF", false),
-      peg$c528 = /^[\n\r\u2028\u2029]/,
-      peg$c529 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c530 = peg$otherExpectation("comment"),
-      peg$c531 = "/*",
-      peg$c532 = peg$literalExpectation("/*", false),
-      peg$c533 = "*/",
-      peg$c534 = peg$literalExpectation("*/", false),
-      peg$c535 = "//",
-      peg$c536 = peg$literalExpectation("//", false),
+      peg$c516 = /^[^\/\\]/,
+      peg$c517 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c518 = "\\/",
+      peg$c519 = peg$literalExpectation("\\/", false),
+      peg$c520 = /^[\0-\x1F\\]/,
+      peg$c521 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c522 = peg$otherExpectation("whitespace"),
+      peg$c523 = "\t",
+      peg$c524 = peg$literalExpectation("\t", false),
+      peg$c525 = "\x0B",
+      peg$c526 = peg$literalExpectation("\x0B", false),
+      peg$c527 = "\f",
+      peg$c528 = peg$literalExpectation("\f", false),
+      peg$c529 = " ",
+      peg$c530 = peg$literalExpectation(" ", false),
+      peg$c531 = "\xA0",
+      peg$c532 = peg$literalExpectation("\xA0", false),
+      peg$c533 = "\uFEFF",
+      peg$c534 = peg$literalExpectation("\uFEFF", false),
+      peg$c535 = /^[\n\r\u2028\u2029]/,
+      peg$c536 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c537 = peg$otherExpectation("comment"),
+      peg$c538 = "/*",
+      peg$c539 = peg$literalExpectation("/*", false),
+      peg$c540 = "*/",
+      peg$c541 = peg$literalExpectation("*/", false),
+      peg$c542 = "//",
+      peg$c543 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -5357,7 +5374,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parsePoolName();
+    s1 = peg$parsePoolSpec();
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePoolAt();
       if (s2 === peg$FAILED) {
@@ -5679,6 +5696,188 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsePoolSpec() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = peg$parsePoolName();
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 47) {
+        s2 = peg$c228;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parsePoolName();
+        if (s3 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 91) {
+            s4 = peg$c48;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseIdentifierName();
+            if (s5 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 93) {
+                s6 = peg$c230;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
+              }
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c232(s1, s3, s5);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parsePoolName();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 91) {
+          s2 = peg$c48;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseIdentifierName();
+          if (s3 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s4 = peg$c230;
+              peg$currPos++;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
+            }
+            if (s4 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c233(s1, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 91) {
+          s1 = peg$c48;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseIdentifierName();
+          if (s2 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s3 = peg$c230;
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
+            }
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c234(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsePoolName();
+          if (s1 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 47) {
+              s2 = peg$c228;
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c229); }
+            }
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parsePoolName();
+              if (s3 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c235(s1, s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parsePoolName();
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c236(s1);
+            }
+            s0 = s1;
+          }
+        }
+      }
+    }
+
+    return s0;
+  }
+
   function peg$parsePoolName() {
     var s0, s1;
 
@@ -5686,7 +5885,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c228(s1);
+      s1 = peg$c237(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5711,18 +5910,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsePoolNameChar() {
+    var s0;
+
+    if (peg$c238.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+    }
+
+    return s0;
+  }
+
   function peg$parseLayoutArg() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c230); }
+        if (peg$silentFails === 0) { peg$fail(peg$c241); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5732,7 +5945,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c231(s4, s5);
+              s1 = peg$c242(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5764,12 +5977,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c232) {
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c243) {
         s2 = input.substr(peg$currPos, 6);
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c233); }
+        if (peg$silentFails === 0) { peg$fail(peg$c244); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5777,7 +5990,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c234(s4);
+            s1 = peg$c245(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5803,30 +6016,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c235) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c246) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
+      if (peg$silentFails === 0) { peg$fail(peg$c247); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c237();
+      s1 = peg$c248();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c238) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c249) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c239); }
+        if (peg$silentFails === 0) { peg$fail(peg$c250); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c240();
+        s1 = peg$c251();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -5834,7 +6047,7 @@ function peg$parse(input, options) {
         s1 = peg$c108;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c237();
+          s1 = peg$c248();
         }
         s0 = s1;
       }
@@ -5849,26 +6062,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
         s2 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c230); }
+        if (peg$silentFails === 0) { peg$fail(peg$c241); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c241) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c252) {
             s4 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c242); }
+            if (peg$silentFails === 0) { peg$fail(peg$c253); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c237();
+            s1 = peg$c248();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5890,26 +6103,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
           s2 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c230); }
+          if (peg$silentFails === 0) { peg$fail(peg$c241); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c243) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c254) {
               s4 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c244); }
+              if (peg$silentFails === 0) { peg$fail(peg$c255); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c240();
+              s1 = peg$c251();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5936,16 +6149,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c245) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c256) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c257); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c247();
+      s1 = peg$c258();
     }
     s0 = s1;
 
@@ -5956,12 +6169,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c248) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c259) {
       s1 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c260); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5976,7 +6189,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c250(s3, s4, s5);
+              s1 = peg$c261(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6015,7 +6228,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c251(s4);
+            s1 = peg$c262(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6050,7 +6263,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c252(s4);
+            s1 = peg$c263(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6095,7 +6308,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c253(s1, s7);
+              s4 = peg$c264(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6131,7 +6344,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c253(s1, s7);
+                s4 = peg$c264(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6244,7 +6457,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c254(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6279,7 +6492,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c255(s1, s5);
+              s1 = peg$c266(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6322,11 +6535,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c256;
+          s3 = peg$c267;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c257); }
+          if (peg$silentFails === 0) { peg$fail(peg$c268); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6348,7 +6561,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c258(s1, s5, s9);
+                      s1 = peg$c269(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6410,7 +6623,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6440,7 +6653,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6461,7 +6674,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6492,7 +6705,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6522,7 +6735,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6543,7 +6756,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6576,7 +6789,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c261(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6606,7 +6819,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRelativeExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s3;
-                  s4 = peg$c261(s1, s5, s7);
+                  s4 = peg$c272(s1, s5, s7);
                   s3 = s4;
                 } else {
                   peg$currPos = s3;
@@ -6627,7 +6840,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c260(s1, s2);
+          s1 = peg$c271(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6655,7 +6868,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c262();
+      s1 = peg$c273();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6717,7 +6930,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6747,7 +6960,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6768,7 +6981,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6846,7 +7059,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6876,7 +7089,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6897,7 +7110,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6916,19 +7129,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c263;
+      s1 = peg$c274;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c265;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -6957,7 +7170,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c259(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6987,7 +7200,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c259(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7008,7 +7221,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7035,11 +7248,11 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c267;
+        s1 = peg$c228;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7068,7 +7281,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c269(s3);
+          s1 = peg$c278(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7131,7 +7344,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s1);
+            s1 = peg$c279(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7236,28 +7449,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c271) {
-      s0 = peg$c271;
+    if (input.substr(peg$currPos, 3) === peg$c280) {
+      s0 = peg$c280;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c273) {
-        s0 = peg$c273;
+      if (input.substr(peg$currPos, 5) === peg$c282) {
+        s0 = peg$c282;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c274); }
+        if (peg$silentFails === 0) { peg$fail(peg$c283); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c275) {
-          s0 = peg$c275;
+        if (input.substr(peg$currPos, 6) === peg$c284) {
+          s0 = peg$c284;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c276); }
+          if (peg$silentFails === 0) { peg$fail(peg$c285); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -7278,12 +7491,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c273) {
-      s1 = peg$c273;
+    if (input.substr(peg$currPos, 5) === peg$c282) {
+      s1 = peg$c282;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c283); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7337,12 +7550,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c275) {
-      s1 = peg$c275;
+    if (input.substr(peg$currPos, 6) === peg$c284) {
+      s1 = peg$c284;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7375,7 +7588,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c277(s5, s8);
+                    s1 = peg$c286(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7429,7 +7642,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c278(s1);
+      s1 = peg$c287(s1);
     }
     s0 = s1;
 
@@ -7508,7 +7721,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c279(s1, s5);
+                  s1 = peg$c288(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7584,7 +7797,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c280(s2, s6);
+                    s1 = peg$c289(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7631,7 +7844,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c281();
+        s1 = peg$c290();
       }
       s0 = s1;
     }
@@ -7662,7 +7875,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c282(s1, s7);
+              s4 = peg$c291(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7698,7 +7911,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c282(s1, s7);
+                s4 = peg$c291(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7751,7 +7964,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExprPattern();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c283(s2);
+        s1 = peg$c292(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7844,7 +8057,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c284();
+            s1 = peg$c293();
           }
           s0 = s1;
         }
@@ -7858,12 +8071,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c285) {
-      s1 = peg$c285;
+    if (input.substr(peg$currPos, 4) === peg$c294) {
+      s1 = peg$c294;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -7889,7 +8102,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c287(s2);
+        s1 = peg$c296(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7920,15 +8133,15 @@ function peg$parse(input, options) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c288;
+              s4 = peg$c230;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c289); }
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c290(s3);
+              s1 = peg$c297(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7980,15 +8193,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c288;
+                  s7 = peg$c230;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c231); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c291(s2, s6);
+                  s1 = peg$c298(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8043,15 +8256,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c288;
+                  s6 = peg$c230;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c231); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c292(s5);
+                  s1 = peg$c299(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8102,15 +8315,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c288;
+                    s6 = peg$c230;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c231); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c293(s2);
+                    s1 = peg$c300(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8149,15 +8362,15 @@ function peg$parse(input, options) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c288;
+                s3 = peg$c230;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c294(s2);
+                s1 = peg$c301(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8201,7 +8414,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c295(s3);
+                  s1 = peg$c302(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8310,15 +8523,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c296;
+              s5 = peg$c303;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c298(s3);
+              s1 = peg$c305(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8358,7 +8571,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8434,7 +8647,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c300(s1, s5);
+              s1 = peg$c307(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8479,15 +8692,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c288;
+              s5 = peg$c230;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c289); }
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c301(s3);
+              s1 = peg$c308(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8517,12 +8730,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c302) {
-      s1 = peg$c302;
+    if (input.substr(peg$currPos, 2) === peg$c309) {
+      s1 = peg$c309;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c303); }
+      if (peg$silentFails === 0) { peg$fail(peg$c310); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8531,16 +8744,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c304) {
-              s5 = peg$c304;
+            if (input.substr(peg$currPos, 2) === peg$c311) {
+              s5 = peg$c311;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c312); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c306(s3);
+              s1 = peg$c313(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8570,12 +8783,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c307) {
-      s1 = peg$c307;
+    if (input.substr(peg$currPos, 2) === peg$c314) {
+      s1 = peg$c314;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c308); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8584,16 +8797,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c309) {
-              s5 = peg$c309;
+            if (input.substr(peg$currPos, 2) === peg$c316) {
+              s5 = peg$c316;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c317); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s3);
+              s1 = peg$c318(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8633,7 +8846,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8648,7 +8861,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c281();
+        s1 = peg$c290();
       }
       s0 = s1;
     }
@@ -8675,7 +8888,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c283(s4);
+            s1 = peg$c292(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8718,7 +8931,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c312(s1, s5);
+              s1 = peg$c319(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8783,7 +8996,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c313(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c320(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8861,7 +9074,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c314(s3);
+            s1 = peg$c321(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8895,7 +9108,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s1, s5);
+              s1 = peg$c322(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9042,7 +9255,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c316(s4, s5);
+              s1 = peg$c323(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9168,7 +9381,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c317(s1, s4);
+        s4 = peg$c324(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9177,7 +9390,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c317(s1, s4);
+          s4 = peg$c324(s1, s4);
         }
         s3 = s4;
       }
@@ -9239,7 +9452,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c318(s1, s5, s6, s10, s14);
+                                s1 = peg$c325(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9316,7 +9529,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c319(s2);
+        s1 = peg$c326(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9475,7 +9688,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c320(s6, s7);
+                  s1 = peg$c327(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9521,7 +9734,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c321(s2);
+        s1 = peg$c328(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9536,7 +9749,7 @@ function peg$parse(input, options) {
       s1 = peg$c108;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c237();
+        s1 = peg$c248();
       }
       s0 = s1;
     }
@@ -9557,7 +9770,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c322(s4);
+            s1 = peg$c329(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9592,16 +9805,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c275) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c284) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c324();
+      s1 = peg$c331();
     }
     s0 = s1;
 
@@ -9612,16 +9825,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c325) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c332) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c326); }
+      if (peg$silentFails === 0) { peg$fail(peg$c333); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c327();
+      s1 = peg$c334();
     }
     s0 = s1;
 
@@ -9641,7 +9854,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328();
+      s1 = peg$c335();
     }
     s0 = s1;
 
@@ -9661,7 +9874,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c329();
+      s1 = peg$c336();
     }
     s0 = s1;
 
@@ -9677,67 +9890,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c331();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseGROUP() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c332) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c334();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseHAVING() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c335) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c337();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseORDER() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c230); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -9748,13 +9901,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseON() {
+  function peg$parseGROUP() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c339) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c339) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c340); }
@@ -9768,13 +9921,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLIMIT() {
+  function peg$parseHAVING() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c342) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c342) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c343); }
@@ -9788,20 +9941,80 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseORDER() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c345();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseON() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c346) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c348();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseLIMIT() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c351();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parseASC() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c252) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c242); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c237();
+      s1 = peg$c248();
     }
     s0 = s1;
 
@@ -9812,16 +10025,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c243) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c254) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c255); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c240();
+      s1 = peg$c251();
     }
     s0 = s1;
 
@@ -9990,7 +10203,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c345(s1);
+        s1 = peg$c352(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10005,7 +10218,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c345(s1);
+        s1 = peg$c352(s1);
       }
       s0 = s1;
     }
@@ -10031,7 +10244,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c346(s1);
+        s1 = peg$c353(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10046,7 +10259,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c346(s1);
+        s1 = peg$c353(s1);
       }
       s0 = s1;
     }
@@ -10061,7 +10274,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347(s1);
+      s1 = peg$c354(s1);
     }
     s0 = s1;
 
@@ -10075,7 +10288,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348(s1);
+      s1 = peg$c355(s1);
     }
     s0 = s1;
 
@@ -10086,30 +10299,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c349) {
-      s1 = peg$c349;
+    if (input.substr(peg$currPos, 4) === peg$c356) {
+      s1 = peg$c356;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c358();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c352) {
-        s1 = peg$c352;
+      if (input.substr(peg$currPos, 5) === peg$c359) {
+        s1 = peg$c359;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c353); }
+        if (peg$silentFails === 0) { peg$fail(peg$c360); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354();
+        s1 = peg$c361();
       }
       s0 = s1;
     }
@@ -10121,16 +10334,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c355) {
-      s1 = peg$c355;
+    if (input.substr(peg$currPos, 4) === peg$c362) {
+      s1 = peg$c362;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c357();
+      s1 = peg$c364();
     }
     s0 = s1;
 
@@ -10169,7 +10382,7 @@ function peg$parse(input, options) {
       s2 = peg$parseTypeExternal();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c358(s2);
+        s1 = peg$c365(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10216,7 +10429,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s1);
+            s1 = peg$c279(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10283,7 +10496,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c251(s5);
+                  s1 = peg$c262(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10348,7 +10561,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c270(s5);
+                    s1 = peg$c279(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10401,7 +10614,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c228(s1);
+        s1 = peg$c237(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10450,7 +10663,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c359(s1, s7);
+                        s1 = peg$c366(s1, s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10493,7 +10706,7 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c360(s1);
+          s1 = peg$c367(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10519,7 +10732,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c361(s3);
+                  s1 = peg$c368(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10551,7 +10764,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362(s1);
+      s1 = peg$c369(s1);
     }
     s0 = s1;
 
@@ -10576,7 +10789,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10609,7 +10822,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s4);
+            s1 = peg$c279(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10650,15 +10863,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c296;
+              s5 = peg$c303;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c363(s3);
+              s1 = peg$c370(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10697,15 +10910,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c288;
+                s5 = peg$c230;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c364(s3);
+                s1 = peg$c371(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10729,12 +10942,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c302) {
-          s1 = peg$c302;
+        if (input.substr(peg$currPos, 2) === peg$c309) {
+          s1 = peg$c309;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c303); }
+          if (peg$silentFails === 0) { peg$fail(peg$c310); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10743,16 +10956,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c304) {
-                  s5 = peg$c304;
+                if (input.substr(peg$currPos, 2) === peg$c311) {
+                  s5 = peg$c311;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c312); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c365(s3);
+                  s1 = peg$c372(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10776,12 +10989,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c307) {
-            s1 = peg$c307;
+          if (input.substr(peg$currPos, 2) === peg$c314) {
+            s1 = peg$c314;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c308); }
+            if (peg$silentFails === 0) { peg$fail(peg$c315); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10804,16 +11017,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c309) {
-                            s9 = peg$c309;
+                          if (input.substr(peg$currPos, 2) === peg$c316) {
+                            s9 = peg$c316;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c310); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c317); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c366(s3, s7);
+                            s1 = peg$c373(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10877,15 +11090,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c296;
+              s5 = peg$c303;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c363(s3);
+              s1 = peg$c370(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10924,15 +11137,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c288;
+                s5 = peg$c230;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c364(s3);
+                s1 = peg$c371(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10956,12 +11169,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c302) {
-          s1 = peg$c302;
+        if (input.substr(peg$currPos, 2) === peg$c309) {
+          s1 = peg$c309;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c303); }
+          if (peg$silentFails === 0) { peg$fail(peg$c310); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10970,16 +11183,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c304) {
-                  s5 = peg$c304;
+                if (input.substr(peg$currPos, 2) === peg$c311) {
+                  s5 = peg$c311;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c312); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c365(s3);
+                  s1 = peg$c372(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11003,12 +11216,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c307) {
-            s1 = peg$c307;
+          if (input.substr(peg$currPos, 2) === peg$c314) {
+            s1 = peg$c314;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c308); }
+            if (peg$silentFails === 0) { peg$fail(peg$c315); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11031,16 +11244,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c309) {
-                            s9 = peg$c309;
+                          if (input.substr(peg$currPos, 2) === peg$c316) {
+                            s9 = peg$c316;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c310); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c317); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c366(s3, s7);
+                            s1 = peg$c373(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11100,92 +11313,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c367) {
-      s1 = peg$c367;
+    if (input.substr(peg$currPos, 5) === peg$c374) {
+      s1 = peg$c374;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c375); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c369) {
-        s1 = peg$c369;
+      if (input.substr(peg$currPos, 6) === peg$c376) {
+        s1 = peg$c376;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c370); }
+        if (peg$silentFails === 0) { peg$fail(peg$c377); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c371) {
-          s1 = peg$c371;
+        if (input.substr(peg$currPos, 6) === peg$c378) {
+          s1 = peg$c378;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c372); }
+          if (peg$silentFails === 0) { peg$fail(peg$c379); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c373) {
-            s1 = peg$c373;
+          if (input.substr(peg$currPos, 6) === peg$c380) {
+            s1 = peg$c380;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c374); }
+            if (peg$silentFails === 0) { peg$fail(peg$c381); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c375) {
-              s1 = peg$c375;
+            if (input.substr(peg$currPos, 4) === peg$c382) {
+              s1 = peg$c382;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c376); }
+              if (peg$silentFails === 0) { peg$fail(peg$c383); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c377) {
-                s1 = peg$c377;
+              if (input.substr(peg$currPos, 5) === peg$c384) {
+                s1 = peg$c384;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c378); }
+                if (peg$silentFails === 0) { peg$fail(peg$c385); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c379) {
-                  s1 = peg$c379;
+                if (input.substr(peg$currPos, 5) === peg$c386) {
+                  s1 = peg$c386;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c380); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c387); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c381) {
-                    s1 = peg$c381;
+                  if (input.substr(peg$currPos, 5) === peg$c388) {
+                    s1 = peg$c388;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c382); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c389); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c383) {
-                      s1 = peg$c383;
+                    if (input.substr(peg$currPos, 7) === peg$c390) {
+                      s1 = peg$c390;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c384); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c391); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c385) {
-                        s1 = peg$c385;
+                      if (input.substr(peg$currPos, 4) === peg$c392) {
+                        s1 = peg$c392;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c393); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c387) {
-                          s1 = peg$c387;
+                        if (input.substr(peg$currPos, 6) === peg$c394) {
+                          s1 = peg$c394;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c388); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c395); }
                         }
                       }
                     }
@@ -11199,7 +11412,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c389();
+      s1 = peg$c396();
     }
     s0 = s1;
 
@@ -11210,52 +11423,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c390) {
-      s1 = peg$c390;
+    if (input.substr(peg$currPos, 8) === peg$c397) {
+      s1 = peg$c397;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c391); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c392) {
-        s1 = peg$c392;
+      if (input.substr(peg$currPos, 4) === peg$c399) {
+        s1 = peg$c399;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c400); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c394) {
-          s1 = peg$c394;
+        if (input.substr(peg$currPos, 5) === peg$c401) {
+          s1 = peg$c401;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c395); }
+          if (peg$silentFails === 0) { peg$fail(peg$c402); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c396) {
-            s1 = peg$c396;
+          if (input.substr(peg$currPos, 7) === peg$c403) {
+            s1 = peg$c403;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c397); }
+            if (peg$silentFails === 0) { peg$fail(peg$c404); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c398) {
-              s1 = peg$c398;
+            if (input.substr(peg$currPos, 2) === peg$c405) {
+              s1 = peg$c405;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c399); }
+              if (peg$silentFails === 0) { peg$fail(peg$c406); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c400) {
-                s1 = peg$c400;
+              if (input.substr(peg$currPos, 3) === peg$c407) {
+                s1 = peg$c407;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c401); }
+                if (peg$silentFails === 0) { peg$fail(peg$c408); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11266,20 +11479,20 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c402) {
-                    s1 = peg$c402;
+                  if (input.substr(peg$currPos, 5) === peg$c409) {
+                    s1 = peg$c409;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c403); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c410); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c355) {
-                      s1 = peg$c355;
+                    if (input.substr(peg$currPos, 4) === peg$c362) {
+                      s1 = peg$c362;
                       peg$currPos += 4;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c363); }
                     }
                   }
                 }
@@ -11291,7 +11504,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c389();
+      s1 = peg$c396();
     }
     s0 = s1;
 
@@ -11312,7 +11525,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11345,7 +11558,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s4);
+            s1 = peg$c279(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11388,7 +11601,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c404(s1, s5);
+              s1 = peg$c411(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11428,7 +11641,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c306(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11461,7 +11674,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeFieldExternal();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s4);
+            s1 = peg$c279(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11504,7 +11717,7 @@ function peg$parse(input, options) {
             s5 = peg$parseTypeExternal();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c404(s1, s5);
+              s1 = peg$c411(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11556,121 +11769,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c405) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c407();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseOrToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c408) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c410();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseInToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c412();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseNotToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c271) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c412) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
@@ -11704,7 +11803,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseByToken() {
+  function peg$parseOrToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -11742,15 +11841,129 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseInToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c418); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c419();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseNotToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c280) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c421();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseByToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c422) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c423); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c424();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c418.test(input.charAt(peg$currPos))) {
+    if (peg$c425.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c419); }
+      if (peg$silentFails === 0) { peg$fail(peg$c426); }
     }
 
     return s0;
@@ -11761,12 +11974,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
     }
 
@@ -11780,7 +11993,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c422(s1);
+      s1 = peg$c429(s1);
     }
     s0 = s1;
 
@@ -11835,7 +12048,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c423();
+          s1 = peg$c430();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11852,11 +12065,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c424;
+        s1 = peg$c431;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c425); }
+        if (peg$silentFails === 0) { peg$fail(peg$c432); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11866,11 +12079,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c426;
+          s1 = peg$c433;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c427); }
+          if (peg$silentFails === 0) { peg$fail(peg$c434); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -11978,17 +12191,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c428;
+        s2 = peg$c435;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c429); }
+        if (peg$silentFails === 0) { peg$fail(peg$c436); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c430();
+          s1 = peg$c437();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12013,21 +12226,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c265;
+        s2 = peg$c276;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c265;
+            s4 = peg$c276;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c266); }
+            if (peg$silentFails === 0) { peg$fail(peg$c277); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12062,36 +12275,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c420.test(input.charAt(peg$currPos))) {
+    if (peg$c427.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c428); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c420.test(input.charAt(peg$currPos))) {
+        if (peg$c427.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c421); }
+          if (peg$silentFails === 0) { peg$fail(peg$c428); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c420.test(input.charAt(peg$currPos))) {
+          if (peg$c427.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c428); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12120,20 +12333,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c420.test(input.charAt(peg$currPos))) {
+    if (peg$c427.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c428); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12208,22 +12421,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c420.test(input.charAt(peg$currPos))) {
+                if (peg$c427.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c428); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c420.test(input.charAt(peg$currPos))) {
+                    if (peg$c427.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c428); }
                     }
                   }
                 } else {
@@ -12278,28 +12491,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c431;
+      s0 = peg$c438;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c432); }
+      if (peg$silentFails === 0) { peg$fail(peg$c439); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c263;
+        s1 = peg$c274;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c264); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c265;
+          s1 = peg$c276;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c266); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12325,22 +12538,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c420.test(input.charAt(peg$currPos))) {
+                if (peg$c427.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c428); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c420.test(input.charAt(peg$currPos))) {
+                    if (peg$c427.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c428); }
                     }
                   }
                 } else {
@@ -12393,11 +12606,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c265;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12443,7 +12656,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c433();
+        s1 = peg$c440();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12505,76 +12718,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c434) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c441) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c435); }
+      if (peg$silentFails === 0) { peg$fail(peg$c442); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c436) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c443) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c437); }
+        if (peg$silentFails === 0) { peg$fail(peg$c444); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c438) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c445) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c439); }
+          if (peg$silentFails === 0) { peg$fail(peg$c446); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c440) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c447) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c441); }
+            if (peg$silentFails === 0) { peg$fail(peg$c448); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c442) {
+            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c449) {
               s0 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c443); }
+              if (peg$silentFails === 0) { peg$fail(peg$c450); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c444) {
+              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c451) {
                 s0 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c445); }
+                if (peg$silentFails === 0) { peg$fail(peg$c452); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c446) {
+                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c453) {
                   s0 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c447); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c454); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c448) {
+                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c455) {
                     s0 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c449); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c456); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c450) {
+                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c457) {
                       s0 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c451); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c458); }
                     }
                   }
                 }
@@ -12759,7 +12972,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c452(s1, s2);
+        s1 = peg$c459(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12780,12 +12993,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c453) {
-            s3 = peg$c453;
+          if (input.substr(peg$currPos, 2) === peg$c460) {
+            s3 = peg$c460;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c454); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12798,7 +13011,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c455(s1, s2, s4, s5);
+                s1 = peg$c462(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12822,12 +13035,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c453) {
-          s1 = peg$c453;
+        if (input.substr(peg$currPos, 2) === peg$c460) {
+          s1 = peg$c460;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c454); }
+          if (peg$silentFails === 0) { peg$fail(peg$c461); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12840,7 +13053,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c456(s2, s3);
+              s1 = peg$c463(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12865,16 +13078,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c453) {
-                s3 = peg$c453;
+              if (input.substr(peg$currPos, 2) === peg$c460) {
+                s3 = peg$c460;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c454); }
+                if (peg$silentFails === 0) { peg$fail(peg$c461); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c457(s1, s2);
+                s1 = peg$c464(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12890,16 +13103,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c453) {
-              s1 = peg$c453;
+            if (input.substr(peg$currPos, 2) === peg$c460) {
+              s1 = peg$c460;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c454); }
+              if (peg$silentFails === 0) { peg$fail(peg$c461); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c458();
+              s1 = peg$c465();
             }
             s0 = s1;
           }
@@ -12936,7 +13149,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c459(s2);
+        s1 = peg$c466(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12965,7 +13178,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c460(s1);
+        s1 = peg$c467(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12986,17 +13199,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c267;
+        s2 = peg$c228;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c461(s1, s3);
+          s1 = peg$c468(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13021,17 +13234,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c267;
+        s2 = peg$c228;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c462(s1, s3);
+          s1 = peg$c469(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13056,7 +13269,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c463(s1);
+      s1 = peg$c470(s1);
     }
     s0 = s1;
 
@@ -13079,22 +13292,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c420.test(input.charAt(peg$currPos))) {
+    if (peg$c427.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c428); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c420.test(input.charAt(peg$currPos))) {
+        if (peg$c427.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c421); }
+          if (peg$silentFails === 0) { peg$fail(peg$c428); }
         }
       }
     } else {
@@ -13114,11 +13327,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c265;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13143,33 +13356,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c265;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c420.test(input.charAt(peg$currPos))) {
+          if (peg$c427.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c428); }
           }
         }
       } else {
@@ -13185,22 +13398,22 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c420.test(input.charAt(peg$currPos))) {
+          if (peg$c427.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c428); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c420.test(input.charAt(peg$currPos))) {
+              if (peg$c427.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                if (peg$silentFails === 0) { peg$fail(peg$c428); }
               }
             }
           } else {
@@ -13213,7 +13426,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c464();
+              s1 = peg$c471();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13238,11 +13451,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c265;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13257,22 +13470,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c420.test(input.charAt(peg$currPos))) {
+          if (peg$c427.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c428); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c420.test(input.charAt(peg$currPos))) {
+              if (peg$c427.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                if (peg$silentFails === 0) { peg$fail(peg$c428); }
               }
             }
           } else {
@@ -13285,7 +13498,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c464();
+              s1 = peg$c471();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13312,20 +13525,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c465) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c472) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c473); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c474.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c475); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13377,12 +13590,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c469.test(input.charAt(peg$currPos))) {
+    if (peg$c476.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c470); }
+      if (peg$silentFails === 0) { peg$fail(peg$c477); }
     }
 
     return s0;
@@ -13393,11 +13606,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c471;
+      s1 = peg$c478;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c479); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13408,15 +13621,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c471;
+          s3 = peg$c478;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c472); }
+          if (peg$silentFails === 0) { peg$fail(peg$c479); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c473(s2);
+          s1 = peg$c480(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13433,11 +13646,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c474;
+        s1 = peg$c481;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c475); }
+        if (peg$silentFails === 0) { peg$fail(peg$c482); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13448,15 +13661,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c474;
+            s3 = peg$c481;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c475); }
+            if (peg$silentFails === 0) { peg$fail(peg$c482); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c473(s2);
+            s1 = peg$c480(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13482,11 +13695,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c471;
+      s2 = peg$c478;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c479); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13504,7 +13717,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c476); }
+        if (peg$silentFails === 0) { peg$fail(peg$c483); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13521,11 +13734,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c426;
+        s1 = peg$c433;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c427); }
+        if (peg$silentFails === 0) { peg$fail(peg$c434); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13560,7 +13773,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c477(s1, s2);
+        s1 = peg$c484(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13589,12 +13802,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c478.test(input.charAt(peg$currPos))) {
+    if (peg$c485.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c479); }
+      if (peg$silentFails === 0) { peg$fail(peg$c486); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13610,12 +13823,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
     }
 
@@ -13627,11 +13840,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c426;
+      s1 = peg$c433;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c427); }
+      if (peg$silentFails === 0) { peg$fail(peg$c434); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13690,7 +13903,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c480(s3, s4);
+            s1 = peg$c487(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13801,7 +14014,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c481();
+          s1 = peg$c488();
         }
         s0 = s1;
       }
@@ -13815,12 +14028,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c420.test(input.charAt(peg$currPos))) {
+      if (peg$c427.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c428); }
       }
     }
 
@@ -13832,11 +14045,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c426;
+      s1 = peg$c433;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c427); }
+      if (peg$silentFails === 0) { peg$fail(peg$c434); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -13872,7 +14085,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c482();
+      s1 = peg$c489();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -13886,16 +14099,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c483();
+        s1 = peg$c490();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c467.test(input.charAt(peg$currPos))) {
+        if (peg$c474.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c468); }
+          if (peg$silentFails === 0) { peg$fail(peg$c475); }
         }
       }
     }
@@ -13910,11 +14123,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c474;
+      s2 = peg$c481;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c482); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13932,7 +14145,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c476); }
+        if (peg$silentFails === 0) { peg$fail(peg$c483); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13949,11 +14162,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c426;
+        s1 = peg$c433;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c427); }
+        if (peg$silentFails === 0) { peg$fail(peg$c434); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13979,11 +14192,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c484;
+      s1 = peg$c491;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c485); }
+      if (peg$silentFails === 0) { peg$fail(peg$c492); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -13991,7 +14204,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c486();
+          s1 = peg$c493();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14019,20 +14232,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c474;
+      s0 = peg$c481;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c482); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c471;
+        s1 = peg$c478;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c472); }
+        if (peg$silentFails === 0) { peg$fail(peg$c479); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14041,94 +14254,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c426;
+          s0 = peg$c433;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c427); }
+          if (peg$silentFails === 0) { peg$fail(peg$c434); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c487;
+            s1 = peg$c494;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c488); }
+            if (peg$silentFails === 0) { peg$fail(peg$c495); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c489();
+            s1 = peg$c496();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c490;
+              s1 = peg$c497;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c491); }
+              if (peg$silentFails === 0) { peg$fail(peg$c498); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c492();
+              s1 = peg$c499();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c493;
+                s1 = peg$c500;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c494); }
+                if (peg$silentFails === 0) { peg$fail(peg$c501); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c495();
+                s1 = peg$c502();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c496;
+                  s1 = peg$c503;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c497); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c504); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c498();
+                  s1 = peg$c505();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c499;
+                    s1 = peg$c506;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c500); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c507); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c501();
+                    s1 = peg$c508();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c502;
+                      s1 = peg$c509;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c503); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c510); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c504();
+                      s1 = peg$c511();
                     }
                     s0 = s1;
                   }
@@ -14156,7 +14369,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c482();
+      s1 = peg$c489();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14170,16 +14383,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c505();
+        s1 = peg$c512();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c467.test(input.charAt(peg$currPos))) {
+        if (peg$c474.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c468); }
+          if (peg$silentFails === 0) { peg$fail(peg$c475); }
         }
       }
     }
@@ -14192,11 +14405,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c506;
+      s1 = peg$c513;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c507); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14228,7 +14441,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c508(s2);
+        s1 = peg$c515(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14241,11 +14454,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c506;
+        s1 = peg$c513;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c507); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14312,15 +14525,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c296;
+              s4 = peg$c303;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c508(s3);
+              s1 = peg$c515(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14348,21 +14561,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c267;
+      s1 = peg$c228;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c229); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c267;
+          s3 = peg$c228;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          if (peg$silentFails === 0) { peg$fail(peg$c229); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14404,39 +14617,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c509.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c510); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c511) {
-        s2 = peg$c511;
+      if (input.substr(peg$currPos, 2) === peg$c518) {
+        s2 = peg$c518;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c512); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c509.test(input.charAt(peg$currPos))) {
+        if (peg$c516.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c510); }
+          if (peg$silentFails === 0) { peg$fail(peg$c517); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c511) {
-            s2 = peg$c511;
+          if (input.substr(peg$currPos, 2) === peg$c518) {
+            s2 = peg$c518;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c512); }
+            if (peg$silentFails === 0) { peg$fail(peg$c519); }
           }
         }
       }
@@ -14455,12 +14668,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c513.test(input.charAt(peg$currPos))) {
+    if (peg$c520.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c521); }
     }
 
     return s0;
@@ -14518,7 +14731,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c483); }
     }
 
     return s0;
@@ -14529,51 +14742,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c516;
+      s0 = peg$c523;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c517); }
+      if (peg$silentFails === 0) { peg$fail(peg$c524); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c518;
+        s0 = peg$c525;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c526); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c520;
+          s0 = peg$c527;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c521); }
+          if (peg$silentFails === 0) { peg$fail(peg$c528); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c522;
+            s0 = peg$c529;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c523); }
+            if (peg$silentFails === 0) { peg$fail(peg$c530); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c524;
+              s0 = peg$c531;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c525); }
+              if (peg$silentFails === 0) { peg$fail(peg$c532); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c526;
+                s0 = peg$c533;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c527); }
+                if (peg$silentFails === 0) { peg$fail(peg$c534); }
               }
             }
           }
@@ -14583,7 +14796,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c515); }
+      if (peg$silentFails === 0) { peg$fail(peg$c522); }
     }
 
     return s0;
@@ -14592,12 +14805,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c528.test(input.charAt(peg$currPos))) {
+    if (peg$c535.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c529); }
+      if (peg$silentFails === 0) { peg$fail(peg$c536); }
     }
 
     return s0;
@@ -14611,7 +14824,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c530); }
+      if (peg$silentFails === 0) { peg$fail(peg$c537); }
     }
 
     return s0;
@@ -14621,24 +14834,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c531) {
-      s1 = peg$c531;
+    if (input.substr(peg$currPos, 2) === peg$c538) {
+      s1 = peg$c538;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c532); }
+      if (peg$silentFails === 0) { peg$fail(peg$c539); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c533) {
-        s5 = peg$c533;
+      if (input.substr(peg$currPos, 2) === peg$c540) {
+        s5 = peg$c540;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c534); }
+        if (peg$silentFails === 0) { peg$fail(peg$c541); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -14665,12 +14878,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c533) {
-          s5 = peg$c533;
+        if (input.substr(peg$currPos, 2) === peg$c540) {
+          s5 = peg$c540;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c534); }
+          if (peg$silentFails === 0) { peg$fail(peg$c541); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -14694,12 +14907,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c533) {
-          s3 = peg$c533;
+        if (input.substr(peg$currPos, 2) === peg$c540) {
+          s3 = peg$c540;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c534); }
+          if (peg$silentFails === 0) { peg$fail(peg$c541); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -14724,12 +14937,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c535) {
-      s1 = peg$c535;
+    if (input.substr(peg$currPos, 2) === peg$c542) {
+      s1 = peg$c542;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c536); }
+      if (peg$silentFails === 0) { peg$fail(peg$c543); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14847,7 +15060,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c483); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -489,8 +489,8 @@ PoolProc
   = "from"i _ body:PoolBody { RETURN(body) }
 
 PoolBody
-  = name:PoolName at:PoolAt? over:PoolRange? order:OrderArg? {
-      RETURN(MAP("kind": "Pool", "name": name, "at": at, "range": over, "scan_order": order))
+  = spec:PoolSpec at:PoolAt? over:PoolRange? order:OrderArg? {
+      RETURN(MAP("kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order))
     }
 
 HTTPProc
@@ -514,10 +514,29 @@ PoolRange
       RETURN(MAP("kind":"Range","lower": lower, "upper": upper))
     }
 
+PoolSpec
+  = pool:PoolName "/" branch:PoolName "[" meta:IdentifierName "]" {
+      RETURN(MAP("pool": pool, "branch": branch, "meta": meta))
+    }
+  / pool:PoolName "[" meta:IdentifierName "]" {
+      RETURN(MAP("pool": pool, "branch": NULL, "meta": meta))
+    }
+  / "[" meta:IdentifierName "]" {
+      RETURN(MAP("pool": NULL, "branch": NULL, "meta": meta))
+    }
+  / pool:PoolName "/" branch:PoolName {
+      RETURN(MAP("pool": pool, "branch": branch, "meta": NULL))
+    }
+  / pool:PoolName {
+      RETURN(MAP("pool": pool, "branch": NULL, "meta": NULL))
+    }
+
 PoolName
   = name:IdentifierName { RETURN(name) }
   / id:KSUID { RETURN(id) }
   / s:QuotedString { RETURN(s) }
+
+PoolNameChar = [A-Za-z0-9_$.[\]]
 
 LayoutArg
   = _ "order"i _ keys:FieldExprs order:OrderSuffix {

--- a/compiler/reader.go
+++ b/compiler/reader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/brimdata/zed/compiler/ast"
+	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/proc"
@@ -36,15 +37,15 @@ func CompileForInternalWithOrder(pctx *proc.Context, p ast.Proc, r zio.Reader, l
 
 type internalAdaptor struct{}
 
-func (f *internalAdaptor) Lookup(_ context.Context, _ string) (ksuid.KSUID, error) {
-	return ksuid.Nil, nil
+func (f *internalAdaptor) LookupIDs(context.Context, string, string) (ksuid.KSUID, ksuid.KSUID, error) {
+	return ksuid.Nil, ksuid.Nil, nil
 }
 
-func (*internalAdaptor) Layout(_ context.Context, _ ksuid.KSUID) (order.Layout, error) {
-	return order.Nil, errors.New("invalid pool scan specified for internally streamed Zed query")
+func (f *internalAdaptor) Layout(context.Context, dag.Source) order.Layout {
+	return order.Nil
 }
 
-func (*internalAdaptor) NewScheduler(context.Context, *zson.Context, ksuid.KSUID, ksuid.KSUID, extent.Span, zbuf.Filter) (proc.Scheduler, error) {
+func (*internalAdaptor) NewScheduler(context.Context, *zson.Context, dag.Source, extent.Span, zbuf.Filter) (proc.Scheduler, error) {
 	return nil, errors.New("invalid pool or file scan specified for internally streamed Zed query")
 }
 

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -2,7 +2,6 @@ package semantic
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/compiler/ast/zed"
 	"github.com/brimdata/zed/compiler/kernel"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/field"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/nano"
@@ -73,43 +73,7 @@ func semSource(ctx context.Context, scope *Scope, source ast.Source, adaptor pro
 			Layout: layout,
 		}, nil
 	case *ast.Pool:
-		id, err := ParseID(p.Name)
-		if err != nil {
-			id, err = adaptor.Lookup(ctx, p.Name)
-			if err != nil {
-				return nil, err
-			}
-		}
-		var at ksuid.KSUID
-		if p.At != "" {
-			at, err = ParseID(p.At)
-			if err != nil {
-				return nil, err
-			}
-		}
-		var lower, upper dag.Expr
-		if r := p.Range; r != nil {
-			if r.Lower != nil {
-				lower, err = semExpr(scope, r.Lower)
-				if err != nil {
-					return nil, err
-				}
-			}
-			if r.Upper != nil {
-				upper, err = semExpr(scope, r.Upper)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-		return &dag.Pool{
-			Kind:      "Pool",
-			ID:        id,
-			ScanLower: lower,
-			ScanUpper: upper,
-			ScanOrder: p.ScanOrder,
-			At:        at,
-		}, nil
+		return semPool(ctx, scope, p, adaptor)
 	case *kernel.Reader:
 		// kernel.Reader implements both ast.Source and dag.Source
 		return p, nil
@@ -135,6 +99,69 @@ func semLayout(p *ast.Layout) (order.Layout, error) {
 		return order.Nil, err
 	}
 	return order.NewLayout(which, keys), nil
+}
+
+func semPool(ctx context.Context, scope *Scope, p *ast.Pool, adaptor proc.DataAdaptor) (dag.Source, error) {
+	if p.Spec.Pool == "" {
+		if p.Spec.Branch != "" {
+			return nil, errors.New("cannot specify a branch name without a pool name")
+		}
+		if p.Spec.Meta == "" {
+			return nil, errors.New("pool name missing")
+		}
+		return &dag.LakeMeta{
+			Kind: "LakeMeta",
+			Meta: p.Spec.Meta,
+		}, nil
+	}
+	poolID, err := parser.ParseID(p.Spec.Pool)
+	if err != nil {
+		poolID, _, err = adaptor.LookupIDs(ctx, p.Spec.Pool, p.Spec.Branch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var at ksuid.KSUID
+	if p.At != "" {
+		at, err = parser.ParseID(p.At)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var lower, upper dag.Expr
+	if r := p.Range; r != nil {
+		if r.Lower != nil {
+			lower, err = semExpr(scope, r.Lower)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if r.Upper != nil {
+			upper, err = semExpr(scope, r.Upper)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	if p.Spec.Meta != "" {
+		return &dag.PoolMeta{
+			Kind:      "PoolMeta",
+			Meta:      p.Spec.Meta,
+			ID:        poolID,
+			ScanLower: lower,
+			ScanUpper: upper,
+			ScanOrder: p.ScanOrder,
+			At:        at,
+		}, nil
+	}
+	return &dag.Pool{
+		Kind:      "Pool",
+		ID:        poolID,
+		ScanLower: lower,
+		ScanUpper: upper,
+		ScanOrder: p.ScanOrder,
+		At:        at,
+	}, nil
 }
 
 func semSequential(ctx context.Context, scope *Scope, seq *ast.Sequential, adaptor proc.DataAdaptor) (*dag.Sequential, error) {
@@ -550,28 +577,4 @@ func isConst(p ast.Proc) bool {
 		return true
 	}
 	return false
-}
-
-//XXX this needs to find a common home that doesn't import lake
-func ParseID(s string) (ksuid.KSUID, error) {
-	// Check if this is a cut-and-paste from ZNG, which encodes
-	// the 20-byte KSUID as a 40 character hex string with 0x prefix.
-	var id ksuid.KSUID
-	if len(s) == 42 && s[0:2] == "0x" {
-		b, err := hex.DecodeString(s[2:])
-		if err != nil {
-			return ksuid.Nil, fmt.Errorf("illegal hex tag: %s", s)
-		}
-		id, err = ksuid.FromBytes(b)
-		if err != nil {
-			return ksuid.Nil, fmt.Errorf("illegal hex tag: %s", s)
-		}
-	} else {
-		var err error
-		id, err = ksuid.Parse(s)
-		if err != nil {
-			return ksuid.Nil, fmt.Errorf("%s: invalid commit ID", s)
-		}
-	}
-	return id, nil
 }

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -5,10 +5,8 @@ import (
 
 	"github.com/brimdata/zed/api"
 	"github.com/brimdata/zed/driver"
-	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/lake/index"
-	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
@@ -33,11 +31,12 @@ type Interface interface {
 	Commit(ctx context.Context, pool ksuid.KSUID, id ksuid.KSUID, commit api.CommitRequest) error
 	Squash(ctx context.Context, pool ksuid.KSUID, ids []ksuid.KSUID) (ksuid.KSUID, error)
 
-	// XXX See issue #2922.  These methods should  be query endpoints...
+	// XXX ScanStaging will go away with issue #2626
 	// this way when the log converts to a sub-pool the API here is the same...
-	ScanLog(ctx context.Context, pool ksuid.KSUID, w zio.Writer, head, tail journal.ID) error
 	ScanStaging(ctx context.Context, pool ksuid.KSUID, w zio.Writer, ids []ksuid.KSUID) error
-	ScanSegments(ctx context.Context, pool ksuid.KSUID, w zio.Writer, at ksuid.KSUID, partitions bool, span extent.Span) error
-	ScanIndexRules(ctx context.Context, w zio.Writer, names []string) error
-	ScanPools(context.Context, zio.Writer) error
+}
+
+func ScanIndexRules(ctx context.Context, api Interface, d driver.Driver) error {
+	_, err := api.Query(ctx, d, "from [index_rules]")
+	return err
 }

--- a/lake/commit/log.go
+++ b/lake/commit/log.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zngbytes"
+	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
 )
 
@@ -89,8 +90,8 @@ func (l *Log) Open(ctx context.Context, head, tail journal.ID) (io.Reader, error
 	return l.journal.Open(ctx, head, tail)
 }
 
-func (l *Log) OpenAsZNG(ctx context.Context, head, tail journal.ID) (*zngio.Reader, error) {
-	return l.journal.OpenAsZNG(ctx, head, tail)
+func (l *Log) OpenAsZNG(ctx context.Context, zctx *zson.Context, head, tail journal.ID) (*zngio.Reader, error) {
+	return l.journal.OpenAsZNG(ctx, zctx, head, tail)
 }
 
 func (l *Log) Head(ctx context.Context) (*Snapshot, error) {

--- a/lake/index/store.go
+++ b/lake/index/store.go
@@ -64,7 +64,7 @@ func (s *Store) load(ctx context.Context) error {
 	if head == s.at {
 		return nil
 	}
-	r, err := s.journal.OpenAsZNG(ctx, head, 0)
+	r, err := s.journal.OpenAsZNG(ctx, zson.NewContext(), head, 0)
 	if err != nil {
 		return err
 	}

--- a/lake/journal/kvs/store.go
+++ b/lake/journal/kvs/store.go
@@ -52,7 +52,7 @@ func (s *Store) load(ctx context.Context) error {
 	if head == s.at {
 		return nil
 	}
-	r, err := s.journal.OpenAsZNG(ctx, head, 0)
+	r, err := s.journal.OpenAsZNG(ctx, zson.NewContext(), head, 0)
 	if err != nil {
 		return err
 	}

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -160,12 +160,12 @@ func (q *Queue) Open(ctx context.Context, head, tail ID) (io.Reader, error) {
 	return q.NewReader(ctx, head, tail), nil
 }
 
-func (q *Queue) OpenAsZNG(ctx context.Context, head, tail ID) (*zngio.Reader, error) {
+func (q *Queue) OpenAsZNG(ctx context.Context, zctx *zson.Context, head, tail ID) (*zngio.Reader, error) {
 	r, err := q.Open(ctx, head, tail)
 	if err != nil {
 		return nil, err
 	}
-	return zngio.NewReader(r, zson.NewContext()), nil
+	return zngio.NewReader(r, zctx), nil
 }
 
 func writeID(ctx context.Context, engine storage.Engine, u *storage.URI, id ID) error {

--- a/lake/mock/mock.go
+++ b/lake/mock/mock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/proc"
@@ -59,29 +60,33 @@ func fakeID(name string) ksuid.KSUID {
 	return id
 }
 
-func (l *Lake) Lookup(_ context.Context, name string) (ksuid.KSUID, error) {
-	pool, ok := l.pools[name]
+func (l *Lake) LookupIDs(_ context.Context, poolName, branchName string) (ksuid.KSUID, ksuid.KSUID, error) {
+	pool, ok := l.pools[poolName]
 	if !ok {
 		var err error
-		pool, err = NewPool(name)
+		pool, err = NewPool(poolName)
 		if err != nil {
-			return ksuid.Nil, err
+			return ksuid.Nil, ksuid.Nil, err
 		}
-		l.pools[name] = pool
+		l.pools[poolName] = pool
 	}
-	return pool.id, nil
+	return pool.id, ksuid.Nil, nil
 }
 
-func (l *Lake) Layout(_ context.Context, id ksuid.KSUID) (order.Layout, error) {
+func (l *Lake) Layout(_ context.Context, src dag.Source) order.Layout {
+	poolSrc, ok := src.(*dag.Pool)
+	if !ok {
+		return order.Nil
+	}
 	for _, pool := range l.pools {
-		if pool.id == id {
-			return pool.layout, nil
+		if pool.id == poolSrc.ID {
+			return pool.layout
 		}
 	}
-	return order.Nil, fmt.Errorf("%s: no such pool", id)
+	return order.Nil
 }
 
-func (*Lake) NewScheduler(context.Context, *zson.Context, ksuid.KSUID, ksuid.KSUID, extent.Span, zbuf.Filter) (proc.Scheduler, error) {
+func (*Lake) NewScheduler(context.Context, *zson.Context, dag.Source, extent.Span, zbuf.Filter) (proc.Scheduler, error) {
 	return nil, fmt.Errorf("mock.Lake.NewScheduler() should not be called")
 }
 

--- a/lake/root.go
+++ b/lake/root.go
@@ -1,14 +1,18 @@
 package lake
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"sort"
 
+	"github.com/brimdata/zed/compiler/ast/dag"
+	"github.com/brimdata/zed/expr"
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/lake/commit"
 	"github.com/brimdata/zed/lake/index"
+	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/lake/journal/kvs"
 	"github.com/brimdata/zed/lake/segment"
 	"github.com/brimdata/zed/order"
@@ -16,32 +20,40 @@ import (
 	"github.com/brimdata/zed/proc"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zngbytes"
 	"github.com/brimdata/zed/zqe"
 	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
 )
 
-var ErrPoolExists = errors.New("pool already exists")
-var ErrPoolNotFound = errors.New("pool not found")
+var (
+	ErrPoolExists   = errors.New("pool already exists")
+	ErrPoolNotFound = errors.New("pool not found")
+)
 
 const (
-	PoolsTag      = "pools"
-	IndexRulesTag = "index_rules"
+	Version         = 1
+	PoolsTag        = "pools"
+	MetaTag         = "metas"
+	IndexRulesTag   = "index_rules"
+	LakeMagicFile   = "lake.zng"
+	LakeMagicString = "ZED LAKE"
 )
 
 // The Root of the lake represents the path prefix and configuration state
 // for all of the data pools in the lake.
 type Root struct {
-	*Config
-	engine storage.Engine
-	path   *storage.URI
+	engine     storage.Engine
+	path       *storage.URI
+	pools      *kvs.Store
+	indexRules *index.Store
 }
 
 var _ proc.DataAdaptor = (*Root)(nil)
 
-type Config struct {
-	pools      *kvs.Store
-	indexRules *index.Store
+type LakeMagic struct {
+	Magic   string `zng:"magic"`
+	Version int    `zng:"version"`
 }
 
 func newRoot(engine storage.Engine, path *storage.URI) *Root {
@@ -67,11 +79,9 @@ func Create(ctx context.Context, engine storage.Engine, path *storage.URI) (*Roo
 	if err := r.loadConfig(ctx); err == nil {
 		return nil, fmt.Errorf("%s: lake already exists", path)
 	}
-	c, err := r.createConfig(ctx)
-	if err != nil {
+	if err := r.createConfig(ctx); err != nil {
 		return nil, err
 	}
-	r.Config = c
 	return r, nil
 }
 
@@ -83,37 +93,113 @@ func CreateOrOpen(ctx context.Context, engine storage.Engine, path *storage.URI)
 	return Create(ctx, engine, path)
 }
 
-func (r *Root) createConfig(ctx context.Context) (*Config, error) {
+func (r *Root) createConfig(ctx context.Context) error {
 	poolPath := r.path.AppendPath(PoolsTag)
 	rulesPath := r.path.AppendPath(IndexRulesTag)
 	types := []interface{}{PoolConfig{}}
-	pools, err := kvs.Create(ctx, r.engine, poolPath, types)
+	var err error
+	r.pools, err = kvs.Create(ctx, r.engine, poolPath, types)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	indexRules, err := index.CreateStore(ctx, r.engine, rulesPath)
+	r.indexRules, err = index.CreateStore(ctx, r.engine, rulesPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return &Config{pools, indexRules}, nil
+	if err := r.writeLakeMagic(ctx); err != nil {
+		return err
+	}
+	return err
 }
 
 func (r *Root) loadConfig(ctx context.Context) error {
+	if err := r.readLakeMagic(ctx); err != nil {
+		return err
+	}
 	poolPath := r.path.AppendPath(PoolsTag)
 	rulesPath := r.path.AppendPath(IndexRulesTag)
 	types := []interface{}{PoolConfig{}}
-	pools, err := kvs.Open(ctx, r.engine, poolPath, types)
+	var err error
+	r.pools, err = kvs.Open(ctx, r.engine, poolPath, types)
 	if err != nil {
 		return err
 	}
-	indexRules, err := index.OpenStore(ctx, r.engine, rulesPath)
+	r.indexRules, err = index.OpenStore(ctx, r.engine, rulesPath)
+	return err
+}
+
+func (r *Root) writeLakeMagic(ctx context.Context) error {
+	if err := r.readLakeMagic(ctx); err == nil {
+		return errors.New("lake already exists")
+	}
+	magic := &LakeMagic{
+		Magic:   LakeMagicString,
+		Version: Version,
+	}
+	serializer := zngbytes.NewSerializer()
+	if err := serializer.Write(magic); err != nil {
+		return err
+	}
+	if err := serializer.Close(); err != nil {
+		return err
+	}
+	path := r.path.AppendPath(LakeMagicFile)
+	err := r.engine.PutIfNotExists(ctx, path, serializer.Bytes())
+	if err == storage.ErrNotSupported {
+		//XXX workaround for now: see issue #2686
+		reader := bytes.NewReader(serializer.Bytes())
+		err = storage.Put(ctx, r.engine, path, reader)
+	}
+	return err
+}
+
+func (r *Root) readLakeMagic(ctx context.Context) error {
+	path := r.path.AppendPath(LakeMagicFile)
+	reader, err := r.engine.Get(ctx, path)
 	if err != nil {
 		return err
 	}
-	r.Config = &Config{pools, indexRules}
+	deserializer := zngbytes.NewDeserializer(reader, []interface{}{
+		LakeMagic{},
+	})
+	v, err := deserializer.Read()
+	if err != nil {
+		return err
+	}
+	magic, ok := v.(*LakeMagic)
+	if !ok {
+		return fmt.Errorf("corrupt lake magic file %q: unknown type: %T", LakeMagicFile, v)
+	}
+	if magic.Magic != LakeMagicString {
+		return fmt.Errorf("corrupt lake magic: %q should be %q", magic.Magic, LakeMagicString)
+	}
+	if magic.Version != Version {
+		return fmt.Errorf("unsupported lake version: found version %d while expecting %d", magic.Version, Version)
+	}
 	return nil
 }
 
+func (r *Root) batchifyPools(ctx context.Context, zctx *zson.Context, f expr.Filter) (zbuf.Array, error) {
+	m := zson.NewZNGMarshalerWithContext(zctx)
+	m.Decorate(zson.StyleSimple)
+	pools, err := r.ListPools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var batch zbuf.Array
+	for k := range pools {
+		rec, err := m.MarshalRecord(&pools[k])
+		if err != nil {
+			return nil, err
+		}
+		if f == nil || f(rec) {
+			batch.Append(rec)
+		}
+	}
+	return batch, nil
+}
+
+//XXX ScanPools will go away with issue #2953
 func (r *Root) ScanPools(ctx context.Context, w zio.Writer) error {
 	m := zson.NewZNGMarshaler()
 	m.Decorate(zson.StyleSimple)
@@ -182,23 +268,32 @@ func (r *Root) LookupPoolByName(ctx context.Context, name string) *PoolConfig {
 	return lookupPoolByName(pools, name)
 }
 
-func (r *Root) Lookup(ctx context.Context, nameOrID string) (ksuid.KSUID, error) {
-	if pool := r.LookupPoolByName(ctx, nameOrID); pool != nil {
-		return pool.ID, nil
+func (r *Root) LookupIDs(ctx context.Context, poolName string, branchName string) (ksuid.KSUID, ksuid.KSUID, error) {
+	if poolName == "" {
+		return ksuid.Nil, ksuid.Nil, errors.New("no pool name given")
 	}
-	id, err := ksuid.Parse(nameOrID)
+	poolID, err := ksuid.Parse(poolName)
 	if err != nil {
-		return ksuid.Nil, fmt.Errorf("%s: %w", nameOrID, ErrPoolNotFound)
+		pool := r.LookupPoolByName(ctx, poolName)
+		if pool == nil {
+			return ksuid.Nil, ksuid.Nil, fmt.Errorf("%s: pool not found", poolName)
+		}
+		poolID = pool.ID
 	}
-	return id, nil
+	// XXX need to look up branch ID
+	return poolID, ksuid.Nil, nil
 }
 
-func (r *Root) Layout(ctx context.Context, id ksuid.KSUID) (order.Layout, error) {
-	p := r.LookupPool(ctx, id)
-	if p == nil {
-		return order.Nil, fmt.Errorf("no such pool ID: %s", id)
+func (r *Root) Layout(ctx context.Context, src dag.Source) order.Layout {
+	poolSrc, ok := src.(*dag.Pool)
+	if !ok {
+		return order.Nil
 	}
-	return p.Layout, nil
+	pool := r.LookupPool(ctx, poolSrc.ID)
+	if pool == nil {
+		return order.Nil
+	}
+	return pool.Layout
 }
 
 func (r *Root) OpenPool(ctx context.Context, id ksuid.KSUID) (*Pool, error) {
@@ -305,23 +400,21 @@ func (r *Root) LookupIndexRules(ctx context.Context, name string) ([]index.Rule,
 	return r.indexRules.Lookup(ctx, name)
 }
 
-func (r *Root) ScanIndexRules(ctx context.Context, w zio.Writer, names []string) error {
-	m := zson.NewZNGMarshaler()
+func (r *Root) batchifyIndexRules(ctx context.Context, zctx *zson.Context, f expr.Filter) (zbuf.Array, error) {
+	m := zson.NewZNGMarshalerWithContext(zctx)
 	m.Decorate(zson.StyleSimple)
-	if len(names) == 0 {
-		var err error
-		names, err = r.indexRules.Names(ctx)
-		if err != nil {
-			return err
-		}
+	names, err := r.indexRules.Names(ctx)
+	if err != nil {
+		return nil, err
 	}
+	var batch zbuf.Array
 	for _, name := range names {
 		rules, err := r.indexRules.Lookup(ctx, name)
 		if err != nil {
 			if err == index.ErrNoSuchRule {
 				continue
 			}
-			return err
+			return nil, err
 		}
 		sort.Slice(rules, func(i, j int) bool {
 			return rules[i].CreateTime() < rules[j].CreateTime()
@@ -329,17 +422,103 @@ func (r *Root) ScanIndexRules(ctx context.Context, w zio.Writer, names []string)
 		for _, rule := range rules {
 			rec, err := m.MarshalRecord(rule)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			if err := w.Write(rec); err != nil {
-				return err
+			if f == nil || !f(rec) {
+				batch.Append(rec)
 			}
 		}
 	}
-	return nil
+	return batch, nil
 }
 
-func (r *Root) NewScheduler(ctx context.Context, zctx *zson.Context, id, at ksuid.KSUID, span extent.Span, filter zbuf.Filter) (proc.Scheduler, error) {
+func (r *Root) NewScheduler(ctx context.Context, zctx *zson.Context, src dag.Source, span extent.Span, filter zbuf.Filter) (proc.Scheduler, error) {
+	switch src := src.(type) {
+	case *dag.Pool:
+		return r.newPoolScheduler(ctx, zctx, src.ID, src.At, span, filter)
+	case *dag.LakeMeta:
+		return r.newLakeMetaScheduler(ctx, zctx, src.Meta, filter)
+	case *dag.PoolMeta:
+		return r.newPoolMetaScheduler(ctx, zctx, src.ID, src.Meta, src.At, span, filter)
+	default:
+		return nil, fmt.Errorf("internal error: unsupported source type in lake.Root.NewScheduler(): %T", src)
+	}
+}
+
+func (r *Root) newLakeMetaScheduler(ctx context.Context, zctx *zson.Context, meta string, filter zbuf.Filter) (proc.Scheduler, error) {
+	f, err := filter.AsFilter()
+	if err != nil {
+		return nil, err
+	}
+	var batch zbuf.Array
+	switch meta {
+	case "pools":
+		batch, err = r.batchifyPools(ctx, zctx, f)
+	case "index_rules":
+		batch, err = r.batchifyIndexRules(ctx, zctx, f)
+	default:
+		return nil, fmt.Errorf("unknown lake metadata type: %q", meta)
+	}
+	if err != nil {
+		return nil, err
+	}
+	s, err := zbuf.NewScanner(ctx, &batch, filter)
+	if err != nil {
+		return nil, err
+	}
+	return newScannerScheduler(s), nil
+}
+
+func (r *Root) newPoolMetaScheduler(ctx context.Context, zctx *zson.Context, poolID ksuid.KSUID, meta string, tag ksuid.KSUID, span extent.Span, filter zbuf.Filter) (proc.Scheduler, error) {
+	p, err := r.OpenPool(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+	switch meta {
+	case "objects":
+		snap, err := p.SnapshotOf(ctx, tag)
+		if err != nil {
+			return nil, err
+		}
+		reader, err := p.readerOfObjects(ctx, zctx, snap, span)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
+	case "partitions":
+		snap, err := p.SnapshotOf(ctx, tag)
+		if err != nil {
+			return nil, err
+		}
+		reader, err := p.readerOfPartitions(ctx, zctx, snap, span)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
+	case "log":
+		reader, err := p.Log().OpenAsZNG(ctx, zctx, journal.Nil, journal.Nil)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
+	default:
+		return nil, fmt.Errorf("unknown pool metadata type: %q", meta)
+	}
+}
+
+func (r *Root) newPoolScheduler(ctx context.Context, zctx *zson.Context, id, at ksuid.KSUID, span extent.Span, filter zbuf.Filter) (proc.Scheduler, error) {
 	pool, err := r.OpenPool(ctx, id)
 	if err != nil {
 		return nil, err

--- a/lake/ztests/ls.yaml
+++ b/lake/ztests/ls.yaml
@@ -17,7 +17,6 @@ outputs:
   - name: stdout
     data: |
       {
-          version: 0,
           name: "logs",
           layout: {
               order: "desc" (=Which),

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -3,6 +3,7 @@ package proc
 import (
 	"context"
 
+	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/zbuf"
@@ -30,9 +31,9 @@ type Interface interface {
 }
 
 type DataAdaptor interface {
-	Lookup(context.Context, string) (ksuid.KSUID, error)
-	Layout(context.Context, ksuid.KSUID) (order.Layout, error)
-	NewScheduler(context.Context, *zson.Context, ksuid.KSUID, ksuid.KSUID, extent.Span, zbuf.Filter) (Scheduler, error)
+	LookupIDs(context.Context, string, string) (ksuid.KSUID, ksuid.KSUID, error)
+	Layout(context.Context, dag.Source) order.Layout
+	NewScheduler(context.Context, *zson.Context, dag.Source, extent.Span, zbuf.Filter) (Scheduler, error)
 	Open(context.Context, *zson.Context, string, zbuf.Filter) (zbuf.PullerCloser, error)
 }
 

--- a/service/auth_test.go
+++ b/service/auth_test.go
@@ -53,7 +53,7 @@ func TestAuthIdentity(t *testing.T) {
 		Auth:   authConfig,
 		Logger: zap.NewNop(),
 	})
-	_, err := conn.ScanPools(context.Background())
+	_, err := conn.Query(context.Background(), "from [pools]")
 	require.Error(t, err)
 	require.Equal(t, 1.0, promCounterValue(core.Registry(), "request_errors_unauthorized_total"))
 
@@ -75,7 +75,7 @@ func TestAuthIdentity(t *testing.T) {
 		UserID:   "test_user_id",
 	}, res)
 
-	_, err = conn.ScanPools(context.Background())
+	_, err = conn.Query(context.Background(), "from [pools]")
 	require.NoError(t, err)
 }
 

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -56,7 +56,7 @@ func (c *testClient) zioreader(r *client.Response) zio.Reader {
 }
 
 func (c *testClient) TestPoolList() []lake.PoolConfig {
-	r, err := c.ScanPools(context.Background())
+	r, err := c.Query(context.Background(), "from [pools]")
 	require.NoError(c, err)
 	var confs []lake.PoolConfig
 	zr := c.zioreader(r)

--- a/service/core.go
+++ b/service/core.go
@@ -145,8 +145,6 @@ func (c *Core) addAPIServerRoutes() {
 	c.authhandle("/pool/{pool}", handlePoolPut).Methods("PUT")
 	c.authhandle("/pool/{pool}/add", handleAdd).Methods("POST")
 	c.authhandle("/pool/{pool}/delete", handleDelete).Methods("POST")
-	c.authhandle("/pool/{pool}/log", handleScanLog).Methods("GET")
-	c.authhandle("/pool/{pool}/segments", handleScanSegments).Methods("GET")
 	c.authhandle("/pool/{pool}/squash", handleSquash).Methods("POST")
 	c.authhandle("/pool/{pool}/staging", handleScanStaging).Methods("GET")
 	c.authhandle("/pool/{pool}/staging/{commit}", handleCommit).Methods("POST")

--- a/service/search/search.go
+++ b/service/search/search.go
@@ -117,7 +117,7 @@ func (s *SearchOp) Run(ctx context.Context, adaptor proc.DataAdaptor, pool *lake
 		Kind: "Trunk",
 		Source: &ast.Pool{
 			Kind:      "Pool",
-			Name:      pool.Name,
+			Spec:      ast.PoolSpec{Pool: pool.Name},
 			Range:     scanRange,
 			ScanOrder: scanOrder,
 		},

--- a/service/ztests/curl-create.yaml
+++ b/service/ztests/curl-create.yaml
@@ -12,4 +12,4 @@ inputs:
 outputs:
   - name: stdout
     regexp: |
-      \{"kind":"PoolConfig","value":\{"id":"\w{42}","layout":\{"keys":\[\["ts"\]\],"order":"desc"},"name":"test","threshold":524288000,"version":0\}\}
+      \{"kind":"PoolConfig","value":\{"id":"\w{42}","layout":\{"keys":\[\["ts"\]\],"order":"desc"},"name":"test","threshold":524288000\}\}

--- a/service/ztests/curl-pool-get.yaml
+++ b/service/ztests/curl-pool-get.yaml
@@ -15,4 +15,4 @@ inputs:
 outputs:
   - name: stdout
     regexp: |
-      \{"kind":"PoolConfig","value":\{"id":"\w{42}","layout":\{"keys":\[\["ts"\]\],"order":"desc"\},"name":"test","threshold":524288000,"version":0\}\}
+      \{"kind":"PoolConfig","value":\{"id":"\w{42}","layout":\{"keys":\[\["ts"\]\],"order":"desc"\},"name":"test","threshold":524288000\}\}

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -433,7 +433,14 @@ func (c *canon) proc(p ast.Proc) {
 
 func (c *canon) pool(p *ast.Pool) {
 	//XXX TBD name, from, to, id etc
-	c.write("%s", p.Name)
+	s := p.Spec.Pool
+	if p.Spec.Branch != "" {
+		s += "/" + p.Spec.Branch
+	}
+	if p.Spec.Meta != "" {
+		s += "[" + p.Spec.Meta + "]"
+	}
+	c.write("%s", s)
 }
 
 func (c *canon) http(p *ast.HTTP) {

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -385,6 +385,12 @@ func source(src dag.Source) string {
 		return fmt.Sprintf("get %s", p.URL)
 	case *dag.Pool:
 		return fmt.Sprintf("%s", p.ID)
+	case *dag.PoolMeta:
+		return fmt.Sprintf("%s.$%s", p.ID, p.Meta)
+	case *dag.BranchMeta:
+		return fmt.Sprintf("%s/%s.$%s", p.ID, p.Branch, p.Meta)
+	case *dag.LakeMeta:
+		return fmt.Sprintf("$%s", p.Meta)
 		//XXX from, to, order
 	case *kernel.Reader:
 		return "(internal reader)"


### PR DESCRIPTION
This commit adds a meta-query capability where lake metadata
can be queried via the query endpoint.  Instead of maintaining
a set of API endpoints for every possible introspection, we
manage a namespace of meta-query sources at the lake, pool,
and (soon) branch levels.  These names are available via
the "from" command via a new bracket syntax, e.g., foo[log]
is the "log" metadata source of pool "foo".

To this end, we ported a number of the zed lake CLI commands
to use the query API and removed several methods from
lake/api/Interface.

We also included stubs and forward references anticipating the
forthcoming work to add branches.

Closes #2935