### PR TITLE
force -z output over zng for terminal output

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -86,17 +86,8 @@ func (f *Flags) Init() error {
 		f.outputFile = ""
 	}
 	if f.outputFile == "" && f.Format == "zng" && terminal.IsTerminalFile(os.Stdout) && !f.forceBinary {
-		return errors.New("writing binary zng data to terminal; override with -B or use -z for ZSON.")
-	}
-	return nil
-}
-
-func (f *Flags) InitWithFormat(format string) error {
-	if f.outputFile == "-" {
-		f.outputFile = ""
-	}
-	if f.outputFile == "" && f.Format == "zng" && terminal.IsTerminalFile(os.Stdout) && !f.forceBinary {
-		return errors.New("writing binary zng data to terminal; override with -B or use -z for ZSON.")
+		f.Format = "zson"
+		f.ZSON.Pretty = 0
 	}
 	return nil
 }


### PR DESCRIPTION
This commit makes interactive Zed CLI output much more user friendly
by overriding the default zng format when sending output to a terminal.
This means that you no longer have to specify -z when running commands
interactively, which is nice for demos as you pivot between sending
output to a pipe or a file then showing the output on the terminal.

We also deleted the unused method outputflags.Flags.InitWithFormat().

Closes #2974