### PR TITLE
change defaults for ZNG validation

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -24,9 +24,9 @@ func (f *Flags) Options() anyio.ReaderOpts {
 	return f.ReaderOpts
 }
 
-func (f *Flags) SetFlags(fs *flag.FlagSet) {
+func (f *Flags) SetFlags(fs *flag.FlagSet, validate bool) {
 	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,zng,zst,json,ndjson,zeek,zjson,csv,tzng,parquet]")
-	fs.BoolVar(&f.Zng.Validate, "validate", true, "validate the input format when reading ZNG streams")
+	fs.BoolVar(&f.Zng.Validate, "validate", validate, "validate the input format when reading ZNG streams")
 	f.ReadMax = auto.NewBytes(zngio.MaxSize)
 	fs.Var(&f.ReadMax, "readmax", "maximum memory used read buffers in MiB, MB, etc")
 	f.ReadSize = auto.NewBytes(zngio.ReadSize)

--- a/cmd/zed/index/convert/command.go
+++ b/cmd/zed/index/convert/command.go
@@ -51,7 +51,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.StringVar(&c.order, "order", "asc", "specify data in ascending (asc) or descending (desc) order")
 	f.StringVar(&c.outputFile, "o", "index.zng", "name of index output file")
 	f.StringVar(&c.keys, "k", "", "comma-separated list of field names for keys")
-	c.inputFlags.SetFlags(f)
+	c.inputFlags.SetFlags(f, true)
 
 	return c, nil
 }

--- a/cmd/zed/index/create/command.go
+++ b/cmd/zed/index/create/command.go
@@ -50,8 +50,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.StringVar(&c.keyField, "k", "", "field name of search keys")
 	f.BoolVar(&c.inputReady, "x", false, "input file is already sorted keys (and optional values)")
 	f.BoolVar(&c.skip, "S", false, "skip all records except for the first of each stream")
-	c.inputFlags.SetFlags(f)
-
+	c.inputFlags.SetFlags(f, true)
 	return c, nil
 }
 

--- a/cmd/zed/lake/load/command.go
+++ b/cmd/zed/lake/load/command.go
@@ -51,7 +51,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	}
 	f.Var(&c.seekStride, "seekstride", "size of seek-index unit for ZNG data, as '32KB', '1MB', etc.")
 	c.CommitFlags.SetFlags(f)
-	c.inputFlags.SetFlags(f)
+	c.inputFlags.SetFlags(f, true)
 	c.procFlags.SetFlags(f)
 	c.lakeFlags.SetFlags(f)
 	return c, nil

--- a/cmd/zed/query/command.go
+++ b/cmd/zed/query/command.go
@@ -92,7 +92,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	c.outputFlags.SetFlags(f)
-	c.inputFlags.SetFlags(f)
+	c.inputFlags.SetFlags(f, false)
 	c.procFlags.SetFlags(f)
 	f.BoolVar(&c.verbose, "v", false, "show verbose details")
 	f.BoolVar(&c.stats, "S", false, "display search stats on stderr")

--- a/cmd/zed/zst/create/command.go
+++ b/cmd/zed/zst/create/command.go
@@ -53,7 +53,7 @@ func MibToBytes(mib float64) int {
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zst.Command)}
-	c.inputFlags.SetFlags(f)
+	c.inputFlags.SetFlags(f, true)
 	c.outputFlags.SetFlagsWithFormat(f, "zst")
 	return c, nil
 }

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -449,7 +449,10 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
-	zr, err := anyio.NewReader(anyio.GzipReader(r.Body), zson.NewContext())
+	// Force validation of ZNG when initialing loading into the lake.
+	var opts anyio.ReaderOpts
+	opts.Zng.Validate = true
+	zr, err := anyio.NewReaderWithOpts(anyio.GzipReader(r.Body), zson.NewContext(), opts)
 	if err != nil {
 		w.Error(err)
 		return

--- a/zio/anyio/reader.go
+++ b/zio/anyio/reader.go
@@ -57,6 +57,9 @@ func NewReaderWithOpts(r io.Reader, zctx *zson.Context, opts ReaderOpts) (zio.Re
 	}
 	track.Reset()
 
+	// For the matching reader, force validation to true so we are extra
+	// careful about auto-matching ZNG.  Then, once matched, relaxed
+	// validation to the user setting in the actual reader returned.
 	zngOpts := opts.Zng
 	zngOpts.Validate = true
 	zngErr := match(zngio.NewReaderWithOpts(track, zson.NewContext(), zngOpts), "zng")

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -554,7 +554,7 @@ func runzq(path, zed, input string, outputFlags []string, inputFlags []string) (
 	}
 	var inflags inputflags.Flags
 	var flags flag.FlagSet
-	inflags.SetFlags(&flags)
+	inflags.SetFlags(&flags, true)
 	if err := flags.Parse(inputFlags); err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
This commit changes the default settings for ZNG validation
on the query command to be false while on the ingest commands
to be true.  We also fixed in a bug in the load service endpoint,
where validation was not being done.