### PR TITLE
change "zed lake use" with no args to print HEAD

### DIFF
--- a/cmd/zed/lake/use/command.go
+++ b/cmd/zed/lake/use/command.go
@@ -83,11 +83,10 @@ func (c *Command) Run(args []string) error {
 	case 0:
 		if c.poolName == "" {
 			head, err := c.lakeFlags.HEAD()
-			if err == nil {
+			if err == nil && !head.IsZero() {
 				fmt.Printf("HEAD at %s\n", head)
-				return nil
 			}
-			return errors.New("a branch name or commit ID must be given")
+			return errors.New("no branch HEAD set: pool name and branch name or commit ID must be given")
 		}
 		poolName, branchName = c.poolName, "main"
 	case 1:

--- a/cmd/zed/lake/use/command.go
+++ b/cmd/zed/lake/use/command.go
@@ -83,10 +83,11 @@ func (c *Command) Run(args []string) error {
 	case 0:
 		if c.poolName == "" {
 			head, err := c.lakeFlags.HEAD()
-			if err == nil && !head.IsZero() {
-				fmt.Printf("HEAD at %s\n", head)
+			if err != nil || head.IsZero() {
+				return errors.New("no branch HEAD set: pool name and branch name or commit ID must be given")
 			}
-			return errors.New("no branch HEAD set: pool name and branch name or commit ID must be given")
+			fmt.Printf("HEAD at %s\n", head)
+			return nil
 		}
 		poolName, branchName = c.poolName, "main"
 	case 1:

--- a/cmd/zed/lake/use/command.go
+++ b/cmd/zed/lake/use/command.go
@@ -78,33 +78,38 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer cleanup()
-	var branchName, baseName string
+	var poolName, branchName, baseName string
 	switch len(args) {
 	case 0:
 		if c.poolName == "" {
+			head, err := c.lakeFlags.HEAD()
+			if err == nil {
+				fmt.Printf("HEAD at %s\n", head)
+				return nil
+			}
 			return errors.New("a branch name or commit ID must be given")
 		}
+		poolName, branchName = c.poolName, "main"
 	case 1:
 		branchName = args[0]
+		if c.poolName != "" {
+			poolName, baseName = c.poolName, "main"
+		} else if head, err := c.lakeFlags.HEAD(); err == nil {
+			poolName, baseName = head.Pool, head.Branch
+		}
 	case 2:
+		if !c.branch {
+			return errors.New("cannot specify a base for a new branch without -b")
+		}
 		branchName = args[0]
 		baseName = args[1]
+		if c.poolName != "" {
+			poolName = c.poolName
+		} else if head, err := c.lakeFlags.HEAD(); err == nil {
+			poolName = head.Pool
+		}
 	default:
 		return errors.New("too many arguments")
-	}
-	if baseName != "" && !c.branch {
-		return errors.New("cannot specify a base for a new branch without -b")
-	}
-	head, err := c.lakeFlags.HEAD()
-	if err != nil {
-		return err
-	}
-	poolName := head.Pool
-	if c.poolName != "" {
-		poolName = c.poolName
-		if branchName == "" {
-			branchName = "main"
-		}
 	}
 	commitish, err := lakeparse.ParseCommitish(branchName)
 	if err != nil {
@@ -115,10 +120,7 @@ func (c *Command) Run(args []string) error {
 		poolName, branchName = poolSpec, branchSpec
 	}
 	if poolName == "" {
-		if c.poolName == "" {
-			return lakeflags.ErrNoHEAD
-		}
-
+		return lakeflags.ErrNoHEAD
 	}
 	lake, err := c.lake.Open(ctx)
 	if err != nil {
@@ -136,7 +138,7 @@ func (c *Command) Run(args []string) error {
 			return errors.New("new branch name cannot be a commit ID")
 		}
 		if baseName == "" {
-			baseName = head.Branch
+			return errors.New("no HEAD or branch base specified for -b")
 		}
 		baseCommit, err := lakeparse.ParseID(baseName)
 		if err != nil {

--- a/lake/ztests/head-empty.yaml
+++ b/lake/ztests/head-empty.yaml
@@ -1,0 +1,20 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake use || true
+  zed lake create -q POOL
+  echo ===
+  zed lake use -p POOL
+  echo ===
+  zed lake use
+
+outputs:
+  - name: stdout
+    data: |
+      ===
+      Switched to branch "main" on pool "POOL"
+      ===
+      HEAD at POOL@main
+  - name: stderr
+    regexp: |
+      no branch HEAD set: pool name and branch name or commit ID must be given

--- a/lakeparse/head.go
+++ b/lakeparse/head.go
@@ -42,3 +42,7 @@ func (c *Commitish) FromSpec(meta string) (string, error) {
 func (c *Commitish) String() string {
 	return fmt.Sprintf("%s@%s", c.Pool, c.Branch)
 }
+
+func (c *Commitish) IsZero() bool {
+	return c.Pool == "" && c.Branch == ""
+}

--- a/lakeparse/head.go
+++ b/lakeparse/head.go
@@ -38,3 +38,7 @@ func (c *Commitish) FromSpec(meta string) (string, error) {
 	}
 	return s, nil
 }
+
+func (c *Commitish) String() string {
+	return fmt.Sprintf("%s@%s", c.Pool, c.Branch)
+}


### PR DESCRIPTION
This commit changes the "use" command to print the current HEAD
if there are no command-line args, which is useful for a quick
reminder of the branch you're on.  We also reworked the logic
a bit for better readability.