### PR TITLE
better index format for multi-type multi-keys

### DIFF
--- a/cmd/zed/index/convert/command.go
+++ b/cmd/zed/index/convert/command.go
@@ -84,8 +84,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer file.Close()
-	writer, err := index.NewWriter(zctx, local, c.outputFile,
-		index.KeyFields(field.DottedList(c.keys)...),
+	writer, err := index.NewWriter(zctx, local, c.outputFile, field.DottedList(c.keys),
 		index.FrameThresh(c.frameThresh),
 		index.Order(o),
 	)

--- a/index/mem.go
+++ b/index/mem.go
@@ -1,8 +1,6 @@
 package index
 
 import (
-	"sort"
-
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/expr"
 	"github.com/brimdata/zed/field"

--- a/index/mem.go
+++ b/index/mem.go
@@ -52,9 +52,9 @@ func (t *MemTable) open() {
 		for _, value := range t.table {
 			t.values = append(t.values, value)
 		}
-		resolvers := make([]expr.Evaluator, len(t.keys))
-		for k, key := range t.keys {
-			resolvers[k] = expr.NewDotExpr(key)
+		resolvers := make([]expr.Evaluator, 0, len(t.keys))
+		for _, key := range t.keys {
+			resolvers = append(resolvers, expr.NewDotExpr(key))
 		}
 		compare := expr.NewCompareFn(false, resolvers...)
 		sort.SliceStable(t.values, func(a, b int) bool {

--- a/index/mem.go
+++ b/index/mem.go
@@ -1,12 +1,11 @@
 package index
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/expr"
-	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/field"
 )
 
 // MemTable implements an in-memory table to build a microindex.
@@ -14,40 +13,31 @@ import (
 // are either single column ("key") or a two-column ("key", "value") where the
 // types of the columns depend upon the zed.Values entered into the table.
 type MemTable struct {
-	table   map[string]zcode.Bytes
-	keys    []zcode.Bytes
-	offset  int
-	zctx    *zed.Context
-	builder *zed.Builder
-	keyType zed.Type
-	valType zed.Type
+	keys   field.List
+	table  map[string]*zed.Record
+	values []*zed.Record
+	sorted bool
+	zctx   *zed.Context
 }
 
-func NewMemTable(zctx *zed.Context) *MemTable {
+func NewMemTable(zctx *zed.Context, keys field.List) *MemTable {
 	return &MemTable{
-		table: make(map[string]zcode.Bytes),
+		keys:  keys,
+		table: make(map[string]*zed.Record),
 		zctx:  zctx,
 	}
 }
 
 func (t *MemTable) Read() (*zed.Record, error) {
-	if t.keyType == nil {
-		return nil, nil
-	}
-	if t.builder == nil {
+	if !t.sorted {
 		t.open()
 	}
-	off := t.offset
-	if off >= len(t.keys) {
+	if len(t.values) == 0 {
 		return nil, nil
 	}
-	key := t.keys[off]
-	t.offset = off + 1
-	zkey := zcode.Bytes(key)
-	if t.valType != nil {
-		return t.builder.Build(zkey, t.table[string(key)]), nil
-	}
-	return t.builder.Build(zkey), nil
+	rec := t.values[0]
+	t.values = t.values[1:]
+	return rec, nil
 }
 
 func (t *MemTable) Size() int {
@@ -58,56 +48,26 @@ func (t *MemTable) open() {
 	n := len(t.table)
 	if n > 0 {
 		//XXX escaping to GC
-		t.keys = make([]zcode.Bytes, n)
-		k := 0
-		for key := range t.table {
-			t.keys[k] = []byte(key)
-			k++
+		t.values = make([]*zed.Record, 0, n)
+		for _, value := range t.table {
+			t.values = append(t.values, value)
 		}
-		compare := expr.LookupCompare(t.keyType)
-		sort.SliceStable(t.keys, func(a, b int) bool {
-			return compare(t.keys[a], t.keys[b]) < 0
+		resolvers := make([]expr.Evaluator, len(t.keys))
+		for k, key := range t.keys {
+			resolvers[k] = expr.NewDotExpr(key)
+		}
+		compare := expr.NewCompareFn(false, resolvers...)
+		sort.SliceStable(t.values, func(a, b int) bool {
+			return compare(t.values[a], t.values[b]) < 0
 		})
 	}
-	t.offset = 0
-	cols := []zed.Column{{"key", t.keyType}}
-	if t.valType != nil {
-		cols = append(cols, zed.Column{"value", t.valType})
-	}
-	typ := t.zctx.MustLookupTypeRecord(cols)
-	t.builder = zed.NewBuilder(typ)
+	t.sorted = true
 }
 
-func checkType(which string, before *zed.Type, after zed.Type) error {
-	if *before == nil {
-		*before = after
-	} else if *before != after {
-		return fmt.Errorf("type of %s field changed from %s to %s", which, *before, after)
-	}
-	return nil
-}
-
-func (t *MemTable) EnterKey(key zed.Value) error {
-	if t.builder != nil {
+func (t *MemTable) Enter(rec *zed.Record) error {
+	if t.sorted {
 		panic("MemTable.Enter() cannot be called after reading")
 	}
-	if err := checkType("key", &t.keyType, key.Type); err != nil {
-		return err
-	}
-	t.table[string(key.Bytes)] = nil
-	return nil
-}
-
-func (t *MemTable) EnterKeyVal(key, val zed.Value) error {
-	if t.builder != nil {
-		panic("MemTable.Enter() cannot be called after reading")
-	}
-	if err := checkType("key", &t.keyType, key.Type); err != nil {
-		return err
-	}
-	if err := checkType("value", &t.valType, val.Type); err != nil {
-		return err
-	}
-	t.table[string(key.Bytes)] = val.Bytes
+	t.table[string(rec.Bytes)] = rec
 	return nil
 }

--- a/index/mem.go
+++ b/index/mem.go
@@ -56,10 +56,7 @@ func (t *MemTable) open() {
 		for _, key := range t.keys {
 			resolvers = append(resolvers, expr.NewDotExpr(key))
 		}
-		compare := expr.NewCompareFn(false, resolvers...)
-		sort.SliceStable(t.values, func(a, b int) bool {
-			return compare(t.values[a], t.values[b]) < 0
-		})
+		expr.SortStable(t.values, expr.NewCompareFn(false, resolvers...))
 	}
 	t.sorted = true
 }

--- a/index/reader.go
+++ b/index/reader.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/field"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
@@ -133,6 +134,6 @@ func (r *Reader) Order() order.Which {
 	return r.trailer.Order
 }
 
-func (r *Reader) Keys() *zed.TypeRecord {
-	return r.trailer.KeyType
+func (r *Reader) Keys() field.List {
+	return r.trailer.Keys
 }

--- a/index/stat.go
+++ b/index/stat.go
@@ -4,17 +4,13 @@ import (
 	"context"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/field"
 	"github.com/brimdata/zed/pkg/storage"
 )
 
-type InfoKey struct {
-	Name     string `zed:"name"`
-	TypeName string `zed:"type"`
-}
-
 type Info struct {
-	Size int64     `zed:"size"`
-	Keys []InfoKey `zed:"keys"`
+	Size int64      `zed:"size"`
+	Keys field.List `zed:"keys"`
 }
 
 // Stat returns summary information about the microindex at uri.
@@ -29,16 +25,8 @@ func Stat(ctx context.Context, engine storage.Engine, uri *storage.URI) (*Info, 
 	}
 	defer r.Close()
 
-	columns := r.Keys().Columns
-	keys := make([]InfoKey, len(columns))
-	for i, c := range columns {
-		keys[i] = InfoKey{
-			Name:     c.Name,
-			TypeName: c.Type.String(),
-		}
-	}
 	return &Info{
 		Size: size,
-		Keys: keys,
+		Keys: r.Keys(),
 	}, nil
 }

--- a/index/trailer.go
+++ b/index/trailer.go
@@ -7,75 +7,42 @@ import (
 	"io"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/field"
 	"github.com/brimdata/zed/order"
-	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zio/zngio"
+	"github.com/brimdata/zed/zson"
 )
 
 const (
-	MagicField       = "magic"
-	VersionField     = "version"
-	DescendingField  = "descending"
-	ChildField       = "child_field"
-	FrameThreshField = "frame_thresh"
-	SectionsField    = "sections"
-	KeysField        = "keys"
-
-	MagicVal      = "zed_index" //XXX
-	VersionVal    = 2
-	ChildFieldVal = "_child"
-
+	Magic          = "zed_index" //XXX
+	Version        = 3
 	TrailerMaxSize = 4096
+	ChildFieldName = "_child"
 )
 
 type Trailer struct {
-	Magic            string
-	Version          int
-	Order            order.Which
-	ChildOffsetField string
-	FrameThresh      int
-	KeyType          *zed.TypeRecord
-	Sections         []int64
+	Magic            string      `zed:"magic"`
+	Version          int         `zed:"version"`
+	Order            order.Which `zed:"order"`
+	ChildOffsetField string      `zed:"child_field"`
+	FrameThresh      int         `zed:"frame_thresh"`
+	Sections         []int64     `zed:"sections"`
+	Keys             field.List  `zed:"keys"`
 }
 
-var ErrNotIndex = errors.New("not a zed index")
+var (
+	ErrNotIndex        = errors.New("not a zed index")
+	ErrTrailerNotFound = errors.New("zed index trailer not found")
+)
 
-func newTrailerRecord(zctx *zed.Context, childField string, frameThresh int, sections []int64, keyType *zed.TypeRecord, o order.Which) (*zed.Record, error) {
-	sectionsType := zctx.LookupTypeArray(zed.TypeInt64)
-	cols := []zed.Column{
-		{MagicField, zed.TypeString},
-		{VersionField, zed.TypeInt32},
-		{DescendingField, zed.TypeBool},
-		{ChildField, zed.TypeString},
-		{FrameThreshField, zed.TypeInt32},
-		{SectionsField, sectionsType},
-		{KeysField, keyType},
-	}
-	typ, err := zctx.LookupTypeRecord(cols)
-	if err != nil {
-		return nil, err
-	}
-	var desc bool
-	if o == order.Desc {
-		desc = true
-	}
-	builder := zed.NewBuilder(typ)
-	return builder.Build(
-		zed.EncodeString(MagicVal),
-		zed.EncodeInt(VersionVal),
-		zed.EncodeBool(desc),
-		zed.EncodeString(childField),
-		zed.EncodeInt(int64(frameThresh)),
-		encodeSections(sections),
-		nil), nil
-}
-
-func encodeSections(sections []int64) zcode.Bytes {
-	var b zcode.Builder
-	for _, s := range sections {
-		b.AppendPrimitive(zed.EncodeInt(s))
-	}
-	return b.Bytes()
+var startOfTrailer = []byte{
+	zed.TypeDefArray,
+	zed.IDInt64,
+	zed.TypeDefArray,
+	zed.IDString,
+	zed.TypeDefArray,
+	zed.IDTypeName,
+	zed.TypeDefRecord,
 }
 
 func readTrailer(r io.ReaderAt, size int64) (*Trailer, int, error) {
@@ -87,122 +54,42 @@ func readTrailer(r io.ReaderAt, size int64) (*Trailer, int, error) {
 	if _, err := r.ReadAt(buf, size-n); err != nil {
 		return nil, 0, err
 	}
-	for off := int(n) - 3; off >= 0; off-- {
-		// look for end of stream followed by an array[int64] typedef then
-		// a record typedef indicating the possible presence of the trailer,
-		// which we then try to decode.
-		if bytes.Equal(buf[off:(off+3)], []byte{zed.TypeDefArray, zed.IDInt64, zed.TypeDefRecord}) {
-			if off > 0 && buf[off-1] != zed.CtrlEOS {
-				// If this isn't right after an end-of-stream
-				// (and we're not at the start of index), then
-				// we skip because it can't be a valid trailer.
-				continue
-			}
-			r := bytes.NewReader(buf[off:n])
-			rec, _ := zngio.NewReader(r, zed.NewContext()).Read()
-			if rec == nil {
-				continue
-			}
-			_, err := trailerVersion(rec)
-			if err != nil {
-				return nil, 0, err
-			}
-			trailer, _ := recordToTrailer(rec)
-			if trailer != nil {
-				return trailer, int(n) - off, nil
-			}
-		}
+	// look for end of stream followed by an array[int64] typedef then
+	// a record typedef indicating the possible presence of the trailer,
+	// which we then try to decode.
+	off := bytes.LastIndex(buf, startOfTrailer)
+	if off == -1 {
+		return nil, 0, ErrTrailerNotFound
 	}
-	return nil, 0, errors.New("zed index trailer not found")
-}
-
-func trailerVersion(rec *zed.Record) (int, error) {
-	version, err := rec.AccessInt(VersionField)
-	if err != nil {
-		return -1, errors.New("zed index version field is not a valid int32")
+	if off > 0 && buf[off-1] != zed.CtrlEOS {
+		// If this isn't right after an end-of-stream
+		// (and we're not at the start of index), then
+		// we skip because it can't be a valid trailer.
+		return nil, 0, ErrTrailerNotFound
 	}
-	if version != VersionVal {
-		return -1, fmt.Errorf("zed index version %d found while expecting version %d", version, VersionVal)
+	rec, _ := zngio.NewReader(bytes.NewReader(buf[off:n]), zed.NewContext()).Read()
+	if rec == nil {
+		return nil, 0, ErrTrailerNotFound
 	}
-	return int(version), nil
-}
-
-func recordToTrailer(rec *zed.Record) (*Trailer, error) {
 	var trailer Trailer
-	var err error
-	trailer.Magic, err = rec.AccessString(MagicField)
-	if err != nil || trailer.Magic != MagicVal {
-		return nil, ErrNotIndex
+	if err := zson.UnmarshalZNGRecord(rec, &trailer); err != nil {
+		return nil, 0, err
 	}
-	trailer.Version, err = trailerVersion(rec)
-	if err != nil {
-		return nil, err
+	if trailer.Magic != Magic {
+		return nil, 0, ErrNotIndex
 	}
-	desc, err := rec.AccessBool(DescendingField)
-	if err != nil {
-		return nil, err
+	if trailer.Version != Version {
+		return nil, 0, fmt.Errorf("zed index version %d found while expecting version %d", trailer.Version, Version)
 	}
-	if desc {
-		trailer.Order = order.Desc
-	}
-
-	trailer.ChildOffsetField, err = rec.AccessString(ChildField)
-	if err != nil {
-		return nil, ErrNotIndex
-	}
-	keys, err := rec.ValueByField(KeysField)
-	if err != nil {
-		return nil, ErrNotIndex
-	}
-	var ok bool
-	trailer.KeyType, ok = keys.Type.(*zed.TypeRecord)
-	if !ok {
-		return nil, ErrNotIndex
-	}
-	trailer.Sections, err = decodeSections(rec)
-	if err != nil {
-		return nil, err
-	}
-	return &trailer, nil
+	return &trailer, int(n) - off, nil
 }
 
-func decodeSections(rec *zed.Record) ([]int64, error) {
-	v, err := rec.Access(SectionsField)
-	if err != nil {
-		return nil, err
-	}
-	arrayType, ok := v.Type.(*zed.TypeArray)
-	if !ok {
-		return nil, fmt.Errorf("%s field in zed index trailer is not an arrray", SectionsField)
-	}
-	if v.Bytes == nil {
-		// This is an empty index.  Just return nil/success.
-		return nil, nil
-	}
-	zvals, err := zed.Split(arrayType.Type, v.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	var sizes []int64
-	for _, zv := range zvals {
-		if zv.Type != zed.TypeInt64 {
-			return nil, errors.New("section element is not an int64")
-		}
-		size, err := zed.DecodeInt(zv.Bytes)
-		if err != nil {
-			return nil, errors.New("int64 section element could not be decoded")
-		}
-		sizes = append(sizes, size)
-	}
-	return sizes, nil
-}
-
-func uniqChildField(zctx *zed.Context, keys *zed.Record) string {
+func uniqChildField(keys field.List) string {
 	// This loop works around the corner case that the field reserved
 	// for the child pointer is in use by another key...
-	childField := ChildFieldVal
-	for k := 0; keys.HasField(childField); k++ {
-		childField = fmt.Sprintf("%s_%d", ChildFieldVal, k)
+	f := ChildFieldName
+	for k := 0; keys.Has(field.Path{f}); k++ {
+		f = fmt.Sprintf("%s_%d", ChildFieldName, k)
 	}
-	return childField
+	return f
 }

--- a/index/trailer.go
+++ b/index/trailer.go
@@ -31,8 +31,8 @@ type Trailer struct {
 }
 
 var (
-	ErrNotIndex        = errors.New("not a zed index")
-	ErrTrailerNotFound = errors.New("zed index trailer not found")
+	ErrNotIndex        = errors.New("not a Zed index")
+	ErrTrailerNotFound = errors.New("Zed index trailer not found")
 )
 
 var startOfTrailer = []byte{

--- a/index/trailer.go
+++ b/index/trailer.go
@@ -79,7 +79,7 @@ func readTrailer(r io.ReaderAt, size int64) (*Trailer, int, error) {
 		return nil, 0, ErrNotIndex
 	}
 	if trailer.Version != Version {
-		return nil, 0, fmt.Errorf("zed index version %d found while expecting version %d", trailer.Version, Version)
+		return nil, 0, fmt.Errorf("Zed index version %d found while expecting version %d", trailer.Version, Version)
 	}
 	return &trailer, int(n) - off, nil
 }

--- a/index/writer.go
+++ b/index/writer.go
@@ -83,6 +83,9 @@ func NewWriter(zctx *zed.Context, engine storage.Engine, path string, keys field
 }
 
 func NewWriterWithContext(ctx context.Context, zctx *zed.Context, engine storage.Engine, path string, keys field.List, options ...Option) (*Writer, error) {
+	if len(keys) == 0 {
+		return nil, errors.New("must specify at least one key")
+	}
 	w := &Writer{
 		keys:       keys,
 		zctx:       zctx,
@@ -91,9 +94,6 @@ func NewWriterWithContext(ctx context.Context, zctx *zed.Context, engine storage
 	}
 	for _, opt := range options {
 		opt.apply(w)
-	}
-	if len(keys) == 0 {
-		return nil, errors.New("must specify at least one key")
 	}
 	if w.frameThresh == 0 {
 		w.frameThresh = frameThresh

--- a/index/writer.go
+++ b/index/writer.go
@@ -84,10 +84,10 @@ func NewWriter(zctx *zed.Context, engine storage.Engine, path string, keys field
 
 func NewWriterWithContext(ctx context.Context, zctx *zed.Context, engine storage.Engine, path string, keys field.List, options ...Option) (*Writer, error) {
 	w := &Writer{
-		zctx:       zctx,
-		childField: uniqChildField(keys),
-		engine:     engine,
 		keys:       keys,
+		zctx:       zctx,
+		engine:     engine,
+		childField: uniqChildField(keys),
 	}
 	for _, opt := range options {
 		opt.apply(w)

--- a/index/writer.go
+++ b/index/writer.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/brimdata/zed/pkg/bufwriter"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio/zngio"
+	"github.com/brimdata/zed/zson"
 )
 
 // Writer implements the zio.Writer interface. A Writer creates a zed index,
@@ -46,14 +48,13 @@ import (
 // instead of Close().
 type Writer struct {
 	uri         *storage.URI
-	keyFields   field.List
+	keys        field.List
 	zctx        *zed.Context
 	engine      storage.Engine
 	writer      *indexWriter
 	cutter      *expr.Cutter
 	tmpdir      string
 	frameThresh int
-	keyType     *zed.TypeRecord
 	iow         io.WriteCloser
 	childField  string
 	nlevel      int
@@ -77,20 +78,22 @@ type indexWriter struct {
 // provide keys in increasing lexicographic order.  Duplicate keys are not
 // allowed but will not be detected.  Close() or Abort() must be called when
 // done writing.
-func NewWriter(zctx *zed.Context, engine storage.Engine, path string, options ...Option) (*Writer, error) {
-	return NewWriterWithContext(context.Background(), zctx, engine, path, options...)
+func NewWriter(zctx *zed.Context, engine storage.Engine, path string, keys field.List, options ...Option) (*Writer, error) {
+	return NewWriterWithContext(context.Background(), zctx, engine, path, keys, options...)
 }
 
-func NewWriterWithContext(ctx context.Context, zctx *zed.Context, engine storage.Engine, path string, options ...Option) (*Writer, error) {
+func NewWriterWithContext(ctx context.Context, zctx *zed.Context, engine storage.Engine, path string, keys field.List, options ...Option) (*Writer, error) {
 	w := &Writer{
-		zctx:   zctx,
-		engine: engine,
+		zctx:       zctx,
+		childField: uniqChildField(keys),
+		engine:     engine,
+		keys:       keys,
 	}
 	for _, opt := range options {
 		opt.apply(w)
 	}
-	if w.keyFields == nil {
-		w.keyFields = field.List{field.New("key")}
+	if len(keys) == 0 {
+		return nil, errors.New("must specify at least one key")
 	}
 	if w.frameThresh == 0 {
 		w.frameThresh = frameThresh
@@ -111,7 +114,7 @@ func NewWriterWithContext(ctx context.Context, zctx *zed.Context, engine storage
 	if err != nil {
 		return nil, err
 	}
-	fields, resolvers := compiler.CompileAssignments(w.keyFields, w.keyFields)
+	fields, resolvers := compiler.CompileAssignments(w.keys, w.keys)
 	w.cutter, err = expr.NewCutter(zctx, fields, resolvers)
 	return w, err
 }
@@ -126,14 +129,14 @@ func (f optionFunc) apply(w *Writer) { f(w) }
 
 func KeyFields(keys ...field.Path) Option {
 	return optionFunc(func(w *Writer) {
-		w.keyFields = keys
+		w.keys = keys
 	})
 }
 
 func Keys(keys ...string) Option {
 	return optionFunc(func(w *Writer) {
 		for _, k := range keys {
-			w.keyFields = append(w.keyFields, field.Dotted(k))
+			w.keys = append(w.keys, field.Dotted(k))
 		}
 	})
 }
@@ -162,10 +165,8 @@ func (w *Writer) Write(rec *zed.Record) error {
 			return err
 		}
 		if keys == nil {
-			return fmt.Errorf("key(s) not found in record: %q", w.keyFields)
+			return fmt.Errorf("key(s) not found in record: %q", w.keys)
 		}
-		w.keyType = zed.TypeRecordOf(keys.Type)
-		w.childField = uniqChildField(w.zctx, keys)
 	}
 	return w.writer.write(rec)
 }
@@ -200,7 +201,8 @@ func (w *Writer) Close() error {
 		// encountered, then the base layer writer was never created.
 		// In this case, bypass the base layer, write an empty trailer
 		// directly to the output, and close.
-		err := w.writeEmptyTrailer()
+		zw := zngio.NewWriter(w.iow, zngio.WriterOpts{})
+		err := writeTrailer(zw, w.zctx, w.childField, w.frameThresh, nil, w.keys, w.order)
 		if err2 := w.iow.Close(); err == nil {
 			err = err2
 		}
@@ -270,28 +272,20 @@ func (w *Writer) finalize() error {
 			return err
 		}
 	}
-	if w.keyType == nil {
-		return fmt.Errorf("index writer: no sort keys found in input for %q", w.keyFields)
-	}
-	return writeTrailer(base.zng, w.zctx, w.childField, w.frameThresh, sizes, w.keyType, w.order)
+	return writeTrailer(base.zng, w.zctx, w.childField, w.frameThresh, sizes, w.keys, w.order)
 }
 
-func (w *Writer) writeEmptyTrailer() error {
-	var cols []zed.Column
-	for _, key := range w.keyFields {
-		cols = append(cols, zed.Column{key.String(), zed.TypeNull})
+func writeTrailer(w *zngio.Writer, zctx *zed.Context, childField string, frameThresh int, sizes []int64, keys field.List, o order.Which) error {
+	t := Trailer{
+		ChildOffsetField: childField,
+		FrameThresh:      frameThresh,
+		Keys:             keys,
+		Magic:            Magic,
+		Order:            o,
+		Sections:         sizes,
+		Version:          Version,
 	}
-	typ, err := w.zctx.LookupTypeRecord(cols)
-	if err != nil {
-		return err
-	}
-	zw := zngio.NewWriter(w.iow, zngio.WriterOpts{})
-	return writeTrailer(zw, w.zctx, "", w.frameThresh, nil, typ, w.order)
-}
-
-func writeTrailer(w *zngio.Writer, zctx *zed.Context, childField string, frameThresh int, sizes []int64, keyType *zed.TypeRecord, o order.Which) error {
-	// Finally, write the size records as the trailer of the index.
-	rec, err := newTrailerRecord(zctx, childField, frameThresh, sizes, keyType, o)
+	rec, err := zson.NewZNGMarshalerWithContext(zctx).MarshalRecord(t)
 	if err != nil {
 		return err
 	}

--- a/index/ztests/bad-version.yaml
+++ b/index/ztests/bad-version.yaml
@@ -11,9 +11,9 @@ inputs:
       {key:"hello"}
   - name: trailer.zson
     data: |
-      {magic:"zed_index",version:0(int32),descending:false,child_field:"_child",frame_thresh:32768(int32),sections:[16],keys:null({key:string})}
+      {magic:"zed_index",version:0(int32),order:"asc",child_field:"_child",frame_thresh:32768(int32),sections:[16],keys:[["key"]]}
 
 outputs:
   - name: stderr
     regexp: |
-      .*: zed index version 0 found while expecting version 2
+      .*: zed index version 0 found while expecting version 3

--- a/index/ztests/bad-version.yaml
+++ b/index/ztests/bad-version.yaml
@@ -16,4 +16,4 @@ inputs:
 outputs:
   - name: stderr
     regexp: |
-      .*: zed index version 0 found while expecting version 3
+      .*: Zed index version 0 found while expecting version 3

--- a/index/ztests/btree-clash.yaml
+++ b/index/ztests/btree-clash.yaml
@@ -16,4 +16,4 @@ outputs:
     data: ''
   - name: stdout
     data: |
-      {magic:"zed_index",version:2(int32),descending:false,child_field:"_child_0",frame_thresh:50(int32),sections:[33],keys:null({_child:int64})}
+      {magic:"zed_index",version:3,order:"asc",child_field:"_child_0",frame_thresh:50,sections:[33],keys:[["_child"]]}

--- a/index/ztests/create.yaml
+++ b/index/ztests/create.yaml
@@ -10,5 +10,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {key:"hello"}
-      {magic:"zed_index",version:2(int32),descending:false,child_field:"_child",frame_thresh:32768(int32),sections:[16],keys:null({key:string})}
+      {a:"hello"}
+      {magic:"zed_index",version:3,order:"asc",child_field:"_child",frame_thresh:32768,sections:[14],keys:[["a"]]}

--- a/index/ztests/different-types.yaml
+++ b/index/ztests/different-types.yaml
@@ -23,4 +23,3 @@ outputs:
       {a:1.4}
       {a:1}
       {a:"hello"}
-

--- a/index/ztests/different-types.yaml
+++ b/index/ztests/different-types.yaml
@@ -1,0 +1,26 @@
+script: |
+  zed index create -o index.zng -k a in.zson
+  zed index lookup -z -k 127.0.0.1 index.zng
+  zed index lookup -z -k 1.4 index.zng
+  zed index lookup -z -k 1 index.zng
+  zed index lookup -z -k '"hello"' index.zng
+
+inputs:
+  - name: in.zson
+    data: |
+      {a:127.0.0.1,value:"4"}
+      {a:1.4,value:3}
+      {a:1,value:2}
+      {a:"hello",value:1}
+
+
+outputs:
+  - name: stderr
+    data: ""
+  - name: stdout
+    data: |
+      {a:127.0.0.1}
+      {a:1.4}
+      {a:1}
+      {a:"hello"}
+

--- a/index/ztests/empty-file.yaml
+++ b/index/ztests/empty-file.yaml
@@ -5,4 +5,4 @@ script: |
 outputs:
   - name: stderr
     regexp: |
-      .*: zed index trailer not found
+      .*: Zed index trailer not found

--- a/index/ztests/empty-index.yaml
+++ b/index/ztests/empty-index.yaml
@@ -1,7 +1,7 @@
 script: |
   # b isn't in the input so this creates a valid zed index that is empty
   zed index create -o index.zng -k b in.zson
-  zq -z index.zng
+  zq -Z index.zng
   echo ===
   zed index lookup -z -k hello index.zng
   echo ===
@@ -14,6 +14,18 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {magic:"zed_index",version:2(int32),descending:false,child_field:"",frame_thresh:32768(int32),sections:null([int64]),keys:null({key:null})}
+      {
+          magic: "zed_index",
+          version: 3,
+          order: "asc",
+          child_field: "_child",
+          frame_thresh: 32768,
+          sections: null ([int64]),
+          keys: [
+              [
+                  "b"
+              ]
+          ]
+      }
       ===
       ===

--- a/index/ztests/levels.yaml
+++ b/index/ztests/levels.yaml
@@ -11,19 +11,19 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {magic:"zed_index",version:2(int32),descending:false,child_field:"_child",frame_thresh:200(int32),sections:[24069,36,414,3192],keys:null({key:string})}
+      {magic:"zed_index",version:3,order:"asc",child_field:"_child",frame_thresh:200,sections:[23835,34,396,3185],keys:[["s"]]}
       ===
-      {key:"Algedi-pigeonman",_child:0}
-      {key:"Rupicola-overponderous",_child:222}
-      {key:"antiprohibitionist-sinusoid",_child:440}
-      {key:"brochure-chiropodous",_child:640}
-      {key:"cowhiding-pterylographic",_child:851}
-      {key:"equinate-serialist",_child:1060}
-      {key:"heaper-praedial",_child:1275}
-      {key:"intracranial-preyful",_child:1484}
-      {key:"milliard-diffusely",_child:1690}
-      {key:"overwomanly-transverberation",_child:1904}
-      {key:"placoganoidean-spookery",_child:2134}
-      {key:"recollapse-accompliceship",_child:2338}
-      {key:"seventy-unbracing",_child:2543}
-      {key:"supraprotest-asseveratively",_child:2745}
+      {s:"Algedi-pigeonman",_child:0}
+      {s:"Rupicola-overponderous",_child:220}
+      {s:"antiprohibitionist-sinusoid",_child:436}
+      {s:"caneology-preroyally",_child:662}
+      {s:"curatorship-bose",_child:870}
+      {s:"fontful-korymboi",_child:1082}
+      {s:"horizometer-misogamy",_child:1294}
+      {s:"laevotartaric-pseudohyoscyamine",_child:1501}
+      {s:"monumentally-Manihot",_child:1713}
+      {s:"palinode-penality",_child:1919}
+      {s:"predikant-tentorial",_child:2147}
+      {s:"roborant-ultraparallel",_child:2368}
+      {s:"sorediferous-iliocaudal",_child:2585}
+      {s:"tibourbou-crisper",_child:2808}

--- a/index/ztests/manual.yaml
+++ b/index/ztests/manual.yaml
@@ -1,7 +1,7 @@
 script: |
   zed index create -o index.zng -k s babble.zson
   zq -z index.zng > index.zson
-  zq -o sorted.zng "count() by s | cut s | sort s" babble.zson
+  zq -o sorted.zng "by s | sort s" babble.zson
   zed index convert -o manual.zng -k s sorted.zng
   zq -z manual.zng > manual.zson
   diff index.zson manual.zson

--- a/index/ztests/manual.yaml
+++ b/index/ztests/manual.yaml
@@ -1,8 +1,8 @@
 script: |
   zed index create -o index.zng -k s babble.zson
   zq -z index.zng > index.zson
-  zq -o sorted.zng "count() by s | put key:=s | cut key | sort key" babble.zson
-  zed index convert -o manual.zng -k key sorted.zng
+  zq -o sorted.zng "count() by s | cut s | sort s" babble.zson
+  zed index convert -o manual.zng -k s sorted.zng
   zq -z manual.zng > manual.zson
   diff index.zson manual.zson
 

--- a/index/ztests/no-trailer.yaml
+++ b/index/ztests/no-trailer.yaml
@@ -9,4 +9,4 @@ inputs:
 outputs:
   - name: stderr
     regexp: |
-      .*: zed index trailer not found
+      .*: Zed index trailer not found

--- a/lake/index/rule.go
+++ b/lake/index/rule.go
@@ -96,24 +96,20 @@ func Equivalent(a, b Rule) bool {
 	return false
 }
 
-// XXX See issue #2923
-const keyName = "key"
-
 func (f *FieldRule) Zed() string {
-	if len(f.Fields) != 1 {
-		// XXX see issue #2923.  Multiple field keys not supported.
-		// The code below does a cut assignment presuming one key.
-		// This is problematic.  We should change the index files
-		// to presume the original names of the keys and just do
-		// a non-assignmnet cut on all of the fields.
-		panic("issue #2923")
+	var fields string
+	for i, field := range f.Fields {
+		if i > 0 {
+			fields += ", "
+		}
+		fields += field.String()
 	}
-	return fmt.Sprintf("cut %s:=%s | count() by %s | sort %s", keyName, f.Fields[0], keyName, keyName)
+	return fmt.Sprintf("cut %s | count() by %s | sort %s", fields, fields, fields)
 }
 
 func (t *TypeRule) Zed() string {
-	// XXX See issue #2923 as this doesn't make sense.
-	return fmt.Sprintf("explode this by %s as %s | count() by %s | sort %s", t.Type, keyName, keyName, keyName)
+	// XXX See issue #3140 as this does not allow for multiple type keys
+	return fmt.Sprintf("explode this by %s as %s | count() by %s | sort %s", t.Type, "key", "key", "key")
 }
 
 func (a *AggRule) Zed() string {
@@ -169,11 +165,11 @@ func (a *AggRule) RuleID() ksuid.KSUID {
 }
 
 func (f *FieldRule) RuleKeys() field.List {
-	return field.DottedList(keyName)
+	return f.Fields
 }
 
 func (t *TypeRule) RuleKeys() field.List {
-	return nil
+	return field.DottedList("key")
 }
 
 func (a *AggRule) RuleKeys() field.List {

--- a/lake/index/rule.go
+++ b/lake/index/rule.go
@@ -109,7 +109,7 @@ func (f *FieldRule) Zed() string {
 
 func (t *TypeRule) Zed() string {
 	// XXX See issue #3140 as this does not allow for multiple type keys
-	return fmt.Sprintf("explode this by %s as %s | count() by %s | sort %s", t.Type, "key", "key", "key")
+	return fmt.Sprintf("explode this by %s as key | count() by key | sort key", t.Type)
 }
 
 func (a *AggRule) Zed() string {

--- a/lake/index/writer_test.go
+++ b/lake/index/writer_test.go
@@ -2,14 +2,11 @@ package index
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/storage"
-	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
-	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,26 +30,6 @@ func TestWriterWriteAfterClose(t *testing.T) {
 	assert.EqualError(t, err, "index writer closed")
 	err = w.Write(nil)
 	assert.EqualError(t, err, "index writer closed")
-}
-
-func TestWriterError(t *testing.T) {
-	const r1 = `{ts:1970-01-01T00:00:01Z,id:"id1"}`
-	const r2 = "{ts:1970-01-01T00:00:02Z,id:2}"
-	o := Object{Rule: NewFieldRule("test", "id"), ID: ksuid.New()}
-	w := testWriter(t, o)
-	zctx := zed.NewContext()
-	arr1, err := zbuf.ReadAll(zson.NewReader(strings.NewReader(r1), zctx))
-	require.NoError(t, err)
-	arr2, err := zbuf.ReadAll(zson.NewReader(strings.NewReader(r2), zctx))
-	require.NoError(t, err)
-	require.NoError(t, zio.Copy(w, arr1.NewReader()))
-	require.NoError(t, zio.Copy(w, arr2.NewReader()))
-
-	err = w.Close()
-	assert.EqualError(t, err, `key type changed from "{key:int64}" to "{key:string}"`)
-
-	// if an on close, the writer should have removed the index
-	assert.NoFileExists(t, w.URI.Filepath())
 }
 
 func testWriter(t *testing.T, o Object) *Writer {


### PR DESCRIPTION
For microindexes, store the key name(s) in the trailer (without type)
and do not rename the key to "key", rather keep the original record
name.

Allow a key to have multiple typed values.

Closes #2923