### PR TITLE
Change prefix used for temp storage from "zq" to "zed"

### DIFF
--- a/proc/spill/merge.go
+++ b/proc/spill/merge.go
@@ -23,7 +23,7 @@ type MergeSort struct {
 	zctx      *zson.Context
 }
 
-const TempPrefix = "zq-spill-"
+const TempPrefix = "zed-spill-"
 
 func TempDir() (string, error) {
 	return os.MkdirTemp("", TempPrefix)


### PR DESCRIPTION
I was working on updating some wiki docs to explain to users when & how Brim/Zed use temporary storage. During the exercise I noticed that the temp prefix used at the moment still says `zq-spill-`, but now we talk more about the Zed system, Zed lakes, etc., so I figured we might as well clean this up before I document it.