### PR TITLE
change behavior of lake checkout state

### DIFF
--- a/cli/lakeflags/state.go
+++ b/cli/lakeflags/state.go
@@ -3,13 +3,25 @@ package lakeflags
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
-const headFile = ".zed_head"
+const headFile = ".ZED_HEAD"
+
+func headPath() string {
+	path := os.Getenv("ZED_HEAD_PATH")
+	if path == "" {
+		path = os.Getenv("HOME")
+	}
+	if path == "." {
+		path = ""
+	}
+	return filepath.Join(path, headFile)
+}
 
 func readHead() (string, error) {
-	b, err := os.ReadFile(headFile)
+	b, err := os.ReadFile(headPath())
 	if err != nil {
 		return "", err
 	}
@@ -18,7 +30,7 @@ func readHead() (string, error) {
 
 func WriteHead(pool, branch string) error {
 	head := fmt.Sprintf("%s@%s\n", pool, branch)
-	err := os.WriteFile(headFile, []byte(head), 0644)
+	err := os.WriteFile(headPath(), []byte(head), 0644)
 	if err != nil {
 		err = fmt.Errorf("%q: failed to write HEAD: %w", headFile, err)
 	}

--- a/cli/lakeflags/state.go
+++ b/cli/lakeflags/state.go
@@ -10,14 +10,14 @@ import (
 const headFile = ".zed_head"
 
 func headPath() string {
-	path := os.Getenv("ZED_HEAD_PATH")
-	if path == "" {
-		path, _ = os.UserHomeDir()
+	dir := os.Getenv("ZED_HEAD_DIR")
+	if dir == "" {
+		dir, _ = os.UserHomeDir()
 	}
-	if path == "." {
-		path = ""
+	if dir == "." {
+		dir = ""
 	}
-	return filepath.Join(path, headFile)
+	return filepath.Join(dir, headFile)
 }
 
 func readHead() (string, error) {

--- a/cli/lakeflags/state.go
+++ b/cli/lakeflags/state.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 )
 
-const headFile = ".ZED_HEAD"
+const headFile = ".zed_head"
 
 func headPath() string {
 	path := os.Getenv("ZED_HEAD_PATH")
 	if path == "" {
-		path = os.Getenv("HOME")
+		path, _ = os.UserHomeDir()
 	}
 	if path == "." {
 		path = ""

--- a/cmd/zed/lake/ztests/zed-head-env.yaml
+++ b/cmd/zed/lake/ztests/zed-head-env.yaml
@@ -1,12 +1,12 @@
 script: |
   export ZED_LAKE_ROOT=test
-  export ZED_HEAD_PATH=x
+  export ZED_HEAD_DIR=x
   mkdir x
   zed lake init -q
   zed lake create -q -q POOL
   zed lake checkout -q POOL@main
   cat x/.zed_head
-  export ZED_HEAD_PATH=.
+  export ZED_HEAD_DIR=.
   mkdir y
   cd y
   zed lake checkout -R ../test -q POOL@main

--- a/cmd/zed/lake/ztests/zed-head-env.yaml
+++ b/cmd/zed/lake/ztests/zed-head-env.yaml
@@ -5,12 +5,12 @@ script: |
   zed lake init -q
   zed lake create -q -q POOL
   zed lake checkout -q POOL@main
-  cat x/.ZED_HEAD
+  cat x/.zed_head
   export ZED_HEAD_PATH=.
   mkdir y
   cd y
   zed lake checkout -R ../test -q POOL@main
-  cat .ZED_HEAD
+  cat .zed_head
 
 outputs:
   - name: stdout

--- a/cmd/zed/lake/ztests/zed-head-env.yaml
+++ b/cmd/zed/lake/ztests/zed-head-env.yaml
@@ -1,0 +1,19 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  export ZED_HEAD_PATH=x
+  mkdir x
+  zed lake init -q
+  zed lake create -q -q POOL
+  zed lake checkout -q POOL@main
+  cat x/.ZED_HEAD
+  export ZED_HEAD_PATH=.
+  mkdir y
+  cd y
+  zed lake checkout -R ../test -q POOL@main
+  cat .ZED_HEAD
+
+outputs:
+  - name: stdout
+    data: |
+      POOL@main
+      POOL@main


### PR DESCRIPTION
This commit changes the default behavior of the checkout command
to store the HEAD pointer in $HOME.  The environment variable
ZED_HEAD_PATH can be defined to override this behavior.  In particular,
setting ZED_HEAD_PATH to ".", will revert to the previous behavior
where the HEAD pointer is stored in the current working directory.