### PR TITLE
allow any char after backslash when parsing Zed regexps

### DIFF
--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -1140,28 +1140,26 @@ function peg$parse(input, options) {
           },
       peg$c514 = /^[^\/\\]/,
       peg$c515 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c516 = "\\/",
-      peg$c517 = peg$literalExpectation("\\/", false),
-      peg$c518 = /^[\0-\x1F\\]/,
-      peg$c519 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c520 = peg$otherExpectation("whitespace"),
-      peg$c521 = "\t",
-      peg$c522 = peg$literalExpectation("\t", false),
-      peg$c523 = "\x0B",
-      peg$c524 = peg$literalExpectation("\x0B", false),
-      peg$c525 = "\f",
-      peg$c526 = peg$literalExpectation("\f", false),
-      peg$c527 = " ",
-      peg$c528 = peg$literalExpectation(" ", false),
-      peg$c529 = "\xA0",
-      peg$c530 = peg$literalExpectation("\xA0", false),
-      peg$c531 = "\uFEFF",
-      peg$c532 = peg$literalExpectation("\uFEFF", false),
-      peg$c533 = /^[\n\r\u2028\u2029]/,
-      peg$c534 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c535 = peg$otherExpectation("comment"),
-      peg$c540 = "//",
-      peg$c541 = peg$literalExpectation("//", false),
+      peg$c516 = /^[\0-\x1F\\]/,
+      peg$c517 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c518 = peg$otherExpectation("whitespace"),
+      peg$c519 = "\t",
+      peg$c520 = peg$literalExpectation("\t", false),
+      peg$c521 = "\x0B",
+      peg$c522 = peg$literalExpectation("\x0B", false),
+      peg$c523 = "\f",
+      peg$c524 = peg$literalExpectation("\f", false),
+      peg$c525 = " ",
+      peg$c526 = peg$literalExpectation(" ", false),
+      peg$c527 = "\xA0",
+      peg$c528 = peg$literalExpectation("\xA0", false),
+      peg$c529 = "\uFEFF",
+      peg$c530 = peg$literalExpectation("\uFEFF", false),
+      peg$c531 = /^[\n\r\u2028\u2029]/,
+      peg$c532 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c533 = peg$otherExpectation("comment"),
+      peg$c538 = "//",
+      peg$c539 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -14313,7 +14311,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseRegexpBody() {
-    var s0, s1, s2;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = [];
@@ -14325,12 +14323,32 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c515); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c516) {
-        s2 = peg$c516;
-        peg$currPos += 2;
+      s2 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 92) {
+        s3 = peg$c431;
+        peg$currPos++;
       } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c432); }
+      }
+      if (s3 !== peg$FAILED) {
+        if (input.length > peg$currPos) {
+          s4 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c481); }
+        }
+        if (s4 !== peg$FAILED) {
+          s3 = [s3, s4];
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c517); }
       }
     }
     if (s2 !== peg$FAILED) {
@@ -14344,12 +14362,32 @@ function peg$parse(input, options) {
           if (peg$silentFails === 0) { peg$fail(peg$c515); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c516) {
-            s2 = peg$c516;
-            peg$currPos += 2;
+          s2 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 92) {
+            s3 = peg$c431;
+            peg$currPos++;
           } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c432); }
+          }
+          if (s3 !== peg$FAILED) {
+            if (input.length > peg$currPos) {
+              s4 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c481); }
+            }
+            if (s4 !== peg$FAILED) {
+              s3 = [s3, s4];
+              s2 = s3;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c517); }
           }
         }
       }
@@ -14368,12 +14406,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c518.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -14442,51 +14480,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c521;
+      s0 = peg$c519;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c520); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c523;
+        s0 = peg$c521;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c522); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c525;
+          s0 = peg$c523;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c526); }
+          if (peg$silentFails === 0) { peg$fail(peg$c524); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c527;
+            s0 = peg$c525;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c526); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c529;
+              s0 = peg$c527;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c530); }
+              if (peg$silentFails === 0) { peg$fail(peg$c528); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c531;
+                s0 = peg$c529;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c532); }
+                if (peg$silentFails === 0) { peg$fail(peg$c530); }
               }
             }
           }
@@ -14495,7 +14533,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c520); }
+      if (peg$silentFails === 0) { peg$fail(peg$c518); }
     }
 
     return s0;
@@ -14504,12 +14542,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c533.test(input.charAt(peg$currPos))) {
+    if (peg$c531.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c534); }
+      if (peg$silentFails === 0) { peg$fail(peg$c532); }
     }
 
     return s0;
@@ -14522,7 +14560,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c535); }
+      if (peg$silentFails === 0) { peg$fail(peg$c533); }
     }
 
     return s0;
@@ -14532,12 +14570,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c540) {
-      s1 = peg$c540;
+    if (input.substr(peg$currPos, 2) === peg$c538) {
+      s1 = peg$c538;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c541); }
+      if (peg$silentFails === 0) { peg$fail(peg$c539); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -11118,10 +11118,18 @@ var g = &grammar{
 								ignoreCase: false,
 								inverted:   true,
 							},
-							&litMatcher{
-								pos:        position{line: 1388, col: 13, offset: 38725},
-								val:        "\\/",
-								ignoreCase: false,
+							&seqExpr{
+								pos: position{line: 1388, col: 15, offset: 38727},
+								exprs: []interface{}{
+									&litMatcher{
+										pos:        position{line: 1388, col: 15, offset: 38727},
+										val:        "\\",
+										ignoreCase: false,
+									},
+									&anyMatcher{
+										line: 1388, col: 20, offset: 38732,
+									},
+								},
 							},
 						},
 					},
@@ -11130,9 +11138,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1390, col: 1, offset: 38765},
+			pos:  position{line: 1390, col: 1, offset: 38768},
 			expr: &charClassMatcher{
-				pos:        position{line: 1391, col: 5, offset: 38781},
+				pos:        position{line: 1391, col: 5, offset: 38784},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11142,42 +11150,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1393, col: 1, offset: 38796},
+			pos:  position{line: 1393, col: 1, offset: 38799},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1393, col: 6, offset: 38801},
+				pos: position{line: 1393, col: 6, offset: 38804},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1393, col: 6, offset: 38801},
+					pos:  position{line: 1393, col: 6, offset: 38804},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1395, col: 1, offset: 38812},
+			pos:  position{line: 1395, col: 1, offset: 38815},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1395, col: 6, offset: 38817},
+				pos: position{line: 1395, col: 6, offset: 38820},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1395, col: 6, offset: 38817},
+					pos:  position{line: 1395, col: 6, offset: 38820},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1397, col: 1, offset: 38828},
+			pos:  position{line: 1397, col: 1, offset: 38831},
 			expr: &choiceExpr{
-				pos: position{line: 1398, col: 5, offset: 38841},
+				pos: position{line: 1398, col: 5, offset: 38844},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1398, col: 5, offset: 38841},
+						pos:  position{line: 1398, col: 5, offset: 38844},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1399, col: 5, offset: 38856},
+						pos:  position{line: 1399, col: 5, offset: 38859},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1400, col: 5, offset: 38875},
+						pos:  position{line: 1400, col: 5, offset: 38878},
 						name: "Comment",
 					},
 				},
@@ -11185,45 +11193,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1402, col: 1, offset: 38884},
+			pos:  position{line: 1402, col: 1, offset: 38887},
 			expr: &anyMatcher{
-				line: 1403, col: 5, offset: 38904,
+				line: 1403, col: 5, offset: 38907,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1405, col: 1, offset: 38907},
+			pos:         position{line: 1405, col: 1, offset: 38910},
 			expr: &choiceExpr{
-				pos: position{line: 1406, col: 5, offset: 38935},
+				pos: position{line: 1406, col: 5, offset: 38938},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1406, col: 5, offset: 38935},
+						pos:        position{line: 1406, col: 5, offset: 38938},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1407, col: 5, offset: 38944},
+						pos:        position{line: 1407, col: 5, offset: 38947},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1408, col: 5, offset: 38953},
+						pos:        position{line: 1408, col: 5, offset: 38956},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1409, col: 5, offset: 38962},
+						pos:        position{line: 1409, col: 5, offset: 38965},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1410, col: 5, offset: 38970},
+						pos:        position{line: 1410, col: 5, offset: 38973},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1411, col: 5, offset: 38983},
+						pos:        position{line: 1411, col: 5, offset: 38986},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11232,9 +11240,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1413, col: 1, offset: 38993},
+			pos:  position{line: 1413, col: 1, offset: 38996},
 			expr: &charClassMatcher{
-				pos:        position{line: 1414, col: 5, offset: 39012},
+				pos:        position{line: 1414, col: 5, offset: 39015},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11244,45 +11252,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1420, col: 1, offset: 39342},
+			pos:         position{line: 1420, col: 1, offset: 39345},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1423, col: 5, offset: 39413},
+				pos:  position{line: 1423, col: 5, offset: 39416},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1425, col: 1, offset: 39432},
+			pos:  position{line: 1425, col: 1, offset: 39435},
 			expr: &seqExpr{
-				pos: position{line: 1426, col: 5, offset: 39453},
+				pos: position{line: 1426, col: 5, offset: 39456},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1426, col: 5, offset: 39453},
+						pos:        position{line: 1426, col: 5, offset: 39456},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1426, col: 10, offset: 39458},
+						pos: position{line: 1426, col: 10, offset: 39461},
 						expr: &seqExpr{
-							pos: position{line: 1426, col: 11, offset: 39459},
+							pos: position{line: 1426, col: 11, offset: 39462},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1426, col: 11, offset: 39459},
+									pos: position{line: 1426, col: 11, offset: 39462},
 									expr: &litMatcher{
-										pos:        position{line: 1426, col: 12, offset: 39460},
+										pos:        position{line: 1426, col: 12, offset: 39463},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1426, col: 17, offset: 39465},
+									pos:  position{line: 1426, col: 17, offset: 39468},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1426, col: 35, offset: 39483},
+						pos:        position{line: 1426, col: 35, offset: 39486},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11291,29 +11299,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1428, col: 1, offset: 39489},
+			pos:  position{line: 1428, col: 1, offset: 39492},
 			expr: &seqExpr{
-				pos: position{line: 1429, col: 5, offset: 39511},
+				pos: position{line: 1429, col: 5, offset: 39514},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1429, col: 5, offset: 39511},
+						pos:        position{line: 1429, col: 5, offset: 39514},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1429, col: 10, offset: 39516},
+						pos: position{line: 1429, col: 10, offset: 39519},
 						expr: &seqExpr{
-							pos: position{line: 1429, col: 11, offset: 39517},
+							pos: position{line: 1429, col: 11, offset: 39520},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1429, col: 11, offset: 39517},
+									pos: position{line: 1429, col: 11, offset: 39520},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1429, col: 12, offset: 39518},
+										pos:  position{line: 1429, col: 12, offset: 39521},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1429, col: 27, offset: 39533},
+									pos:  position{line: 1429, col: 27, offset: 39536},
 									name: "SourceCharacter",
 								},
 							},
@@ -11324,19 +11332,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1431, col: 1, offset: 39552},
+			pos:  position{line: 1431, col: 1, offset: 39555},
 			expr: &seqExpr{
-				pos: position{line: 1431, col: 7, offset: 39558},
+				pos: position{line: 1431, col: 7, offset: 39561},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1431, col: 7, offset: 39558},
+						pos: position{line: 1431, col: 7, offset: 39561},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1431, col: 7, offset: 39558},
+							pos:  position{line: 1431, col: 7, offset: 39561},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1431, col: 19, offset: 39570},
+						pos:  position{line: 1431, col: 19, offset: 39573},
 						name: "LineTerminator",
 					},
 				},
@@ -11344,16 +11352,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1433, col: 1, offset: 39586},
+			pos:  position{line: 1433, col: 1, offset: 39589},
 			expr: &choiceExpr{
-				pos: position{line: 1433, col: 7, offset: 39592},
+				pos: position{line: 1433, col: 7, offset: 39595},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1433, col: 7, offset: 39592},
+						pos:  position{line: 1433, col: 7, offset: 39595},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1433, col: 11, offset: 39596},
+						pos:  position{line: 1433, col: 11, offset: 39599},
 						name: "EOF",
 					},
 				},
@@ -11361,11 +11369,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1435, col: 1, offset: 39601},
+			pos:  position{line: 1435, col: 1, offset: 39604},
 			expr: &notExpr{
-				pos: position{line: 1435, col: 7, offset: 39607},
+				pos: position{line: 1435, col: 7, offset: 39610},
 				expr: &anyMatcher{
-					line: 1435, col: 8, offset: 39608,
+					line: 1435, col: 8, offset: 39611,
 				},
 			},
 		},

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -1054,32 +1054,30 @@ function peg$parse(input, options) {
           },
       peg$c514 = /^[^\/\\]/,
       peg$c515 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c516 = "\\/",
-      peg$c517 = peg$literalExpectation("\\/", false),
-      peg$c518 = /^[\0-\x1F\\]/,
-      peg$c519 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c520 = peg$otherExpectation("whitespace"),
-      peg$c521 = "\t",
-      peg$c522 = peg$literalExpectation("\t", false),
-      peg$c523 = "\x0B",
-      peg$c524 = peg$literalExpectation("\x0B", false),
-      peg$c525 = "\f",
-      peg$c526 = peg$literalExpectation("\f", false),
-      peg$c527 = " ",
-      peg$c528 = peg$literalExpectation(" ", false),
-      peg$c529 = "\xA0",
-      peg$c530 = peg$literalExpectation("\xA0", false),
-      peg$c531 = "\uFEFF",
-      peg$c532 = peg$literalExpectation("\uFEFF", false),
-      peg$c533 = /^[\n\r\u2028\u2029]/,
-      peg$c534 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c535 = peg$otherExpectation("comment"),
-      peg$c536 = "/*",
-      peg$c537 = peg$literalExpectation("/*", false),
-      peg$c538 = "*/",
-      peg$c539 = peg$literalExpectation("*/", false),
-      peg$c540 = "//",
-      peg$c541 = peg$literalExpectation("//", false),
+      peg$c516 = /^[\0-\x1F\\]/,
+      peg$c517 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c518 = peg$otherExpectation("whitespace"),
+      peg$c519 = "\t",
+      peg$c520 = peg$literalExpectation("\t", false),
+      peg$c521 = "\x0B",
+      peg$c522 = peg$literalExpectation("\x0B", false),
+      peg$c523 = "\f",
+      peg$c524 = peg$literalExpectation("\f", false),
+      peg$c525 = " ",
+      peg$c526 = peg$literalExpectation(" ", false),
+      peg$c527 = "\xA0",
+      peg$c528 = peg$literalExpectation("\xA0", false),
+      peg$c529 = "\uFEFF",
+      peg$c530 = peg$literalExpectation("\uFEFF", false),
+      peg$c531 = /^[\n\r\u2028\u2029]/,
+      peg$c532 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c533 = peg$otherExpectation("comment"),
+      peg$c534 = "/*",
+      peg$c535 = peg$literalExpectation("/*", false),
+      peg$c536 = "*/",
+      peg$c537 = peg$literalExpectation("*/", false),
+      peg$c538 = "//",
+      peg$c539 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -14630,7 +14628,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseRegexpBody() {
-    var s0, s1, s2;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = [];
@@ -14642,12 +14640,32 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c515); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c516) {
-        s2 = peg$c516;
-        peg$currPos += 2;
+      s2 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 92) {
+        s3 = peg$c431;
+        peg$currPos++;
       } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c432); }
+      }
+      if (s3 !== peg$FAILED) {
+        if (input.length > peg$currPos) {
+          s4 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c481); }
+        }
+        if (s4 !== peg$FAILED) {
+          s3 = [s3, s4];
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c517); }
       }
     }
     if (s2 !== peg$FAILED) {
@@ -14661,12 +14679,32 @@ function peg$parse(input, options) {
           if (peg$silentFails === 0) { peg$fail(peg$c515); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c516) {
-            s2 = peg$c516;
-            peg$currPos += 2;
+          s2 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 92) {
+            s3 = peg$c431;
+            peg$currPos++;
           } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c432); }
+          }
+          if (s3 !== peg$FAILED) {
+            if (input.length > peg$currPos) {
+              s4 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c481); }
+            }
+            if (s4 !== peg$FAILED) {
+              s3 = [s3, s4];
+              s2 = s3;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c517); }
           }
         }
       }
@@ -14685,12 +14723,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c518.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -14759,51 +14797,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c521;
+      s0 = peg$c519;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c520); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c523;
+        s0 = peg$c521;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c522); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c525;
+          s0 = peg$c523;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c526); }
+          if (peg$silentFails === 0) { peg$fail(peg$c524); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c527;
+            s0 = peg$c525;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c526); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c529;
+              s0 = peg$c527;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c530); }
+              if (peg$silentFails === 0) { peg$fail(peg$c528); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c531;
+                s0 = peg$c529;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c532); }
+                if (peg$silentFails === 0) { peg$fail(peg$c530); }
               }
             }
           }
@@ -14813,7 +14851,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c520); }
+      if (peg$silentFails === 0) { peg$fail(peg$c518); }
     }
 
     return s0;
@@ -14822,12 +14860,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c533.test(input.charAt(peg$currPos))) {
+    if (peg$c531.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c534); }
+      if (peg$silentFails === 0) { peg$fail(peg$c532); }
     }
 
     return s0;
@@ -14841,7 +14879,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c535); }
+      if (peg$silentFails === 0) { peg$fail(peg$c533); }
     }
 
     return s0;
@@ -14851,24 +14889,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c536) {
-      s1 = peg$c536;
+    if (input.substr(peg$currPos, 2) === peg$c534) {
+      s1 = peg$c534;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c537); }
+      if (peg$silentFails === 0) { peg$fail(peg$c535); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c538) {
-        s5 = peg$c538;
+      if (input.substr(peg$currPos, 2) === peg$c536) {
+        s5 = peg$c536;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c539); }
+        if (peg$silentFails === 0) { peg$fail(peg$c537); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -14895,12 +14933,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c538) {
-          s5 = peg$c538;
+        if (input.substr(peg$currPos, 2) === peg$c536) {
+          s5 = peg$c536;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c539); }
+          if (peg$silentFails === 0) { peg$fail(peg$c537); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -14924,12 +14962,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c538) {
-          s3 = peg$c538;
+        if (input.substr(peg$currPos, 2) === peg$c536) {
+          s3 = peg$c536;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c539); }
+          if (peg$silentFails === 0) { peg$fail(peg$c537); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -14954,12 +14992,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c540) {
-      s1 = peg$c540;
+    if (input.substr(peg$currPos, 2) === peg$c538) {
+      s1 = peg$c538;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c541); }
+      if (peg$silentFails === 0) { peg$fail(peg$c539); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -1342,7 +1342,7 @@ Regexp
   = "/" body:RegexpBody "/" !KeyWordStart { RETURN(body) }
 
 RegexpBody
-  = ([^/\\]/"\\/")+ { RETURN(TEXT) }
+  = ([^/\\] / "\\" .)+ { RETURN(TEXT) }
 
 EscapedChar
   = [\x00-\x1f\\]

--- a/expr/ztests/regexp-escapes.yaml
+++ b/expr/ztests/regexp-escapes.yaml
@@ -1,0 +1,8 @@
+# Add \a and \v when they can be be represented in a ZSON string
+# (https://github.com/brimdata/zed/issues/3041).
+zed: '/\f\t\n\r\(\)\*\+\.\/\?\[\]\{\}/'
+
+input: &input |
+  {a:"\f\t\n\r()*+./?[]{}"}
+
+output: *input


### PR DESCRIPTION
The parser allows only one backslash escape sequence in regular
expressions: "\/".  This is too restrictive.  Instead, allow a backslash
followed by any character.  (This means the parser now allows invalid
escape sequences, but the expr packages will reject them when it tries
to compile them.)

Closes #3037.