### PR TITLE
move interface implementation assertions after types

### DIFF
--- a/api/queryio/zjson.go
+++ b/api/queryio/zjson.go
@@ -10,13 +10,13 @@ import (
 	"github.com/brimdata/zed/zson"
 )
 
-var _ ControlWriter = &ZJSONWriter{}
-
 type ZJSONWriter struct {
 	encoder   *json.Encoder
 	marshaler *zson.MarshalZNGContext
 	stream    *zjsonio.Stream
 }
+
+var _ ControlWriter = (*ZJSONWriter)(nil)
 
 func NewZJSONWriter(w io.Writer) *ZJSONWriter {
 	m := zson.NewZNGMarshaler()

--- a/cmd/zed/api/command.go
+++ b/cmd/zed/api/command.go
@@ -19,12 +19,12 @@ var Cmd = &charm.Spec{
 	New:   New,
 }
 
-var _ zedlake.Command = (*Command)(nil)
-
 type Command struct {
 	*root.Command
 	Host string
 }
+
+var _ zedlake.Command = (*Command)(nil)
 
 const HostEnv = "ZED_LAKE_HOST"
 

--- a/compiler/kernel/proc.go
+++ b/compiler/kernel/proc.go
@@ -60,9 +60,9 @@ type Reader struct {
 	Layout order.Layout
 }
 
-func (*Reader) Source() {}
-
 var _ dag.Source = (*Reader)(nil)
+
+func (*Reader) Source() {}
 
 func isContainerOp(op dag.Op) bool {
 	switch op.(type) {

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -19,12 +19,12 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
-var _ Interface = (*LocalSession)(nil)
-
 type LocalSession struct {
 	root   *lake.Root
 	engine storage.Engine
 }
+
+var _ Interface = (*LocalSession)(nil)
 
 func OpenLocalLake(ctx context.Context, lakePath *storage.URI) (*LocalSession, error) {
 	engine := storage.NewLocalEngine()

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -23,11 +23,11 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
-var _ Interface = (*RemoteSession)(nil)
-
 type RemoteSession struct {
 	conn *client.Connection
 }
+
+var _ Interface = (*RemoteSession)(nil)
 
 func OpenRemoteLake(ctx context.Context, host string) (*RemoteSession, error) {
 	return &RemoteSession{

--- a/proc/rename/renamer.go
+++ b/proc/rename/renamer.go
@@ -11,8 +11,6 @@ import (
 	"github.com/brimdata/zed/zson"
 )
 
-var _ proc.Function = (*Function)(nil)
-
 type Function struct {
 	zctx *zson.Context
 	// For the dst field name, we just store the leaf name since the
@@ -21,6 +19,8 @@ type Function struct {
 	dsts    field.List
 	typeMap map[int]*zng.TypeRecord
 }
+
+var _ proc.Function = (*Function)(nil)
 
 func NewFunction(zctx *zson.Context, srcs, dsts field.List) *Function {
 	return &Function{zctx, srcs, dsts, make(map[int]*zng.TypeRecord)}


### PR DESCRIPTION
Conventionally, an assertion that a type implements an interface (e.g.,
"var _ I = (*T)(nil)" at top level) conventionally follows the type
declaration.