### PR TITLE
add back -p for checkout

### DIFF
--- a/cmd/zed/lake/checkout/command.go
+++ b/cmd/zed/lake/checkout/command.go
@@ -14,7 +14,7 @@ import (
 
 var Checkout = &charm.Spec{
 	Name:  "checkout",
-	Usage: "checkout [-b] branch",
+	Usage: "checkout [-p pool] [-b] branch [base]",
 	Short: "checkout a branch",
 	Long: `
 The lake checkout command sets the working branch as indicated.
@@ -22,6 +22,9 @@ This allows commands like load, rebase, merge etc to function without
 having to specify the working branch.  The branch specifier may also be
 a commit ID, in which case you entered a headless state and commands
 like load that require a branch name for HEAD will report an error.
+
+Checkout may also be run with the -p to indicate a pool name.  In this case,
+the main branch of the specified pool is checked out.
 
 Any command that relies upon HEAD can also be run with the -HEAD option
 to refer to a different HEAD without performing a checkout.
@@ -53,12 +56,14 @@ func init() {
 type Command struct {
 	lake      zedlake.Command
 	branch    bool
+	poolName  string
 	lakeFlags lakeflags.Flags
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{lake: parent.(zedlake.Command)}
 	f.BoolVar(&c.branch, "b", false, "create the branch then check it out")
+	f.StringVar(&c.poolName, "p", "", "check out the main branch of the given pool")
 	c.lakeFlags.SetFlags(f)
 	return c, nil
 }
@@ -69,19 +74,34 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer cleanup()
+	var branchName, baseName string
 	switch len(args) {
 	case 0:
-		return errors.New("a branch name or commit ID must be given")
-	case 1, 2:
+		if c.poolName == "" {
+			return errors.New("a branch name or commit ID must be given")
+		}
+	case 1:
+		branchName = args[0]
+	case 2:
+		branchName = args[0]
+		baseName = args[1]
 	default:
 		return errors.New("too many arguments")
 	}
-	branchName := args[0]
+	if baseName != "" && !c.branch {
+		return errors.New("cannot specify a base for a new branch without -b")
+	}
 	head, err := c.lakeFlags.HEAD()
 	if err != nil {
 		return err
 	}
-	poolName, baseName := head.Pool, head.Branch
+	poolName := head.Pool
+	if c.poolName != "" {
+		poolName = c.poolName
+		if branchName == "" {
+			branchName = "main"
+		}
+	}
 	commitish, err := lakeparse.ParseCommitish(branchName)
 	if err != nil {
 		return err
@@ -91,10 +111,10 @@ func (c *Command) Run(args []string) error {
 		poolName, branchName = poolSpec, branchSpec
 	}
 	if poolName == "" {
-		return lakeflags.ErrNoHEAD
-	}
-	if len(args) == 2 {
-		baseName = args[1]
+		if c.poolName == "" {
+			return lakeflags.ErrNoHEAD
+		}
+
 	}
 	lake, err := c.lake.Open(ctx)
 	if err != nil {
@@ -110,6 +130,9 @@ func (c *Command) Run(args []string) error {
 	if c.branch {
 		if _, err := lakeparse.ParseID(branchName); err == nil {
 			return errors.New("new branch name cannot be a commit ID")
+		}
+		if baseName == "" {
+			baseName = head.Branch
 		}
 		baseCommit, err := lakeparse.ParseID(baseName)
 		if err != nil {

--- a/cmd/zed/lake/checkout/command.go
+++ b/cmd/zed/lake/checkout/command.go
@@ -23,7 +23,7 @@ having to specify the working branch.  The branch specifier may also be
 a commit ID, in which case you entered a headless state and commands
 like load that require a branch name for HEAD will report an error.
 
-Checkout may also be run with the -p to indicate a pool name.  In this case,
+Checkout may also be run with -p to indicate a pool name.  In this case,
 the main branch of the specified pool is checked out.
 
 Any command that relies upon HEAD can also be run with the -HEAD option
@@ -155,7 +155,11 @@ func (c *Command) Run(args []string) error {
 		if c.branch {
 			new = "a new "
 		}
-		fmt.Printf("Switched to %sbranch %q\n", new, branchName)
+		if c.poolName != "" {
+			fmt.Printf("Switched to %sbranch %q on pool %q\n", new, branchName, c.poolName)
+		} else {
+			fmt.Printf("Switched to %sbranch %q\n", new, branchName)
+		}
 	}
 	return nil
 }

--- a/cmd/zed/lake/index/apply.go
+++ b/cmd/zed/lake/index/apply.go
@@ -15,8 +15,8 @@ import (
 
 var Apply = &charm.Spec{
 	Name:  "apply",
-	Usage: "apply -p pool rule tag [tag ...]",
-	Short: "apply index rule to one or more data objects",
+	Usage: "apply rule tag [tag ...]",
+	Short: "apply index rule to one or more data objects in a branch",
 	New:   NewApply,
 }
 

--- a/cmd/zed/lake/load/command.go
+++ b/cmd/zed/lake/load/command.go
@@ -21,13 +21,10 @@ import (
 
 var Load = &charm.Spec{
 	Name:  "load",
-	Usage: "load [options] -p pool[@branch] file|S3-object|- ...",
+	Usage: "load [options] file|S3-object|- ...",
 	Short: "add and commit data to a branch",
 	Long: `
 The load command adds data to a pool and commits it to a branch.
-
-A pool and branch must be specified with the -p option.  If a pool name is given
-without a branch name, then the branch is assumed to be "main".
 `,
 	New: New,
 }

--- a/cmd/zed/lake/log/command.go
+++ b/cmd/zed/lake/log/command.go
@@ -15,10 +15,10 @@ import (
 
 var Log = &charm.Spec{
 	Name:  "log",
-	Usage: "log [options] -p pool[@commit]",
+	Usage: "log [options]",
 	Short: "display the commit log history starting at any commit",
 	Long: `
-"zed lake log" outputs a commit history of any branch or unnamed commit object
+The log command outputs a commit history of any branch or unnamed commit object
 from a data pool in the format desired.
 By default, the output is in the human-readable "lake" format
 but ZNG can be used to easily be pipe a log to zq or other tooling for analysis.

--- a/cmd/zed/lake/merge/command.go
+++ b/cmd/zed/lake/merge/command.go
@@ -13,8 +13,8 @@ import (
 
 var Merge = &charm.Spec{
 	Name:  "merge",
-	Usage: "merge -p pool@child-branch parent-branch",
-	Short: "merge a branch into another",
+	Usage: "merge branch",
+	Short: "merge current branch into another",
 	Long: `
 `,
 	New: New,

--- a/lake/ztests/checkout-dash-p.yaml
+++ b/lake/ztests/checkout-dash-p.yaml
@@ -1,0 +1,23 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -q POOL
+  zed lake checkout -q -p POOL
+  zed lake load -q a.zson
+  zed lake checkout -q -b child
+  zed lake load -q b.zson
+  zed lake checkout -q -p POOL
+  zed lake query -z "*"
+
+inputs:
+  - name: a.zson
+    data: |
+      {a:1}
+  - name: b.zson
+    data: |
+      {b:1}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1}


### PR DESCRIPTION
This commit adds back the pool option -p but only for checkout,
which checks out the main branch of the indicated pool.
This will help with the gentle slope for new users who don't need
to initially undestand or even know about branches.

We also updated various CLI help to reflect that the -p argument
is no longer relevant to them.