### PR TITLE
Zeek shaper updates for v4.1.0

### DIFF
--- a/zeek/Shaping-Zeek-NDJSON.md
+++ b/zeek/Shaping-Zeek-NDJSON.md
@@ -1,13 +1,14 @@
 # Shaping Zeek NDJSON
 
 - [Summary](#summary)
+- [Zeek Version/Configuration](#zeek-versionconfiguration)
 - [Reference Shaper Contents](#reference-shaper-contents)
   * [Leading Type Definitions](#leading-type-definitions)
-  * [Type Definitions Per Zeek Log `_path`](#type-definitions-per-zeek-log-_path)
+  * [Default Type Definitions Per Zeek Log `_path`](#default-type-definitions-per-zeek-log-_path)
+  * [Version-Specific Type Definitions](#version-specific-type-definitions)
   * [Mapping From `_path` Values to Types](#mapping-from-_path-values-to-types)
   * [Zed Pipeline](#zed-pipeline)
 - [Invoking the Shaper From `zq`](#invoking-the-shaper-from-zq)
-- [Zeek Version/Configuration](#zeek-versionconfiguration)
 - [Importing Shaped Data Into Brim](#importing-shaped-data-into-brim)
 - [Contact us!](#contact-us)
 
@@ -30,6 +31,37 @@ A full description of all that's possible with shapers is beyond the scope of
 this doc. However, this example for shaping Zeek NDJSON is quite simple and
 is described below.
 
+# Zeek Version/Configuration
+
+The fields and data types in the reference `shaper.zed` reflect the default
+NDJSON-format logs output by Zeek releases up to the version number referenced
+in the comments at the top of that file. They have been revisited periodically
+as new Zeek versions have been released.
+
+Most changes we've observed in Zeek logs between versions have involved only the
+addition of new fields. Because of this, we expect the shaper should be usable
+as-is for Zeek releases older than the one most recently tested, since fields
+in the shaper not present in your environment would just be filled in with
+`null` values.
+
+[Zeek v4.1.0](https://github.com/zeek/zeek/releases/tag/v4.1.0) is the first
+release we've seen since starting to maintain this reference shaper where
+field names for the same log type have _changed_ between releases. Because
+of this, as shown below, the shaper includes `switch` logic that applies
+different type definitions based on the observed field names that are known
+to be specific to newer Zeek releases.
+
+All attempts will be made to update this reference shaper in a timely manner
+as new Zeek versions are released. However, if you have modified your Zeek
+installation with [packages](https://packages.zeek.org/)
+or other customizations, or if you are using a [Corelight Sensor](https://corelight.com/products/appliance-sensors/)
+that produces Zeek logs with many fields and logs beyond those found in open
+source Zeek, the reference shaper will not cover all the fields in your logs.
+[As described below](#zed-pipeline), the reference shaper will assign
+inferred types to such additional fields. By exploring your data, you can then
+iteratively enhance your shaper to match your environment. If you need
+assistance, please speak up on our [public Slack](https://www.brimsecurity.com/join-slack/).
+
 # Reference Shaper Contents
 
 The reference `shaper.zed` may seem large, but ultimately it follows a
@@ -50,7 +82,7 @@ doc. The `conn_id` type will just save us from having to repeat these fields
 individually in the many Zeek record types that contain an embedded `id`
 record.
 
-## Type Definitions Per Zeek Log `_path`
+## Default Type Definitions Per Zeek Log `_path`
 
 The bulk of this Zed shaper consists of detailed per-field data type
 definitions for each record in the default set of NDJSON logs output by Zeek.
@@ -69,6 +101,16 @@ type dce_rpc={_path:string,ts:time,uid:bstring,id:conn_id,rtt:duration,named_pip
 > **Note:** See [the role of `_path` ](Reading-Zeek-Log-Formats.md#the-role-of-_path)
 > for important details if you're using Zeek's built-in [ASCII logger](https://docs.zeek.org/en/current/scripts/base/frameworks/logging/writers/ascii.zeek.html)
 > to generate NDJSON rather than the [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs) package.
+
+## Version-Specific Type Definitions
+
+The next block of type definitions are exceptions for Zeek v4.1.0 where the
+names of fields for certain log types have changed from prior releases.
+
+```
+type ssl_4_1_0={_path:string,ts:time,uid:bstring,id:conn_id,version:bstring,cipher:bstring,curve:bstring,server_name:bstring,resumed:bool,last_alert:bstring,next_protocol:bstring,established:bool,ssl_history:bstring,cert_chain_fps:[bstring],client_cert_chain_fps:[bstring],subject:bstring,issuer:bstring,client_subject:bstring,client_issuer:bstring,sni_matches_cert:bool,validation_status:bstring,_write_ts:time};
+type x509_4_1_0={_path:string,ts:time,fingerprint:bstring,certificate:{version:uint64,serial:bstring,subject:bstring,issuer:bstring,not_valid_before:time,not_valid_after:time,key_alg:bstring,sig_alg:bstring,key_type:bstring,key_length:uint64,exponent:bstring,curve:bstring},san:{dns:[bstring],uri:[bstring],email:[bstring],ip:[ip]},basic_constraints:{ca:bool,path_len:uint64},host_cert:bool,client_cert:bool,_write_ts:time};
+```
 
 ## Mapping From `_path` Values to Types
 
@@ -92,10 +134,14 @@ The Zed shaper ends with a pipeline that stitches together everything we've defi
 so far.
 
 ```
-put this := unflatten(this) | put this := shape(schemas[_path])
+put this := unflatten(this) | switch (
+  _path=="ssl" has(ssl_history) => put this := shape(ssl_4_1_0);
+  _path=="x509" has(fingerprint) => put this := shape(x509_4_1_0);
+  default => put this := shape(schemas[_path]);
+)
 ```
 
-Picking this apart, it transforms reach record as it's being read, in two
+Picking this apart, it transforms reach record as it's being read, in three
 steps:
 
 1. `unflatten()` reverses the Zeek NDJSON logger's "flattening" of nested
@@ -106,8 +152,14 @@ steps:
    access the individual values using the same dotted syntax like `id.orig_h`
    when needed.
 
-2. `shape()` applies the type definition based on the value found in the
-   incoming record's `_path` field. This includes:
+2. The `switch()` detects if fields specific to Zeek v4.1.0 are present for the
+   two log types for which the [version-specific type definitions](#version-specific-type-definitions)
+   should be applied. For all log lines and types other than these exceptions,
+   the [default type definitions](#default-type-definitions-per-zeek-log-_path)
+   are applied.
+
+3. Each `shape()` call applies an appropriate type definition based on the
+   nature of the incoming record. The logic of `shape()` includes:
 
    * For any fields referenced in the type definition that aren't present in
      the input record, the field is added with a `null` value. (Note: This
@@ -128,7 +180,7 @@ steps:
    Zed pipeline, e.g.:
 
       ```
-      put this := unflatten(this) | put this := shape(schemas[_path]) | put this := crop(schemas[_path])
+      ... | put this := shape(schemas[_path]) | put this := crop(schemas[_path])
       ```
 
    Open issues [zed/2585](https://github.com/brimdata/zed/issues/2585) and
@@ -169,27 +221,6 @@ shell to always invoke `zq` with the necessary `-I` flag pointing to the path
 of your finalized shaper. [zed/1059](https://github.com/brimdata/zed/issues/1059)
 tracks a planned enhancement to persist such settings within Zed itself rather
 than relying on external mechanisms such as shell aliases.
-
-# Zeek Version/Configuration
-
-The fields and data types in the reference `shaper.zed` reflect the default
-NDJSON-format logs output by the Zeek version referenced in the comments at the
-top of that file. They have been revisited periodically as new
-Zeek versions have been released and in that time we've only seen a couple new
-fields appear and none have been removed. Because of this, we expect the
-shaper should be usable as-is for Zeek releases older than the
-one most recently tested, since fields in the shaper not present in your
-environment would just be filled in with `null` values. All attempts will be
-made to update it in a timely manner as new Zeek versions are released.
-
-However, if you have modified your Zeek installation with [packages](https://packages.zeek.org/)
-or other customizations, or if you are using a [Corelight Sensor](https://corelight.com/products/appliance-sensors/)
-that produces Zeek logs with many fields and logs beyond those found in open
-source Zeek, the reference shaper will not cover all the fields in your logs.
-[As described above](#zed-pipeline), the reference shaper will assign
-inferred types to such additional fields. By exploring your data, you can then
-iteratively enhance your shaper to match your environment. If you need
-assistance, please speak up on our [public Slack](https://www.brimsecurity.com/join-slack/).
 
 # Importing Shaped Data Into Brim
 

--- a/zeek/Shaping-Zeek-NDJSON.md
+++ b/zeek/Shaping-Zeek-NDJSON.md
@@ -40,7 +40,7 @@ as new Zeek versions have been released.
 
 Most changes we've observed in Zeek logs between versions have involved only the
 addition of new fields. Because of this, we expect the shaper should be usable
-as-is for Zeek releases older than the one most recently tested, since fields
+as is for Zeek releases older than the one most recently tested, since fields
 in the shaper not present in your environment would just be filled in with
 `null` values.
 

--- a/zeek/shaper.zed
+++ b/zeek/shaper.zed
@@ -1,10 +1,13 @@
 // This reference Zed shaper for Zeek NDJSON logs was most recently tested with
-// Zeek v4.0.1. The fields and data types reflect the default NDJSON
+// Zeek v4.1.0. The fields and data types reflect the default NDJSON
 // logs output by that Zeek version when using the JSON Streaming Logs package.
 
 type port=uint16;
 type zenum=string;
 type conn_id={orig_h:ip,orig_p:port,resp_h:ip,resp_p:port};
+
+// This first block of type definitions cover the fields we've observed in
+// an out-of-the-box Zeek v4.0.3 and earlier.
 
 type broker={_path:string,ts:time,ty:zenum,ev:bstring,peer:{address:bstring,bound_port:port},message:bstring,_write_ts:time};
 type capture_loss={_path:string,ts:time,ts_delta:duration,peer:bstring,gaps:uint64,acks:uint64,percent_lost:float64,_write_ts:time};
@@ -31,11 +34,12 @@ type mysql={_path:string,ts:time,uid:bstring,id:conn_id,cmd:bstring,arg:bstring,
 type netcontrol={_path:string,ts:time,rule_id:bstring,category:zenum,cmd:bstring,state:zenum,action:bstring,target:zenum,entity_type:bstring,entity:bstring,mod:bstring,msg:bstring,priority:int64,expire:duration,location:bstring,plugin:bstring,_write_ts:time};
 type netcontrol_drop={_path:string,ts:time,rule_id:bstring,orig_h:ip,orig_p:port,resp_h:ip,resp_p:port,expire:duration,location:bstring,_write_ts:time};
 type netcontrol_shunt={_path:string,ts:time,rule_id:bstring,f:{src_h:ip,src_p:port,dst_h:ip,dst_p:port},expire:duration,location:bstring,_write_ts:time};
-type notice={_path:string,ts:time,uid:bstring,id:conn_id,fuid:bstring,file_mime_type:bstring,file_desc:bstring,proto:zenum,note:zenum,msg:bstring,sub:bstring,src:ip,dst:ip,p:port,n:uint64,peer_descr:bstring,actions:|[zenum]|,suppress_for:duration,remote_location:{country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64},_write_ts:time};
-type notice_alarm={_path:string,ts:time,uid:bstring,id:conn_id,fuid:bstring,file_mime_type:bstring,file_desc:bstring,proto:zenum,note:zenum,msg:bstring,sub:bstring,src:ip,dst:ip,p:port,n:uint64,peer_descr:bstring,actions:|[zenum]|,suppress_for:duration,remote_location:{country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64},_write_ts:time};
+type notice={_path:string,ts:time,uid:bstring,id:conn_id,fuid:bstring,file_mime_type:bstring,file_desc:bstring,proto:zenum,note:zenum,msg:bstring,sub:bstring,src:ip,dst:ip,p:port,n:uint64,peer_descr:bstring,actions:|[zenum]|,email_dest:set[bstring],suppress_for:duration,remote_location:{country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64},_write_ts:time};
+type notice_alarm={_path:string,ts:time,uid:bstring,id:conn_id,fuid:bstring,file_mime_type:bstring,file_desc:bstring,proto:zenum,note:zenum,msg:bstring,sub:bstring,src:ip,dst:ip,p:port,n:uint64,peer_descr:bstring,actions:|[zenum]|,email_dest:set[bstring],suppress_for:duration,remote_location:{country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64},_write_ts:time};
 type ntlm={_path:string,ts:time,uid:bstring,id:conn_id,username:bstring,hostname:bstring,domainname:bstring,server_nb_computer_name:bstring,server_dns_computer_name:bstring,server_tree_name:bstring,success:bool,_write_ts:time};
 type ntp={_path:string,ts:time,uid:bstring,id:conn_id,version:uint64,mode:uint64,stratum:uint64,poll:duration,precision:duration,root_delay:duration,root_disp:duration,ref_id:bstring,ref_time:time,org_time:time,rec_time:time,xmt_time:time,num_exts:uint64,_write_ts:time};
-type openflow={_path:string,ts:time,dpid:uint64,match:{in_port:uint64,dl_src:bstring,dl_dst:bstring,dl_vlan:uint64,dl_vlan_pcp:uint64,dl_type:uint64,nw_tos:uint64,nw_proto:uint64,nw_src:net,nw_dst:net,tp_src:uint64,tp_dst:uint64},flow_mod:{cookie:uint64,table_id:uint64,command:zenum=(string),idle_timeout:uint64,hard_timeout:uint64,priority:uint64,out_port:uint64,out_group:uint64,flags:uint64,actions:{out_ports:[uint64],vlan_vid:uint64,vlan_pcp:uint64,vlan_strip:bool,dl_src:bstring,dl_dst:bstring,nw_tos:uint64,nw_src:ip,nw_dst:ip,tp_src:uint64,tp_dst:uint64}}};
+type ocsp={_path:string,ts:time,id:bstring,hashAlgorithm:bstring,issuerNameHash:bstring,issuerKeyHash:bstring,serialNumber:bstring,certStatus:bstring,revoketime:time,revokereason:bstring,thisUpdate:time,nextUpdate:time,_write_ts:time"}
+type openflow={_path:string,ts:time,dpid:uint64,match:{in_port:uint64,dl_src:bstring,dl_dst:bstring,dl_vlan:uint64,dl_vlan_pcp:uint64,dl_type:uint64,nw_tos:uint64,nw_proto:uint64,nw_src:net,nw_dst:net,tp_src:uint64,tp_dst:uint64},flow_mod:{cookie:uint64,table_id:uint64,command:zenum=(string),idle_timeout:uint64,hard_timeout:uint64,priority:uint64,out_port:uint64,out_group:uint64,flags:uint64,actions:{out_ports:[uint64],vlan_vid:uint64,vlan_pcp:uint64,vlan_strip:bool,dl_src:bstring,dl_dst:bstring,nw_tos:uint64,nw_src:ip,nw_dst:ip,tp_src:uint64,tp_dst:uint64}},_write_ts:time};
 type packet_filter={_path:string,ts:time,node:bstring,filter:bstring,init:bool,success:bool,_write_ts:time};
 type pe={_path:string,ts:time,id:bstring,machine:bstring,compile_ts:time,os:bstring,subsystem:bstring,is_exe:bool,is_64bit:bool,uses_aslr:bool,uses_dep:bool,uses_code_integrity:bool,uses_seh:bool,has_import_table:bool,has_export_table:bool,has_cert_table:bool,has_debug_data:bool,section_names:[bstring],_write_ts:time};
 type radius={_path:string,ts:time,uid:bstring,id:conn_id,username:bstring,mac:bstring,framed_addr:ip,tunnel_client:bstring,connect_info:bstring,reply_msg:bstring,result:bstring,ttl:duration,_write_ts:time};
@@ -57,6 +61,16 @@ type syslog={_path:string,ts:time,uid:bstring,id:conn_id,proto:zenum,facility:bs
 type tunnel={_path:string,ts:time,uid:bstring,id:conn_id,tunnel_type:zenum,action:zenum,_write_ts:time};
 type weird={_path:string,ts:time,uid:bstring,id:conn_id,name:bstring,addl:bstring,notice:bool,peer:bstring,source:bstring,_write_ts:time};
 type x509={_path:string,ts:time,id:bstring,certificate:{version:uint64,serial:bstring,subject:bstring,issuer:bstring,not_valid_before:time,not_valid_after:time,key_alg:bstring,sig_alg:bstring,key_type:bstring,key_length:uint64,exponent:bstring,curve:bstring},san:{dns:[bstring],uri:[bstring],email:[bstring],ip:[ip]},basic_constraints:{ca:bool,path_len:uint64},_write_ts:time};
+
+// This second block of type definitions represent changes needed to cover
+// an out-of-the-box Zeek v4.1.0. In other Zeek revisions, we were accustomed
+// to only seeing new fields added, but this represented the first time fields
+// have changed, e.g. in SSL logs, "cert_chain_fuids" became "cert_chain_fps".
+// Therefore we have wholly separate type definitions for this revision so we
+// can cover 100% of the expected fields.
+
+type ssl_4_1_0={_path:string,ts:time,uid:bstring,id:conn_id,version:bstring,cipher:bstring,curve:bstring,server_name:bstring,resumed:bool,last_alert:bstring,next_protocol:bstring,established:bool,ssl_history:bstring,cert_chain_fps:[bstring],client_cert_chain_fps:[bstring],subject:bstring,issuer:bstring,client_subject:bstring,client_issuer:bstring,sni_matches_cert:bool,validation_status:bstring,_write_ts:time};
+type x509_4_1_0={_path:string,ts:time,fingerprint:bstring,certificate:{version:uint64,serial:bstring,subject:bstring,issuer:bstring,not_valid_before:time,not_valid_after:time,key_alg:bstring,sig_alg:bstring,key_type:bstring,key_length:uint64,exponent:bstring,curve:bstring},san:{dns:[bstring],uri:[bstring],email:[bstring],ip:[ip]},basic_constraints:{ca:bool,path_len:uint64},host_cert:bool,client_cert:bool,_write_ts:time};
 
 const schemas = |{
   "broker": broker,
@@ -113,4 +127,13 @@ const schemas = |{
   x509
 }|
 
-put this := unflatten(this) | put this := shape(schemas[_path])
+// We'll check for the presence of fields we know are unique to records that
+// changed in Zeek v4.1.0 and shape those with special v4.1.0-specific config.
+// For everything else we'll apply the type definitions that were known to
+// cover Zeek v4.0.3 and earlier.
+
+put this := unflatten(this) | switch (
+  _path=="ssl" has(ssl_history) => put this := shape(ssl_4_1_0);
+  _path="x509" has(fingerprint) => put this := shape(x509_4_1_0);
+  default => put this := shape(schemas[_path])
+}

--- a/zeek/shaper.zed
+++ b/zeek/shaper.zed
@@ -7,7 +7,8 @@ type zenum=string;
 type conn_id={orig_h:ip,orig_p:port,resp_h:ip,resp_p:port};
 
 // This first block of type definitions cover the fields we've observed in
-// an out-of-the-box Zeek v4.0.3 and earlier.
+// an out-of-the-box Zeek v4.0.3 and earlier, as well as all out-of-the-box
+// Zeek v4.1.0 log types except for "ssl" and "x509".
 
 type broker={_path:string,ts:time,ty:zenum,ev:bstring,peer:{address:bstring,bound_port:port},message:bstring,_write_ts:time};
 type capture_loss={_path:string,ts:time,ts_delta:duration,peer:bstring,gaps:uint64,acks:uint64,percent_lost:float64,_write_ts:time};
@@ -65,7 +66,7 @@ type x509={_path:string,ts:time,id:bstring,certificate:{version:uint64,serial:bs
 // This second block of type definitions represent changes needed to cover
 // an out-of-the-box Zeek v4.1.0. In other Zeek revisions, we were accustomed
 // to only seeing new fields added, but this represented the first time fields
-// have changed, e.g. in SSL logs, "cert_chain_fuids" became "cert_chain_fps".
+// have changed, e.g., in SSL logs, "cert_chain_fuids" became "cert_chain_fps".
 // Therefore we have wholly separate type definitions for this revision so we
 // can cover 100% of the expected fields.
 
@@ -129,8 +130,7 @@ const schemas = |{
 
 // We'll check for the presence of fields we know are unique to records that
 // changed in Zeek v4.1.0 and shape those with special v4.1.0-specific config.
-// For everything else we'll apply the type definitions that were known to
-// cover Zeek v4.0.3 and earlier.
+// For everything else we'll apply the default type definitions.
 
 put this := unflatten(this) | switch (
   _path=="ssl" has(ssl_history) => put this := shape(ssl_4_1_0);

--- a/zeek/shaper.zed
+++ b/zeek/shaper.zed
@@ -6,7 +6,7 @@ type port=uint16;
 type zenum=string;
 type conn_id={orig_h:ip,orig_p:port,resp_h:ip,resp_p:port};
 
-// This first block of type definitions cover the fields we've observed in
+// This first block of type definitions covers the fields we've observed in
 // an out-of-the-box Zeek v4.0.3 and earlier, as well as all out-of-the-box
 // Zeek v4.1.0 log types except for "ssl" and "x509".
 

--- a/zeek/shaper.zed
+++ b/zeek/shaper.zed
@@ -102,6 +102,7 @@ const schemas = |{
   "notice_alarm": notice_alarm,
   "ntlm": ntlm,
   "ntp": ntp,
+  "ocsp": ocsp,
   "openflow": openflow,
   "packet_filter": packet_filter,
   "pe": pe,

--- a/zeek/shaper.zed
+++ b/zeek/shaper.zed
@@ -34,11 +34,11 @@ type mysql={_path:string,ts:time,uid:bstring,id:conn_id,cmd:bstring,arg:bstring,
 type netcontrol={_path:string,ts:time,rule_id:bstring,category:zenum,cmd:bstring,state:zenum,action:bstring,target:zenum,entity_type:bstring,entity:bstring,mod:bstring,msg:bstring,priority:int64,expire:duration,location:bstring,plugin:bstring,_write_ts:time};
 type netcontrol_drop={_path:string,ts:time,rule_id:bstring,orig_h:ip,orig_p:port,resp_h:ip,resp_p:port,expire:duration,location:bstring,_write_ts:time};
 type netcontrol_shunt={_path:string,ts:time,rule_id:bstring,f:{src_h:ip,src_p:port,dst_h:ip,dst_p:port},expire:duration,location:bstring,_write_ts:time};
-type notice={_path:string,ts:time,uid:bstring,id:conn_id,fuid:bstring,file_mime_type:bstring,file_desc:bstring,proto:zenum,note:zenum,msg:bstring,sub:bstring,src:ip,dst:ip,p:port,n:uint64,peer_descr:bstring,actions:|[zenum]|,email_dest:set[bstring],suppress_for:duration,remote_location:{country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64},_write_ts:time};
-type notice_alarm={_path:string,ts:time,uid:bstring,id:conn_id,fuid:bstring,file_mime_type:bstring,file_desc:bstring,proto:zenum,note:zenum,msg:bstring,sub:bstring,src:ip,dst:ip,p:port,n:uint64,peer_descr:bstring,actions:|[zenum]|,email_dest:set[bstring],suppress_for:duration,remote_location:{country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64},_write_ts:time};
+type notice={_path:string,ts:time,uid:bstring,id:conn_id,fuid:bstring,file_mime_type:bstring,file_desc:bstring,proto:zenum,note:zenum,msg:bstring,sub:bstring,src:ip,dst:ip,p:port,n:uint64,peer_descr:bstring,actions:|[zenum]|,email_dest:|[bstring]|,suppress_for:duration,remote_location:{country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64},_write_ts:time};
+type notice_alarm={_path:string,ts:time,uid:bstring,id:conn_id,fuid:bstring,file_mime_type:bstring,file_desc:bstring,proto:zenum,note:zenum,msg:bstring,sub:bstring,src:ip,dst:ip,p:port,n:uint64,peer_descr:bstring,actions:|[zenum]|,email_dest:|[bstring]|,suppress_for:duration,remote_location:{country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64},_write_ts:time};
 type ntlm={_path:string,ts:time,uid:bstring,id:conn_id,username:bstring,hostname:bstring,domainname:bstring,server_nb_computer_name:bstring,server_dns_computer_name:bstring,server_tree_name:bstring,success:bool,_write_ts:time};
 type ntp={_path:string,ts:time,uid:bstring,id:conn_id,version:uint64,mode:uint64,stratum:uint64,poll:duration,precision:duration,root_delay:duration,root_disp:duration,ref_id:bstring,ref_time:time,org_time:time,rec_time:time,xmt_time:time,num_exts:uint64,_write_ts:time};
-type ocsp={_path:string,ts:time,id:bstring,hashAlgorithm:bstring,issuerNameHash:bstring,issuerKeyHash:bstring,serialNumber:bstring,certStatus:bstring,revoketime:time,revokereason:bstring,thisUpdate:time,nextUpdate:time,_write_ts:time"}
+type ocsp={_path:string,ts:time,id:bstring,hashAlgorithm:bstring,issuerNameHash:bstring,issuerKeyHash:bstring,serialNumber:bstring,certStatus:bstring,revoketime:time,revokereason:bstring,thisUpdate:time,nextUpdate:time,_write_ts:time}
 type openflow={_path:string,ts:time,dpid:uint64,match:{in_port:uint64,dl_src:bstring,dl_dst:bstring,dl_vlan:uint64,dl_vlan_pcp:uint64,dl_type:uint64,nw_tos:uint64,nw_proto:uint64,nw_src:net,nw_dst:net,tp_src:uint64,tp_dst:uint64},flow_mod:{cookie:uint64,table_id:uint64,command:zenum=(string),idle_timeout:uint64,hard_timeout:uint64,priority:uint64,out_port:uint64,out_group:uint64,flags:uint64,actions:{out_ports:[uint64],vlan_vid:uint64,vlan_pcp:uint64,vlan_strip:bool,dl_src:bstring,dl_dst:bstring,nw_tos:uint64,nw_src:ip,nw_dst:ip,tp_src:uint64,tp_dst:uint64}},_write_ts:time};
 type packet_filter={_path:string,ts:time,node:bstring,filter:bstring,init:bool,success:bool,_write_ts:time};
 type pe={_path:string,ts:time,id:bstring,machine:bstring,compile_ts:time,os:bstring,subsystem:bstring,is_exe:bool,is_64bit:bool,uses_aslr:bool,uses_dep:bool,uses_code_integrity:bool,uses_seh:bool,has_import_table:bool,has_export_table:bool,has_cert_table:bool,has_debug_data:bool,section_names:[bstring],_write_ts:time};
@@ -123,8 +123,7 @@ const schemas = |{
   "syslog": syslog,
   "tunnel": tunnel,
   "weird": weird,
-  "x509":
-  x509
+  "x509": x509
 }|
 
 // We'll check for the presence of fields we know are unique to records that
@@ -134,6 +133,6 @@ const schemas = |{
 
 put this := unflatten(this) | switch (
   _path=="ssl" has(ssl_history) => put this := shape(ssl_4_1_0);
-  _path="x509" has(fingerprint) => put this := shape(x509_4_1_0);
-  default => put this := shape(schemas[_path])
-}
+  _path=="x509" has(fingerprint) => put this := shape(x509_4_1_0);
+  default => put this := shape(schemas[_path]);
+)


### PR DESCRIPTION
For some time now, each time a new Zeek version is released, I use our [print-types.zeek](https://github.com/brimdata/zeek/blob/master/brim/print-types.zeek) script to see if there's new log types in the default output and/or new/changed fields in the existing log types. I then update the reference Zed shaper appropriately. Since this is data with which we've got a lot of prior experience, I feel like it's good shaping practice.

When I went to do this for the recently-released Zeek v4.1.0, for the first time since maintaining the reference shaper, I actually saw field names _change_ from what they were prior. This poses a unique challenge because when fields were only being added, the only side effect of applying the newest shaper on older logs was that there'd be some extra fields filled in with `null`. In fact, I've always thought this has an up side, since it "future proofs" the user for when they _do_ upgrade to the newer Zeek release, since their shaped Zeek logs would continue to fit within the type definition they're already been using. But to cover fields that change, it seemed like I'd either have to:

1. Start maintaining separate version-specific reference shapers. Specifically, that would now include one for Zeek v4.0.3 and earlier and another for Zeek v4.1.0 and newer. I'd maintain just those two until yet another set of field name changes comes along.

2. Continue to maintain a single shaper, but introduce flow control logic to detect the changes that are unique to Zeek v4.1.0 and newer and apply them only when necessary.

In the interest of maintaining minimal redundant config and showing an approach that might be applicable in other contexts, in this PR I'm opting for the latter approach.

The diffs on which the changes are based is in the attached [types-diff.txt](https://github.com/brimdata/zed/files/7117335/types-diff.txt).