### PR TITLE
require "dir=" prefix on mdtest-command directory

### DIFF
--- a/docs/language/aggregate-functions/README.md
+++ b/docs/language/aggregate-functions/README.md
@@ -40,7 +40,7 @@ Multiple aggregate functions may be invoked at the same time.
 To simultaneously calculate the minimum, maximum, and average of connection
 duration:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'min(duration),max(duration),avg(duration)' conn.log.gz
 ```
 
@@ -58,7 +58,7 @@ instead use `:=` to specify an explicit name for the generated field.
 
 #### Example:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'quickest:=min(duration),longest:=max(duration),typical:=avg(duration)' conn.log.gz
 ```
 
@@ -85,7 +85,7 @@ function will operate.
 To check whether we've seen higher DNS round-trip times when servers return
 longer lists of `answers`:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'answers != null | every 5m short_rtt:=avg(rtt) where len(answers)<=2, short_count:=count() where len(answers)<=2, long_rtt:=avg(rtt) where len(answers)>2, long_count:=count() where len(answers)>2 | sort ts' dns.log.gz
 ```
 
@@ -117,7 +117,7 @@ ts                   short_rtt            short_count long_rtt             long_
 Let's say you've been studying `weird` records and noticed that lots of
 connections have made one or more bad HTTP requests.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count() by name | sort -r count' weird.log.gz
 ```
 
@@ -134,7 +134,7 @@ above_hole_data_without_any_acks            107
 To count the number of connections for which this was the _only_ category of
 `weird` record observed:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'only_bads:=and(name=="bad_HTTP_request") by uid | count() where only_bads==true' weird.log.gz
 ```
 
@@ -159,7 +159,7 @@ count
 
 To see the `name` of a Zeek `weird` record in our sample data:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'any(name)' weird.log.gz
 ```
 
@@ -189,7 +189,7 @@ TCP_ack_underflow_or_misorder
 To calculate the average number of bytes originated by all connections as
 captured in Zeek `conn` records:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'avg(orig_bytes)' conn.log.gz
 ```
 
@@ -215,7 +215,7 @@ avg
 To assemble the sequence of HTTP methods invoked in each interaction with the
 Bing search engine:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'host=="www.bing.com" | methods:=collect(method) by uid | sort uid' http.log.gz
 ```
 
@@ -244,7 +244,7 @@ CI0SCN14gWpY087KA3 GET,POST,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET
 
 To count the number of records in the entire sample data set:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count()' *.log.gz
 ```
 
@@ -260,7 +260,7 @@ Let's say we wanted to know how many records contain a field called `mime_type`.
 The following example shows us that count and that the field is present in
 our Zeek `ftp` and `files` records.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count(mime_type) by _path | filter count > 0 | sort -r count' *.log.gz
 ```
 
@@ -286,7 +286,7 @@ ftp   93
 
 To see an approximate count of unique `uid` values in our sample data set:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'countdistinct(uid)' *
 ```
 
@@ -298,7 +298,7 @@ countdistinct
 
 To see the precise value, which may take longer to execute:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count() by uid | count()' *
 ```
 
@@ -327,7 +327,7 @@ to perform this test, the Zed using `countdistinct()` executed almost 3x faster.
 To see the maximum number of bytes originated by any connection in our sample
 data:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'max(orig_bytes)' conn.log.gz
 ```
 
@@ -353,7 +353,7 @@ max
 To see the quickest round trip time of all DNS queries observed in our sample
 data:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'min(rtt)' dns.log.gz
 ```
 
@@ -379,7 +379,7 @@ min
 Let's say you've noticed there's lots of HTTP traffic happening on ports higher
 than the standard port `80`.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count() by id.resp_p | sort -r count' http.log.gz
 ```
 
@@ -396,7 +396,7 @@ id.resp_p count
 The following query confirms this high-port traffic is present, but that none
 of those ports are higher than what TCP allows.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'some_high_ports:=or(id.resp_p>80),impossible_ports:=or(id.resp_p>65535)' http.log.gz
 ```
 
@@ -422,7 +422,7 @@ T               F
 To calculate the total number of bytes across all file payloads logged in our
 sample data:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'sum(total_bytes)' files.log.gz
 ```
 
@@ -449,7 +449,7 @@ sum
 To observe which HTTP methods were invoked in each interaction with the Bing
 search engine:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'host=="www.bing.com" | methods:=union(method) by uid | sort uid' http.log.gz
 ```
 

--- a/docs/language/data-types/README.md
+++ b/docs/language/data-types/README.md
@@ -30,7 +30,7 @@ However, if we cast it to an `ip` type, now the CIDR match is successful. The
 `bad cast` warning on stderr tells us that some of the values for `ref_id`
 could _not_ be successfully cast to `ip`.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'put ref_id:=ip(ref_id)| filter ref_id in 83.162.0.0/16 | count()' ntp.log.gz
 ```
 

--- a/docs/language/expressions/README.md
+++ b/docs/language/expressions/README.md
@@ -3,7 +3,7 @@
 Comprehensive documentation for Zed expressions is still a work in progress. In
 the meantime, here's an example expression with simple math to get started:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'duration > 100 | put total_bytes:=orig_bytes+resp_bytes | cut orig_bytes,resp_bytes,total_bytes' conn.log.gz
 ```
 

--- a/docs/language/grouping/README.md
+++ b/docs/language/grouping/README.md
@@ -42,7 +42,7 @@ specification of each unit.
 To see the total number of bytes originated across all connections during each
 minute:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'every 1m sum(orig_bytes) | sort -r ts' conn.log.gz
 ```
 
@@ -61,7 +61,7 @@ ts                   sum
 To see which 30-second intervals contained the most records, expressing the
 duration as a half-minute:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'every 0.5m count() | sort -r count' *.log.gz
 ```
 
@@ -79,7 +79,7 @@ ts                   count
 To see the highest-numbered responding network port during each 90-second
 interval, expressing the duration as a mix of minutes and seconds:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'every 1m30s max(id.resp_p) | sort -r ts' conn.log.gz
 ```
 
@@ -105,7 +105,7 @@ The simplest example summarizes the unique values of the named field(s), which
 requires no aggregate function. To see which protocols were observed in our
 Zeek `conn` records:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'by proto | sort' conn.log.gz
 ```
 
@@ -121,7 +121,7 @@ If you work a lot at the UNIX/Linux shell, you might have sought to accomplish
 the same via a familiar, verbose idiom. This works in Zed, but the `by`
 shorthand is preferable.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'cut proto | sort | uniq' conn.log.gz
 ```
 
@@ -139,7 +139,7 @@ By specifying multiple comma-separated field names, one batch is formed for each
 unique combination of values found in those fields. To see which responding
 IP+port combinations generated the most traffic:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'sum(resp_bytes) by id.resp_h,id.resp_p  | sort -r sum' conn.log.gz
 ```
 
@@ -166,7 +166,7 @@ responding DNS servers generated the longest answers, we can group by
 both `id.resp_h` and an expression that evaluates the length of `answers`
 arrays.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'len(answers) > 0 | count() by id.resp_h,num_answers:=len(answers) | sort -r num_answers,count' dns.log.gz
 ```
 
@@ -188,7 +188,7 @@ the grouping to have effect.
 Let's say we've performed separate aggregations for fields present in different
 Zeek records. First we count the unique `host` values in `http` records.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count() by host | sort -r | head 3' http.log.gz
 ```
 
@@ -202,7 +202,7 @@ host       count
 
 Next we count the unique `query` values in `dns` records.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count() by query | sort -r | head 3' dns.log.gz
 ```
 
@@ -226,7 +226,7 @@ and the `host` field not being present in any of the `dns` records. This can
 be observed by looking at the [ZSON](../../formats/zson.md)
 representation of the type definitions for each record type.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f zson 'count() by _path,typeof(.) | sort _path' http.log.gz dns.log.gz
 ```
 
@@ -250,7 +250,7 @@ records under a single schema. This has the effect of populating missing
 fields with null values. Now that the named fields are present in
 all records, the `by` grouping has the desired effect.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'fuse | count() by host,query | sort -r | head 3' http.log.gz dns.log.gz
 ```
 
@@ -273,7 +273,7 @@ should be used downstream of the aggregate function(s) in the Zed pipeline.
 If we were counting records into 5-minute batches and wanted to see these
 results ordered by incrementing timestamp of each batch:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'every 5m count() | sort ts' *.log.gz
 ```
 
@@ -289,7 +289,7 @@ ts                   count
 
 If we'd wanted to see them ordered from lowest to highest record count:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'every 5m count() | sort count' *.log.gz
 ```
 

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -44,7 +44,7 @@ The following available operators are documented in detail below:
 
 To return only the `ts` and `uid` columns of `conn` records:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'cut ts,uid' conn.log.gz
 ```
 
@@ -65,7 +65,7 @@ the Zeek `smb_mapping` logs in our sample data contain the field named
 `share_type`, the following query returns records for many other log types that
 contain the `_path` and/or `ts` that we included in our field list.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'cut _path,ts,share_type' *
 ```
 
@@ -86,7 +86,7 @@ Contrast this with a [similar example](#example-2-3) that shows how
 If no records are found that contain any of the named fields, `cut` returns a
 warning.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'cut nothere,alsoabsent' weird.log.gz
 ```
 
@@ -100,7 +100,7 @@ cut: no record found with columns nothere,alsoabsent
 To return only the `ts` and `uid` columns of `conn` records, with `ts` renamed
 to `time`:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'cut time:=ts,uid' conn.log.gz
 ```
 
@@ -128,7 +128,7 @@ time                        uid
 To return all fields _other than_ the `_path` field and `id` record of `weird`
 records:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'drop _path,id' weird.log.gz
 ```
 
@@ -161,7 +161,7 @@ ts                          uid                name                             
 
 To further trim the data returned in our [`cut`](#cut) example:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'cut ts,uid | filter uid=="CXWfTK3LRdiuQxBbM6"' conn.log.gz
 ```
 
@@ -175,7 +175,7 @@ ts                          uid
 
 An alternative syntax for our [`and` example](../search-syntax/README.md#and):
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'filter www.*cdn*.com _path=="ssl"' *.log.gz
 ```
 
@@ -202,7 +202,7 @@ ssl   2018-03-24T17:24:00.189735Z CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85
 
 Let's say you'd started with table-formatted output of both `stats` and `weird` records:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'ts < 1521911721' stats.log.gz weird.log.gz
 ```
 
@@ -240,7 +240,7 @@ is assembled in a first pass through the data stream, which enables the
 presentation of the results under a single, wider header row with no further
 interruptions between the subsequent data rows.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f csv 'ts < 1521911721 | fuse' stats.log.gz weird.log.gz
 ```
 
@@ -272,7 +272,7 @@ Other output formats invoked via `zq -f` that benefit greatly from the use of
 
 To see the first `dns` record:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'head' dns.log.gz
 ```
 
@@ -286,7 +286,7 @@ dns   2018-03-24T17:15:20.865716Z C2zK5f13SbCtKcyiW5 10.47.1.100 41772     10.0.
 
 To see the first five `conn` records with activity on port `80`:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'id.resp_p==80 | head 5' conn.log.gz
 ```
 
@@ -610,7 +610,7 @@ zq -z -I embed-opposite.zed
 
 To return only the `ts` and `uid` columns of `conn` records:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'pick ts,uid' conn.log.gz
 ```
 
@@ -631,7 +631,7 @@ data contains the field named `share_type`, the following query returns columns
 for only that record type. The many other Zeek record types that also include
 `_path` and/or `ts` fields are not returned.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'pick _path,ts,share_type' *
 ```
 
@@ -652,7 +652,7 @@ Contrast this with a [similar example](#example-2) that shows how
 If no records are found that contain any of the named fields, `pick` returns a
 warning.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'pick nothere,alsoabsent' weird.log.gz
 ```
 
@@ -666,7 +666,7 @@ pick: no record found with columns nothere,alsoabsent
 To return only the `ts` and `uid` columns of `conn` records, with `ts` renamed
 to `time`:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'pick time:=ts,uid' conn.log.gz
 ```
 
@@ -695,7 +695,7 @@ time                        uid
 
 Compute a `total_bytes` field in `conn` records:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -q -f table 'put total_bytes := orig_bytes + resp_bytes | sort -r total_bytes | cut id, orig_bytes, resp_bytes, total_bytes' conn.log.gz
 ```
 
@@ -715,7 +715,7 @@ As noted above the `put` keyword is entirely optional. Here we omit
 it and create a new field to hold the lowercase representation of
 another field value.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'cut method | lower_method:=to_lower(method)' http.log.gz
 ```
 
@@ -744,7 +744,7 @@ GET     get
 
 Rename `ts` to `time`, rename one of the inner fields of `id`, and rename the `id` record itself to `conntuple`:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
  zq -f table 'rename time:=ts, id.src:=id.orig_h, conntuple:=id' conn.log.gz
 ```
 
@@ -773,7 +773,7 @@ conn  2018-03-24T17:15:22.690601Z CuKFds250kxFgkhh8f 10.47.25.80    50813       
 
 To sort `x509` records by `certificate.subject`:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'sort certificate.subject' x509.log.gz
 ```
 
@@ -798,7 +798,7 @@ Now we'll sort `x509` records first by `certificate.subject`, then by the `id`.
 Compared to the previous example, note how this changes the order of some
 records that had the same `certificate.subject` value.
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'sort certificate.subject,id' x509.log.gz
 ```
 
@@ -826,7 +826,7 @@ a `sort` in reverse order. Note that even though we didn't list a field name as
 an explicit argument, the `sort` operator did what we wanted because it found a
 field of the `uint64` [data type](../data-types/README.md).
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count() by id.orig_h | sort -r' conn.log.gz
 ```
 
@@ -846,7 +846,7 @@ In this example we count the number of times each distinct username appears in
 `http` records, but deliberately put the unset username at the front of the
 list:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'count() by username | sort -nulls first username' http.log.gz
 ```
 
@@ -877,7 +877,7 @@ wwonka       1
 
 To see the last `dns` record:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'tail' dns.log.gz
 ```
 
@@ -891,7 +891,7 @@ dns   2018-03-24T17:36:30.151237Z C0ybvu4HG3yWv6H5cb 172.31.255.5 60878     10.0
 
 To see the last five `conn` records with activity on port `80`:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'id.resp_p==80 | tail 5' conn.log.gz
 ```
 
@@ -920,7 +920,7 @@ conn  2018-03-24T17:36:28.752765Z COICgc1FXHKteyFy67 10.0.0.227     61314     10
 
 To see a count of the top issuers of X.509 certificates:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'cut certificate.issuer | sort | uniq -c | sort -r' x509.log.gz
 ```
 

--- a/docs/language/search-syntax/README.md
+++ b/docs/language/search-syntax/README.md
@@ -28,7 +28,7 @@ we'll sometimes make use of the `-z` option to output the text-based
 [ZSON](../../formats/zson.md) format, which is readable at the command line.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -z '*' conn.log.gz
 ```
 
@@ -61,7 +61,7 @@ zq -z '* | cut server_tree_name' ntlm.log.gz
 
 #### Example:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -z 'cut server_tree_name' ntlm.log.gz
 ```
 
@@ -97,7 +97,7 @@ appears within `string`-type fields (such as the field `certificate.subject` in
 > matching field values.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table '10.150.0.85' *.log.gz
 ```
 
@@ -138,7 +138,7 @@ search. If typed bare as our Zed query, we'd experience two problems:
 However, wrapping in quotes gives the desired result.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table '"O=Internet Widgits"' *.log.gz
 ```
 
@@ -169,7 +169,7 @@ hostnames that include the letters `cdn` in the middle of them, such as
 `www.cdn.amazon.com` or `www.herokucdn.com`.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'www.*cdn*.com' *.log.gz
 ```
 
@@ -198,7 +198,7 @@ matches records that contain the substring `CN=*` as is often found in the
 start of certificate subjects.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table '"CN=*"' *.log.gz
 ```
 
@@ -242,7 +242,7 @@ But if you're only interested in records having to do with "ad" or "tag"
 services, the following regexp search can accomplish this.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table '/www.google(ad|tag)services.com/' *.log.gz
 ```
 
@@ -273,7 +273,7 @@ will only match records containing the field called `uid` where it is set to
 the precise string value `ChhAfsfyuz4n2hFMe`.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'uid=="ChhAfsfyuz4n2hFMe"' *.log.gz
 ```
 
@@ -293,7 +293,7 @@ we match records in which the values in the fields for originating and
 responding ports are the same.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'id.orig_p==id.resp_p' conn.log.gz
 ```
 
@@ -317,7 +317,7 @@ in two ways.
    our sample data are of `string` type, since it logs an HTTP header that is
    often a hostname or an IP address.
 
-   ```mdtest-command zed-sample-data/zeek-default
+   ```mdtest-command dir=zed-sample-data/zeek-default
    zq -z 'count() by host | sort count,host' http.log.gz
    ```
 
@@ -358,7 +358,7 @@ following example produces no output.
 
 #### Example:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'certificate.subject=="Widgits"' *.log.gz
 ```
 
@@ -370,7 +370,7 @@ To achieve this with a field/value match, we enter `matches` before specifying
 a [glob wildcard](#glob-wildcards).
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'certificate.subject matches *Widgits*' *.log.gz
 ```
 
@@ -388,7 +388,7 @@ x509  2018-03-24T17:15:47.493786Z FdBWBA3eODh6nHFt82 3                   C5F8CDF
 [Regular expressions](#regular-expressions) can also be used with `matches`.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'uri matches /scripts\/waE8_BuNCEKM.(pl|sh)/' http.log.gz
 ```
 
@@ -414,7 +414,7 @@ multiple responses that may have been returned for a query. To determine which
 responses included hostname `e5803.b.akamaiedge.net`, we'll use `in`.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table '"e5803.b.akamaiedge.net" in answers' dns.log.gz
 ```
 
@@ -438,7 +438,7 @@ However, the `query` field does exist in our `dns` records, so the following
 example does return matches.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'query in answers' dns.log.gz
 ```
 
@@ -455,7 +455,7 @@ Determining whether the value of a Zeek `ip`-type field is contained within a
 subnet also uses `in`.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'id.resp_h in 208.78.0.0/16' conn.log.gz
 ```
 
@@ -477,7 +477,7 @@ In addition to testing for equality via `==` and finding patterns via
 For example, the following search finds connections that have transferred many bytes.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'orig_bytes > 1000000' *.log.gz
 ```
 
@@ -496,7 +496,7 @@ such as this search that finds DNS requests that were issued for hostnames at
 the high end of the alphabet.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'query > "zippy"' *.log.gz
 ```
 
@@ -553,7 +553,7 @@ couple `ssl` records. You could quickly isolate just the SSL records by
 leveraging this implicit `and`.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'www.*cdn*.com _path=="ssl"' *.log.gz
 ```
 
@@ -576,7 +576,7 @@ For example, we can revisit two of our previous example searches that each only
 returned a few records, searching now with `or` to see them all at once.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'orig_bytes > 1000000 or query > "zippy"' *.log.gz
 ```
 
@@ -607,7 +607,7 @@ some of the less-common Zeek record types by inverting the logic of a
 [regexp match](#regular-expressions).
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'not _path matches /conn|dns|files|ssl|x509|http|weird/' *.log.gz
 ```
 
@@ -640,7 +640,7 @@ all `smb_mapping` records in which the `share_type` field is set to a value
 other than `DISK`.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'not share_type=="DISK" _path=="smb_mapping"' *.log.gz
 ```
 
@@ -662,7 +662,7 @@ _other than_ `smb_mapping` records that have the value of their `share_type`
 field set to `DISK`.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table 'not (share_type=="DISK" _path=="smb_mapping")' *.log.gz
 ```
 
@@ -683,7 +683,7 @@ conn  2018-03-24T17:15:23.205187Z CBrzd94qfowOqJwCHa 10.47.25.80    50813     10
 Parentheses can also be nested.
 
 #### Example:
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -f table '((not share_type=="DISK") and (service=="IPC")) _path=="smb_mapping"' *.log.gz
 ```
 

--- a/mdtest/mdtest_test.go
+++ b/mdtest/mdtest_test.go
@@ -71,6 +71,18 @@ other code block
 			strerror: "line 2: unpaired mdtest-output",
 		},
 		{
+			name: "mdtest-command with unknown word",
+			markdown: `
+~~~mdtest-command unknown
+block 1
+~~~
+~~~mdtest-output
+block 2
+~~~
+`,
+			strerror: `line 2: unknown word in mdtest-command info string: "unknown"`,
+		},
+		{
 			name: "two commands",
 			markdown: `
 ~~~mdtest-command 1
@@ -88,16 +100,16 @@ block 3
 		{
 			name: "two tests",
 			markdown: `
-~~~mdtest-command 1
+~~~mdtest-command dir=1
 block 1
 ~~~
-~~~mdtest-output 1
+~~~mdtest-output
 block 2
 ~~~
-~~~mdtest-command 2
+~~~mdtest-command dir=2
 block 3
 ~~~
-~~~mdtest-output 2
+~~~mdtest-output
 block 4
 ~~~
 `,
@@ -144,6 +156,7 @@ block 2
 			if tc.strerror != "" {
 				assert.EqualError(t, err, tc.strerror)
 			} else {
+				assert.NoError(t, err)
 				assert.Equal(t, inputs, tc.inputs)
 				assert.Equal(t, tests, tc.tests)
 			}

--- a/mdtest/test.go
+++ b/mdtest/test.go
@@ -1,6 +1,7 @@
 package mdtest
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -13,6 +14,7 @@ type Test struct {
 	Command  string
 	Dir      string
 	Expected string
+	Fails    bool
 	Head     bool
 	Line     int
 }
@@ -24,6 +26,13 @@ func (t *Test) Run() error {
 	c.Stdin = strings.NewReader(t.Command)
 	outBytes, err := c.CombinedOutput()
 	out := string(outBytes)
+	if t.Fails {
+		if errors.As(err, new(*exec.ExitError)) {
+			err = nil
+		} else if err == nil {
+			err = errors.New("command succeeded unexpectedly")
+		}
+	}
 	if err != nil {
 		if out != "" {
 			return fmt.Errorf("%w\noutput:\n%s", err, out)

--- a/zeek/Reading-Zeek-Log-Formats.md
+++ b/zeek/Reading-Zeek-Log-Formats.md
@@ -24,7 +24,7 @@ being read via `zq` and output as [ZSON](../docs/formats/zson.md).
 
 #### Example:
 
-```mdtest-command zed-sample-data/zeek-default
+```mdtest-command dir=zed-sample-data/zeek-default
 zq -Z 'head 1' conn.log.gz
 ```
 
@@ -85,7 +85,7 @@ which was generated using the JSON Streaming Logs package.
 
 #### Example:
 
-```mdtest-command zed-sample-data/zeek-ndjson
+```mdtest-command dir=zed-sample-data/zeek-ndjson
 zq -Z 'head 1' conn.ndjson.gz
 ```
 


### PR DESCRIPTION
Change the syntax for specifying a working directory in an  
mdtest-command block info string from "mdtest-command path/to/dir" to  
"mdtest-command dir=path/to/dir" in preparation for adding a new info  
string option.

Fixes #2857