### PR TITLE
pass context to proc/spill.MergeSort.Spill

### DIFF
--- a/proc/sort/sort.go
+++ b/proc/sort/sort.go
@@ -126,7 +126,7 @@ func (p *Proc) createRuns(firstRunRecs []*zng.Record) (*spill.MergeSort, error) 
 	if err != nil {
 		return nil, err
 	}
-	if err := rm.Spill(firstRunRecs); err != nil {
+	if err := rm.Spill(p.pctx.Context, firstRunRecs); err != nil {
 		rm.Cleanup()
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (p *Proc) createRuns(firstRunRecs []*zng.Record) (*spill.MergeSort, error) 
 			return nil, err
 		}
 		if recs != nil {
-			if err := rm.Spill(recs); err != nil {
+			if err := rm.Spill(p.pctx.Context, recs); err != nil {
 				rm.Cleanup()
 				return nil, err
 			}

--- a/proc/spill/merge.go
+++ b/proc/spill/merge.go
@@ -2,6 +2,7 @@ package spill
 
 import (
 	"container/heap"
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -59,10 +60,15 @@ func (r *MergeSort) Cleanup() {
 // temp directory.  Since we sort each chunk in memory before spilling, the
 // different chunks can be easily merged into sorted order when reading back
 // the chunks sequentially.
-func (r *MergeSort) Spill(recs []*zng.Record) error {
-	expr.SortStable(recs, r.compareFn)
+func (r *MergeSort) Spill(ctx context.Context, recs []*zng.Record) error {
+	// Sorting can be slow, so check for cancellation.
+	if err := goWithContext(ctx, func() {
+		expr.SortStable(recs, r.compareFn)
+	}); err != nil {
+		return err
+	}
 	filename := filepath.Join(r.tempDir, strconv.Itoa(r.nspill))
-	runFile, err := newPeeker(filename, r.nspill, recs, r.zctx)
+	runFile, err := newPeeker(ctx, filename, r.nspill, recs, r.zctx)
 	if err != nil {
 		return err
 	}
@@ -74,6 +80,20 @@ func (r *MergeSort) Spill(recs []*zng.Record) error {
 	r.spillSize += size
 	heap.Push(r, runFile)
 	return nil
+}
+
+func goWithContext(ctx context.Context, f func()) error {
+	ch := make(chan struct{})
+	go func() {
+		f()
+		close(ch)
+	}()
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Peek returns the next record without advancing the reader.  The record stops


### PR DESCRIPTION
In proc/spill.MergeSort.Spill, sorting the records and writing them to a
file can both take multiple seconds.  For callers, this can mean a
significant delay in responding to context cancellation.  Fix this by
passing a context.Context to proc/spill.MergeSort.Spill and checking it
for cancellation.

Together with #3009, this closes #2983.