### PR TITLE
index update command

### DIFF
--- a/cmd/zed/lake/index/apply.go
+++ b/cmd/zed/lake/index/apply.go
@@ -13,26 +13,26 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
-var Apply = &charm.Spec{
+var apply = &charm.Spec{
 	Name:  "apply",
 	Usage: "apply rule tag [tag ...]",
 	Short: "apply index rule to one or more data objects in a branch",
-	New:   NewApply,
+	New:   newApply,
 }
 
-type ApplyCommand struct {
+type applyCommand struct {
 	*Command
 	ids []ksuid.KSUID
 	zedlake.CommitFlags
 }
 
-func NewApply(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &ApplyCommand{Command: parent.(*Command)}
+func newApply(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &applyCommand{Command: parent.(*Command)}
 	c.CommitFlags.SetFlags(f)
 	return c, nil
 }
 
-func (c *ApplyCommand) Run(args []string) error {
+func (c *applyCommand) Run(args []string) error {
 	ctx, cleanup, err := c.lake.Root().Init()
 	if err != nil {
 		return err

--- a/cmd/zed/lake/index/command.go
+++ b/cmd/zed/lake/index/command.go
@@ -39,11 +39,11 @@ new index objects to reflect the change.
 }
 
 func init() {
-	Index.Add(Apply)
-	Index.Add(Create)
-	Index.Add(Drop)
-	Index.Add(Ls)
-	Index.Add(Update)
+	Index.Add(apply)
+	Index.Add(create)
+	Index.Add(drop)
+	Index.Add(ls)
+	Index.Add(update)
 	zedlake.Cmd.Add(Index)
 }
 

--- a/cmd/zed/lake/index/command.go
+++ b/cmd/zed/lake/index/command.go
@@ -43,6 +43,7 @@ func init() {
 	Index.Add(Create)
 	Index.Add(Drop)
 	Index.Add(Ls)
+	Index.Add(Update)
 	zedlake.Cmd.Add(Index)
 }
 

--- a/cmd/zed/lake/index/create.go
+++ b/cmd/zed/lake/index/create.go
@@ -17,22 +17,22 @@ import (
 	"github.com/brimdata/zed/zson"
 )
 
-var Create = &charm.Spec{
+var create = &charm.Spec{
 	Name:  "create",
 	Usage: "create [options] rule-name pattern",
 	Short: "create an index rule for a lake",
-	New:   NewCreate,
+	New:   newCreate,
 }
 
-type CreateCommand struct {
+type createCommand struct {
 	*Command
 	framesize   int
 	outputFlags outputflags.Flags
 	procFlags   procflags.Flags
 }
 
-func NewCreate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &CreateCommand{Command: parent.(*Command)}
+func newCreate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &createCommand{Command: parent.(*Command)}
 	f.IntVar(&c.framesize, "framesize", 32*1024, "minimum frame size used in microindex file")
 	c.outputFlags.DefaultFormat = "lake"
 	c.outputFlags.SetFlags(f)
@@ -40,7 +40,7 @@ func NewCreate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	return c, nil
 }
 
-func (c *CreateCommand) Run(args []string) error {
+func (c *createCommand) Run(args []string) error {
 	ctx, cleanup, err := c.lake.Root().Init(&c.procFlags, &c.outputFlags)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func (c *CreateCommand) Run(args []string) error {
 	return err
 }
 
-func (c *CreateCommand) parseIndexRules(ctx context.Context, lake api.Interface, ruleName string, args []string) ([]index.Rule, error) {
+func (c *createCommand) parseIndexRules(ctx context.Context, lake api.Interface, ruleName string, args []string) ([]index.Rule, error) {
 	var rules []index.Rule
 	for len(args) > 0 {
 		rest, rule, err := parseRule(args, ruleName)

--- a/cmd/zed/lake/index/drop.go
+++ b/cmd/zed/lake/index/drop.go
@@ -10,22 +10,22 @@ import (
 	"github.com/brimdata/zed/pkg/rlimit"
 )
 
-var Drop = &charm.Spec{
+var drop = &charm.Spec{
 	Name:  "drop",
 	Usage: "drop [-R root] [options] id... ",
 	Short: "drop rule from a lake index",
-	New:   NewDrop,
+	New:   newDrop,
 }
 
-type DropCommand struct {
+type dropCommand struct {
 	*Command
 }
 
-func NewDrop(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	return &DropCommand{Command: parent.(*Command)}, nil
+func newDrop(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &dropCommand{Command: parent.(*Command)}, nil
 }
 
-func (c *DropCommand) Run(args []string) error {
+func (c *dropCommand) Run(args []string) error {
 	ctx, cleanup, err := c.lake.Root().Init()
 	if err != nil {
 		return err

--- a/cmd/zed/lake/index/ls.go
+++ b/cmd/zed/lake/index/ls.go
@@ -11,26 +11,26 @@ import (
 	"github.com/brimdata/zed/pkg/storage"
 )
 
-var Ls = &charm.Spec{
+var ls = &charm.Spec{
 	Name:  "ls",
 	Usage: "ls [-R root] [options]",
 	Short: "list and display lake index rules",
-	New:   NewLs,
+	New:   newLs,
 }
 
-type LsCommand struct {
+type lsCommand struct {
 	*Command
 	outputFlags outputflags.Flags
 }
 
-func NewLs(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &LsCommand{Command: parent.(*Command)}
+func newLs(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &lsCommand{Command: parent.(*Command)}
 	c.outputFlags.DefaultFormat = "lake"
 	c.outputFlags.SetFlags(f)
 	return c, nil
 }
 
-func (c *LsCommand) Run(args []string) error {
+func (c *lsCommand) Run(args []string) error {
 	ctx, cleanup, err := c.lake.Root().Init(&c.outputFlags)
 	if err != nil {
 		return err

--- a/cmd/zed/lake/index/update.go
+++ b/cmd/zed/lake/index/update.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/brimdata/zed/cli/lakeflags"
+	zedlake "github.com/brimdata/zed/cmd/zed/lake"
+	"github.com/brimdata/zed/pkg/charm"
+	"github.com/brimdata/zed/pkg/rlimit"
+)
+
+var Update = &charm.Spec{
+	Name:  "update",
+	Usage: "update",
+	Short: "index all object in a branch using the current set of index rules",
+	New:   NewUpdate,
+}
+
+type UpdateCommand struct {
+	*Command
+	zedlake.CommitFlags
+}
+
+func NewUpdate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &UpdateCommand{Command: parent.(*Command)}
+	c.CommitFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *UpdateCommand) Run(args []string) error {
+	ctx, cleanup, err := c.lake.Root().Init()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
+		return err
+	}
+	lake, err := c.lake.Open(ctx)
+	if err != nil {
+		return err
+	}
+	head, err := c.lakeFlags.HEAD()
+	if err != nil {
+		return err
+	}
+	if head.Pool == "" {
+		return lakeflags.ErrNoHEAD
+	}
+	poolID, err := lake.PoolID(ctx, head.Pool)
+	if err != nil {
+		return err
+	}
+	commit, err := lake.UpdateIndex(ctx, poolID, head.Branch)
+	if err != nil {
+		return err
+	}
+	if !c.lakeFlags.Quiet {
+		fmt.Printf("%s committed\n", commit)
+	}
+	return nil
+}

--- a/cmd/zed/lake/index/update.go
+++ b/cmd/zed/lake/index/update.go
@@ -10,25 +10,25 @@ import (
 	"github.com/brimdata/zed/pkg/rlimit"
 )
 
-var Update = &charm.Spec{
+var update = &charm.Spec{
 	Name:  "update",
 	Usage: "update",
 	Short: "index all object in a branch using the current set of index rules",
-	New:   NewUpdate,
+	New:   newUpdate,
 }
 
-type UpdateCommand struct {
+type updateCommand struct {
 	*Command
 	zedlake.CommitFlags
 }
 
-func NewUpdate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &UpdateCommand{Command: parent.(*Command)}
+func newUpdate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &updateCommand{Command: parent.(*Command)}
 	c.CommitFlags.SetFlags(f)
 	return c, nil
 }
 
-func (c *UpdateCommand) Run(args []string) error {
+func (c *updateCommand) Run(args []string) error {
 	ctx, cleanup, err := c.lake.Root().Init()
 	if err != nil {
 		return err

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -33,6 +33,7 @@ type Interface interface {
 	AddIndexRules(context.Context, []index.Rule) error
 	DeleteIndexRules(context.Context, []ksuid.KSUID) ([]index.Rule, error)
 	ApplyIndexRules(ctx context.Context, rule string, pool ksuid.KSUID, branchName string, ids []ksuid.KSUID) (ksuid.KSUID, error)
+	UpdateIndex(ctx context.Context, pool ksuid.KSUID, branchName string) (ksuid.KSUID, error)
 }
 
 func ScanIndexRules(ctx context.Context, api Interface, d driver.Driver) error {

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -171,3 +171,15 @@ func (l *LocalSession) ApplyIndexRules(ctx context.Context, name string, poolID 
 	}
 	return commit, nil
 }
+
+func (l *LocalSession) UpdateIndex(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {
+	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
+	if err != nil {
+		return ksuid.Nil, err
+	}
+	rules, err := l.root.AllIndexRules(ctx)
+	if err != nil {
+		return ksuid.Nil, err
+	}
+	return branch.UpdateIndex(ctx, rules)
+}

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -163,6 +163,10 @@ func (*RemoteSession) ApplyIndexRules(ctx context.Context, rule string, poolID k
 	return ksuid.Nil, errors.New("unsupported see issue #2934")
 }
 
+func (*RemoteSession) UpdateIndex(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {
+	return ksuid.Nil, errors.New("unsupported see issue #2934")
+}
+
 func (r *RemoteSession) Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ScannerStats, error) {
 	res, err := r.conn.Query(ctx, head, src, srcfiles...)
 	if err != nil {

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -307,7 +307,7 @@ func (b *Branch) UpdateIndex(ctx context.Context, rules []index.Rule) (ksuid.KSU
 	if len(objects) == 0 {
 		return ksuid.Nil, errors.New("indices are up to date")
 	}
-	author := "indexer"
+	const author = "indexer"
 	message := index_message(rules)
 	return b.commit(ctx, func(parent *branches.Config, retries int) (*commits.Object, error) {
 		return commits.NewAddIndexesObject(parent.Commit, author, message, retries, objects), nil

--- a/lake/commits/snapshot.go
+++ b/lake/commits/snapshot.go
@@ -152,6 +152,20 @@ func (s *Snapshot) SelectIndexes(scan extent.Span, order order.Which) []*index.O
 	return indexes
 }
 
+func (s *Snapshot) Unindexed(rules []index.Rule) map[ksuid.KSUID][]index.Rule {
+	unindexed := make(map[ksuid.KSUID][]index.Rule)
+	for id := range s.objects {
+		to := rules
+		if o, ok := s.indexes[id]; ok {
+			to = o.Missing(rules)
+		}
+		if len(to) > 0 {
+			unindexed[id] = to
+		}
+	}
+	return unindexed
+}
+
 func (s *Snapshot) Copy() *Snapshot {
 	out := NewSnapshot()
 	for key, val := range s.objects {

--- a/lake/index/object.go
+++ b/lake/index/object.go
@@ -64,3 +64,13 @@ func (m Map) All() []*Object {
 }
 
 type ObjectRules map[ksuid.KSUID]*Object
+
+func (o ObjectRules) Missing(rules []Rule) []Rule {
+	var missing []Rule
+	for _, r := range rules {
+		if _, ok := o[r.RuleID()]; !ok {
+			missing = append(missing, r)
+		}
+	}
+	return missing
+}

--- a/lake/index/store.go
+++ b/lake/index/store.go
@@ -111,6 +111,17 @@ func (s *Store) stale() bool {
 	return time.Now().Sub(s.loadTime) > time.Second
 }
 
+func (s *Store) All(ctx context.Context) ([]Rule, error) {
+	if err := s.load(ctx); err != nil {
+		return nil, err
+	}
+	rules := make([]Rule, 0, len(s.table))
+	for _, r := range s.table {
+		rules = append(rules, r)
+	}
+	return rules, nil
+}
+
 func (s *Store) Names(ctx context.Context) ([]string, error) {
 	if err := s.load(ctx); err != nil {
 		return nil, err

--- a/lake/root.go
+++ b/lake/root.go
@@ -391,6 +391,10 @@ func (r *Root) LookupIndexRules(ctx context.Context, name string) ([]index.Rule,
 	return r.indexRules.Lookup(ctx, name)
 }
 
+func (r *Root) AllIndexRules(ctx context.Context) ([]index.Rule, error) {
+	return r.indexRules.All(ctx)
+}
+
 func (r *Root) batchifyIndexRules(ctx context.Context, zctx *zson.Context, f expr.Filter) (zbuf.Array, error) {
 	m := zson.NewZNGMarshalerWithContext(zctx)
 	m.Decorate(zson.StylePackage)

--- a/lake/ztests/index/update.yaml
+++ b/lake/ztests/index/update.yaml
@@ -1,0 +1,38 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -q test
+  zed lake index create -q foo field foo
+  zed lake index create -q bar field bar
+  zed lake load -q -use test@main 1.zson
+  zed lake load -q -use test@main 2.zson
+  zed lake load -q -use test@main 3.zson
+  zed lake index update -q -use test@main
+  zed lake query -z -I query.zed
+
+inputs:
+  - name: 1.zson
+    data: |
+      {foo:1,bar:1}
+  - name: 2.zson
+    data: |
+      {foo:2,bar:2}
+  - name: 3.zson
+    data: |
+      {foo:3,bar:3}
+  - name: query.zed
+    data: |
+      from (
+        :index_rules => sort id;
+        test@main:indices => sort rule.id | cut o:=this;
+      )
+      | left join on id = o.rule.id
+      | count() by name,fields 
+      | sort name
+
+outputs:
+  - name: stdout
+    data: |
+      {name:"bar",fields:[["bar"](=field.Path)](=field.List),count:3(uint64)}
+      {name:"foo",fields:[["foo"](=field.Path)](=field.List),count:3(uint64)}
+

--- a/lake/ztests/index/update.yaml
+++ b/lake/ztests/index/update.yaml
@@ -24,7 +24,7 @@ inputs:
     data: |
       from (
         :index_rules => sort id;
-        test@main:indices => sort rule.id | cut o:=this;
+        test@main:indexes => sort rule.id | cut o:=this;
       )
       | left join on id = o.rule.id
       | count() by name,fields 

--- a/lake/ztests/index/update.yaml
+++ b/lake/ztests/index/update.yaml
@@ -35,4 +35,3 @@ outputs:
     data: |
       {name:"bar",fields:[["bar"](=field.Path)](=field.List),count:3(uint64)}
       {name:"foo",fields:[["foo"](=field.Path)](=field.List),count:3(uint64)}
-

--- a/ztest/shell.go
+++ b/ztest/shell.go
@@ -33,6 +33,5 @@ func RunShell(dir Dir, bindir, script string, stdin io.Reader, useenvs []string)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	fmt.Println("stderr", stderr.String())
 	return stdout.String(), stderr.String(), err
 }


### PR DESCRIPTION
Add index update command which ensures that there is an index for each
member of the current index rule set for every object at a commit point.

Closes #3076