### PR TITLE
Add index object meta query

### DIFF
--- a/cmd/zed/lake/index/command.go
+++ b/cmd/zed/lake/index/command.go
@@ -11,7 +11,7 @@ import (
 var Index = &charm.Spec{
 	Name:  "index",
 	Usage: "index [subcommand]",
-	Short: "create and drop indices, index data",
+	Short: "create and drop indexes, index data",
 	Long: `
 The index subcommands control the creation, management, and deletion
 of search indexes in a Zed lake.  Unlike traditional approaches to search

--- a/docs/lake/service-api.md
+++ b/docs/lake/service-api.md
@@ -47,7 +47,7 @@ The supported mime types are as follows:
 
 <!-- XXX: Index revamp -->
 <!-- - [Create Index](#create-index) -->
-<!-- - [List Indices](#list-indices) -->
+<!-- - [List Indexes](#list-indexes) -->
 <!-- - [Drop Index](#drop-index) -->
 <!-- - [Index Data](#index-data) -->
 

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -287,7 +287,7 @@ func (b *Branch) ApplyIndexRules(ctx context.Context, rules []index.Rule, ids []
 	author := "indexer"
 	message := index_message(rules)
 	return b.commit(ctx, func(parent *branches.Config, retries int) (*commits.Object, error) {
-		return commits.NewAddIndicesObject(parent.Commit, author, message, retries, idxrefs), nil
+		return commits.NewAddIndexesObject(parent.Commit, author, message, retries, idxrefs), nil
 	})
 }
 

--- a/lake/commits/actions.go
+++ b/lake/commits/actions.go
@@ -91,3 +91,17 @@ func (a *AddIndex) String() string {
 func (a *AddIndex) CommitID() ksuid.KSUID {
 	return a.Commit
 }
+
+type DeleteIndex struct {
+	Commit ksuid.KSUID `zng:"commit"`
+	ID     ksuid.KSUID `zng:"id"`
+	RuleID ksuid.KSUID `zng:"rule_id"`
+}
+
+func (d *DeleteIndex) String() string {
+	return fmt.Sprintf("DEL_INDEX %s/%s", d.RuleID, d.ID)
+}
+
+func (d *DeleteIndex) CommitID() ksuid.KSUID {
+	return d.Commit
+}

--- a/lake/commits/object.go
+++ b/lake/commits/object.go
@@ -54,9 +54,9 @@ func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, i
 	return o
 }
 
-func NewAddIndicesObject(parent ksuid.KSUID, author, message string, retries int, indices []*index.Object) *Object {
+func NewAddIndexesObject(parent ksuid.KSUID, author, message string, retries int, indexes []*index.Object) *Object {
 	o := NewObject(parent, author, message, retries)
-	for _, index := range indices {
+	for _, index := range indexes {
 		o.appendAddIndex(index)
 	}
 	return o

--- a/lake/commits/patch.go
+++ b/lake/commits/patch.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/order"
 	"github.com/segmentio/ksuid"
 )
@@ -48,6 +49,11 @@ func (p *Patch) SelectAll() DataObjects {
 	return objects
 }
 
+func (p *Patch) SelectIndices(span extent.Span, o order.Which) []*index.Object {
+	objects := p.base.SelectIndices(span, o)
+	return append(objects, p.diff.SelectIndices(span, o)...)
+}
+
 func (p *Patch) DataObjects() []ksuid.KSUID {
 	var ids []ksuid.KSUID
 	for _, dataObject := range p.diff.SelectAll() {
@@ -86,6 +92,14 @@ func (p *Patch) DeleteObject(id ksuid.KSUID) error {
 	// needed delete Actions when building the transaction patch.
 	p.deletes = append(p.deletes, id)
 	return nil
+}
+
+func (p *Patch) AddIndexObject(object *index.Object) error {
+	return errors.New("ADD_INDEX unsupported for patches #3000")
+}
+
+func (p *Patch) DeleteIndexObject(ruleID ksuid.KSUID, id ksuid.KSUID) error {
+	return errors.New("DEL_INDEX unsupported for patches #3000")
 }
 
 func (p *Patch) NewCommitObject(parent ksuid.KSUID, retries int, author, message string) *Object {

--- a/lake/commits/patch.go
+++ b/lake/commits/patch.go
@@ -49,9 +49,9 @@ func (p *Patch) SelectAll() DataObjects {
 	return objects
 }
 
-func (p *Patch) SelectIndices(span extent.Span, o order.Which) []*index.Object {
-	objects := p.base.SelectIndices(span, o)
-	return append(objects, p.diff.SelectIndices(span, o)...)
+func (p *Patch) SelectIndexes(span extent.Span, o order.Which) []*index.Object {
+	objects := p.base.SelectIndexes(span, o)
+	return append(objects, p.diff.SelectIndexes(span, o)...)
 }
 
 func (p *Patch) DataObjects() []ksuid.KSUID {

--- a/lake/commits/snapshot.go
+++ b/lake/commits/snapshot.go
@@ -48,8 +48,8 @@ func NewSnapshot() *Snapshot {
 	return &Snapshot{
 		objects:        make(map[ksuid.KSUID]*data.Object),
 		deletedObjects: make(map[ksuid.KSUID]*data.Object),
-		indexes:        index.NewMap(),
-		deletedIndexes: index.NewMap(),
+		indexes:        make(index.Map),
+		deletedIndexes: make(index.Map),
 	}
 }
 
@@ -88,7 +88,7 @@ func (s *Snapshot) DeleteIndexObject(ruleID ksuid.KSUID, id ksuid.KSUID) error {
 	if object == nil {
 		return fmt.Errorf("%s: delete of a non-existent index object: %w", index.ObjectName(ruleID, id), ErrWriteConflict)
 	}
-	s.indexes.Remove(ruleID, id)
+	s.indexes.Delete(ruleID, id)
 	s.deletedIndexes.Insert(object)
 	return nil
 }

--- a/lake/commits/snapshot.go
+++ b/lake/commits/snapshot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/order"
 	"github.com/segmentio/ksuid"
 )
@@ -19,20 +20,25 @@ type View interface {
 	Lookup(ksuid.KSUID) (*data.Object, error)
 	Select(extent.Span, order.Which) DataObjects
 	SelectAll() DataObjects
+	SelectIndices(extent.Span, order.Which) []*index.Object
 }
 
 type Writeable interface {
 	View
 	AddDataObject(*data.Object) error
-	DeleteObject(id ksuid.KSUID) error
+	DeleteObject(ksuid.KSUID) error
+	AddIndexObject(*index.Object) error
+	DeleteIndexObject(ksuid.KSUID, ksuid.KSUID) error
 }
 
 // A snapshot summarizes the pool state at any point in
 // the commit object tree.
 // XXX redefine snapshot as type map instead of struct
 type Snapshot struct {
-	objects map[ksuid.KSUID]*data.Object
-	deletes map[ksuid.KSUID]*data.Object
+	objects        map[ksuid.KSUID]*data.Object
+	deletedObjects map[ksuid.KSUID]*data.Object
+	indices        index.Map
+	deletedIndices index.Map
 }
 
 var _ View = (*Snapshot)(nil)
@@ -40,8 +46,10 @@ var _ Writeable = (*Snapshot)(nil)
 
 func NewSnapshot() *Snapshot {
 	return &Snapshot{
-		objects: make(map[ksuid.KSUID]*data.Object),
-		deletes: make(map[ksuid.KSUID]*data.Object),
+		objects:        make(map[ksuid.KSUID]*data.Object),
+		deletedObjects: make(map[ksuid.KSUID]*data.Object),
+		indices:        index.NewMap(),
+		deletedIndices: index.NewMap(),
 	}
 }
 
@@ -51,7 +59,7 @@ func (s *Snapshot) AddDataObject(object *data.Object) error {
 		return fmt.Errorf("%s: add of a duplicate data object: %w", id, ErrWriteConflict)
 	}
 	s.objects[id] = object
-	delete(s.deletes, id)
+	delete(s.deletedObjects, id)
 	return nil
 }
 
@@ -61,7 +69,27 @@ func (s *Snapshot) DeleteObject(id ksuid.KSUID) error {
 		return fmt.Errorf("%s: delete of a non-existent data object: %w", id, ErrWriteConflict)
 	}
 	delete(s.objects, id)
-	s.deletes[id] = object
+	s.deletedObjects[id] = object
+	return nil
+}
+
+func (s *Snapshot) AddIndexObject(object *index.Object) error {
+	id := object.ID
+	if s.indices.Lookup(object.Rule.RuleID(), id) != nil {
+		return fmt.Errorf("%s: add of a duplicate index object: %w", id, ErrWriteConflict)
+	}
+	s.indices.Insert(object)
+	delete(s.deletedIndices, id)
+	return nil
+}
+
+func (s *Snapshot) DeleteIndexObject(ruleID ksuid.KSUID, id ksuid.KSUID) error {
+	object := s.indices.Lookup(ruleID, id)
+	if object == nil {
+		return fmt.Errorf("%s: delete of a non-existent index object: %w", index.ObjectName(ruleID, id), ErrWriteConflict)
+	}
+	s.indices.Remove(ruleID, id)
+	s.deletedIndices.Insert(object)
 	return nil
 }
 
@@ -83,7 +111,7 @@ func (s *Snapshot) Lookup(id ksuid.KSUID) (*data.Object, error) {
 }
 
 func (s *Snapshot) LookupDeleted(id ksuid.KSUID) (*data.Object, error) {
-	o, ok := s.deletes[id]
+	o, ok := s.deletedObjects[id]
 	if !ok {
 		return nil, fmt.Errorf("%s: %w", id, ErrNotFound)
 	}
@@ -109,6 +137,21 @@ func (s *Snapshot) SelectAll() DataObjects {
 	return objects
 }
 
+func (s *Snapshot) SelectIndices(scan extent.Span, order order.Which) []*index.Object {
+	var indices []*index.Object
+	for _, i := range s.indices.All() {
+		o, ok := s.objects[i.ID]
+		if !ok {
+			continue
+		}
+		segspan := o.Span(order)
+		if scan == nil || segspan == nil || extent.Overlaps(scan, segspan) {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
 func (s *Snapshot) Copy() *Snapshot {
 	out := NewSnapshot()
 	for key, val := range s.objects {
@@ -127,12 +170,15 @@ func PlayAction(w Writeable, action Action) error {
 	if _, ok := action.(Action); !ok {
 		return badObject(action)
 	}
-	//XXX other cases like actions.AddIndex etc coming soon...
 	switch action := action.(type) {
 	case *Add:
 		w.AddDataObject(&action.Object)
 	case *Delete:
 		w.DeleteObject(action.ID)
+	case *AddIndex:
+		w.AddIndexObject(&action.Object)
+	case *DeleteIndex:
+		w.DeleteIndexObject(action.RuleID, action.ID)
 	}
 	return nil
 }

--- a/lake/index/object.go
+++ b/lake/index/object.go
@@ -8,17 +8,61 @@ import (
 )
 
 type Object struct {
-	Rule Rule
-	ID   ksuid.KSUID
+	Rule Rule        `zng:"rule"`
+	ID   ksuid.KSUID `zng:"id"`
 }
 
 func (o Object) String() string {
 	//XXX data object looks like this:
 	//	return fmt.Sprintf("%s %d record%s in %d data bytes", o.ID, o.Count, plural(int(o.Count)), o.RowSize)
-	return fmt.Sprintf("%s/%s", o.Rule.RuleID(), o.ID)
+	return ObjectName(o.Rule.RuleID(), o.ID)
+}
+
+func ObjectName(ruleID, id ksuid.KSUID) string {
+	return fmt.Sprintf("%s/%s", ruleID, id)
 }
 
 func (o Object) Path(path *storage.URI) *storage.URI {
 	return path.AppendPath(o.Rule.RuleID().String())
 	//	return xObjectPath(path, o.Rule, o.ID)
 }
+
+type Map map[ksuid.KSUID]ObjectRules
+
+func NewMap() Map { return make(Map) }
+
+func (m Map) Lookup(ruleID, id ksuid.KSUID) *Object {
+	if rules, ok := m[id]; ok {
+		if object, ok := rules[ruleID]; ok {
+			return object
+		}
+	}
+	return nil
+}
+
+func (m Map) Insert(object *Object) {
+	rules, ok := m[object.ID]
+	if !ok {
+		rules = make(map[ksuid.KSUID]*Object)
+		m[object.ID] = rules
+	}
+	rules[object.Rule.RuleID()] = object
+}
+
+func (m Map) Remove(ruleID, id ksuid.KSUID) {
+	if rules, ok := m[id]; ok {
+		delete(rules, id)
+	}
+}
+
+func (m Map) All() []*Object {
+	var objects []*Object
+	for _, rules := range m {
+		for _, object := range rules {
+			objects = append(objects, object)
+		}
+	}
+	return objects
+}
+
+type ObjectRules map[ksuid.KSUID]*Object

--- a/lake/index/object.go
+++ b/lake/index/object.go
@@ -29,8 +29,6 @@ func (o Object) Path(path *storage.URI) *storage.URI {
 
 type Map map[ksuid.KSUID]ObjectRules
 
-func NewMap() Map { return make(Map) }
-
 func (m Map) Lookup(ruleID, id ksuid.KSUID) *Object {
 	if rules, ok := m[id]; ok {
 		if object, ok := rules[ruleID]; ok {
@@ -49,7 +47,7 @@ func (m Map) Insert(object *Object) {
 	rules[object.Rule.RuleID()] = object
 }
 
-func (m Map) Remove(ruleID, id ksuid.KSUID) {
+func (m Map) Delete(ruleID, id ksuid.KSUID) {
 	if rules, ok := m[id]; ok {
 		delete(rules, id)
 	}

--- a/lake/partition.go
+++ b/lake/partition.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zng"
@@ -172,6 +173,35 @@ func objectReader(ctx context.Context, zctx *zson.Context, snap commits.View, sp
 	var scanErr error
 	go func() {
 		scanErr = ScanSpan(ctx, snap, span, order, ch)
+		close(ch)
+	}()
+	m := zson.NewZNGMarshalerWithContext(zctx)
+	m.Decorate(zson.StylePackage)
+	return readerFunc(func() (*zng.Record, error) {
+		select {
+		case p := <-ch:
+			if p.ID == ksuid.Nil {
+				cancel()
+				return nil, scanErr
+			}
+			rec, err := m.MarshalRecord(p)
+			if err != nil {
+				cancel()
+				return nil, err
+			}
+			return rec, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}), nil
+}
+
+func indexObjectReader(ctx context.Context, zctx *zson.Context, snap commits.View, span extent.Span, order order.Which) (zio.Reader, error) {
+	ch := make(chan index.Object)
+	ctx, cancel := context.WithCancel(ctx)
+	var scanErr error
+	go func() {
+		scanErr = ScanIndices(ctx, snap, span, order, ch)
 		close(ch)
 	}()
 	m := zson.NewZNGMarshalerWithContext(zctx)

--- a/lake/root.go
+++ b/lake/root.go
@@ -509,6 +509,20 @@ func (r *Root) newCommitMetaScheduler(ctx context.Context, zctx *zson.Context, p
 			return nil, err
 		}
 		return newScannerScheduler(s), nil
+	case "indices":
+		snap, err := p.commits.Snapshot(ctx, commit)
+		if err != nil {
+			return nil, err
+		}
+		reader, err := indexObjectReader(ctx, zctx, snap, span, p.Layout.Order)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
 	case "partitions":
 		snap, err := p.commits.Snapshot(ctx, commit)
 		if err != nil {

--- a/lake/root.go
+++ b/lake/root.go
@@ -509,7 +509,7 @@ func (r *Root) newCommitMetaScheduler(ctx context.Context, zctx *zson.Context, p
 			return nil, err
 		}
 		return newScannerScheduler(s), nil
-	case "indices":
+	case "indexes":
 		snap, err := p.commits.Snapshot(ctx, commit)
 		if err != nil {
 			return nil, err

--- a/lake/scheduler.go
+++ b/lake/scheduler.go
@@ -168,10 +168,10 @@ func ScanPartitions(ctx context.Context, snap commits.View, span extent.Span, o 
 	return nil
 }
 
-func ScanIndices(ctx context.Context, snap commits.View, span extent.Span, o order.Which, ch chan<- index.Object) error {
-	for _, idx := range snap.SelectIndices(span, o) {
+func ScanIndexes(ctx context.Context, snap commits.View, span extent.Span, o order.Which, ch chan<- *index.Object) error {
+	for _, idx := range snap.SelectIndexes(span, o) {
 		select {
-		case ch <- *idx:
+		case ch <- idx:
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/lake/scheduler.go
+++ b/lake/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/proc"
 	"github.com/brimdata/zed/zbuf"
@@ -160,6 +161,17 @@ func ScanPartitions(ctx context.Context, snap commits.View, span extent.Span, o 
 		}
 		select {
 		case ch <- p:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func ScanIndices(ctx context.Context, snap commits.View, span extent.Span, o order.Which, ch chan<- index.Object) error {
+	for _, idx := range snap.SelectIndices(span, o) {
+		select {
+		case ch <- *idx:
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/lake/ztests/index/apply-by-ip.yaml
+++ b/lake/ztests/index/apply-by-ip.yaml
@@ -21,7 +21,6 @@ inputs:
       )
       | left join on id = o.rule.id
       | count() by name,type
-      | sort name
 
 outputs:
   - name: stderr

--- a/lake/ztests/index/apply-by-ip.yaml
+++ b/lake/ztests/index/apply-by-ip.yaml
@@ -17,7 +17,7 @@ inputs:
     data: |
       from (
         :index_rules => sort id;
-        test@main:indices => sort rule.id | cut o:=this;
+        test@main:indexes => sort rule.id | cut o:=this;
       )
       | left join on id = o.rule.id
       | count() by name,type

--- a/lake/ztests/index/apply-by-ip.yaml
+++ b/lake/ztests/index/apply-by-ip.yaml
@@ -6,20 +6,32 @@ script: |
   zed lake index create -q IPs type ip
   zed lake index apply -use test@main IPs $id
   echo ===
-  zed lake query -Z "from test@main:rawlog | cut this:=object.Rule | drop id,ts"
+  zed lake query -Z -I query.zed
 
 inputs:
   - name: in.zson
     data: |
       {x:127.0.0.1}
       {x:127.0.0.2}
+  - name: query.zed
+    data: |
+      from (
+        :index_rules => sort id;
+        test@main:indices => sort rule.id | cut o:=this;
+      )
+      | left join on id = o.rule.id
+      | count() by name,type
+      | sort name
 
 outputs:
+  - name: stderr
+    data: ""
   - name: stdout
     regexp: |
       \w{27} committed
       ===
       \{
           name: "IPs",
-          type: "ip"
+          type: "ip",
+          count: 1 \(uint64\)
       \}

--- a/ztest/shell.go
+++ b/ztest/shell.go
@@ -33,5 +33,6 @@ func RunShell(dir Dir, bindir, script string, stdin io.Reader, useenvs []string)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
+	fmt.Println("stderr", stderr.String())
 	return stdout.String(), stderr.String(), err
 }


### PR DESCRIPTION
Add the meta query ":indices" that displays all indexed objects at
specific point in the commit history.

Closes #3074