### PR TITLE
enable ANSI escapes on Windows in pkg/terminal/color

### DIFF
--- a/pkg/terminal/color/init_windows.go
+++ b/pkg/terminal/color/init_windows.go
@@ -1,0 +1,14 @@
+package color
+
+import "golang.org/x/sys/windows"
+
+// init enables processing of ANSI (aka VT100) escape sequences by Windows
+// consoles attached to standard output or standard error.
+func init() {
+	for _, handle := range [...]windows.Handle{windows.Stdout, windows.Stderr} {
+		var mode uint32
+		if err := windows.GetConsoleMode(handle, &mode); err == nil {
+			windows.SetConsoleMode(handle, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		}
+	}
+}


### PR DESCRIPTION
Charm help and colorized ZSON both contain ANSI escape sequences, but by
default, Windows consoles don't interpret them.  Add a Windows-only init
function in pkg/terminal/color to enable that.