### PR TITLE
disable escaping of &, <, and > in zio/jsonio.Reader

### DIFF
--- a/zio/jsonio/reader.go
+++ b/zio/jsonio/reader.go
@@ -10,8 +10,10 @@ import (
 )
 
 type Reader struct {
-	zctx    *zed.Context
-	decoder *json.Decoder
+	zctx       *zed.Context
+	decoder    *json.Decoder
+	encoder    *json.Encoder
+	encoderBuf *bytes.Buffer
 }
 
 func NewReader(r io.Reader, zctx *zed.Context) *Reader {
@@ -23,9 +25,14 @@ func NewReader(r io.Reader, zctx *zed.Context) *Reader {
 		// We have an array.  Discard its opening "[" delimiter.
 		d.Token()
 	}
+	var buf bytes.Buffer
+	e := json.NewEncoder(&buf)
+	e.SetEscapeHTML(false)
 	return &Reader{
-		zctx:    zctx,
-		decoder: d,
+		zctx:       zctx,
+		decoder:    d,
+		encoder:    e,
+		encoderBuf: &buf,
 	}
 }
 
@@ -40,9 +47,9 @@ func (r *Reader) Read() (*zed.Record, error) {
 	if _, ok := v.(map[string]interface{}); !ok {
 		v = map[string]interface{}{"value": v}
 	}
-	b, err := json.Marshal(v)
-	if err != nil {
+	r.encoderBuf.Reset()
+	if err := r.encoder.Encode(v); err != nil {
 		return nil, err
 	}
-	return zson.NewReader(bytes.NewReader(b), r.zctx).Read()
+	return zson.NewReader(r.encoderBuf, r.zctx).Read()
 }

--- a/zio/jsonio/ztests/reader.yaml
+++ b/zio/jsonio/ztests/reader.yaml
@@ -12,6 +12,7 @@ inputs:
         "ts": 1521911721.926018012,
         "a": "hello, world",
         "b": {
+          "z": "&, <, and > should not be escaped",
           "x": 4611686018427387904,
           "y": "127.0.0.1"
         }
@@ -30,7 +31,8 @@ outputs:
           a: "hello, world",
           b: {
               x: 4611686018427388000,
-              y: "127.0.0.1"
+              y: "127.0.0.1",
+              z: "&, <, and > should not be escaped"
           },
           ts: 1.521911721926018e+09
       }


### PR DESCRIPTION
A zio/jsonio.Reader escapes &, <, and > inside strings because it uses
encoding/json.Marshal internally.  Switch to an encoding/json.Encoder
and use its SetEscapeHTML method to disable escaping.

Closes #3172.