### PR TITLE
fix zero-length output check in script-style ztests

### DIFF
--- a/ztest/ztest_test.go
+++ b/ztest/ztest_test.go
@@ -1,10 +1,13 @@
 package ztest
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldSkip(t *testing.T) {
@@ -15,4 +18,36 @@ func TestShouldSkip(t *testing.T) {
 	}
 	assert.Equal(t, "reason", (&ZTest{Skip: "reason"}).ShouldSkip(""))
 	assert.Equal(t, `tag "x" does not match ZTEST_TAG=""`, (&ZTest{Tag: "x"}).ShouldSkip(""))
+}
+
+func TestRunShell(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows because RunScript uses cmd.exe instead of bash")
+	}
+	t.Run("outputs", func(t *testing.T) {
+		testDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(testDir, "testdirfile"), []byte("testdirfile\n"), 0644))
+		strptr := func(s string) *string { return &s }
+		err := (&ZTest{
+			Script: `
+				echo stdout
+				echo stderr >&2
+				touch empty
+				echo notempty > notempty
+				echo regexp > regexp
+				echo testdirfile > testdirfile
+				echo testdirfile > testdirfile2
+				`,
+			Outputs: []File{
+				{Name: "stdout", Data: strptr("stdout\n")},
+				{Name: "stderr", Data: strptr("stderr\n")},
+				{Name: "empty", Data: strptr("")},
+				{Name: "notempty", Data: strptr("notempty\n")},
+				{Name: "regexp", Re: "^re"},
+				{Name: "testdirfile"},
+				{Name: "testdirfile2", Source: "testdirfile"},
+			},
+		}).RunScript("", testDir, t.TempDir())
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Script-style ztests often check for a zero-length output with the
equivalent of "data: ''".  I inadvertently disabled those checks in
#3091.  Re-enable them.