### PR TITLE
properly format empty string field name

### DIFF
--- a/zed_test.go
+++ b/zed_test.go
@@ -163,7 +163,8 @@ diff baseline.parquet boomerang.parquet
 			if err != nil {
 				if s := err.Error(); strings.Contains(s, parquetio.ErrEmptyRecordType.Error()) ||
 					strings.Contains(s, parquetio.ErrNullType.Error()) ||
-					strings.Contains(s, parquetio.ErrUnionType.Error()) {
+					strings.Contains(s, parquetio.ErrUnionType.Error()) ||
+					strings.Contains(s, "column has no name") {
 					t.Skip("skipping because the Parquet writer cannot handle an input type")
 				}
 				err = &BoomerangError{

--- a/zng/name.go
+++ b/zng/name.go
@@ -14,6 +14,9 @@ func TypeChar(c rune) bool {
 }
 
 func IsIdentifier(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
 	first := true
 	for _, c := range s {
 		if !IDChar(c) && (first || !unicode.IsDigit(c)) {

--- a/zng/name.go
+++ b/zng/name.go
@@ -14,7 +14,7 @@ func TypeChar(c rune) bool {
 }
 
 func IsIdentifier(s string) bool {
-	if len(s) == 0 {
+	if s == "" {
 		return false
 	}
 	first := true

--- a/zson/ztests/empty-string-field.yaml
+++ b/zson/ztests/empty-string-field.yaml
@@ -1,0 +1,6 @@
+zed: "*"
+
+input: &input |
+  {"":1}
+
+output: *input


### PR DESCRIPTION
The JSON spec allows empty string to be an object key and
it was ZSON's intention to do the same, but the ZSON formatter
was incorrectly printing out the empty field name without quotes.
This commit fixes this bug and adds a test.