### PR TITLE
index: Use KeyValue for lookup

### DIFF
--- a/cmd/zed/index/lookup/command.go
+++ b/cmd/zed/index/lookup/command.go
@@ -80,7 +80,7 @@ func (c *LookupCommand) Run(args []string) error {
 	go func() {
 		if c.closest {
 			var rec *zed.Value
-			rec, searchErr = finder.ClosestLTE(keys)
+			rec, searchErr = finder.ClosestLTE(keys...)
 			if rec != nil {
 				hits <- rec
 			}

--- a/index/findreader.go
+++ b/index/findreader.go
@@ -27,11 +27,11 @@ func NewFinderReader(ctx context.Context, zctx *zed.Context, engine storage.Engi
 }
 
 func (f *FinderReader) init() error {
-	keys, err := f.finder.ParseKeys(f.inputs...)
+	kvs, err := f.finder.ParseKeys(f.inputs...)
 	if err != nil {
 		return err
 	}
-	f.compare, err = expr.NewKeyCompareFn(keys)
+	f.compare = compareFn(kvs)
 	if err != nil {
 		return err
 	}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -30,9 +30,9 @@ func TestSearch(t *testing.T) {
 {key:"key6",value:"value6"}
 `
 	finder := buildAndOpen(t, storage.NewLocalEngine(), reader(data), field.DottedList("key"))
-	keyRec, err := finder.ParseKeys(`"key2"`)
+	kv, err := finder.ParseKeys(`"key2"`)
 	require.NoError(t, err)
-	rec, err := finder.Lookup(keyRec)
+	rec, err := finder.Lookup(kv...)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 	value, err := rec.Slice(1)
@@ -96,17 +96,17 @@ func TestCompare(t *testing.T) {
 	}
 	runtest := func(t *testing.T, finder *index.Finder, op string, value int64, expected int64) {
 		t.Run(fmt.Sprintf("%d%s%d", expected, op, value), func(t *testing.T) {
-			k, err := finder.ParseKeys(fmt.Sprintf("%d", value))
+			kvs, err := finder.ParseKeys(fmt.Sprintf("%d", value))
 			require.NoError(t, err)
 
 			var rec *zed.Value
 			switch op {
 			case ">=":
-				rec, err = finder.ClosestGTE(k)
+				rec, err = finder.ClosestGTE(kvs...)
 			case "<=":
-				rec, err = finder.ClosestLTE(k)
+				rec, err = finder.ClosestLTE(kvs...)
 			case "==":
-				rec, err = finder.Lookup(k)
+				rec, err = finder.Lookup(kvs...)
 			}
 
 			require.NoError(t, err)

--- a/lake/index/match.go
+++ b/lake/index/match.go
@@ -1,38 +1,31 @@
 package index
 
 import (
-	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/compiler/ast/dag"
-	"github.com/brimdata/zed/field"
+	"github.com/brimdata/zed/index"
 	"github.com/brimdata/zed/zson"
 )
 
 type match struct {
 	rule       Rule
-	lookupKeys []*zed.Value
+	lookupKeys []index.KeyValue
 }
 
 type matcher func([]Rule) []match
 
-type predicate struct {
-	field field.Path
-	value zed.Value
-}
-
 func compilePredicates(in []dag.IndexPredicate) (matcher, error) {
-	predicates := make([]predicate, 0, len(in))
+	kvs := make([]index.KeyValue, 0, len(in))
 	for _, d := range in {
 		zv, err := zson.ParsePrimitive(d.Value.Type, d.Value.Text)
 		if err != nil {
 			return nil, err
 		}
-		predicates = append(predicates, predicate{d.Key.Name, zv})
+		kvs = append(kvs, index.KeyValue{Key: d.Key.Name, Value: zv})
 	}
-	zctx := zed.NewContext()
 	return func(rules []Rule) []match {
 		var matches []match
 		for _, r := range rules {
-			if values := matchRule(zctx, r, predicates); len(values) > 0 {
+			if values := matchRule(r, kvs); len(values) > 0 {
 				// XXX Maybe store RuleID in lookup table so we don't have to
 				// loop through all the predicates for rules we've already
 				// matched.
@@ -43,18 +36,14 @@ func compilePredicates(in []dag.IndexPredicate) (matcher, error) {
 	}, nil
 }
 
-func matchRule(zctx *zed.Context, rule Rule, predicates []predicate) []*zed.Value {
-	var recs []*zed.Value
-	for _, p := range predicates {
+func matchRule(rule Rule, in []index.KeyValue) []index.KeyValue {
+	var kvs []index.KeyValue
+	for _, kv := range in {
 		// XXX support indexes with multiple keys #3162
 		// and other rule types.
-		if f, ok := rule.(*FieldRule); ok && p.field.Equal(f.Fields[0]) {
-			rec, err := newLookupKey(zctx, rule, []zed.Value{p.value})
-			if err != nil {
-				panic(err)
-			}
-			recs = append(recs, rec)
+		if f, ok := rule.(*FieldRule); ok && kv.Key.Equal(f.Fields[0]) {
+			kvs = append(kvs, kv)
 		}
 	}
-	return recs
+	return kvs
 }


### PR DESCRIPTION
Instead of constructing a record for Lookup of an index value, have
finder.Lookup* accept KeyValue.