### PR TITLE
set nullsMax based on order in expr/extent.CompareFunc

### DIFF
--- a/expr/extent/span.go
+++ b/expr/extent/span.go
@@ -39,8 +39,8 @@ type Generic struct {
 // then the first value is larger than the last value and Before is true
 // for larger values while After is true for smaller values, etc.
 func CompareFunc(o order.Which) expr.ValueCompareFn {
-	// The values of nullsMax here (used during data reads) and in
-	// zbuf.NewCompareFn (used during data writes) must agree.
+	// The values of nullsMax here (used during lake data reads) and in
+	// zbuf.NewCompareFn (used during lake data writes) must agree.
 	cmp := expr.NewValueCompareFn(o == order.Asc)
 	if o == order.Asc {
 		return cmp

--- a/expr/extent/span.go
+++ b/expr/extent/span.go
@@ -39,8 +39,9 @@ type Generic struct {
 // then the first value is larger than the last value and Before is true
 // for larger values while After is true for smaller values, etc.
 func CompareFunc(o order.Which) expr.ValueCompareFn {
-	//  Treat null as the minimum value.
-	cmp := expr.NewValueCompareFn(false)
+	// The values of nullsMax here (used during data reads) and in
+	// zbuf.NewCompareFn (used during data writes) must agree.
+	cmp := expr.NewValueCompareFn(o == order.Asc)
 	if o == order.Asc {
 		return cmp
 	}

--- a/lake/ztests/null-pool-key.yaml
+++ b/lake/ztests/null-pool-key.yaml
@@ -1,0 +1,33 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  for o in asc desc; do
+    echo // $o
+    zed lake create -q -orderby k:$o $o
+    zed lake load -q -use $o@main in.zson
+    zed lake query -z "from $o range 1 to 3"
+  done
+
+inputs:
+  - name: in.zson
+    data: |
+      {k:null(int64),v:"null"}
+      {k:0,v:"zero"}
+      {k:1,v:"one"}
+      {k:2,v:"two"}
+      {k:3,v:"three"}
+      {k:4,v:"four"}
+
+outputs:
+  - name: stdout
+    data: |
+      // asc
+      {k:1,v:"one"}
+      {k:2,v:"two"}
+      {k:3,v:"three"}
+      // desc
+      {k:3,v:"three"}
+      {k:2,v:"two"}
+      {k:1,v:"one"}
+  - name: stderr
+    data: ''


### PR DESCRIPTION
Treatment of nulls in expr/extent.CompareFunc (used during lake data
reads) must agree with that in zbuf.NewCompareFn (used during lake data
writes).

Fixes #2970.