### PR TITLE
improve onboarding for installing and trying zed

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,3 @@
+# Zed FAQ
+
+Coming soon!

--- a/README.md
+++ b/README.md
@@ -37,23 +37,24 @@ Zed types can be used as schemas.
 Zed also has a cloud-based object design that was modeled after
 the `git` design pattern.  Commits to the lake are transactional
 and consistent.  Search index updates are also transactionally
-consistent with any ingested data and searches can run with or
+consistent with any ingested data, and searches can run with or
 without indexes.
 
 ## Quick Start
 
 _Detailed documentation [is available](docs/README.md)._
 
-The quickest way to get running on macOS, Linux, or windows
+The quickest way to get running on macOS, Linux, or Windows
 is to download a pre-built release binary.
-You can find these binaries on the Github releases page.
+You can find these binaries on the GitHub
+[releases](https://github.com/brimdata/zed/releases) page.
 
 Once installed, you can run the query engine from the command-line using `zq`:
 ```
-echo '{"s":"hello, word"}' | zq -Z -
+echo '{"s":"hello, world"}' | zq -Z -
 ```
 Or you can run a Zed lake server, load it with data using `zapi`, and hit the API.
-In one shell, run the server
+In one shell, run the server:
 ```
 mkdir scratch
 cd scratch
@@ -68,7 +69,7 @@ zapi query "from Demo"
 ```
 You can also use `zed` from Python.  After you install the Zed Python:
 ```
-pip install "git+https://github.com/brimdata/zed#subdirectory=python/zed"
+pip3 install "git+https://github.com/brimdata/zed#subdirectory=python/zed"
 ```
 You can hit the Zed service from a Python program:
 ```python
@@ -80,7 +81,7 @@ client = zed.Client()
 
 # Begin executing a Zed query for all records in the pool named "Demo".
 # This returns an iterator, not a container.
-records = zed.query('from Demo'):
+records = client.query('from Demo'):
 
 # Stream records from the server.
 for record in records:
@@ -111,7 +112,7 @@ make install
 This installs binaries in your `$GOPATH/bin`.
 
 > If you don't have Go installed, download and install it from the
-> [Go instasll page](https://golang.org/doc/install). Go version 1.16 or later is
+> [Go install page](https://golang.org/doc/install). Go version 1.16 or later is
 > required.
 
 ## Contributing
@@ -129,4 +130,4 @@ Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for 
 
 We modeled this README after
 Philip O'Toole's brilliantly succinct
-[description of `rqllite`](https://github.com/rqlite/rqlite).
+[description of `rqlite`](https://github.com/rqlite/rqlite).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ integration with your favorite Python libraries.
 ## How?
 
 Zed solves all these problems with a new format called
-[ZSON](doc/formats/zson.md),
+[ZSON](docs/formats/zson.md),
 which is a superset of JSON and the relational models.
 ZSON is syntax-compatible with JSON
 but it has a comprehensive type system that you can use as little or as much as you like.
@@ -128,5 +128,5 @@ Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for 
 ## Acknowledgment
 
 We modeled this README after
-[Philip O'Toole's](https://www.linkedin.com/in/philipotoole) brilliantly succinct
+Philip O'Toole's brilliantly succinct
 [description of `rqllite`](https://github.com/rqlite/rqlite).

--- a/README.md
+++ b/README.md
@@ -1,51 +1,118 @@
 # Zed [![Tests][tests-img]][tests]
 
-The Zed system provides an open-source, cloud-native, and searchable data lake for
-semi-structured and structured data.
+_Zed_ is a new kind of data lake that provides lightweight search and
+analytics for semi-structured data (like JSON) as well as
+structured data (like relational tables) all in the same package.
 
-[Zed lakes](docs/lake/README.md) utilize a superset of the relational
-and JSON document data models
-yet require no up-front schema definitions to insert data.  They also provide
-transactional views and time travel by leveraging a `git`-like design pattern
-based on a commit journal.  Using this mechanism, a lake's (optional) search indexes
-are transactionally consistent with its data.
+Check out the [Zed FAQ](FAQ.md).
 
-At Zed's foundation lies a new family of self-describing data formats based on the
-[Zed data model](docs/formats/zson.md#1-introduction),
-which unifies the highly structured approach of dataframes and relational tables
-with the loosely structured document model of JSON.
+## Why?
 
-While the Zed system is built around its family of data formats, it is also
-interoperable with popular data formats like CSV, (ND)JSON, and Parquet.
+We think that you shouldn't have to set up one system
+for search and another completely different system for historical analytics.
+And the same search/analytics system that works at cloud scale should run easily as
+a lightweight command-line tool on your laptop.
 
-This repository contains tools and components used to organize, search, analyze,
-and store Zed data, including:
+And rather than having to set up complex ETL pipelines with brittle
+transformation logic, managing your data lake should be as easy as `git`.
 
-* The [`zed`](cmd/zed/README.md) command line tool for managing, searching, and querying a Zed lake
-* The [Zed language](docs/language/README.md) documentation
-* The [Zed formats](docs/formats/README.md) specifications and documentation
+And while _schemas_ are a great way to model and organize your data, they often
+[get in the way](https://github.com/brimdata/sharkfest-21#schemas-a-double-edged-sword)
+when you are just trying to store or transmit your semi-structured data.
 
-The previously released [`zq`](cmd/zed/README.md#zq) tool is now packaged as
-a command-line shortcut for the `zed query` command.
+Finally, we believe a lightweight data store that provides easy search and analytics
+would be a great place to store data sets for data science and
+data engineering experiments running in Python and providing easy
+integration with your favorite Python libraries.
 
-## Installation
+## How?
 
-To install `zed` or any other tool from this repo, you can either clone the repo
- and compile from source, or use a pre-compiled
- [release](https://github.com/brimdata/zed/releases), available for Windows, macOS, and Linux.
+Zed solves all these problems with a new format called
+[ZSON](doc/formats/zson.md),
+which is a superset of JSON and the relational models.
+ZSON is syntax-compatible with JSON
+but it has a comprehensive type system that you can use as little or as much as you like.
+Zed types can be used as schemas.
 
-If you don't have Go installed, download and install it from the
-[Go downloads page](https://golang.org/dl/). Go version 1.16 or later is
-required.
+Zed also has a cloud-based object design that was modeled after
+the `git` design pattern.  Commits to the lake are transactional
+and consistent.  Search index updates are also transactionally
+consistent with any ingested data and searches can run with or
+without indexes.
 
-To install the binaries in `$GOPATH/bin`, clone this repo and
-execute `make install`:
+## Quick Start
 
+_Detailed documentation [is available](docs/README.md)._
+
+The quickest way to get running on macOS, Linux, or windows
+is to download a pre-built release binary.
+You can find these binaries on the Github releases page.
+
+Once installed, you can run the query engine from the command-line using `zq`:
+```
+echo '{"s":"hello, word"}' | zq -Z -
+```
+Or you can run a Zed lake server, load it with data using `zapi`, and hit the API.
+In one shell, run the server
+```
+mkdir scratch
+cd scratch
+zed lake serve
+```
+And in another shell, run the client:
+```
+zapi create Demo
+zapi use Demo@main
+echo '{s:"hello, world"}' | zapi load -
+zapi query "from Demo"
+```
+You can also use `zed` from Python.  After you install the Zed Python:
+```
+pip install "git+https://github.com/brimdata/zed#subdirectory=python/zed"
+```
+You can hit the Zed service from a Python program:
+```python
+import zed
+
+# Connect to the REST API at the default base URL (http://127.0.0.1:9867).
+# To use a different base URL, supply it as an argument.
+client = zed.Client()
+
+# Begin executing a Zed query for all records in the pool named "Demo".
+# This returns an iterator, not a container.
+records = zed.query('from Demo'):
+
+# Stream records from the server.
+for record in records:
+    print(record)
+```
+See the [python/zed](python/zed) for more details.
+
+### Brim
+
+You can use the [Brim app](https://github.com/brimdata/brim)
+to explore, query, and shape the data in your Zed lake.
+
+We originally developed Brim for security-oriented use cases
+(having tight integration with [Zeek](https://zeek.org/),
+[Suricata](https://suricata.io/), and
+[Wireshark](https://www.wireshark.org/)),
+but we are actively extending Brim with UX for handling generic
+data sets to support data science, data engineering, and ETL use cases.
+
+### Building from Source
+
+It's also easy to build `zed` from source:
 ```
 git clone https://github.com/brimdata/zed
 cd zed
 make install
 ```
+This installs binaries in your `$GOPATH/bin`.
+
+> If you don't have Go installed, download and install it from the
+> [Go instasll page](https://golang.org/doc/install). Go version 1.16 or later is
+> required.
 
 ## Contributing
 
@@ -57,3 +124,9 @@ Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for 
 
 [tests-img]: https://github.com/brimdata/zed/workflows/Tests/badge.svg
 [tests]: https://github.com/brimdata/zed/actions?query=workflow%3ATests
+
+## Acknowledgment
+
+We modeled this README after
+[Philip O'Toole's](https://www.linkedin.com/in/philipotoole) brilliantly succinct
+[description of `rqllite`](https://github.com/rqlite/rqlite).

--- a/acknowledgments.txt
+++ b/acknowledgments.txt
@@ -79,7 +79,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 # End https://github.com/araddon/dateparse/blob/master/LICENSE
 
-# Begin https://github.com/rqlite/rqlite/blob/master/LICENS
+# Begin https://github.com/rqlite/rqlite/blob/master/LICENSE
 The MIT License (MIT)
 
 Copyright (c) Philip O'Toole (http://www.philipotoole.com) 2015 - 2021
@@ -103,4 +103,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-# End https://github.com/rqlite/rqlite/blob/master/LICENS
+# End https://github.com/rqlite/rqlite/blob/master/LICENSE

--- a/acknowledgments.txt
+++ b/acknowledgments.txt
@@ -78,3 +78,29 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 # End https://github.com/araddon/dateparse/blob/master/LICENSE
+
+# Begin https://github.com/rqlite/rqlite/blob/master/LICENS
+The MIT License (MIT)
+
+Copyright (c) Philip O'Toole (http://www.philipotoole.com) 2015 - 2021
+Copyright (c) rqlite contributors 2015 - 2021
+Copyright (c) Google 2018 - 2021
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+# End https://github.com/rqlite/rqlite/blob/master/LICENS

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
 # Documentation
 
-> The Brim Data team is small has been  busy writing code and our
+> The Brim team is small and has been busy writing code so our
 > documentation lags development a bit.  We do our
 > best to keep the docs up to date with the implementation, but we are
 > a bit behind.  As the project
-> begins to stabilize, we we will definitely have a comprehensive set of docs.
+> begins to stabilize, we we will have a comprehensive set of docs.
 
 
-* [Language Overview](language)
-* [Zed Operators](language/operators)
-* [Lake Design](lake)
+* [Zed Language Overview](language)
+* [Zed Language Operators](language/operators)
+* [Zed Lake Design](lake)
 * [Zed Formats](formats)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation
+
+> The Brim Data team is small has been  busy writing code and our
+> documentation lags development a bit.  We do our
+> best to keep the docs up to date with the implementation, but we are
+> a bit behind.  As the project
+> begins to stabilize, we we will definitely have a comprehensive set of docs.
+
+
+* [Language Overview](language)
+* [Zed Operators](language/operators)
+* [Lake Design](lake)
+* [Zed Formats](formats)

--- a/python/zed/README.md
+++ b/python/zed/README.md
@@ -7,7 +7,7 @@ The `zed` Python package provides a client for the REST API served by
 
 Install the latest version like this:
 ```sh
-pip install "git+https://github.com/brimdata/zed#subdirectory=python/zed"
+pip3 install "git+https://github.com/brimdata/zed#subdirectory=python/zed"
 ```
 
 Install the version compatible with a local `zed` like this:
@@ -44,7 +44,7 @@ client = zed.Client()
 
 # Begin executing a Zed query for all records in the pool named
 # "TestPool".  This returns an iterator, not a container.
-records = zed.query('from TestPool'):
+records = client.query('from TestPool'):
 
 # Stream records from the server.
 for record in records:


### PR DESCRIPTION
This commit improves the zed README with a more succinct description  
of how to get up and running. @garrisonhess spent 2 hours futzing  
with our repo before he could get a python client hitting the Zed service.  
His feedback led to these improvements.

The FAQ is coming soon in a subsequent PR.

Closes #2570