### PR TITLE
fix emitter.IsTerminal check

### DIFF
--- a/pkg/storage/stdio.go
+++ b/pkg/storage/stdio.go
@@ -33,7 +33,7 @@ func (*StdioEngine) Put(ctx context.Context, u *URI) (io.WriteCloser, error) {
 	default:
 		return nil, fmt.Errorf("cannot write to '%s'", u.Path)
 	}
-	return &nopCloser{f}, nil
+	return &NopCloser{f}, nil
 }
 
 func (*StdioEngine) PutIfNotExists(context.Context, *URI, []byte) error {
@@ -60,11 +60,11 @@ func (*StdioEngine) List(_ context.Context, _ *URI) ([]Info, error) {
 	return nil, errStdioNotSupport
 }
 
-type nopCloser struct {
+type NopCloser struct {
 	io.Writer
 }
 
-func (*nopCloser) Close() error {
+func (*NopCloser) Close() error {
 	return nil
 }
 

--- a/zio/emitter/file.go
+++ b/zio/emitter/file.go
@@ -27,6 +27,9 @@ func IsTerminal(w io.Writer) bool {
 	if f, ok := w.(*os.File); ok {
 		return terminal.IsTerminalFile(f)
 	}
+	if nc, ok := w.(*storage.NopCloser); ok {
+		return IsTerminal(nc.Writer)
+	}
 	return false
 }
 


### PR DESCRIPTION
When we created package storage and a scheme for wrapping stdio,
this broke the emitter.Terminal check.  The fix is to handle
the case when stdout is wrapped in a storage.NopCloser.