### PR TITLE
don't use HEAD in query when const/type in the way

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -48,8 +48,9 @@ func New(pctx *proc.Context, inAST ast.Proc, adaptor proc.DataAdaptor, head *lak
 	var readers []*kernel.Reader
 	var from *ast.From
 	switch proc := seq.Procs[0].(type) {
-	case *ast.From:
-		// Already have an entry point with From.  Do nothing.
+	case *ast.From, *ast.Const, *ast.TypeProc:
+		// Already have an entry point with From.  Or, if there are
+		// const and/or type decls, assume a from comes later. Do nothing.
 	case *ast.Join:
 		readers = []*kernel.Reader{{}, {}}
 		trunk0 := ast.Trunk{

--- a/compiler/semantic/ast.go
+++ b/compiler/semantic/ast.go
@@ -29,9 +29,14 @@ func Analyze(ctx context.Context, seq *ast.Sequential, adaptor proc.DataAdaptor,
 }
 
 func isFrom(seq *ast.Sequential) bool {
-	if len(seq.Procs) == 0 {
-		return false
+	for _, p := range seq.Procs {
+		switch p.(type) {
+		case *ast.Const, *ast.TypeProc:
+		case *ast.From:
+			return true
+		default:
+			return false
+		}
 	}
-	_, ok := seq.Procs[0].(*ast.From)
-	return ok
+	return false
 }


### PR DESCRIPTION
This commit fixes a problem where HEAD is inserted when the
"from" operator appears after const/type declarations.