### PR TITLE
allow "pass" as data source in a "from" trunk

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -410,6 +410,7 @@ type Source interface {
 func (*Pool) Source() {}
 func (*File) Source() {}
 func (*HTTP) Source() {}
+func (*Pass) Source() {}
 
 type Layout struct {
 	Kind  string `json:"kind" unpack:""`

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -74,6 +74,8 @@ func semSource(ctx context.Context, scope *Scope, source ast.Source, adaptor pro
 		}, nil
 	case *ast.Pool:
 		return semPool(ctx, scope, p, adaptor, head)
+	case *ast.Pass:
+		return &dag.Pass{Kind: "Pass"}, nil
 	case *kernel.Reader:
 		// kernel.Reader implements both ast.Source and dag.Source
 		return p, nil

--- a/compiler/ztests/from-pass.yaml
+++ b/compiler/ztests/from-pass.yaml
@@ -1,0 +1,21 @@
+script: zq -z -I join.zed left.zson
+
+inputs:
+  - name: join.zed
+    data: |
+      * | from (
+        pass => sort x ;
+        file right.zson => sort y ;
+      ) | inner join on x=y matched:=true
+  - name: left.zson
+    data: |
+      {x:1,s:"one"}
+      {x:2,s:"two"}
+      {x:3,s:"three"}
+  - name: right.zson
+    data: |
+      {y:2,y:"y-two"}
+outputs:
+  - name: stdout
+    data: |
+      {x:2,s:"two",matched:true}


### PR DESCRIPTION
This commit allows a pass source to be specified in a from trunk.
The code was there to handle it in compiler/kernel but ast.Pass was
missing a method to make it a valid ast.Source.
