### PR TITLE
fix bug where consts blocked "from" operator wiring logic

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -29,6 +29,7 @@ type Runtime struct {
 
 func New(pctx *proc.Context, inAST ast.Proc, adaptor proc.DataAdaptor, head *lakeparse.Commitish) (*Runtime, error) {
 	parserAST := ast.Copy(inAST)
+	constsAST := semantic.LiftConsts(parserAST)
 	// An AST always begins with a Sequential proc with at least one
 	// proc.  If the first proc is a From, then we presume there is no
 	// externally defined input.  Otherwise, we expect two readers
@@ -100,7 +101,7 @@ func New(pctx *proc.Context, inAST ast.Proc, adaptor proc.DataAdaptor, head *lak
 	if from != nil {
 		seq.Prepend(from)
 	}
-	entry, consts, err := semantic.Analyze(pctx.Context, seq, adaptor, head)
+	entry, consts, err := semantic.Analyze(pctx.Context, seq, constsAST, adaptor, head)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/semantic/ast.go
+++ b/compiler/semantic/ast.go
@@ -11,13 +11,13 @@ import (
 )
 
 // Analyze analysis the AST and prepares it for runtime compilation.
-func Analyze(ctx context.Context, seq *ast.Sequential, adaptor proc.DataAdaptor, head *lakeparse.Commitish) (*dag.Sequential, []dag.Op, error) {
+func Analyze(ctx context.Context, seq *ast.Sequential, constsAST []ast.Proc, adaptor proc.DataAdaptor, head *lakeparse.Commitish) (*dag.Sequential, []dag.Op, error) {
 	if !isFrom(seq) {
 		return nil, nil, errors.New("Zed program does not begin with a data source")
 	}
 	scope := NewScope()
 	scope.Enter()
-	consts, err := semConsts(nil, scope, seq)
+	consts, err := semConsts(scope, constsAST)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -553,9 +553,9 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 			As:   as,
 		}, nil
 	case *ast.Const:
-		return nil, errors.New("const declaration must appear in outer block")
+		return nil, errors.New("const declaration must appear at top level")
 	case *ast.TypeProc:
-		return nil, errors.New("type declaration must appear in outer block")
+		return nil, errors.New("type declaration must appear at top level")
 	}
 	return nil, fmt.Errorf("semantic transform: unknown AST type: %v", p)
 }

--- a/compiler/ztests/const-from.yaml
+++ b/compiler/ztests/const-from.yaml
@@ -1,0 +1,24 @@
+script: zq -z -I src.zed
+
+inputs:
+  - name: src.zed
+    data: |
+      const A=1;
+      from (
+        file a.zson => put x:=A+1;
+        file b.zson => put x:=A;
+      ) | sort x
+
+  - name: a.zson
+    data: |
+      {a:1}
+
+  - name: b.zson
+    data: |
+      {b:2}
+
+outputs:
+  - name: stdout
+    data: |
+      {b:2,x:1}
+      {a:1,x:2}

--- a/expr/ztests/type-map.yaml
+++ b/expr/ztests/type-map.yaml
@@ -5,7 +5,7 @@ zed: |
     "conn": conn,
     "dns": dns
   }|
-  split (
+  * | split (
     => cut schema:=schemas[_path];
     => missing(schemas[_path]) | put _UNCLASSIFIED:=true;
   ) | sort .


### PR DESCRIPTION
This commit fixes a bug where type and const declarations interfered
with the logic to determine how to wire up inputs to the flowgraph.
The fix is to require all const/type declarations to appear at the
outer, top block and pull them out at the very start of compilation.

This will be reworked when we add modules, subqueries, UDFs, etc.