### PR TITLE
allow dot operator to work on union containing record

### DIFF
--- a/expr/dot.go
+++ b/expr/dot.go
@@ -30,8 +30,29 @@ func NewDotExpr(f field.Path) Evaluator {
 	return ret
 }
 
-func accessField(record zed.Value, field string) (zed.Value, error) {
-	recType, ok := zed.AliasOf(record.Type).(*zed.TypeRecord)
+func valOf(zv zed.Value) (zed.Value, error) {
+	typ := zv.Type
+	bytes := zv.Bytes
+	for {
+		typ = zed.AliasOf(typ)
+		union, ok := typ.(*zed.TypeUnion)
+		if !ok {
+			return zed.Value{typ, bytes}, nil
+		}
+		var err error
+		typ, _, bytes, err = union.SplitZng(bytes)
+		if err != nil {
+			return zed.Value{}, err
+		}
+	}
+}
+
+func accessField(zv zed.Value, field string) (zed.Value, error) {
+	zv, err := valOf(zv)
+	if err != nil {
+		return zed.Value{}, err
+	}
+	recType, ok := zv.Type.(*zed.TypeRecord)
 	if !ok {
 		return zed.Value{}, zed.ErrMissing
 	}
@@ -40,16 +61,16 @@ func accessField(record zed.Value, field string) (zed.Value, error) {
 		return zed.Value{}, zed.ErrMissing
 	}
 	typ := recType.Columns[idx].Type
-	if record.Bytes == nil {
+	if zv.Bytes == nil {
 		// Value was unset.  Return unset value of the indicated type.
 		return zed.Value{typ, nil}, nil
 	}
 	//XXX see PR #1071 to improve this (though we need this for Index anyway)
-	zv, err := getNthFromContainer(record.Bytes, uint(idx))
+	fv, err := getNthFromContainer(zv.Bytes, uint(idx))
 	if err != nil {
 		return zed.Value{}, err
 	}
-	return zed.Value{recType.Columns[idx].Type, zv}, nil
+	return zed.Value{recType.Columns[idx].Type, fv}, nil
 }
 
 func (f *DotExpr) Eval(rec *zed.Record) (zed.Value, error) {

--- a/expr/ztests/union-deref.yaml
+++ b/expr/ztests/union-deref.yaml
@@ -1,0 +1,7 @@
+zed: 'cut a:=r[0].a,b:=r[1].b'
+
+input: |
+  {r:[{a:1},{b:1.5}]}
+
+output: |
+  {a:1,b:1.5}


### PR DESCRIPTION
This commit arranges for the dot operator to work on union values when the underlying value is a record.  We need to generalize this across all operators in the system, where we automatically promote union values to their underlying value when used in expressions expecting a non-union type.
