### PR TITLE
zio/tableio: preserve field name case in output

### DIFF
--- a/docs/lake/README.md
+++ b/docs/lake/README.md
@@ -104,7 +104,7 @@ zed lake query "count()" | zq -f table -
 ```
 which, for example, results in:
 ```
-COUNT
+count
 1462078
 ```
 
@@ -336,7 +336,7 @@ zed lake find -x custom.zng 10.164.94.120 | zq -f table "count=sum(count) by _pa
 ```
 You'll get
 ```
-_PATH       COUNT
+_path       count
 conn        26726
 http        13485
 ssl         9538
@@ -458,7 +458,7 @@ zed lake map "sort -r count | head 1000" wordcounts.zng | zq -f table "sum(count
 ```
 and you get the top-ten URIs...
 ```
-URI                     SUM
+uri                     sum
 /wordpress/wp-login.php 6516
 /                       5848
 /api/get/3/6            4677
@@ -503,7 +503,7 @@ zed lake find -x graph.zng 216.58.193.195 | zq -f table "count=sum(count) by fro
 to get a listing of all of the edges from IP 216.58.193.195 to any other IP,
 which looks like this:
 ```
-FROM_ADDR      TO_ADDR      COUNT
+from_addr      to_addr      count
 216.58.193.195 10.47.2.155  55
 216.58.193.195 10.47.2.100  47
 216.58.193.195 10.47.6.162  31

--- a/docs/language/aggregate-functions/README.md
+++ b/docs/language/aggregate-functions/README.md
@@ -46,7 +46,7 @@ zq -f table 'min(duration),max(duration),avg(duration)' conn.log.gz
 
 #### Output:
 ```mdtest-output
-MIN      MAX         AVG
+min      max         avg
 0.000001 1269.512465 1.6373747834138621
 ```
 
@@ -64,7 +64,7 @@ zq -f table 'quickest:=min(duration),longest:=max(duration),typical:=avg(duratio
 
 #### Output:
 ```mdtest-output
-QUICKEST LONGEST     TYPICAL
+quickest longest     typical
 0.000001 1269.512465 1.6373747834138621
 ```
 
@@ -91,7 +91,7 @@ zq -f table 'answers != null | every 5m short_rtt:=avg(rtt) where len(answers)<=
 
 #### Output:
 ```mdtest-output
-TS                   SHORT_RTT            SHORT_COUNT LONG_RTT             LONG_COUNT
+ts                   short_rtt            short_count long_rtt             long_count
 2018-03-24T17:15:00Z 0.004386461911629731 7628        0.01571223665048545  824
 2018-03-24T17:20:00Z 0.006360169034406226 9010        0.01992656544502617  764
 2018-03-24T17:25:00Z 0.006063177039132521 8486        0.02742244411764705  680
@@ -123,7 +123,7 @@ zq -f table 'count() by name | sort -r count' weird.log.gz
 
 #### Output:
 ```mdtest-output head
-NAME                                        COUNT
+name                                        count
 bad_HTTP_request                            11777
 line_terminated_with_single_CR              11734
 unknown_HTTP_method                         140
@@ -140,7 +140,7 @@ zq -f table 'only_bads:=and(name=="bad_HTTP_request") by uid | count() where onl
 
 #### Output:
 ```mdtest-output
-COUNT
+count
 37
 ```
 
@@ -169,7 +169,7 @@ case, the output is:
 
 #### Output:
 ```mdtest-output
-ANY
+any
 TCP_ack_underflow_or_misorder
 ```
 
@@ -195,7 +195,7 @@ zq -f table 'avg(orig_bytes)' conn.log.gz
 
 #### Output:
 ```mdtest-output
-AVG
+avg
 176.9861548654682
 ```
 
@@ -221,7 +221,7 @@ zq -f table 'host=="www.bing.com" | methods:=collect(method) by uid | sort uid' 
 
 #### Output:
 ```mdtest-output head
-UID                METHODS
+uid                methods
 C1iilt2FG8PnyEl0bb GET,GET,POST,GET,GET,POST
 C31wi6XQB8h9igoa5  GET,GET,POST,POST,POST
 CFwagt4ivDe3p6R7U8 GET,GET,POST,POST,GET,GET,GET,POST,POST,GET,GET,GET,GET,POST
@@ -250,7 +250,7 @@ zq -f table 'count()' *.log.gz
 
 #### Output:
 ```mdtest-output
-COUNT
+count
 1462078
 ```
 
@@ -265,7 +265,7 @@ zq -f table 'count(mime_type) by _path | filter count > 0 | sort -r count' *.log
 ```
 
 ```mdtest-output
-_PATH COUNT
+_path count
 files 162986
 ftp   93
 ```
@@ -292,7 +292,7 @@ zq -f table 'countdistinct(uid)' *
 
 #### Output:
 ```mdtest-output
-COUNTDISTINCT
+countdistinct
 1029651
 ```
 
@@ -304,7 +304,7 @@ zq -f table 'count() by uid | count()' *
 
 #### Output:
 ```mdtest-output
-COUNT
+count
 1021953
 ```
 
@@ -333,7 +333,7 @@ zq -f table 'max(orig_bytes)' conn.log.gz
 
 #### Output:
 ```mdtest-output
-MAX
+max
 4862366
 ```
 
@@ -359,7 +359,7 @@ zq -f table 'min(rtt)' dns.log.gz
 
 #### Output:
 ```mdtest-output
-MIN
+min
 0.000012
 ```
 
@@ -385,7 +385,7 @@ zq -f table 'count() by id.resp_p | sort -r count' http.log.gz
 
 #### Output:
 ```mdtest-output head
-ID.RESP_P COUNT
+id.resp_p count
 80        134496
 8080      5204
 5800      1691
@@ -397,13 +397,13 @@ The following query confirms this high-port traffic is present, but that none
 of those ports are higher than what TCP allows.
 
 ```mdtest-command zed-sample-data/zeek-default
-zq -f table 'some_highports:=or(id.resp_p>80),impossible_ports:=or(id.resp_p>65535)' http.log.gz
+zq -f table 'some_high_ports:=or(id.resp_p>80),impossible_ports:=or(id.resp_p>65535)' http.log.gz
 ```
 
 #### Output:
 ```mdtest-output
-SOME_HIGHPORTS IMPOSSIBLE_PORTS
-T              F
+some_high_ports impossible_ports
+T               F
 ```
 
 ---
@@ -428,7 +428,7 @@ zq -f table 'sum(total_bytes)' files.log.gz
 
 #### Output:
 ```mdtest-output
-SUM
+sum
 3092961270
 ```
 
@@ -455,7 +455,7 @@ zq -f table 'host=="www.bing.com" | methods:=union(method) by uid | sort uid' ht
 
 #### Output:
 ```mdtest-output head
-UID                METHODS
+uid                methods
 C1iilt2FG8PnyEl0bb GET,POST
 C31wi6XQB8h9igoa5  GET,POST
 CFwagt4ivDe3p6R7U8 GET,POST

--- a/docs/language/data-types/README.md
+++ b/docs/language/data-types/README.md
@@ -37,6 +37,6 @@ zq -f table 'put ref_id:=ip(ref_id)| filter ref_id in 83.162.0.0/16 | count()' n
 #### Output:
 ```mdtest-output
 bad cast
-COUNT
+count
 28
 ```

--- a/docs/language/expressions/README.md
+++ b/docs/language/expressions/README.md
@@ -9,7 +9,7 @@ zq -f table 'duration > 100 | put total_bytes:=orig_bytes+resp_bytes | cut orig_
 
 #### Output:
 ```mdtest-output head
-ORIG_BYTES RESP_BYTES TOTAL_BYTES
+orig_bytes resp_bytes total_bytes
 32         0          32
 32         0          32
 406        1720       2126

--- a/docs/language/grouping/README.md
+++ b/docs/language/grouping/README.md
@@ -48,7 +48,7 @@ zq -f table 'every 1m sum(orig_bytes) | sort -r ts' conn.log.gz
 
 #### Output:
 ```mdtest-output head
-TS                   SUM
+ts                   sum
 2018-03-24T17:36:00Z 1443272
 2018-03-24T17:35:00Z 3851308
 2018-03-24T17:34:00Z 4704644
@@ -67,7 +67,7 @@ zq -f table 'every 0.5m count() | sort -r count' *.log.gz
 
 #### Output:
 ```mdtest-output head
-TS                   COUNT
+ts                   count
 2018-03-24T17:19:00Z 73512
 2018-03-24T17:16:30Z 59701
 2018-03-24T17:20:00Z 51229
@@ -85,7 +85,7 @@ zq -f table 'every 1m30s max(id.resp_p) | sort -r ts' conn.log.gz
 
 #### Output:
 ```mdtest-output head
-TS                   MAX
+ts                   max
 2018-03-24T17:36:00Z 60008
 2018-03-24T17:34:30Z 60008
 2018-03-24T17:33:00Z 65389
@@ -111,7 +111,7 @@ zq -f table 'by proto | sort' conn.log.gz
 
 #### Output:
 ```mdtest-output
-PROTO
+proto
 icmp
 tcp
 udp
@@ -127,7 +127,7 @@ zq -f table 'cut proto | sort | uniq' conn.log.gz
 
 #### Output:
 ```mdtest-output
-PROTO
+proto
 icmp
 tcp
 udp
@@ -145,7 +145,7 @@ zq -f table 'sum(resp_bytes) by id.resp_h,id.resp_p  | sort -r sum' conn.log.gz
 
 #### Output:
 ```mdtest-output head
-ID.RESP_H       ID.RESP_P SUM
+id.resp_h       id.resp_p sum
 52.216.132.61   443       1781778597
 10.47.3.200     80        1544111786
 91.189.91.23    80        745226873
@@ -172,7 +172,7 @@ zq -f table 'len(answers) > 0 | count() by id.resp_h,num_answers:=len(answers) |
 
 #### Output:
 ```mdtest-output head
-ID.RESP_H       NUM_ANSWERS COUNT
+id.resp_h       num_answers count
 10.0.0.100      16          4
 216.239.34.10   16          2
 209.112.113.33  15          2
@@ -194,7 +194,7 @@ zq -f table 'count() by host | sort -r | head 3' http.log.gz
 
 #### Output:
 ```mdtest-output
-HOST       COUNT
+host       count
 10.47.7.58 24693
 10.47.2.58 16499
 10.47.6.58 15180
@@ -208,7 +208,7 @@ zq -f table 'count() by query | sort -r | head 3' dns.log.gz
 
 #### Output:
 ```mdtest-output
-QUERY                                                     COUNT
+query                                                     count
 ise.wrccdc.org                                            22160
 *\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 3834
 videosearch.ubuntu.com                                    1088
@@ -256,7 +256,7 @@ zq -f table 'fuse | count() by host,query | sort -r | head 3' http.log.gz dns.lo
 
 #### Output:
 ```mdtest-output
-HOST       QUERY          COUNT
+host       query          count
 10.47.7.58 -              24693
 -          ise.wrccdc.org 22160
 10.47.2.58 -              16499
@@ -279,7 +279,7 @@ zq -f table 'every 5m count() | sort ts' *.log.gz
 
 #### Output:
 ```mdtest-output
-TS                   COUNT
+ts                   count
 2018-03-24T17:15:00Z 441229
 2018-03-24T17:20:00Z 337264
 2018-03-24T17:25:00Z 310546
@@ -295,7 +295,7 @@ zq -f table 'every 5m count() | sort count' *.log.gz
 
 #### Output:
 ```mdtest-output
-TS                   COUNT
+ts                   count
 2018-03-24T17:35:00Z 98755
 2018-03-24T17:30:00Z 274284
 2018-03-24T17:25:00Z 310546

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -50,7 +50,7 @@ zq -f table 'cut ts,uid' conn.log.gz
 
 #### Output:
 ```mdtest-output head
-TS                          UID
+ts                          uid
 2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
 2018-03-24T17:15:21.926018Z CM59GGQhNEoKONb5i
@@ -71,7 +71,7 @@ zq -f table 'cut _path,ts,share_type' *
 
 #### Output:
 ```mdtest-output head
-_PATH        TS
+_path        ts
 capture_loss 2018-03-24T17:30:20.600852Z
 capture_loss 2018-03-24T17:36:30.158766Z
 conn         2018-03-24T17:15:21.255387Z
@@ -106,7 +106,7 @@ zq -f table 'cut time:=ts,uid' conn.log.gz
 
 #### Output:
 ```mdtest-output head
-TIME                        UID
+time                        uid
 2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
 2018-03-24T17:15:21.926018Z CM59GGQhNEoKONb5i
@@ -134,7 +134,7 @@ zq -f table 'drop _path,id' weird.log.gz
 
 #### Output:
 ```mdtest-output head
-TS                          UID                NAME                             ADDL             NOTICE PEER
+ts                          uid                name                             addl             notice peer
 2018-03-24T17:15:20.600843Z C1zOivgBT6dBmknqk  TCP_ack_underflow_or_misorder    -                F      zeek
 2018-03-24T17:15:20.608108Z -                  truncated_header                 -                F      zeek
 2018-03-24T17:15:20.610033Z C45Ff03lESjMQQQej1 above_hole_data_without_any_acks -                F      zeek
@@ -167,7 +167,7 @@ zq -f table 'cut ts,uid | filter uid=="CXWfTK3LRdiuQxBbM6"' conn.log.gz
 
 #### Output:
 ```mdtest-output
-TS                          UID
+ts                          uid
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
 ```
 
@@ -181,7 +181,7 @@ zq -f table 'filter www.*cdn*.com _path=="ssl"' *.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H    ID.RESP_P VERSION CIPHER                                CURVE     SERVER_NAME       RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS                                                            CLIENT_CERT_CHAIN_FUIDS SUBJECT            ISSUER                                  CLIENT_SUBJECT CLIENT_ISSUER VALIDATION_STATUS
+_path ts                          uid                id.orig_h   id.orig_p id.resp_h    id.resp_p version cipher                                curve     server_name       resumed last_alert next_protocol established cert_chain_fuids                                                            client_cert_chain_fuids subject            issuer                                  client_subject client_issuer validation_status
 ssl   2018-03-24T17:23:00.244457Z CUG0fiQAzL4rNWxai  10.47.2.100 36150     52.85.83.228 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FXKmyTbr7HlvyL1h8,FADhCTvkq1ILFnD3j,FoVjYR16c3UIuXj4xk,FmiRYe1P53KOolQeVi   (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
 ssl   2018-03-24T17:24:00.189735Z CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FuW2cZ3leE606wXSia,Fu5kzi1BUwnF0bSCsd,FyTViI32zPvCmNXgSi,FwV6ff3JGj4NZcVPE4 (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
 ```
@@ -208,9 +208,9 @@ zq -f table 'ts < 1521911721' stats.log.gz weird.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          PEER MEM PKTS_PROC BYTES_RECV PKTS_DROPPED PKTS_LINK PKT_LAG EVENTS_PROC EVENTS_QUEUED ACTIVE_TCP_CONNS ACTIVE_UDP_CONNS ACTIVE_ICMP_CONNS TCP_CONNS UDP_CONNS ICMP_CONNS TIMERS ACTIVE_TIMERS FILES ACTIVE_FILES DNS_REQUESTS ACTIVE_DNS_REQUESTS REASSEM_TCP_SIZE REASSEM_FILE_SIZE REASSEM_FRAG_SIZE REASSEM_UNKNOWN_SIZE
+_path ts                          peer mem pkts_proc bytes_recv pkts_dropped pkts_link pkt_lag events_proc events_queued active_tcp_conns active_udp_conns active_icmp_conns tcp_conns udp_conns icmp_conns timers active_timers files active_files dns_requests active_dns_requests reassem_tcp_size reassem_file_size reassem_frag_size reassem_unknown_size
 stats 2018-03-24T17:15:20.600725Z zeek 74  26        29375      -            -         -       404         11            1                0                0                 1         0         0          36     32            0     0            0            0                   1528             0                 0                 0
-_PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H      ID.RESP_P NAME                             ADDL NOTICE PEER
+_path ts                          uid                id.orig_h   id.orig_p id.resp_h      id.resp_p name                             addl notice peer
 weird 2018-03-24T17:15:20.600843Z C1zOivgBT6dBmknqk  10.47.1.152 49562     23.217.103.245 80        TCP_ack_underflow_or_misorder    -    F      zeek
 weird 2018-03-24T17:15:20.608108Z -                  -           -         -              -         truncated_header                 -    F      zeek
 weird 2018-03-24T17:15:20.610033Z C45Ff03lESjMQQQej1 10.47.5.155 40712     91.189.91.23   80        above_hole_data_without_any_acks -    F      zeek
@@ -278,7 +278,7 @@ zq -f table 'head' dns.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT     QUERY          QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                        TTLS       REJECTED
+_path ts                          uid                id.orig_h   id.orig_p id.resp_h  id.resp_p proto trans_id rtt     query          qclass qclass_name qtype qtype_name rcode rcode_name AA TC RD RA Z answers                        TTLs       rejected
 dns   2018-03-24T17:15:20.865716Z C2zK5f13SbCtKcyiW5 10.47.1.100 41772     10.0.0.100 53        udp   36329    0.00087 ise.wrccdc.org 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 ise.wrccdc.cpp.edu,134.71.3.16 2230,41830 F
 ```
 
@@ -292,7 +292,7 @@ zq -f table 'id.resp_p==80 | head 5' conn.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H   ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY   ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid                id.orig_h     id.orig_p id.resp_h   id.resp_p proto service duration orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history   orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:15:20.602122Z C4RZ6d4r5mJHlSYFI6 10.164.94.120 33299     10.47.3.200 80        tcp   -       0.003077 0          235        RSTO       -          -          0            ^dtfAR    4         208           4         678           -
 conn  2018-03-24T17:15:20.606178Z CnKmhv4RfyAZ3fVc8b 10.164.94.120 36125     10.47.3.200 80        tcp   -       0.000002 0          0          RSTOS0     -          -          0            R         2         104           0         0             -
 conn  2018-03-24T17:15:20.604325Z C65IMkEAWNlE1f6L8  10.164.94.120 45941     10.47.3.200 80        tcp   -       0.002708 0          242        RSTO       -          -          0            ^dtfAR    4         208           4         692           -
@@ -616,7 +616,7 @@ zq -f table 'pick ts,uid' conn.log.gz
 
 #### Output:
 ```mdtest-output head
-TS                          UID
+ts                          uid
 2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
 2018-03-24T17:15:21.926018Z CM59GGQhNEoKONb5i
@@ -637,7 +637,7 @@ zq -f table 'pick _path,ts,share_type' *
 
 #### Output:
 ```mdtest-output head
-_PATH       TS                          SHARE_TYPE
+_path       ts                          share_type
 smb_mapping 2018-03-24T17:15:21.382822Z DISK
 smb_mapping 2018-03-24T17:15:21.625534Z PIPE
 smb_mapping 2018-03-24T17:15:22.021668Z PIPE
@@ -672,7 +672,7 @@ zq -f table 'pick time:=ts,uid' conn.log.gz
 
 #### Output:
 ```mdtest-output head
-TIME                        UID
+time                        uid
 2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl
 2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6
 2018-03-24T17:15:21.926018Z CM59GGQhNEoKONb5i
@@ -701,7 +701,7 @@ zq -q -f table 'put total_bytes := orig_bytes + resp_bytes | sort -r total_bytes
 
 #### Output:
 ```mdtest-output head
-ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P ORIG_BYTES RESP_BYTES TOTAL_BYTES
+id.orig_h     id.orig_p id.resp_h       id.resp_p orig_bytes resp_bytes total_bytes
 10.47.7.154   27300     52.216.132.61   443       859        1781771107 1781771966
 10.164.94.120 33691     10.47.3.200     80        355        1543916493 1543916848
 10.47.8.100   37110     128.101.240.215 80        16398      376626606  376643004
@@ -732,7 +732,7 @@ Rename `ts` to `time`, rename one of the inner fields of `id`, and rename the `i
 
 #### Output:
 ```mdtest-output head
-_PATH TIME                        UID                CONNTUPLE.SRC  CONNTUPLE.ORIG_P CONNTUPLE.RESP_H CONNTUPLE.RESP_P PROTO SERVICE  DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY     ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path time                        uid                conntuple.src  conntuple.orig_p conntuple.resp_h conntuple.resp_p proto service  duration orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history     orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl 10.164.94.120  39681            10.47.3.155      3389             tcp   -        0.004266 97         19         RSTR       -          -          0            ShADTdtr    10        730           6         342           -
 conn  2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6 10.47.25.80    50817            10.128.0.218     23189            tcp   -        0.000486 0          0          REJ        -          -          0            Sr          2         104           2         80            -
 conn  2018-03-24T17:15:21.926018Z CM59GGQhNEoKONb5i  10.47.25.80    50817            10.128.0.218     23189            tcp   -        0.000538 0          0          REJ        -          -          0            Sr          2         104           2         80            -
@@ -761,7 +761,7 @@ zq -f table 'sort certificate.subject' x509.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH TS                          ID                 CERTIFICATE.VERSION CERTIFICATE.SERIAL                     CERTIFICATE.SUBJECT                                                                               CERTIFICATE.ISSUER                                                                                                                                       CERTIFICATE.NOT_VALID_BEFORE CERTIFICATE.NOT_VALID_AFTER CERTIFICATE.KEY_ALG CERTIFICATE.SIG_ALG     CERTIFICATE.KEY_TYPE CERTIFICATE.KEY_LENGTH CERTIFICATE.EXPONENT CERTIFICATE.CURVE SAN.DNS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      SAN.URI SAN.EMAIL SAN.IP BASIC_CONSTRAINTS.CA BASIC_CONSTRAINTS.PATH_LEN
+_path ts                          id                 certificate.version certificate.serial                     certificate.subject                                                                               certificate.issuer                                                                                                                                       certificate.not_valid_before certificate.not_valid_after certificate.key_alg certificate.sig_alg     certificate.key_type certificate.key_length certificate.exponent certificate.curve san.dns                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      san.uri san.email san.ip basic_constraints.ca basic_constraints.path_len
 x509  2018-03-24T17:29:38.233315Z Fn2Gkp2Qd434JylJX9 3                   CB11D05B561B4BB1                       C=/C=US/ST=HI/O=Goldner and Sons/OU=1080p/CN=goldner.sons.net/emailAddress=1080p@goldner.sons.net C=/C=US/ST=HI/O=Goldner and Sons/OU=1080p/CN=goldner.sons.net/emailAddress=1080p@goldner.sons.net                                                        2016-05-09T10:09:02Z         2018-05-09T10:09:02Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            -       -         -      T                    -
 x509  2018-03-24T17:18:48.524223Z Fxq7P31K2FS3v7CBSh 3                   031489479BCD9C116EA7B6162E5E68E6       CN=*.adnxs.com,O=AppNexus\\, Inc.,L=New York,ST=New York,C=US                                     CN=DigiCert ECC Secure Server CA,O=DigiCert Inc,C=US                                                                                                     2018-01-25T08:00:00Z         2019-01-25T20:00:00Z        id-ecPublicKey      ecdsa-with-SHA256       ecdsa                256                    -                    prime256v1        *.adnxs.com,adnxs.com                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        -       -         -      F                    -
 x509  2018-03-24T17:18:48.524679Z F6WWPk3ajsHLrmNFdb 3                   031489479BCD9C116EA7B6162E5E68E6       CN=*.adnxs.com,O=AppNexus\\, Inc.,L=New York,ST=New York,C=US                                     CN=DigiCert ECC Secure Server CA,O=DigiCert Inc,C=US                                                                                                     2018-01-25T08:00:00Z         2019-01-25T20:00:00Z        id-ecPublicKey      ecdsa-with-SHA256       ecdsa                256                    -                    prime256v1        *.adnxs.com,adnxs.com                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        -       -         -      F                    -
@@ -786,7 +786,7 @@ zq -f table 'sort certificate.subject,id' x509.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH TS                          ID                 CERTIFICATE.VERSION CERTIFICATE.SERIAL                     CERTIFICATE.SUBJECT                                                                               CERTIFICATE.ISSUER                                                                                                                                       CERTIFICATE.NOT_VALID_BEFORE CERTIFICATE.NOT_VALID_AFTER CERTIFICATE.KEY_ALG CERTIFICATE.SIG_ALG     CERTIFICATE.KEY_TYPE CERTIFICATE.KEY_LENGTH CERTIFICATE.EXPONENT CERTIFICATE.CURVE SAN.DNS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      SAN.URI SAN.EMAIL SAN.IP BASIC_CONSTRAINTS.CA BASIC_CONSTRAINTS.PATH_LEN
+_path ts                          id                 certificate.version certificate.serial                     certificate.subject                                                                               certificate.issuer                                                                                                                                       certificate.not_valid_before certificate.not_valid_after certificate.key_alg certificate.sig_alg     certificate.key_type certificate.key_length certificate.exponent certificate.curve san.dns                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      san.uri san.email san.ip basic_constraints.ca basic_constraints.path_len
 x509  2018-03-24T17:29:38.233315Z Fn2Gkp2Qd434JylJX9 3                   CB11D05B561B4BB1                       C=/C=US/ST=HI/O=Goldner and Sons/OU=1080p/CN=goldner.sons.net/emailAddress=1080p@goldner.sons.net C=/C=US/ST=HI/O=Goldner and Sons/OU=1080p/CN=goldner.sons.net/emailAddress=1080p@goldner.sons.net                                                        2016-05-09T10:09:02Z         2018-05-09T10:09:02Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            -       -         -      T                    -
 x509  2018-03-24T17:18:48.524679Z F6WWPk3ajsHLrmNFdb 3                   031489479BCD9C116EA7B6162E5E68E6       CN=*.adnxs.com,O=AppNexus\\, Inc.,L=New York,ST=New York,C=US                                     CN=DigiCert ECC Secure Server CA,O=DigiCert Inc,C=US                                                                                                     2018-01-25T08:00:00Z         2019-01-25T20:00:00Z        id-ecPublicKey      ecdsa-with-SHA256       ecdsa                256                    -                    prime256v1        *.adnxs.com,adnxs.com                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        -       -         -      F                    -
 x509  2018-03-24T17:18:48.524223Z Fxq7P31K2FS3v7CBSh 3                   031489479BCD9C116EA7B6162E5E68E6       CN=*.adnxs.com,O=AppNexus\\, Inc.,L=New York,ST=New York,C=US                                     CN=DigiCert ECC Secure Server CA,O=DigiCert Inc,C=US                                                                                                     2018-01-25T08:00:00Z         2019-01-25T20:00:00Z        id-ecPublicKey      ecdsa-with-SHA256       ecdsa                256                    -                    prime256v1        *.adnxs.com,adnxs.com                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        -       -         -      F                    -
@@ -814,7 +814,7 @@ zq -f table 'count() by id.orig_h | sort -r' conn.log.gz
 
 #### Output:
 ```mdtest-output head
-ID.ORIG_H                COUNT
+id.orig_h                count
 10.174.251.215           279014
 10.47.24.81              162237
 10.47.26.82              153056
@@ -834,7 +834,7 @@ zq -f table 'count() by username | sort -nulls first username' http.log.gz
 
 #### Output:
 ```mdtest-output
-USERNAME     COUNT
+username     count
 -            139175
 M32318       4854
 agloop       1
@@ -865,7 +865,7 @@ zq -f table 'tail' dns.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H ID.RESP_P PROTO TRANS_ID RTT QUERY           QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS TTLS REJECTED
+_path ts                          uid                id.orig_h    id.orig_p id.resp_h id.resp_p proto trans_id rtt query           qclass qclass_name qtype qtype_name rcode rcode_name AA TC RD RA Z answers TTLs rejected
 dns   2018-03-24T17:36:30.151237Z C0ybvu4HG3yWv6H5cb 172.31.255.5 60878     10.0.0.1  53        udp   36243    -   talk.google.com 1      C_INTERNET  1     A          -     -          F  F  T  F  0 -       -    F
 ```
 
@@ -879,7 +879,7 @@ zq -f table 'id.resp_p==80 | tail 5' conn.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H      ID.ORIG_P ID.RESP_H    ID.RESP_P PROTO SERVICE DURATION  ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY    ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid                id.orig_h      id.orig_p id.resp_h    id.resp_p proto service duration  orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history    orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:33:23.087149Z CqPl942ft1MCpuNQgk 10.218.221.240 63812     10.47.2.20   80        tcp   -       15.607782 0          0          S1         -          -          0            Sh         2         88            10        440           -
 conn  2018-03-24T17:36:25.557756Z CKCuBO2N2sY6m8qkv6 10.128.0.247   30549     10.47.22.65  80        tcp   http    0.006639  334        271        SF         -          -          0            ShADTftFa  10        1092          6         806           -
 conn  2018-03-24T17:35:20.422826Z Cy1XB41BipfyCcCGVh 10.128.0.247   30487     10.47.2.58   80        tcp   http    68.309996 21249      15506      S1         -          -          0            ShADTadtTt 242       52202         270       41836         -
@@ -908,7 +908,7 @@ zq -f table 'cut certificate.issuer | sort | uniq -c | sort -r' x509.log.gz
 
 #### Output:
 ```mdtest-output head
-CERTIFICATE.ISSUER                                                                                                                                       _UNIQ
+certificate.issuer                                                                                                                                       _uniq
 O=VMware Installer                                                                                                                                       1761
 CN=Snozberry                                                                                                                                             1108
 ...

--- a/docs/language/search-syntax/README.md
+++ b/docs/language/search-syntax/README.md
@@ -103,7 +103,7 @@ zq -f table '10.150.0.85' *.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H   ID.RESP_P PROTO SERVICE DURATION  ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY         ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid                id.orig_h    id.orig_p id.resp_h   id.resp_p proto service duration  orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history         orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:15:22.18798Z  CFis4J1xm9BOgtib34 10.47.8.10   56800     10.150.0.85 443       tcp   -       1.000534  31         77         SF         -          -          0            ^dtAfDTFr       8         382           10        554           -
 conn  2018-03-24T17:15:25.527535Z CnvVUp1zg3fnDKrlFk 10.47.27.186 58665     10.150.0.85 443       tcp   -       1.000958  31         77         SF         -          -          0            ^dtAfDFTr       8         478           10        626           -
 conn  2018-03-24T17:15:27.167552Z CsSFJyH4ucFtpmhqa  10.10.18.2   57331     10.150.0.85 443       tcp   -       1.000978  31         77         SF         -          -          0            ^dtAfDFTr       8         478           10        626           -
@@ -144,9 +144,9 @@ zq -f table '"O=Internet Widgits"' *.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH  TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H   ID.RESP_P FUID               FILE_MIME_TYPE FILE_DESC PROTO NOTE                     MSG                                                              SUB                                                          SRC          DST         P   N PEER_DESCR ACTIONS            SUPPRESS_FOR REMOTE_LOCATION.COUNTRY_CODE REMOTE_LOCATION.REGION REMOTE_LOCATION.CITY REMOTE_LOCATION.LATITUDE REMOTE_LOCATION.LONGITUDE
+_path  ts                          uid                id.orig_h    id.orig_p id.resp_h   id.resp_p fuid               file_mime_type file_desc proto note                     msg                                                              sub                                                          src          dst         p   n peer_descr actions            suppress_for remote_location.country_code remote_location.region remote_location.city remote_location.latitude remote_location.longitude
 notice 2018-03-24T17:15:32.521729Z Ckwqsn2ZSiVGtyiFO5 10.47.24.186 55782     10.150.0.85 443       FZW30y2Nwc9i0qmdvg -              -         tcp   SSL::Invalid_Server_Cert SSL certificate validation failed with (self signed certificate) CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU 10.47.24.186 10.150.0.85 443 - -          Notice::ACTION_LOG 3600         -                            -                      -                    -                        -
-_PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H   ID.RESP_P VERSION CIPHER                                CURVE  SERVER_NAME RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS   CLIENT_CERT_CHAIN_FUIDS SUBJECT                                                      ISSUER                                                       CLIENT_SUBJECT CLIENT_ISSUER VALIDATION_STATUS
+_path ts                          uid                id.orig_h    id.orig_p id.resp_h   id.resp_p version cipher                                curve  server_name resumed last_alert next_protocol established cert_chain_fuids   client_cert_chain_fuids subject                                                      issuer                                                       client_subject client_issuer validation_status
 ssl   2018-03-24T17:15:32.513518Z Ckwqsn2ZSiVGtyiFO5 10.47.24.186 55782     10.150.0.85 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 x25519 -           F       -          h2            T           FZW30y2Nwc9i0qmdvg (empty)                 CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU -              -             self signed certificate
 ssl   2018-03-24T17:15:42.629228Z CqwJmZ2Lzd42fuvg4k 10.47.8.10   56802     10.150.0.85 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 x25519 -           F       -          h2            T           Fo9ltu1O8DGE0KAgC  (empty)                 CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU -              -             self signed certificate
 ssl   2018-03-24T17:15:46.542733Z CvTTHG2M6xPqDMDLB7 10.47.27.186 58666     10.150.0.85 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 x25519 -           F       -          h2            T           F7oQQK1qo9HfmlN048 (empty)                 CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU -              -             self signed certificate
@@ -175,7 +175,7 @@ zq -f table 'www.*cdn*.com' *.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY              QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                                                                                                                                                                                                                                                                                                      TTLS                                REJECTED
+_path ts                          uid                id.orig_h   id.orig_p id.resp_h  id.resp_p proto trans_id rtt      query              qclass qclass_name qtype qtype_name rcode rcode_name AA TC RD RA Z answers                                                                                                                                                                                                                                                                                                                                      TTLs                                rejected
 dns   2018-03-24T17:16:24.038839Z ChS4MN2D9iPNzSwAw4 10.47.2.154 59353     10.0.0.100 53        udp   11089    0.000785 www.amazon.com     1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.cdn.amazon.com,d3ag4hukkh62yn.cloudfront.net,54.192.139.227                                                                                                                                                                                                                                                                              578,57,57                           F
 dns   2018-03-24T17:16:24.038843Z ChS4MN2D9iPNzSwAw4 10.47.2.154 59353     10.0.0.100 53        udp   11089    0.000784 www.amazon.com     1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.cdn.amazon.com,d3ag4hukkh62yn.cloudfront.net,54.192.139.227                                                                                                                                                                                                                                                                              578,57,57                           F
 dns   2018-03-24T17:16:24.038845Z ChS4MN2D9iPNzSwAw4 10.47.2.154 59353     10.0.0.100 53        udp   15749    0.001037 www.amazon.com     1      C_INTERNET  28    AAAA       0     NOERROR    F  F  T  T  0 www.cdn.amazon.com,d3ag4hukkh62yn.cloudfront.net                                                                                                                                                                                                                                                                                             578,57                              F
@@ -204,9 +204,9 @@ zq -f table '"CN=*"' *.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH  TS                          UID                ID.ORIG_H  ID.ORIG_P ID.RESP_H   ID.RESP_P FUID              FILE_MIME_TYPE FILE_DESC PROTO NOTE                     MSG                                                                             SUB                                                                                          SRC        DST         P   N PEER_DESCR ACTIONS            SUPPRESS_FOR REMOTE_LOCATION.COUNTRY_CODE REMOTE_LOCATION.REGION REMOTE_LOCATION.CITY REMOTE_LOCATION.LATITUDE REMOTE_LOCATION.LONGITUDE
+_path  ts                          uid                id.orig_h  id.orig_p id.resp_h   id.resp_p fuid              file_mime_type file_desc proto note                     msg                                                                             sub                                                                                          src        dst         p   n peer_descr actions            suppress_for remote_location.country_code remote_location.region remote_location.city remote_location.latitude remote_location.longitude
 notice 2018-03-24T17:16:58.268179Z CVkrLo2Wjo4r51ZDZ7 10.47.8.10 56808     64.4.54.254 443       FYwv52OzGGIJPop3l -              -         tcp   SSL::Invalid_Server_Cert SSL certificate validation failed with (unable to get local issuer certificate) CN=*.vortex-win.data.microsoft.com,OU=Microsoft,O=Microsoft Corporation,L=Redmond,ST=WA,C=US 10.47.8.10 64.4.54.254 443 - -          Notice::ACTION_LOG 3600         -                            -                      -                    -                        -
-_PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H       ID.RESP_P VERSION CIPHER                                        CURVE     SERVER_NAME                                             RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS                                                            CLIENT_CERT_CHAIN_FUIDS                                  SUBJECT                                                                                                                                                  ISSUER                                                                                                                                   CLIENT_SUBJECT                                             CLIENT_ISSUER                                            VALIDATION_STATUS
+_path ts                          uid                id.orig_h    id.orig_p id.resp_h       id.resp_p version cipher                                        curve     server_name                                             resumed last_alert next_protocol established cert_chain_fuids                                                            client_cert_chain_fuids                                  subject                                                                                                                                                  issuer                                                                                                                                   client_subject                                             client_issuer                                            validation_status
 ssl   2018-03-24T17:15:23.363645Z Ck6KyHTvFSs6ilQ43  10.47.26.160 49161     216.58.193.195  443       TLSv12  TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       x25519    fonts.gstatic.com                                       F       -          h2            T           FPxVI11Qp4XsZx8MIf,F287wP3LNxC1jQJZsb                                       (empty)                                                  CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US                                                                                          CN=Google Internet Authority G3,O=Google Trust Services,C=US                                                                             -                                                          -                                                        ok
 ssl   2018-03-24T17:15:23.363999Z CdREh1wNA3vUhNI1f  10.47.26.160 49162     216.58.193.195  443       TLSv12  TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       x25519    fonts.gstatic.com                                       F       -          h2            T           FWz7sY1pnCwl9NvQe,FJ469V1AfRW24KDwBc                                        (empty)                                                  CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US                                                                                          CN=Google Internet Authority G3,O=Google Trust Services,C=US                                                                             -                                                          -                                                        ok
 ssl   2018-03-24T17:15:23.37596Z  CYVobu3DR0JyyP1m3g 10.47.26.160 49163     216.58.193.195  443       TLSv12  TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       x25519    ssl.gstatic.com                                         F       -          h2            T           F8iNVI29EYGgwvRa6j,FADPVCnp9r9OThjk9                                        (empty)                                                  CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US                                                                                          CN=Google Internet Authority G3,O=Google Trust Services,C=US                                                                             -                                                          -                                                        ok
@@ -248,7 +248,7 @@ zq -f table '/www.google(ad|tag)services.com/' *.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                     QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                             TTLS      REJECTED
+_path ts                          uid                id.orig_h   id.orig_p id.resp_h  id.resp_p proto trans_id rtt      query                     qclass qclass_name qtype qtype_name rcode rcode_name AA TC RD RA Z answers                                             TTLs      rejected
 dns   2018-03-24T17:15:46.07484Z  CYjLXM1Yp1ZuuVJQV1 10.47.6.154 12478     10.10.6.1  53        udp   49089    0.001342 www.googletagservices.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                             0         F
 dns   2018-03-24T17:15:46.074842Z CYjLXM1Yp1ZuuVJQV1 10.47.6.154 12478     10.10.6.1  53        udp   49089    0.001375 www.googletagservices.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                             0         F
 dns   2018-03-24T17:15:46.07805Z  Cn1BpA2bKVzWn7IvVe 10.47.6.154 38992     10.10.6.1  53        udp   14171    0.000262 www.googletagservices.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                             0         F
@@ -280,7 +280,7 @@ zq -f table 'uid=="ChhAfsfyuz4n2hFMe"' *.log.gz
 #### Output:
 
 ```mdtest-output
-_PATH TS                          UID               ID.ORIG_H    ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid               id.orig_h    id.orig_p id.resp_h  id.resp_p proto service duration orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:36:30.158539Z ChhAfsfyuz4n2hFMe 10.239.34.35 56602     10.47.6.51 873       tcp   -       0.000004 0          0          S0         -          -          0            S       2         88            0         0             -
  ```
 
@@ -300,7 +300,7 @@ zq -f table 'id.orig_p==id.resp_p' conn.log.gz
 #### Output:
 
 ```mdtest-output head
-_PATH TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P PROTO SERVICE DURATION   ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid                id.orig_h     id.orig_p id.resp_h       id.resp_p proto service duration   orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:15:22.942327Z C6QN8gJLaOXw0GiA6  10.47.24.81   60004     10.128.0.238    60004     tcp   -       0.003538   0          0          SF         -          -          0            ShAafF  8         344           8         344           -
 conn  2018-03-24T17:15:38.523165Z CzFhMc47JPCOG4Z9E9 10.47.3.142   137       10.164.94.120   137       udp   dns     2.99937    300        0          S0         -          -          0            D       6         468           0         0             -
 conn  2018-03-24T17:15:31.711351Z C6TwvE4hg1RN9WxuI4 10.47.3.150   137       10.164.94.120   137       udp   dns     19.920781  1200       0          S0         -          -          0            D       24        1872          0         0             -
@@ -377,7 +377,7 @@ zq -f table 'certificate.subject matches *Widgits*' *.log.gz
 #### Output:
 
 ```mdtest-output head
-_PATH TS                          ID                 CERTIFICATE.VERSION CERTIFICATE.SERIAL CERTIFICATE.SUBJECT                                          CERTIFICATE.ISSUER                                           CERTIFICATE.NOT_VALID_BEFORE CERTIFICATE.NOT_VALID_AFTER CERTIFICATE.KEY_ALG CERTIFICATE.SIG_ALG     CERTIFICATE.KEY_TYPE CERTIFICATE.KEY_LENGTH CERTIFICATE.EXPONENT CERTIFICATE.CURVE SAN.DNS SAN.URI SAN.EMAIL SAN.IP BASIC_CONSTRAINTS.CA BASIC_CONSTRAINTS.PATH_LEN
+_path ts                          id                 certificate.version certificate.serial certificate.subject                                          certificate.issuer                                           certificate.not_valid_before certificate.not_valid_after certificate.key_alg certificate.sig_alg     certificate.key_type certificate.key_length certificate.exponent certificate.curve san.dns san.uri san.email san.ip basic_constraints.ca basic_constraints.path_len
 x509  2018-03-24T17:15:32.519299Z FZW30y2Nwc9i0qmdvg 3                   C5F8CDF3FFCBBF2D   CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU 2018-03-22T14:22:37Z         2045-08-06T14:20:00Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -       -       -         -      T                    -
 x509  2018-03-24T17:15:42.635094Z Fo9ltu1O8DGE0KAgC  3                   C5F8CDF3FFCBBF2D   CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU 2018-03-22T14:22:37Z         2045-08-06T14:20:00Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -       -       -         -      T                    -
 x509  2018-03-24T17:15:46.548292Z F7oQQK1qo9HfmlN048 3                   C5F8CDF3FFCBBF2D   CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU 2018-03-22T14:22:37Z         2045-08-06T14:20:00Z        rsaEncryption       sha256WithRSAEncryption rsa                  2048                   65537                -                 -       -       -         -      T                    -
@@ -394,7 +394,7 @@ zq -f table 'uri matches /scripts\/waE8_BuNCEKM.(pl|sh)/' http.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H   ID.RESP_P TRANS_DEPTH METHOD HOST        URI                         REFERRER VERSION USER_AGENT                                                      ORIGIN REQUEST_BODY_LEN RESPONSE_BODY_LEN STATUS_CODE STATUS_MSG INFO_CODE INFO_MSG TAGS    USERNAME PASSWORD PROXIED ORIG_FUIDS ORIG_FILENAMES ORIG_MIME_TYPES RESP_FUIDS         RESP_FILENAMES RESP_MIME_TYPES
+_path ts                          uid                id.orig_h     id.orig_p id.resp_h   id.resp_p trans_depth method host        uri                         referrer version user_agent                                                      origin request_body_len response_body_len status_code status_msg info_code info_msg tags    username password proxied orig_fuids orig_filenames orig_mime_types resp_fuids         resp_filenames resp_mime_types
 http  2018-03-24T17:17:41.67439Z  Cq3Knz2CEXSJB8ktj  10.164.94.120 40913     10.47.3.142 5800      1           GET    10.47.3.142 /scripts/waE8_BuNCEKM.sh    -        1.0     Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0) -      0                151               404         Not Found  -         -        (empty) -        -        -       -          -              -               F8Jbkj1K2qm2xUR1Bj -              text/html
 http  2018-03-24T17:17:42.427215Z C5yUcM3CEFl86YIfY7 10.164.94.120 34369     10.47.3.142 5800      1           GET    10.47.3.142 /scripts/waE8_BuNCEKM.pl    -        1.0     Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0) -      0                151               404         Not Found  -         -        (empty) -        -        -       -          -              -               F5M3Jc4B8xeR13JrP3 -              text/html
 http  2018-03-24T17:17:43.933983Z CxJhWB3aN4LcZP59S1 10.164.94.120 37999     10.47.3.142 5800      1           GET    10.47.3.142 /scripts/waE8_BuNCEKM.shtml -        1.0     Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0) -      0                151               404         Not Found  -         -        (empty) -        -        -       -          -              -               Fq7wId3B4sZn24Jrf6 -              text/html
@@ -420,7 +420,7 @@ zq -f table '"e5803.b.akamaiedge.net" in answers' dns.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                               TTLS         REJECTED
+_path ts                          uid                id.orig_h  id.orig_p id.resp_h  id.resp_p proto trans_id rtt      query                qclass qclass_name qtype qtype_name rcode rcode_name AA TC RD RA Z answers                                                               TTLs         rejected
 dns   2018-03-24T17:20:25.827504Z CATruWimwi1KR0gec  10.47.3.10 63576     10.0.0.100 53        udp   16678    0.072468 www.techrepublic.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.techrepublic.com.edgekey.net,e5803.b.akamaiedge.net,23.55.209.124 180,17936,20 F
 dns   2018-03-24T17:20:25.827506Z CATruWimwi1KR0gec  10.47.3.10 63576     10.0.0.100 53        udp   16678    0.072468 www.techrepublic.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.techrepublic.com.edgekey.net,e5803.b.akamaiedge.net,23.55.209.124 180,17936,20 F
 dns   2018-03-24T17:25:29.650694Z CHx5jo2qosRtQOZs1  10.47.6.10 55186     10.0.0.100 53        udp   30327    0.095174 www.techrepublic.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 www.techrepublic.com.edgekey.net,e5803.b.akamaiedge.net,23.55.209.124 180,17632,20 F
@@ -444,7 +444,7 @@ zq -f table 'query in answers' dns.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY      QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS    TTLS REJECTED
+_path ts                          uid                id.orig_h  id.orig_p id.resp_h  id.resp_p proto trans_id rtt      query      qclass qclass_name qtype qtype_name rcode rcode_name AA TC RD RA Z answers    TTLs rejected
 dns   2018-03-24T17:24:06.142423Z CCd3Uu1nPHikbjizuc 10.47.7.10 53280     10.0.0.100 53        udp   25252    0.000868 10.47.7.30 1      C_INTERNET  1     A          0     NOERROR    T  F  T  T  0 10.47.7.30 0    F
 dns   2018-03-24T17:24:06.142426Z CCd3Uu1nPHikbjizuc 10.47.7.10 53280     10.0.0.100 53        udp   25252    0.000869 10.47.7.30 1      C_INTERNET  1     A          0     NOERROR    T  F  T  T  0 10.47.7.30 0    F
 dns   2018-03-24T17:30:43.213667Z CV4T3j1mb4LbxNNgBl 10.47.7.10 53647     10.0.0.100 53        udp   45561    0.001054 10.47.7.30 1      C_INTERNET  1     A          0     NOERROR    T  F  T  T  0 10.47.7.30 0    F
@@ -461,7 +461,7 @@ zq -f table 'id.resp_h in 208.78.0.0/16' conn.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H     ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid                id.orig_h   id.orig_p id.resp_h     id.resp_p proto service duration orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:32:44.212387Z CngWP41W7wzyQtMG4k 10.47.26.25 59095     208.78.71.136 53        udp   dns     0.003241 72         402        SF         -          -          0            Dd      2         128           2         458           -
 conn  2018-03-24T17:32:52.32455Z  CgZ2D84oSTX0Xw2fEl 10.47.26.25 59095     208.78.70.136 53        udp   dns     0.004167 144        804        SF         -          -          0            Dd      4         256           4         916           -
 conn  2018-03-24T17:33:07.538564Z CGfWHn2Y6IDSBra1K4 10.47.26.25 59095     208.78.71.31  53        udp   dns     3.044438 276        1188       SF         -          -          0            Dd      6         444           6         1356          -
@@ -483,7 +483,7 @@ zq -f table 'orig_bytes > 1000000' *.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H    ID.RESP_P PROTO SERVICE DURATION    ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY          ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid                id.orig_h    id.orig_p id.resp_h    id.resp_p proto service duration    orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history          orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:25:15.208232Z CVimRo24ubbKqFvNu7 172.30.255.1 11        10.128.0.207 0         icmp  -       100.721937  1647088    0          OTH        -          -          0            -                44136     2882896       0         0             -
 conn  2018-03-24T17:15:20.630818Z CO0MhB2NCc08xWaly8 10.47.1.154  49814     134.71.3.17  443       tcp   -       1269.512465 1618740    12880888   OTH        -          -          0            ^dtADTatTtTtTtT  110169    7594230       111445    29872050      -
 conn  2018-03-24T17:15:20.637761Z Cmgywj2O8KZAHHjddb 10.47.1.154  49582     134.71.3.17  443       tcp   -       1266.367457 1594682    53255700   OTH        -          -          0            ^dtADTatTtTtTtTW 131516    8407458       142488    110641641     -
@@ -502,7 +502,7 @@ zq -f table 'query > "zippy"' *.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID               ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                                                    QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                                TTLS       REJECTED
+_path ts                          uid               id.orig_h  id.orig_p id.resp_h  id.resp_p proto trans_id rtt      query                                                    qclass qclass_name qtype qtype_name rcode rcode_name AA TC RD RA Z answers                                                                TTLs       rejected
 dns   2018-03-24T17:30:09.84174Z  Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001694 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0          F
 dns   2018-03-24T17:30:09.841742Z Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001697 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0          F
 dns   2018-03-24T17:34:52.637234Z CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53        udp   43239    0.019491 zn_0pxrmhobblncaad-hpsupport.siteintercept.qualtrics.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 cloud.qualtrics.com.edgekey.net,e3672.ksd.akamaiedge.net,23.55.215.198 3600,17,20 F
@@ -559,7 +559,7 @@ zq -f table 'www.*cdn*.com _path=="ssl"' *.log.gz
 
 #### Output:
 ```mdtest-output
-_PATH TS                          UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H    ID.RESP_P VERSION CIPHER                                CURVE     SERVER_NAME       RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS                                                            CLIENT_CERT_CHAIN_FUIDS SUBJECT            ISSUER                                  CLIENT_SUBJECT CLIENT_ISSUER VALIDATION_STATUS
+_path ts                          uid                id.orig_h   id.orig_p id.resp_h    id.resp_p version cipher                                curve     server_name       resumed last_alert next_protocol established cert_chain_fuids                                                            client_cert_chain_fuids subject            issuer                                  client_subject client_issuer validation_status
 ssl   2018-03-24T17:23:00.244457Z CUG0fiQAzL4rNWxai  10.47.2.100 36150     52.85.83.228 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FXKmyTbr7HlvyL1h8,FADhCTvkq1ILFnD3j,FoVjYR16c3UIuXj4xk,FmiRYe1P53KOolQeVi   (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
 ssl   2018-03-24T17:24:00.189735Z CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FuW2cZ3leE606wXSia,Fu5kzi1BUwnF0bSCsd,FyTViI32zPvCmNXgSi,FwV6ff3JGj4NZcVPE4 (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
 ```
@@ -583,13 +583,13 @@ zq -f table 'orig_bytes > 1000000 or query > "zippy"' *.log.gz
 #### Output:
 
 ```mdtest-output head
-_PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H    ID.RESP_P PROTO SERVICE DURATION    ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY          ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid                id.orig_h    id.orig_p id.resp_h    id.resp_p proto service duration    orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history          orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:25:15.208232Z CVimRo24ubbKqFvNu7 172.30.255.1 11        10.128.0.207 0         icmp  -       100.721937  1647088    0          OTH        -          -          0            -                44136     2882896       0         0             -
 conn  2018-03-24T17:15:20.630818Z CO0MhB2NCc08xWaly8 10.47.1.154  49814     134.71.3.17  443       tcp   -       1269.512465 1618740    12880888   OTH        -          -          0            ^dtADTatTtTtTtT  110169    7594230       111445    29872050      -
 conn  2018-03-24T17:15:20.637761Z Cmgywj2O8KZAHHjddb 10.47.1.154  49582     134.71.3.17  443       tcp   -       1266.367457 1594682    53255700   OTH        -          -          0            ^dtADTatTtTtTtTW 131516    8407458       142488    110641641     -
 conn  2018-03-24T17:15:20.705347Z CWtQuI2IMNyE1pX47j 10.47.6.161  52121     134.71.3.17  443       tcp   -       1269.320626 2267243    54791018   OTH        -          -          0            DTadtATttTtTtT   152819    10575303      158738    113518994     -
 conn  2018-03-24T17:33:05.415532Z Cy3R5w2pfv8oSEpa2j 10.47.8.19   49376     10.128.0.214 443       tcp   -       202.457994  4862366    1614249    S1         -          -          0            ShAdtttDTaTTTt   7280      10015980      6077      3453020       -
-_PATH TS                          UID               ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                                                    QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                                TTLS       REJECTED
+_path ts                          uid               id.orig_h  id.orig_p id.resp_h  id.resp_p proto trans_id rtt      query                                                    qclass qclass_name qtype qtype_name rcode rcode_name AA TC RD RA Z answers                                                                TTLs       rejected
 dns   2018-03-24T17:30:09.84174Z  Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001694 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0          F
 dns   2018-03-24T17:30:09.841742Z Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001697 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0          F
 dns   2018-03-24T17:34:52.637234Z CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53        udp   43239    0.019491 zn_0pxrmhobblncaad-hpsupport.siteintercept.qualtrics.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 cloud.qualtrics.com.edgekey.net,e3672.ksd.akamaiedge.net,23.55.215.198 3600,17,20 F
@@ -614,10 +614,10 @@ zq -f table 'not _path matches /conn|dns|files|ssl|x509|http|weird/' *.log.gz
 #### Output:
 
 ```mdtest-output head
-_PATH        TS                          TS_DELTA   PEER GAPS ACKS    PERCENT_LOST
+_path        ts                          ts_delta   peer gaps acks    percent_lost
 capture_loss 2018-03-24T17:30:20.600852Z 900.000127 zeek 1400 1414346 0.098986
 capture_loss 2018-03-24T17:36:30.158766Z 369.557914 zeek 919  663314  0.138547
-_PATH   TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H   ID.RESP_P RTT      NAMED_PIPE     ENDPOINT              OPERATION
+_path   ts                          uid                id.orig_h     id.orig_p id.resp_h   id.resp_p rtt      named_pipe     endpoint              operation
 dce_rpc 2018-03-24T17:15:25.396014Z CgxsNA1p2d0BurXd7c 10.164.94.120 36643     10.47.3.151 1030      0.000431 1030           samr                  SamrConnect2
 dce_rpc 2018-03-24T17:15:41.35659Z  CveQB24ujSZ3l34LRi 10.128.0.233  33692     10.47.21.25 135       0.000684 135            IObjectExporter       ComplexPing
 dce_rpc 2018-03-24T17:15:54.621588Z CWyKrz4YlSyPGoE8Bf 10.128.0.214  41717     10.47.8.142 445       0.002721 \\pipe\\ntsvcs svcctl                OpenSCManagerW
@@ -646,7 +646,7 @@ zq -f table 'not share_type=="DISK" _path=="smb_mapping"' *.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH       TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H    ID.RESP_P PATH                     SERVICE NATIVE_FILE_SYSTEM SHARE_TYPE
+_path       ts                          uid                id.orig_h     id.orig_p id.resp_h    id.resp_p path                     service native_file_system share_type
 smb_mapping 2018-03-24T17:15:21.625534Z ChZRry3Z4kv3i25TJf 10.164.94.120 36315     10.47.8.208  445       \\\\SNOZBERRY\\IPC$      IPC     -                  PIPE
 smb_mapping 2018-03-24T17:15:22.021668Z C0jyse1JYc82Acu4xl 10.164.94.120 34691     10.47.8.208  445       \\\\SNOZBERRY\\IPC$      IPC     -                  PIPE
 smb_mapping 2018-03-24T17:15:24.619169Z C2byFA2Y10G1GLUXgb 10.164.94.120 35337     10.47.27.80  445       \\\\PC-NEWMAN\\IPC$      -       -                  PIPE
@@ -668,10 +668,10 @@ zq -f table 'not (share_type=="DISK" _path=="smb_mapping")' *.log.gz
 
 #### Output:
 ```mdtest-output head
-_PATH        TS                          TS_DELTA   PEER GAPS ACKS    PERCENT_LOST
+_path        ts                          ts_delta   peer gaps acks    percent_lost
 capture_loss 2018-03-24T17:30:20.600852Z 900.000127 zeek 1400 1414346 0.098986
 capture_loss 2018-03-24T17:36:30.158766Z 369.557914 zeek 919  663314  0.138547
-_PATH TS                          UID                ID.ORIG_H      ID.ORIG_P ID.RESP_H     ID.RESP_P PROTO SERVICE  DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY     ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
+_path ts                          uid                id.orig_h      id.orig_p id.resp_h     id.resp_p proto service  duration orig_bytes resp_bytes conn_state local_orig local_resp missed_bytes history     orig_pkts orig_ip_bytes resp_pkts resp_ip_bytes tunnel_parents
 conn  2018-03-24T17:15:21.255387Z C8Tful1TvM3Zf5x8fl 10.164.94.120  39681     10.47.3.155   3389      tcp   -        0.004266 97         19         RSTR       -          -          0            ShADTdtr    10        730           6         342           -
 conn  2018-03-24T17:15:21.411148Z CXWfTK3LRdiuQxBbM6 10.47.25.80    50817     10.128.0.218  23189     tcp   -        0.000486 0          0          REJ        -          -          0            Sr          2         104           2         80            -
 conn  2018-03-24T17:15:21.926018Z CM59GGQhNEoKONb5i  10.47.25.80    50817     10.128.0.218  23189     tcp   -        0.000538 0          0          REJ        -          -          0            Sr          2         104           2         80            -
@@ -689,7 +689,7 @@ zq -f table '((not share_type=="DISK") and (service=="IPC")) _path=="smb_mapping
 
 #### Output:
 ```mdtest-output head
-_PATH       TS                          UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H    ID.RESP_P PATH                     SERVICE NATIVE_FILE_SYSTEM SHARE_TYPE
+_path       ts                          uid                id.orig_h     id.orig_p id.resp_h    id.resp_p path                     service native_file_system share_type
 smb_mapping 2018-03-24T17:15:21.625534Z ChZRry3Z4kv3i25TJf 10.164.94.120 36315     10.47.8.208  445       \\\\SNOZBERRY\\IPC$      IPC     -                  PIPE
 smb_mapping 2018-03-24T17:15:22.021668Z C0jyse1JYc82Acu4xl 10.164.94.120 34691     10.47.8.208  445       \\\\SNOZBERRY\\IPC$      IPC     -                  PIPE
 smb_mapping 2018-03-24T17:15:31.475945Z Cvaqhu3VhuXlDOMgXg 10.164.94.120 37127     10.47.3.151  445       \\\\COTTONCANDY4\\IPC$   IPC     -                  PIPE

--- a/lake/ztests/custom-index-key.yaml
+++ b/lake/ztests/custom-index-key.yaml
@@ -19,6 +19,6 @@ outputs:
   - name: stdout
     data: |
       ===
-      _PATH COUNT
+      _path count
       conn  2
       http  1

--- a/lake/ztests/index-drop.yaml
+++ b/lake/ztests/index-drop.yaml
@@ -21,9 +21,9 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      DESC        ZQL INPUT INDEX_COUNT CHUNK_COUNT
+      desc        zql input index_count chunk_count
       field-_path _   _     1           1
       type-ip     _   _     1           1
       ===
-      DESC    ZQL INPUT INDEX_COUNT CHUNK_COUNT
+      desc    zql input index_count chunk_count
       type-ip _   _     1           1

--- a/lake/ztests/index-new-data.yaml
+++ b/lake/ztests/index-new-data.yaml
@@ -20,12 +20,12 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      DESC               ZQL              INPUT INDEX_COUNT CHUNK_COUNT
+      desc               zql              input index_count chunk_count
       field-_path:string _                _     0           0
       type-ip            _                _     0           0
       zql-countbypath    count() by _path _     0           0
       ===
-      DESC               ZQL              INPUT INDEX_COUNT CHUNK_COUNT
+      desc               zql              input index_count chunk_count
       field-_path:string _                _     2           2
       type-ip            _                _     2           2
       zql-countbypath    count() by _path _     2           2

--- a/lake/ztests/index-on-compact.yaml
+++ b/lake/ztests/index-on-compact.yaml
@@ -22,10 +22,10 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      DESC               ZQL INPUT INDEX_COUNT CHUNK_COUNT
+      desc               zql input index_count chunk_count
       field-_path:string _   _     0           4
       type-ip            _   _     0           4
       ===
-      DESC               ZQL INPUT INDEX_COUNT CHUNK_COUNT
+      desc               zql input index_count chunk_count
       field-_path:string _   _     1           1
       type-ip            _   _     1           1

--- a/proc/groupby/ztests/count-assign.yaml
+++ b/proc/groupby/ztests/count-assign.yaml
@@ -15,5 +15,5 @@ input: |
 output-flags: -f table
 
 output: |
-  C
+  c
   10

--- a/proc/groupby/ztests/count.yaml
+++ b/proc/groupby/ztests/count.yaml
@@ -15,5 +15,5 @@ input: |
 output-flags: -f table
 
 output: |
-  COUNT
+  count
   10

--- a/proc/ztests/cut.yaml
+++ b/proc/ztests/cut.yaml
@@ -14,6 +14,6 @@ input: |
 output-flags: -f table
 
 output: |
-  FOO
+  foo
   key1 value1
   key1 value2

--- a/service/ztests/ls-pools.yaml
+++ b/service/ztests/ls-pools.yaml
@@ -34,7 +34,7 @@ outputs:
           name: "p2"
       }
       ===
-      NAME
+      name
       p1
       p2
       ===

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -38,16 +38,6 @@ func NewWriter(w io.WriteCloser, utf8 bool) *Writer {
 	}
 }
 
-func (w *Writer) writeHeader(typ *zng.TypeRecord) {
-	// write out descriptor headers
-	columnNames := []string{}
-	for _, col := range typ.Columns {
-		//XXX not sure about ToUpper here...
-		columnNames = append(columnNames, strings.ToUpper(col.Name))
-	}
-	fmt.Fprintln(w.table, strings.Join(columnNames, "\t"))
-}
-
 func (w *Writer) Write(r *zng.Record) error {
 	r, err := w.flattener.Flatten(r)
 	if err != nil {
@@ -92,6 +82,16 @@ func (w *Writer) Write(r *zng.Record) error {
 
 func (w *Writer) flush() error {
 	return w.table.Flush()
+}
+
+func (w *Writer) writeHeader(typ *zng.TypeRecord) {
+	for i, c := range typ.Columns {
+		if i > 0 {
+			w.table.Write([]byte{'\t'})
+		}
+		w.table.Write([]byte(c.Name))
+	}
+	w.table.Write([]byte{'\n'})
 }
 
 func (w *Writer) Close() error {

--- a/zio/tableio/ztests/flatten.yaml
+++ b/zio/tableio/ztests/flatten.yaml
@@ -6,5 +6,5 @@ input: |
 output-flags: -f table
 
 output: |
-  _PATH TS                          UID               ID.ORIG_H ID.ORIG_P ID.RESP_H ID.RESP_P
+  _path ts                          uid               id.orig_h id.orig_p id.resp_h id.resp_p
   conn  2015-03-05T14:25:14.419939Z CogZFI3py5JsFZGik -         -         -         -

--- a/zio/tableio/ztests/nested-record-alias.yaml
+++ b/zio/tableio/ztests/nested-record-alias.yaml
@@ -6,5 +6,5 @@ input: |
 output-flags: -f table
 
 output: |
-  A.B
+  a.b
   1

--- a/zio/tableio/ztests/type-value.yaml
+++ b/zio/tableio/ztests/type-value.yaml
@@ -6,5 +6,5 @@ input: |
 output-flags: -f table
 
 output: |
-  TYPEOF
+  typeof
   ({a:int64})

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -37,7 +37,7 @@
 //    output-flags: -f table
 //
 //    output: |
-//      COUNT
+//      count
 //      2
 //
 // Alternatively, tests can be configured to run as shell scripts.


### PR DESCRIPTION
The table writer uppercases field names, which can surprise users.
Print field names verbatim instead.

Closes #2961.