### PR TITLE
remove github.com/minio/minio replace directive from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,5 +48,3 @@ require (
 )
 
 replace github.com/fraugster/parquet-go => github.com/brimdata/parquet-go v0.3.1
-
-replace github.com/minio/minio => github.com/brimdata/minio v0.0.0-20201019191454-3c6f24527f6d


### PR DESCRIPTION
It should have been removed when github.com/minio/minio was removed from
the require directive.