### PR TITLE
remove zed.Record type alias

### DIFF
--- a/api/queryio/client.go
+++ b/api/queryio/client.go
@@ -48,11 +48,11 @@ func RunClientResponse(ctx context.Context, d driver.Driver, res *client.Respons
 type runner struct {
 	driver driver.Driver
 	cid    int
-	recs   []*zed.Record
+	recs   []*zed.Value
 	stats  zbuf.ScannerStats
 }
 
-func (r *runner) Write(rec *zed.Record) error {
+func (r *runner) Write(rec *zed.Value) error {
 	return r.driver.Write(r.cid, &zbuf.Array{rec})
 }
 

--- a/api/queryio/zjson.go
+++ b/api/queryio/zjson.go
@@ -28,7 +28,7 @@ func NewZJSONWriter(w io.Writer) *ZJSONWriter {
 	}
 }
 
-func (w *ZJSONWriter) Write(rec *zed.Record) error {
+func (w *ZJSONWriter) Write(rec *zed.Value) error {
 	object, err := w.stream.Transform(rec)
 	if err != nil {
 		return err

--- a/api/queryio/zjson_test.go
+++ b/api/queryio/zjson_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mkRecord(t *testing.T, s string) *zed.Record {
+func mkRecord(t *testing.T, s string) *zed.Value {
 	r := zson.NewReader(strings.NewReader(s), zed.NewContext())
 	rec, err := r.Read()
 	require.NoError(t, err)

--- a/api/queryio/zng.go
+++ b/api/queryio/zng.go
@@ -51,7 +51,7 @@ func NewZNGReader(r *zngio.Reader) *ZNGReader {
 	}
 }
 
-func (r *ZNGReader) ReadPayload() (*zed.Record, interface{}, error) {
+func (r *ZNGReader) ReadPayload() (*zed.Value, interface{}, error) {
 	rec, msg, err := r.reader.ReadPayload()
 	if msg != nil {
 		if msg.Encoding != zed.AppEncodingZSON {

--- a/builder.go
+++ b/builder.go
@@ -30,7 +30,7 @@ func NewBuilder(typ *TypeRecord) *Builder {
 // primitive vs container insertions.  This could be the start of a whole package
 // that provides different ways to build Records via, e.g., a marshal API,
 // auto-generated stubs, etc.
-func (b *Builder) Build(zvs ...zcode.Bytes) *Record {
+func (b *Builder) Build(zvs ...zcode.Bytes) *Value {
 	b.Reset()
 	cols := b.Type.Columns
 	for k, zv := range zvs {

--- a/cmd/zed/index/lookup/command.go
+++ b/cmd/zed/index/lookup/command.go
@@ -75,11 +75,11 @@ func (c *LookupCommand) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	hits := make(chan *zed.Record)
+	hits := make(chan *zed.Value)
 	var searchErr error
 	go func() {
 		if c.closest {
-			var rec *zed.Record
+			var rec *zed.Value
 			rec, searchErr = finder.ClosestLTE(keys)
 			if rec != nil {
 				hits <- rec

--- a/compiler/kernel/filter.go
+++ b/compiler/kernel/filter.go
@@ -151,7 +151,7 @@ func CompileFilter(zctx *zed.Context, scope *Scope, node dag.Expr) (expr.Filter,
 		default:
 			return nil, fmt.Errorf("bad boolean value in dag.Literal: %s", v.Text)
 		}
-		return func(*zed.Record) bool { return b }, nil
+		return func(*zed.Value) bool { return b }, nil
 
 	case *dag.Search:
 		return compileSearch(v)
@@ -202,7 +202,7 @@ func compileExprPredicate(zctx *zed.Context, scope *Scope, e dag.Expr) (expr.Fil
 	if err != nil {
 		return nil, err
 	}
-	return func(rec *zed.Record) bool {
+	return func(rec *zed.Value) bool {
 		zv, err := predicate.Eval(rec)
 		return err == nil && zv.Type == zed.TypeBool && zed.IsTrue(zv.Bytes)
 	}, nil

--- a/compiler/kernel/proc.go
+++ b/compiler/kernel/proc.go
@@ -231,7 +231,7 @@ func (b *Builder) compileLeaf(op dag.Op, parent proc.Interface) (proc.Interface,
 
 type filterFunction expr.Filter
 
-func (f filterFunction) Apply(rec *zed.Record) (*zed.Record, error) {
+func (f filterFunction) Apply(rec *zed.Value) (*zed.Value, error) {
 	if f(rec) {
 		return rec, nil
 	}

--- a/context.go
+++ b/context.go
@@ -216,7 +216,7 @@ func (c *Context) LookupTypeAlias(name string, target Type) (*TypeAlias, error) 
 // record along with new rightmost columns as indicated with the given values.
 // If any of the newly provided columns already exists in the specified value,
 // an error is returned.
-func (c *Context) AddColumns(r *Record, newCols []Column, vals []Value) (*Record, error) {
+func (c *Context) AddColumns(r *Value, newCols []Column, vals []Value) (*Value, error) {
 	oldCols := TypeRecordOf(r.Type).Columns
 	outCols := make([]Column, len(oldCols), len(oldCols)+len(newCols))
 	copy(outCols, oldCols)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -286,7 +286,7 @@ func (r *Reader) Write(_ int, batch zbuf.Batch) error {
 	return nil
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	r.once.Do(func() {
 		go func() {
 			r.err = run(r.runtime.Context(), r, r.runtime, nil)

--- a/expr/agg.go
+++ b/expr/agg.go
@@ -39,7 +39,7 @@ func (a *Aggregator) NewFunction() agg.Function {
 	return a.pattern()
 }
 
-func (a *Aggregator) Apply(f agg.Function, rec *zed.Record) error {
+func (a *Aggregator) Apply(f agg.Function, rec *zed.Value) error {
 	if a.filter(rec) {
 		return nil
 	}
@@ -53,7 +53,7 @@ func (a *Aggregator) Apply(f agg.Function, rec *zed.Record) error {
 	return f.Consume(zv)
 }
 
-func (a *Aggregator) filter(rec *zed.Record) bool {
+func (a *Aggregator) filter(rec *zed.Value) bool {
 	if a.where == nil {
 		return false
 	}

--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -74,7 +74,7 @@ func (c *Cutter) FoundCut() bool {
 // Apply returns a new record comprising fields copied from in according to the
 // receiver's configuration.  If the resulting record would be empty, Apply
 // returns nil.
-func (c *Cutter) Apply(in *zed.Record) (*zed.Record, error) {
+func (c *Cutter) Apply(in *zed.Value) (*zed.Value, error) {
 	if len(c.fieldRefs) == 1 && c.fieldRefs[0].IsRoot() {
 		zv, err := c.fieldExprs[0].Eval(in)
 		if err != nil {
@@ -176,7 +176,7 @@ func (c *Cutter) Warning() string {
 	return fmt.Sprintf("no record found with columns %s", fieldList(c.fieldExprs))
 }
 
-func (c *Cutter) Eval(rec *zed.Record) (zed.Value, error) {
+func (c *Cutter) Eval(rec *zed.Value) (zed.Value, error) {
 	out, err := c.Apply(rec)
 	if err != nil {
 		return zed.Value{}, err

--- a/expr/dot.go
+++ b/expr/dot.go
@@ -9,7 +9,7 @@ import (
 
 type RootRecord struct{}
 
-func (r *RootRecord) Eval(rec *zed.Record) (zed.Value, error) {
+func (r *RootRecord) Eval(rec *zed.Value) (zed.Value, error) {
 	return *rec, nil
 }
 
@@ -73,7 +73,7 @@ func accessField(zv zed.Value, field string) (zed.Value, error) {
 	return zed.Value{recType.Columns[idx].Type, fv}, nil
 }
 
-func (f *DotExpr) Eval(rec *zed.Record) (zed.Value, error) {
+func (f *DotExpr) Eval(rec *zed.Value) (zed.Value, error) {
 	lval, err := f.record.Eval(rec)
 	if err != nil {
 		return zed.Value{}, err

--- a/expr/dropper.go
+++ b/expr/dropper.go
@@ -11,7 +11,7 @@ type dropper struct {
 	fieldRefs []Evaluator
 }
 
-func (d *dropper) drop(in *zed.Record) (*zed.Record, error) {
+func (d *dropper) drop(in *zed.Value) (*zed.Value, error) {
 	if d.typ == in.Type {
 		return in, nil
 	}
@@ -46,7 +46,7 @@ func NewDropper(zctx *zed.Context, fields field.List) *Dropper {
 	}
 }
 
-func (d *Dropper) newDropper(r *zed.Record) (*dropper, error) {
+func (d *Dropper) newDropper(r *zed.Value) (*dropper, error) {
 	fields, fieldTypes, match := complementFields(d.fields, nil, zed.TypeRecordOf(r.Type))
 	if !match {
 		// r.Type contains no fields matching d.fields, so we set
@@ -117,7 +117,7 @@ func (_ *Dropper) Warning() string { return "" }
 
 // Apply implements proc.Function and returns a new record comprising fields
 // that are not specified in the set of drop targets.
-func (d *Dropper) Apply(in *zed.Record) (*zed.Record, error) {
+func (d *Dropper) Apply(in *zed.Value) (*zed.Value, error) {
 	id := in.Type.ID()
 	dropper, ok := d.droppers[id]
 	if !ok {

--- a/expr/flattener.go
+++ b/expr/flattener.go
@@ -66,7 +66,7 @@ func recode(dst zcode.Bytes, typ *zed.TypeRecord, in zcode.Bytes) (zcode.Bytes, 
 	return dst, nil
 }
 
-func (f *Flattener) Flatten(r *zed.Record) (*zed.Record, error) {
+func (f *Flattener) Flatten(r *zed.Value) (*zed.Value, error) {
 	id := r.Type.ID()
 	flatType := f.mapper.Lookup(id)
 	if flatType == nil {

--- a/expr/generator.go
+++ b/expr/generator.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Generator interface {
-	Init(*zed.Record)
+	Init(*zed.Value)
 	Next() (zed.Value, error)
 }
 
@@ -14,7 +14,7 @@ type MapMethod struct {
 	src    Generator
 	dollar zed.Value
 	expr   Evaluator
-	rec    *zed.Record
+	rec    *zed.Value
 }
 
 func NewMapMethod(src Generator) *MapMethod {
@@ -29,7 +29,7 @@ func (m *MapMethod) Set(e Evaluator) {
 	m.expr = e
 }
 
-func (m *MapMethod) Init(rec *zed.Record) {
+func (m *MapMethod) Init(rec *zed.Value) {
 	m.rec = rec
 	m.src.Init(rec)
 }
@@ -47,7 +47,7 @@ type FilterMethod struct {
 	src    Generator
 	dollar zed.Value
 	expr   Evaluator
-	rec    *zed.Record
+	rec    *zed.Value
 }
 
 func NewFilterMethod(src Generator) *FilterMethod {
@@ -62,7 +62,7 @@ func (f *FilterMethod) Set(e Evaluator) {
 	f.expr = e
 }
 
-func (f *FilterMethod) Init(rec *zed.Record) {
+func (f *FilterMethod) Init(rec *zed.Value) {
 	f.rec = rec
 	f.src.Init(rec)
 }
@@ -101,7 +101,7 @@ func NewAggExpr(zctx *zed.Context, pattern agg.Pattern, src Generator) *AggExpr 
 	}
 }
 
-func (a *AggExpr) Eval(rec *zed.Record) (zed.Value, error) {
+func (a *AggExpr) Eval(rec *zed.Value) (zed.Value, error) {
 	// XXX This is currently really inefficient while we prototype
 	// this machinery.  We used to have a Reset() method on aggregators
 	// and we should probably reintroduce that for use here so we

--- a/expr/literal.go
+++ b/expr/literal.go
@@ -10,6 +10,6 @@ func NewLiteral(zv zed.Value) *Literal {
 	return &Literal{zv}
 }
 
-func (l *Literal) Eval(*zed.Record) (zed.Value, error) {
+func (l *Literal) Eval(*zed.Value) (zed.Value, error) {
 	return l.zv, nil
 }

--- a/expr/selector.go
+++ b/expr/selector.go
@@ -12,14 +12,14 @@ type Selector struct {
 	cursor    []Evaluator
 	iter      zcode.Iter
 	iterCols  []zed.Column
-	rec       *zed.Record
+	rec       *zed.Value
 }
 
 func NewSelector(selectors []Evaluator) *Selector {
 	return &Selector{selectors: selectors}
 }
 
-func (s *Selector) Init(rec *zed.Record) {
+func (s *Selector) Init(rec *zed.Value) {
 	s.rec = rec
 	s.cursor = s.selectors
 }

--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -43,7 +43,7 @@ func NewShaper(zctx *zed.Context, expr, typExpr Evaluator, tf ShaperTransform) *
 	}
 }
 
-func (s *Shaper) Eval(rec *zed.Record) (zed.Value, error) {
+func (s *Shaper) Eval(rec *zed.Value) (zed.Value, error) {
 	typVal, err := s.typExpr.Eval(rec)
 	if err != nil {
 		return zed.Value{}, err
@@ -87,7 +87,7 @@ func NewConstShaper(zctx *zed.Context, expr Evaluator, shapeTo zed.Type, tf Shap
 	}
 }
 
-func (s *ConstShaper) Apply(in *zed.Record) (*zed.Record, error) {
+func (s *ConstShaper) Apply(in *zed.Value) (*zed.Value, error) {
 	v, err := s.Eval(in)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func (s *ConstShaper) Apply(in *zed.Record) (*zed.Record, error) {
 	return zed.NewRecord(v.Type, v.Bytes), nil
 }
 
-func (c *ConstShaper) Eval(in *zed.Record) (zed.Value, error) {
+func (c *ConstShaper) Eval(in *zed.Value) (zed.Value, error) {
 	inVal, err := c.expr.Eval(in)
 	if err != nil {
 		return zed.Value{}, err

--- a/expr/slice.go
+++ b/expr/slice.go
@@ -26,7 +26,7 @@ func NewSlice(elem, from, to Evaluator) *Slice {
 var ErrSliceIndex = errors.New("slice index is not a number")
 var ErrSliceIndexEmpty = errors.New("slice index is empty")
 
-func sliceIndex(slot Evaluator, elem zed.Value, rec *zed.Record) (int, error) {
+func sliceIndex(slot Evaluator, elem zed.Value, rec *zed.Value) (int, error) {
 	if slot == nil {
 		return 0, ErrSliceIndexEmpty
 	}
@@ -49,7 +49,7 @@ func sliceIndex(slot Evaluator, elem zed.Value, rec *zed.Record) (int, error) {
 	return index, nil
 }
 
-func (s *Slice) Eval(rec *zed.Record) (zed.Value, error) {
+func (s *Slice) Eval(rec *zed.Value) (zed.Value, error) {
 	elem, err := s.elem.Eval(rec)
 	if err != nil {
 		return elem, err

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -9,9 +9,9 @@ import (
 	"github.com/brimdata/zed/zcode"
 )
 
-type CompareFn func(a *zed.Record, b *zed.Record) int
+type CompareFn func(a *zed.Value, b *zed.Value) int
 type ValueCompareFn func(a zed.Value, b zed.Value) int
-type KeyCompareFn func(*zed.Record) int
+type KeyCompareFn func(*zed.Value) int
 
 // Internal function that compares two values of compatible types.
 type comparefn func(a, b zcode.Bytes) int
@@ -34,7 +34,7 @@ func NewCompareFn(nullsMax bool, fields ...Evaluator) CompareFn {
 	var aBytesBuf []byte
 	var pair coerce.Pair
 	comparefns := make(map[zed.Type]comparefn)
-	return func(ra *zed.Record, rb *zed.Record) int {
+	return func(ra *zed.Value, rb *zed.Value) int {
 		for _, resolver := range fields {
 			// XXX return errors?
 			a, _ := resolver.Eval(ra)
@@ -113,7 +113,7 @@ func compareValues(a, b zed.Value, comparefns map[zed.Type]comparefn, pair *coer
 	return cfn(abytes, bbytes)
 }
 
-func NewKeyCompareFn(key *zed.Record) (KeyCompareFn, error) {
+func NewKeyCompareFn(key *zed.Value) (KeyCompareFn, error) {
 	comparefns := make(map[zed.Type]comparefn)
 	var accessors []Evaluator
 	var keyval []zed.Value
@@ -130,7 +130,7 @@ func NewKeyCompareFn(key *zed.Record) (KeyCompareFn, error) {
 		keyval = append(keyval, val)
 		accessors = append(accessors, NewDotExpr(name))
 	}
-	return func(rec *zed.Record) int {
+	return func(rec *zed.Value) int {
 		for k, access := range accessors {
 			// XXX error
 			a, _ := access.Eval(rec)
@@ -164,13 +164,13 @@ func NewKeyCompareFn(key *zed.Record) (KeyCompareFn, error) {
 }
 
 // SortStable performs a stable sort on the provided records.
-func SortStable(records []*zed.Record, compare CompareFn) {
+func SortStable(records []*zed.Value, compare CompareFn) {
 	slice := &RecordSlice{records, compare}
 	sort.Stable(slice)
 }
 
 type RecordSlice struct {
-	records []*zed.Record
+	records []*zed.Value
 	compare CompareFn
 }
 
@@ -191,7 +191,7 @@ func (r *RecordSlice) Less(i, j int) bool {
 
 // Push adds x as element Len(). Implements heap.Interface.
 func (r *RecordSlice) Push(rec interface{}) {
-	r.records = append(r.records, rec.(*zed.Record))
+	r.records = append(r.records, rec.(*zed.Value))
 }
 
 // Pop removes the first element in the array. Implements heap.Interface.
@@ -202,7 +202,7 @@ func (r *RecordSlice) Pop() interface{} {
 }
 
 // Index returns the ith record.
-func (r *RecordSlice) Index(i int) *zed.Record {
+func (r *RecordSlice) Index(i int) *zed.Value {
 	return r.records[i]
 }
 

--- a/expr/unflattener.go
+++ b/expr/unflattener.go
@@ -61,7 +61,7 @@ func (u *Unflattener) lookupBuilderAndType(in *zed.TypeRecord) (*zed.ColumnBuild
 // Apply returns a new record comprising fields copied from in according to the
 // receiver's configuration.  If the resulting record would be empty, Apply
 // returns nil.
-func (u *Unflattener) Apply(in *zed.Record) (*zed.Record, error) {
+func (u *Unflattener) Apply(in *zed.Value) (*zed.Value, error) {
 	b, typ, err := u.lookupBuilderAndType(zed.TypeRecordOf(in.Type))
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (u *Unflattener) Apply(in *zed.Record) (*zed.Record, error) {
 	return zed.NewRecord(typ, zbytes), nil
 }
 
-func (c *Unflattener) Eval(rec *zed.Record) (zed.Value, error) {
+func (c *Unflattener) Eval(rec *zed.Value) (zed.Value, error) {
 	out, err := c.Apply(rec)
 	if err != nil {
 		return zed.Value{}, err

--- a/expr/values.go
+++ b/expr/values.go
@@ -26,7 +26,7 @@ func NewRecordExpr(zctx *zed.Context, names []string, exprs []Evaluator) *Record
 	}
 }
 
-func (r *RecordExpr) Eval(rec *zed.Record) (zed.Value, error) {
+func (r *RecordExpr) Eval(rec *zed.Value) (zed.Value, error) {
 	var changed bool
 	b := r.builder
 	b.Reset()
@@ -71,7 +71,7 @@ func NewArrayExpr(zctx *zed.Context, exprs []Evaluator) *ArrayExpr {
 	}
 }
 
-func (a *ArrayExpr) Eval(rec *zed.Record) (zed.Value, error) {
+func (a *ArrayExpr) Eval(rec *zed.Value) (zed.Value, error) {
 	inner := a.typ.Type
 	container := zed.IsContainerType(inner)
 	b := a.builder
@@ -125,7 +125,7 @@ func NewSetExpr(zctx *zed.Context, exprs []Evaluator) *SetExpr {
 	}
 }
 
-func (s *SetExpr) Eval(rec *zed.Record) (zed.Value, error) {
+func (s *SetExpr) Eval(rec *zed.Value) (zed.Value, error) {
 	var inner zed.Type
 	var container bool
 	b := s.builder
@@ -184,7 +184,7 @@ func NewMapExpr(zctx *zed.Context, entries []Entry) *MapExpr {
 	}
 }
 
-func (m *MapExpr) Eval(rec *zed.Record) (zed.Value, error) {
+func (m *MapExpr) Eval(rec *zed.Value) (zed.Value, error) {
 	var containerKey, containerVal bool
 	var keyType, valType zed.Type
 	b := m.builder

--- a/expr/var.go
+++ b/expr/var.go
@@ -10,7 +10,7 @@ func NewVar(ref *zed.Value) *Var {
 	return &Var{ref}
 }
 
-func (v *Var) Eval(*zed.Record) (zed.Value, error) {
+func (v *Var) Eval(*zed.Value) (zed.Value, error) {
 	zv := *v.ref
 	if zv.Type == nil {
 		return zed.Value{}, zed.ErrMissing

--- a/index/finder.go
+++ b/index/finder.go
@@ -51,15 +51,15 @@ const (
 // key values in the records read from the reader.  If the op argument is eql
 // then only exact matches are returned.  Otherwise, the record with the
 // largest key smaller (or larger) than the key argument is returned.
-func lookup(reader zio.Reader, compare expr.KeyCompareFn, o order.Which, op operator) (*zed.Record, error) {
+func lookup(reader zio.Reader, compare expr.KeyCompareFn, o order.Which, op operator) (*zed.Value, error) {
 	if o == order.Asc {
 		return lookupAsc(reader, compare, op)
 	}
 	return lookupDesc(reader, compare, op)
 }
 
-func lookupAsc(reader zio.Reader, fn expr.KeyCompareFn, op operator) (*zed.Record, error) {
-	var prev *zed.Record
+func lookupAsc(reader zio.Reader, fn expr.KeyCompareFn, op operator) (*zed.Value, error) {
+	var prev *zed.Value
 	for {
 		rec, err := reader.Read()
 		if rec == nil || err != nil {
@@ -84,8 +84,8 @@ func lookupAsc(reader zio.Reader, fn expr.KeyCompareFn, op operator) (*zed.Recor
 	}
 }
 
-func lookupDesc(reader zio.Reader, fn expr.KeyCompareFn, op operator) (*zed.Record, error) {
-	var prev *zed.Record
+func lookupDesc(reader zio.Reader, fn expr.KeyCompareFn, op operator) (*zed.Value, error) {
+	var prev *zed.Value
 	for {
 		rec, err := reader.Read()
 		if rec == nil || err != nil {
@@ -147,7 +147,7 @@ func (f *Finder) search(compare expr.KeyCompareFn) (zio.Reader, error) {
 	return f.newSectionReader(0, off)
 }
 
-func (f *Finder) Lookup(keys *zed.Record) (*zed.Record, error) {
+func (f *Finder) Lookup(keys *zed.Value) (*zed.Value, error) {
 	if f.IsEmpty() {
 		return nil, nil
 	}
@@ -166,7 +166,7 @@ func (f *Finder) Lookup(keys *zed.Record) (*zed.Record, error) {
 	return lookup(reader, compare, f.trailer.Order, eql)
 }
 
-func (f *Finder) LookupAll(ctx context.Context, hits chan<- *zed.Record, keys *zed.Record) error {
+func (f *Finder) LookupAll(ctx context.Context, hits chan<- *zed.Value, keys *zed.Value) error {
 	if f.IsEmpty() {
 		return nil
 	}
@@ -199,17 +199,17 @@ func (f *Finder) LookupAll(ctx context.Context, hits chan<- *zed.Record, keys *z
 
 // ClosestGTE returns the closest record that is greater than or equal to the
 // provided key values.
-func (f *Finder) ClosestGTE(keys *zed.Record) (*zed.Record, error) {
+func (f *Finder) ClosestGTE(keys *zed.Value) (*zed.Value, error) {
 	return f.closest(keys, gte)
 }
 
 // ClosestLTE returns the closest record that is less than or equal to the
 // provided key values.
-func (f *Finder) ClosestLTE(keys *zed.Record) (*zed.Record, error) {
+func (f *Finder) ClosestLTE(keys *zed.Value) (*zed.Value, error) {
 	return f.closest(keys, lte)
 }
 
-func (f *Finder) closest(keys *zed.Record, op operator) (*zed.Record, error) {
+func (f *Finder) closest(keys *zed.Value, op operator) (*zed.Value, error) {
 	if f.IsEmpty() {
 		return nil, nil
 	}
@@ -230,7 +230,7 @@ func (f *Finder) closest(keys *zed.Record, op operator) (*zed.Record, error) {
 // number of key fields, in which case they are "don't cares"
 // in terms of key lookups.  Any don't-care fields must all be
 // at the end of the key record.
-func (f *Finder) ParseKeys(inputs ...string) (*zed.Record, error) {
+func (f *Finder) ParseKeys(inputs ...string) (*zed.Value, error) {
 	if f.IsEmpty() {
 		return nil, nil
 	}

--- a/index/findreader.go
+++ b/index/findreader.go
@@ -39,7 +39,7 @@ func (f *FinderReader) init() error {
 	return err
 }
 
-func (f *FinderReader) Read() (*zed.Record, error) {
+func (f *FinderReader) Read() (*zed.Value, error) {
 	if f.finder.IsEmpty() {
 		return nil, nil
 	}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -99,7 +99,7 @@ func TestCompare(t *testing.T) {
 			k, err := finder.ParseKeys(fmt.Sprintf("%d", value))
 			require.NoError(t, err)
 
-			var rec *zed.Record
+			var rec *zed.Value
 			switch op {
 			case ">=":
 				rec, err = finder.ClosestGTE(k)

--- a/index/mem.go
+++ b/index/mem.go
@@ -12,8 +12,8 @@ import (
 // types of the columns depend upon the zed.Values entered into the table.
 type MemTable struct {
 	keys   field.List
-	table  map[string]*zed.Record
-	values []*zed.Record
+	table  map[string]*zed.Value
+	values []*zed.Value
 	sorted bool
 	zctx   *zed.Context
 }
@@ -21,12 +21,12 @@ type MemTable struct {
 func NewMemTable(zctx *zed.Context, keys field.List) *MemTable {
 	return &MemTable{
 		keys:  keys,
-		table: make(map[string]*zed.Record),
+		table: make(map[string]*zed.Value),
 		zctx:  zctx,
 	}
 }
 
-func (t *MemTable) Read() (*zed.Record, error) {
+func (t *MemTable) Read() (*zed.Value, error) {
 	if !t.sorted {
 		t.open()
 	}
@@ -46,7 +46,7 @@ func (t *MemTable) open() {
 	n := len(t.table)
 	if n > 0 {
 		//XXX escaping to GC
-		t.values = make([]*zed.Record, 0, n)
+		t.values = make([]*zed.Value, 0, n)
 		for _, value := range t.table {
 			t.values = append(t.values, value)
 		}
@@ -59,7 +59,7 @@ func (t *MemTable) open() {
 	t.sorted = true
 }
 
-func (t *MemTable) Enter(rec *zed.Record) error {
+func (t *MemTable) Enter(rec *zed.Value) error {
 	if t.sorted {
 		panic("MemTable.Enter() cannot be called after reading")
 	}

--- a/index/writer.go
+++ b/index/writer.go
@@ -69,7 +69,7 @@ type indexWriter struct {
 	zng        *zngio.Writer
 	frameStart int64
 	frameEnd   int64
-	frameKey   *zed.Record
+	frameKey   *zed.Value
 }
 
 // NewWriter returns a Writer ready to write a zed index or it returns
@@ -153,7 +153,7 @@ func Order(o order.Which) Option {
 	})
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	if w.writer == nil {
 		var err error
 		w.writer, err = newIndexWriter(w, w.iow, "")
@@ -327,7 +327,7 @@ func (w *indexWriter) Close() error {
 	return w.buffer.Close()
 }
 
-func (w *indexWriter) write(rec *zed.Record) error {
+func (w *indexWriter) write(rec *zed.Value) error {
 	offset := w.zng.Position()
 	if offset >= w.frameEnd && w.frameKey != nil {
 		w.frameEnd = offset + int64(w.base.frameThresh)
@@ -378,7 +378,7 @@ func (w *indexWriter) closeFrame() error {
 	return nil
 }
 
-func (w *indexWriter) addToParentIndex(key *zed.Record, offset int64) error {
+func (w *indexWriter) addToParentIndex(key *zed.Value, offset int64) error {
 	if w.parent == nil {
 		var err error
 		w.parent, err = w.newParent()
@@ -389,7 +389,7 @@ func (w *indexWriter) addToParentIndex(key *zed.Record, offset int64) error {
 	return w.parent.writeIndexRecord(key, offset)
 }
 
-func (w *indexWriter) writeIndexRecord(keys *zed.Record, offset int64) error {
+func (w *indexWriter) writeIndexRecord(keys *zed.Value, offset int64) error {
 	col := []zed.Column{{w.base.childField, zed.TypeInt64}}
 	val := zed.EncodeInt(offset)
 	rec, err := w.base.zctx.AddColumns(keys, col, []zed.Value{{zed.TypeInt64, val}})

--- a/lake/commits/reader.go
+++ b/lake/commits/reader.go
@@ -31,7 +31,7 @@ func newLogReader(ctx context.Context, zctx *zed.Context, store *Store, leaf, st
 	}
 }
 
-func (r *LogReader) Read() (*zed.Record, error) {
+func (r *LogReader) Read() (*zed.Value, error) {
 	if r.cursor == ksuid.Nil {
 		return nil, nil
 	}

--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -71,7 +71,7 @@ func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *sto
 	return w, nil
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	key, err := rec.Deref(w.poolKey)
 	if err != nil {
 		key = zed.Value{zed.TypeNull, nil}

--- a/lake/index/combiner.go
+++ b/lake/index/combiner.go
@@ -25,7 +25,7 @@ func NewCombiner(ctx context.Context, engine storage.Engine, path *storage.URI, 
 	return writers, nil
 }
 
-func (c Combiner) Write(rec *zed.Record) error {
+func (c Combiner) Write(rec *zed.Value) error {
 	for _, w := range c {
 		if err := w.Write(rec); err != nil {
 			return err

--- a/lake/index/match.go
+++ b/lake/index/match.go
@@ -9,7 +9,7 @@ import (
 
 type match struct {
 	rule       Rule
-	lookupKeys []*zed.Record
+	lookupKeys []*zed.Value
 }
 
 type matcher func([]Rule) []match
@@ -43,8 +43,8 @@ func compilePredicates(in []dag.IndexPredicate) (matcher, error) {
 	}, nil
 }
 
-func matchRule(zctx *zed.Context, rule Rule, predicates []predicate) []*zed.Record {
-	var recs []*zed.Record
+func matchRule(zctx *zed.Context, rule Rule, predicates []predicate) []*zed.Value {
+	var recs []*zed.Value
 	for _, p := range predicates {
 		// XXX support indexes with multiple keys #3162
 		// and other rule types.

--- a/lake/index/rule.go
+++ b/lake/index/rule.go
@@ -180,7 +180,7 @@ func (a *AggRule) RuleKeys() field.List {
 // newLookupKey creates a Zed Record that can be used as a lookup key for an
 // index created for the provided Rule. The Values provided must be in order
 // with the Key in the rule that it will be paired with it.
-func newLookupKey(zctx *zed.Context, r Rule, values []zed.Value) (*zed.Record, error) {
+func newLookupKey(zctx *zed.Context, r Rule, values []zed.Value) (*zed.Value, error) {
 	keys := r.RuleKeys()
 	// XXX Ensure length of values equals the length of Keys in the Rule or
 	// else zed.ColumnBuilder will throw an error on Encode. We should adjust

--- a/lake/index/writer.go
+++ b/lake/index/writer.go
@@ -40,13 +40,13 @@ type Writer struct {
 	rwCh    rwChan
 }
 
-type rwChan chan *zed.Record
+type rwChan chan *zed.Value
 
-func (c rwChan) Read() (*zed.Record, error) {
+func (c rwChan) Read() (*zed.Value, error) {
 	return <-c, nil
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	select {
 	case <-w.done:
 		if err := w.indexer.err.Load(); err != nil {
@@ -143,6 +143,6 @@ func (d *indexer) Wait() error {
 	return d.err.Load()
 }
 
-func (d *indexer) Write(rec *zed.Record) error {
+func (d *indexer) Write(rec *zed.Value) error {
 	return d.index.Write(rec)
 }

--- a/lake/partition.go
+++ b/lake/partition.go
@@ -148,7 +148,7 @@ func partitionReader(ctx context.Context, zctx *zed.Context, snap commits.View, 
 	}()
 	m := zson.NewZNGMarshalerWithContext(zctx)
 	m.Decorate(zson.StylePackage)
-	return readerFunc(func() (*zed.Record, error) {
+	return readerFunc(func() (*zed.Value, error) {
 		select {
 		case p := <-ch:
 			if p.Objects == nil {
@@ -177,7 +177,7 @@ func objectReader(ctx context.Context, zctx *zed.Context, snap commits.View, spa
 	}()
 	m := zson.NewZNGMarshalerWithContext(zctx)
 	m.Decorate(zson.StylePackage)
-	return readerFunc(func() (*zed.Record, error) {
+	return readerFunc(func() (*zed.Value, error) {
 		select {
 		case p := <-ch:
 			if p.ID == ksuid.Nil {
@@ -206,7 +206,7 @@ func indexObjectReader(ctx context.Context, zctx *zed.Context, snap commits.View
 	}()
 	m := zson.NewZNGMarshalerWithContext(zctx)
 	m.Decorate(zson.StylePackage)
-	return readerFunc(func() (*zed.Record, error) {
+	return readerFunc(func() (*zed.Value, error) {
 		select {
 		case p := <-ch:
 			if p == nil {
@@ -225,6 +225,6 @@ func indexObjectReader(ctx context.Context, zctx *zed.Context, snap commits.View
 	}), nil
 }
 
-type readerFunc func() (*zed.Record, error)
+type readerFunc func() (*zed.Value, error)
 
-func (r readerFunc) Read() (*zed.Record, error) { return r() }
+func (r readerFunc) Read() (*zed.Value, error) { return r() }

--- a/lake/seekindex/lookup.go
+++ b/lake/seekindex/lookup.go
@@ -10,7 +10,7 @@ import (
 
 func Lookup(r zio.Reader, from, to zed.Value, cmp expr.ValueCompareFn) (Range, error) {
 	rg := Range{0, math.MaxInt64}
-	var rec *zed.Record
+	var rec *zed.Value
 	for {
 		var err error
 		rec, err = r.Read()

--- a/lake/sorted.go
+++ b/lake/sorted.go
@@ -105,7 +105,7 @@ func (r *rangeWrapper) AsFilter() (expr.Filter, error) {
 		return nil, err
 	}
 	compare := extent.CompareFunc(r.layout.Order)
-	return func(rec *zed.Record) bool {
+	return func(rec *zed.Value) bool {
 		keyVal, err := rec.Deref(r.layout.Keys[0])
 		if err != nil {
 			// XXX match keyless records.

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -27,13 +27,13 @@ type Writer struct {
 	ctx         context.Context
 	//defs          index.Definitions
 	errgroup *errgroup.Group
-	records  []*zed.Record
+	records  []*zed.Value
 	// XXX this is a simple double buffering model so the cloud-object
 	// writer can run in parallel with the reader filling the records
 	// buffer.  This can be later extended to pass a big bytes buffer
 	// back and forth where the bytes buffer holds all of the record
 	// data efficiently in one big backing store.
-	buffer chan []*zed.Record
+	buffer chan []*zed.Value
 
 	memBuffered int64
 	stats       ImportStats
@@ -53,7 +53,7 @@ type Writer struct {
 // to do useful things like paritioning given the context is a rollup.
 func NewWriter(ctx context.Context, pool *Pool) (*Writer, error) {
 	g, ctx := errgroup.WithContext(ctx)
-	ch := make(chan []*zed.Record, 1)
+	ch := make(chan []*zed.Value, 1)
 	ch <- nil
 	return &Writer{
 		pool:     pool,
@@ -72,7 +72,7 @@ func (w *Writer) newObject() *data.Object {
 	return &w.objects[len(w.objects)-1]
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	if w.ctx.Err() != nil {
 		if err := w.errgroup.Wait(); err != nil {
 			return err
@@ -116,7 +116,7 @@ func (w *Writer) Close() error {
 	return w.errgroup.Wait()
 }
 
-func (w *Writer) writeObject(object *data.Object, recs []*zed.Record) error {
+func (w *Writer) writeObject(object *data.Object, recs []*zed.Value) error {
 	if !w.inputSorted {
 		expr.SortStable(recs, importCompareFn(w.pool))
 	}

--- a/proc/apply.go
+++ b/proc/apply.go
@@ -9,7 +9,7 @@ import (
 
 type Function interface {
 	fmt.Stringer
-	Apply(*zed.Record) (*zed.Record, error)
+	Apply(*zed.Value) (*zed.Value, error)
 	Warning() string
 }
 
@@ -38,7 +38,7 @@ func (a *applier) Pull() (zbuf.Batch, error) {
 			}
 			return nil, err
 		}
-		recs := make([]*zed.Record, 0, batch.Length())
+		recs := make([]*zed.Value, 0, batch.Length())
 		for k := 0; k < batch.Length(); k++ {
 			in := batch.Index(k)
 			out, err := a.function.Apply(in)

--- a/proc/explode/explode.go
+++ b/proc/explode/explode.go
@@ -38,7 +38,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		if proc.EOS(batch, err) {
 			return nil, err
 		}
-		recs := make([]*zed.Record, 0, batch.Length())
+		recs := make([]*zed.Value, 0, batch.Length())
 		for _, rec := range batch.Records() {
 			for _, arg := range p.args {
 				zv, err := arg.Eval(rec)

--- a/proc/exprswitch/exprswitch.go
+++ b/proc/exprswitch/exprswitch.go
@@ -13,9 +13,9 @@ type ExprSwitch struct {
 	parent    proc.Interface
 	evaluator expr.Evaluator
 
-	cases     map[string]chan<- *zed.Record
-	defaultCh chan<- *zed.Record
-	doneChCh  chan chan<- *zed.Record
+	cases     map[string]chan<- *zed.Value
+	defaultCh chan<- *zed.Value
+	doneChCh  chan chan<- *zed.Value
 	err       error
 	once      sync.Once
 }
@@ -24,13 +24,13 @@ func New(parent proc.Interface, e expr.Evaluator) *ExprSwitch {
 	return &ExprSwitch{
 		parent:    parent,
 		evaluator: e,
-		cases:     make(map[string]chan<- *zed.Record),
-		doneChCh:  make(chan chan<- *zed.Record),
+		cases:     make(map[string]chan<- *zed.Value),
+		doneChCh:  make(chan chan<- *zed.Value),
 	}
 }
 
 func (s *ExprSwitch) NewProc(zv zed.Value) proc.Interface {
-	ch := make(chan *zed.Record)
+	ch := make(chan *zed.Value)
 	if zv.IsNil() {
 		s.defaultCh = ch
 	} else {
@@ -83,7 +83,7 @@ func (s *ExprSwitch) run() {
 	}
 }
 
-func (s *ExprSwitch) handleDoneCh(doneCh chan<- *zed.Record) {
+func (s *ExprSwitch) handleDoneCh(doneCh chan<- *zed.Value) {
 	if s.defaultCh == doneCh {
 		s.defaultCh = nil
 	} else {
@@ -98,7 +98,7 @@ func (s *ExprSwitch) handleDoneCh(doneCh chan<- *zed.Record) {
 
 type Proc struct {
 	parent *ExprSwitch
-	ch     <-chan *zed.Record
+	ch     <-chan *zed.Value
 }
 
 func (p *Proc) Pull() (zbuf.Batch, error) {

--- a/proc/fuse/fuser.go
+++ b/proc/fuse/fuser.go
@@ -15,7 +15,7 @@ type Fuser struct {
 	memMaxBytes int
 
 	nbytes  int
-	recs    []*zed.Record
+	recs    []*zed.Value
 	spiller *spill.File
 
 	types      map[zed.Type]struct{}
@@ -44,7 +44,7 @@ func (f *Fuser) Close() error {
 }
 
 // Write buffers rec. If called after Read, Write panics.
-func (f *Fuser) Write(rec *zed.Record) error {
+func (f *Fuser) Write(rec *zed.Value) error {
 	if f.shaper != nil {
 		panic("fuser: write after read")
 	}
@@ -60,7 +60,7 @@ func (f *Fuser) Write(rec *zed.Record) error {
 	return f.stash(rec)
 }
 
-func (f *Fuser) stash(rec *zed.Record) error {
+func (f *Fuser) stash(rec *zed.Value) error {
 	f.nbytes += len(rec.Bytes)
 	if f.nbytes >= f.memMaxBytes {
 		var err error
@@ -83,7 +83,7 @@ func (f *Fuser) stash(rec *zed.Record) error {
 
 // Read returns the next buffered record after transforming it to the unified
 // schema.
-func (f *Fuser) Read() (*zed.Record, error) {
+func (f *Fuser) Read() (*zed.Value, error) {
 	if f.shaper == nil {
 		t, err := f.uberSchema.Type()
 		if err != nil {
@@ -103,11 +103,11 @@ func (f *Fuser) Read() (*zed.Record, error) {
 	return f.shaper.Apply(rec)
 }
 
-func (f *Fuser) next() (*zed.Record, error) {
+func (f *Fuser) next() (*zed.Value, error) {
 	if f.spiller != nil {
 		return f.spiller.Read()
 	}
-	var rec *zed.Record
+	var rec *zed.Value
 	if len(f.recs) > 0 {
 		rec = f.recs[0]
 		f.recs = f.recs[1:]

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -242,7 +242,7 @@ func (cr *countReader) records() int {
 	return cr.n
 }
 
-func (cr *countReader) Read() (*zed.Record, error) {
+func (cr *countReader) Read() (*zed.Value, error) {
 	rec, err := cr.r.Read()
 	if rec != nil {
 		cr.mu.Lock()

--- a/proc/groupby/row.go
+++ b/proc/groupby/row.go
@@ -16,7 +16,7 @@ func newValRow(aggs []*expr.Aggregator) valRow {
 	return cols
 }
 
-func (v valRow) apply(aggs []*expr.Aggregator, rec *zed.Record) error {
+func (v valRow) apply(aggs []*expr.Aggregator, rec *zed.Value) error {
 	for k, a := range aggs {
 		if err := a.Apply(v[k], rec); err != nil {
 			return err
@@ -25,7 +25,7 @@ func (v valRow) apply(aggs []*expr.Aggregator, rec *zed.Record) error {
 	return nil
 }
 
-func (v valRow) consumeAsPartial(rec *zed.Record, vals []expr.Evaluator) error {
+func (v valRow) consumeAsPartial(rec *zed.Value, vals []expr.Evaluator) error {
 	for k, r := range v {
 		v, err := vals[k].Eval(rec)
 		if err != nil {

--- a/proc/head/head.go
+++ b/proc/head/head.go
@@ -38,7 +38,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 	// This batch has more than the needed records.
 	// Create a new batch and copy only the needed records.
 	// Then signal to the upstream that we're done.
-	recs := make([]*zed.Record, remaining)
+	recs := make([]*zed.Value, remaining)
 	for k := 0; k < remaining; k++ {
 		recs[k] = batch.Index(k).Keep()
 	}

--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -27,7 +27,7 @@ type Proc struct {
 	compare     expr.ValueCompareFn
 	cutter      *expr.Cutter
 	joinKey     zed.Value
-	joinSet     []*zed.Record
+	joinSet     []*zed.Value
 	types       map[int]map[int]*zed.TypeRecord
 }
 
@@ -61,7 +61,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		go p.left.run()
 		go p.right.Reader.(*puller).run()
 	})
-	var out []*zed.Record
+	var out []*zed.Value
 	for {
 		leftRec, err := p.left.Read()
 		if err != nil {
@@ -133,7 +133,7 @@ func (p *Proc) setJoinKey(key zed.Value) {
 	p.joinKey.Bytes = append(p.joinKey.Bytes[:0], key.Bytes...)
 }
 
-func (p *Proc) getJoinSet(leftKey zed.Value) ([]*zed.Record, error) {
+func (p *Proc) getJoinSet(leftKey zed.Value) ([]*zed.Value, error) {
 	if p.compare(leftKey, p.joinKey) == 0 {
 		return p.joinSet, nil
 	}
@@ -172,8 +172,8 @@ func (p *Proc) getJoinSet(leftKey zed.Value) ([]*zed.Record, error) {
 // fillJoinSet is called when a join key has been found that matches
 // the current lefthand key.  It returns the all the subsequent records
 // from the righthand stream that match this key.
-func (p *Proc) readJoinSet(joinKey zed.Value) ([]*zed.Record, error) {
-	var recs []*zed.Record
+func (p *Proc) readJoinSet(joinKey zed.Value) ([]*zed.Value, error) {
+	var recs []*zed.Value
 	for {
 		rec, err := p.right.Peek()
 		if err != nil {
@@ -242,7 +242,7 @@ func (p *Proc) combinedType(left, right *zed.TypeRecord) (*zed.TypeRecord, error
 	return typ, nil
 }
 
-func (p *Proc) splice(left, right *zed.Record) (*zed.Record, error) {
+func (p *Proc) splice(left, right *zed.Value) (*zed.Value, error) {
 	if right == nil {
 		// This happens on a simple join, i.e., "join key",
 		// where there are no cut expressions.  For left joins,

--- a/proc/join/puller.go
+++ b/proc/join/puller.go
@@ -12,7 +12,7 @@ type puller struct {
 	proc  proc.Interface
 	ctx   context.Context
 	ch    chan proc.Result
-	recs  []*zed.Record
+	recs  []*zed.Value
 	batch zbuf.Batch
 	off   int
 	len   int
@@ -51,7 +51,7 @@ func (p *puller) Pull() (zbuf.Batch, error) {
 	}
 }
 
-func (p *puller) Read() (*zed.Record, error) {
+func (p *puller) Read() (*zed.Value, error) {
 	if p.off >= p.len {
 		// XXX last batch at EOS gets sent to GC
 		if p.batch != nil {

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -78,7 +78,7 @@ func (p *Proc) maybeWarn(err error) {
 	}
 }
 
-func (p *Proc) eval(in *zed.Record) ([]zed.Value, error) {
+func (p *Proc) eval(in *zed.Value) ([]zed.Value, error) {
 	vals := p.vals
 	for k, cl := range p.clauses {
 		var err error
@@ -343,7 +343,7 @@ func (p *Proc) lookupRule(inType *zed.TypeRecord, vals []zed.Value) (putRule, er
 	return rule, err
 }
 
-func (p *Proc) put(in *zed.Record) (*zed.Record, error) {
+func (p *Proc) put(in *zed.Value) (*zed.Value, error) {
 	vals, err := p.eval(in)
 	if err != nil {
 		p.maybeWarn(err)
@@ -366,7 +366,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 	if proc.EOS(batch, err) {
 		return nil, err
 	}
-	recs := make([]*zed.Record, 0, batch.Length())
+	recs := make([]*zed.Value, 0, batch.Length())
 	for k := 0; k < batch.Length(); k++ {
 		in := batch.Index(k)
 		rec, err := p.put(in)

--- a/proc/rename/renamer.go
+++ b/proc/rename/renamer.go
@@ -61,7 +61,7 @@ func (r *Function) computeType(typ *zed.TypeRecord) (*zed.TypeRecord, error) {
 	return typ, nil
 }
 
-func (r *Function) Apply(in *zed.Record) (*zed.Record, error) {
+func (r *Function) Apply(in *zed.Value) (*zed.Value, error) {
 	id := in.Type.ID()
 	if _, ok := r.typeMap[id]; !ok {
 		typ, err := r.computeType(zed.TypeRecordOf(in.Type))

--- a/proc/sort/sort.go
+++ b/proc/sort/sort.go
@@ -96,9 +96,9 @@ func (p *Proc) sendResult(b zbuf.Batch, err error) {
 	}
 }
 
-func (p *Proc) recordsForOneRun() ([]*zed.Record, bool, error) {
+func (p *Proc) recordsForOneRun() ([]*zed.Value, bool, error) {
 	var nbytes int
-	var recs []*zed.Record
+	var recs []*zed.Value
 	for {
 		batch, err := p.parent.Pull()
 		if err != nil {
@@ -121,7 +121,7 @@ func (p *Proc) recordsForOneRun() ([]*zed.Record, bool, error) {
 	}
 }
 
-func (p *Proc) createRuns(firstRunRecs []*zed.Record) (*spill.MergeSort, error) {
+func (p *Proc) createRuns(firstRunRecs []*zed.Value) (*spill.MergeSort, error) {
 	rm, err := spill.NewMergeSort(p.compareFn)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func (p *Proc) warnAboutUnseenFields() {
 	}
 }
 
-func (p *Proc) setCompareFn(r *zed.Record) {
+func (p *Proc) setCompareFn(r *zed.Value) {
 	resolvers := p.fieldResolvers
 	if resolvers == nil {
 		fld := GuessSortKey(r)
@@ -168,13 +168,13 @@ func (p *Proc) setCompareFn(r *zed.Record) {
 	}
 	compareFn := expr.NewCompareFn(nullsMax, resolvers...)
 	if p.order == order.Desc {
-		p.compareFn = func(a, b *zed.Record) int { return compareFn(b, a) }
+		p.compareFn = func(a, b *zed.Value) int { return compareFn(b, a) }
 	} else {
 		p.compareFn = compareFn
 	}
 }
 
-func GuessSortKey(rec *zed.Record) field.Path {
+func GuessSortKey(rec *zed.Value) field.Path {
 	typ := zed.TypeRecordOf(rec.Type)
 	if f := firstMatchingField(typ, zed.IsInteger); f != nil {
 		return f

--- a/proc/sort/unseen.go
+++ b/proc/sort/unseen.go
@@ -23,7 +23,7 @@ func newUnseenFieldTracker(fields []expr.Evaluator) *unseenFieldTracker {
 	}
 }
 
-func (u *unseenFieldTracker) update(rec *zed.Record) {
+func (u *unseenFieldTracker) update(rec *zed.Value) {
 	recType := zed.TypeRecordOf(rec.Type)
 	if len(u.unseenFields) == 0 || u.seenTypes[recType] {
 		// Either have seen this type or nothing to unsee anymore.

--- a/proc/spill/merge.go
+++ b/proc/spill/merge.go
@@ -59,7 +59,7 @@ func (r *MergeSort) Cleanup() {
 // temp directory.  Since we sort each chunk in memory before spilling, the
 // different chunks can be easily merged into sorted order when reading back
 // the chunks sequentially.
-func (r *MergeSort) Spill(ctx context.Context, recs []*zed.Record) error {
+func (r *MergeSort) Spill(ctx context.Context, recs []*zed.Value) error {
 	// Sorting can be slow, so check for cancellation.
 	if err := goWithContext(ctx, func() {
 		expr.SortStable(recs, r.compareFn)
@@ -97,7 +97,7 @@ func goWithContext(ctx context.Context, f func()) error {
 
 // Peek returns the next record without advancing the reader.  The record stops
 // being valid at the next read call.
-func (r *MergeSort) Peek() (*zed.Record, error) {
+func (r *MergeSort) Peek() (*zed.Value, error) {
 	if r.Len() == 0 {
 		return nil, nil
 	}
@@ -107,7 +107,7 @@ func (r *MergeSort) Peek() (*zed.Record, error) {
 // Read returns the smallest record (per the comparison function provided to MewMergeSort)
 // from among the next records in the spilled chunks.  It implements the merge operation
 // for an external merge sort.
-func (r *MergeSort) Read() (*zed.Record, error) {
+func (r *MergeSort) Read() (*zed.Value, error) {
 	for {
 		if r.Len() == 0 {
 			return nil, nil

--- a/proc/spill/peeker.go
+++ b/proc/spill/peeker.go
@@ -10,11 +10,11 @@ import (
 
 type peeker struct {
 	*File
-	nextRecord *zed.Record
+	nextRecord *zed.Value
 	ordinal    int
 }
 
-func newPeeker(ctx context.Context, filename string, ordinal int, recs []*zed.Record, zctx *zed.Context) (*peeker, error) {
+func newPeeker(ctx context.Context, filename string, ordinal int, recs []*zed.Value, zctx *zed.Context) (*peeker, error) {
 	f, err := NewFileWithPath(filename, zctx)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func newPeeker(ctx context.Context, filename string, ordinal int, recs []*zed.Re
 
 // read is like Read but returns eof at the last record so a MergeSort can
 // do its heap management a bit more easily.
-func (p *peeker) read() (*zed.Record, bool, error) {
+func (p *peeker) read() (*zed.Value, bool, error) {
 	rec := p.nextRecord
 	if rec != nil {
 		rec = rec.Keep()

--- a/proc/switcher/switch.go
+++ b/proc/switcher/switch.go
@@ -61,7 +61,7 @@ func (s *Switcher) gather() {
 }
 
 func (s *Switcher) run() {
-	records := make([][]*zed.Record, s.n)
+	records := make([][]*zed.Value, s.n)
 	results := make([]proc.Result, s.n)
 	for {
 		s.gather()
@@ -76,7 +76,7 @@ func (s *Switcher) run() {
 		for _, rec := range batch.Records() {
 			if i := s.match(rec); i >= 0 {
 				if records[i] == nil {
-					records[i] = make([]*zed.Record, 0, batch.Length())
+					records[i] = make([]*zed.Value, 0, batch.Length())
 				}
 				records[i] = append(records[i], rec)
 			}
@@ -93,7 +93,7 @@ func (s *Switcher) run() {
 	s.parent.Done()
 }
 
-func (s *Switcher) match(rec *zed.Record) int {
+func (s *Switcher) match(rec *zed.Value) int {
 	for i, f := range s.filters {
 		if f(rec) {
 			return i

--- a/proc/tail/tail.go
+++ b/proc/tail/tail.go
@@ -11,7 +11,7 @@ type Proc struct {
 	limit  int
 	count  int
 	off    int
-	q      []*zed.Record
+	q      []*zed.Value
 }
 
 func New(parent proc.Interface, limit int) *Proc {
@@ -19,7 +19,7 @@ func New(parent proc.Interface, limit int) *Proc {
 	return &Proc{
 		parent: parent,
 		limit:  limit,
-		q:      make([]*zed.Record, limit),
+		q:      make([]*zed.Value, limit),
 	}
 }
 
@@ -31,7 +31,7 @@ func (p *Proc) tail() zbuf.Batch {
 	if p.count < p.limit {
 		start = 0
 	}
-	out := make([]*zed.Record, p.count)
+	out := make([]*zed.Value, p.count)
 	for k := 0; k < p.count; k++ {
 		out[k] = p.q[(start+k)%p.limit]
 	}

--- a/proc/top/top.go
+++ b/proc/top/top.go
@@ -61,7 +61,7 @@ func (p *Proc) Done() {
 	p.parent.Done()
 }
 
-func (p *Proc) consume(rec *zed.Record) {
+func (p *Proc) consume(rec *zed.Value) {
 	if p.fields == nil {
 		fld := sort.GuessSortKey(rec)
 		accessor := expr.NewDotExpr(fld)
@@ -84,9 +84,9 @@ func (t *Proc) sorted() zbuf.Batch {
 	if t.records == nil {
 		return nil
 	}
-	out := make([]*zed.Record, t.records.Len())
+	out := make([]*zed.Value, t.records.Len())
 	for i := t.records.Len() - 1; i >= 0; i-- {
-		rec := heap.Pop(t.records).(*zed.Record)
+		rec := heap.Pop(t.records).(*zed.Value)
 		out[i] = rec
 	}
 	// clear records

--- a/proc/uniq/uniq.go
+++ b/proc/uniq/uniq.go
@@ -14,7 +14,7 @@ type Proc struct {
 	parent proc.Interface
 	cflag  bool
 	count  uint64
-	last   *zed.Record
+	last   *zed.Value
 }
 
 func New(pctx *proc.Context, parent proc.Interface, cflag bool) *Proc {
@@ -25,7 +25,7 @@ func New(pctx *proc.Context, parent proc.Interface, cflag bool) *Proc {
 	}
 }
 
-func (p *Proc) wrap(t *zed.Record) *zed.Record {
+func (p *Proc) wrap(t *zed.Value) *zed.Value {
 	if p.cflag {
 		// The leading underscore in "_uniq" is to avoid clashing with existing field
 		// names. Reducers don't have this problem since Zed has a way to assign
@@ -44,7 +44,7 @@ func (p *Proc) wrap(t *zed.Record) *zed.Record {
 	return t
 }
 
-func (p *Proc) appendUniq(out []*zed.Record, t *zed.Record) []*zed.Record {
+func (p *Proc) appendUniq(out []*zed.Value, t *zed.Value) []*zed.Value {
 	if p.count == 0 {
 		p.last = t.Keep()
 		p.count = 1
@@ -75,7 +75,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 			p.last = nil
 			return zbuf.Array{t}, nil
 		}
-		var out []*zed.Record
+		var out []*zed.Value
 		for k := 0; k < batch.Length(); k++ {
 			out = p.appendUniq(out, batch.Index(k))
 		}

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -7,7 +7,7 @@ import (
 
 // Array is a slice of of records that implements the Batch and
 // the Reader interfaces.
-type Array []*zed.Record
+type Array []*zed.Value
 
 var _ zio.Reader = (*Array)(nil)
 var _ zio.Writer = (*Array)(nil)
@@ -24,31 +24,31 @@ func (a Array) Length() int {
 	return len(a)
 }
 
-func (a Array) Records() []*zed.Record {
+func (a Array) Records() []*zed.Value {
 	return a
 }
 
 //XXX should change this to Record()
-func (a Array) Index(k int) *zed.Record {
+func (a Array) Index(k int) *zed.Value {
 	if k < len(a) {
 		return a[k]
 	}
 	return nil
 }
 
-func (a *Array) Append(r *zed.Record) {
+func (a *Array) Append(r *zed.Value) {
 	*a = append(*a, r)
 }
 
-func (a *Array) Write(r *zed.Record) error {
+func (a *Array) Write(r *zed.Value) error {
 	a.Append(r)
 	return nil
 }
 
 // Read returns removes the first element of the Array and returns it,
 // or it returns nil if the Array is empty.
-func (a *Array) Read() (*zed.Record, error) {
-	var rec *zed.Record
+func (a *Array) Read() (*zed.Value, error) {
+	var rec *zed.Value
 	if len(*a) > 0 {
 		rec = (*a)[0]
 		*a = (*a)[1:]

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -26,9 +26,9 @@ import (
 type Batch interface {
 	Ref()
 	Unref()
-	Index(int) *zed.Record
+	Index(int) *zed.Value
 	Length() int
-	Records() []*zed.Record
+	Records() []*zed.Value
 }
 
 // readBatch reads up to n records from zr and returns them as a Batch.  At EOS,
@@ -36,7 +36,7 @@ type Batch interface {
 // error is encoutered, it returns a nil Batch and the error.  Otherwise,
 // readBatch returns a full Batch of n records and nil error.
 func readBatch(zr zio.Reader, n int) (Batch, error) {
-	recs := make([]*zed.Record, 0, n)
+	recs := make([]*zed.Value, 0, n)
 	for len(recs) < n {
 		rec, err := zr.Read()
 		if err != nil {
@@ -115,7 +115,7 @@ type pullerReader struct {
 	idx   int
 }
 
-func (r *pullerReader) Read() (*zed.Record, error) {
+func (r *pullerReader) Read() (*zed.Value, error) {
 	if r.batch == nil {
 		for {
 			batch, err := r.p.Pull()

--- a/zbuf/merger.go
+++ b/zbuf/merger.go
@@ -28,7 +28,7 @@ type Merger struct {
 type mergerPuller struct {
 	Puller
 	ch    chan batch
-	recs  []*zed.Record
+	recs  []*zed.Value
 	batch Batch
 }
 
@@ -48,11 +48,11 @@ func NewCompareFn(layout order.Layout) expr.CompareFn {
 	if layout.Order == order.Asc {
 		return fn
 	}
-	return func(a, b *zed.Record) int { return fn(b, a) }
+	return func(a, b *zed.Value) int { return fn(b, a) }
 }
 
 func totalOrderCompare(fn expr.CompareFn) expr.CompareFn {
-	return func(a, b *zed.Record) int {
+	return func(a, b *zed.Value) int {
 		cmp := fn(a, b)
 		if cmp == 0 {
 			return bytes.Compare(a.Bytes, b.Bytes)
@@ -76,7 +76,7 @@ func NewMerger(ctx context.Context, pullers []Puller, cmp expr.CompareFn) *Merge
 }
 
 func MergeByTs(ctx context.Context, pullers []Puller, o order.Which) *Merger {
-	cmp := func(a, b *zed.Record) int {
+	cmp := func(a, b *zed.Value) int {
 		if o == order.Desc {
 			a, b = b, a
 		}
@@ -116,7 +116,7 @@ func (m *Merger) run() {
 
 // Read fulfills Reader so that we can use ReadBatch or
 // use Merger as a Reader directly.
-func (m *Merger) Read() (*zed.Record, error) {
+func (m *Merger) Read() (*zed.Value, error) {
 	m.once.Do(m.run)
 	leader, err := m.findLeader()
 	if leader < 0 || err != nil {
@@ -127,7 +127,7 @@ func (m *Merger) Read() (*zed.Record, error) {
 	return m.pullers[leader].next(), nil
 }
 
-func (m *mergerPuller) next() *zed.Record {
+func (m *mergerPuller) next() *zed.Value {
 	rec := m.recs[0]
 	m.recs = m.recs[1:]
 	m.batch = nil

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -102,7 +102,7 @@ func (s *scanner) Stats() ScannerStats {
 }
 
 // Read implements Reader.Read.
-func (s *scanner) Read() (*zed.Record, error) {
+func (s *scanner) Read() (*zed.Value, error) {
 	for {
 		if err := s.ctx.Err(); err != nil {
 			return nil, err

--- a/zio/anyio/writer.go
+++ b/zio/anyio/writer.go
@@ -72,7 +72,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) (zio.WriteCloser, error) {
 
 type nullWriter struct{}
 
-func (*nullWriter) Write(*zed.Record) error {
+func (*nullWriter) Write(*zed.Value) error {
 	return nil
 }
 

--- a/zio/combiner.go
+++ b/zio/combiner.go
@@ -31,7 +31,7 @@ func NewCombiner(ctx context.Context, readers []Reader) *Combiner {
 type combinerResult struct {
 	err error
 	idx int
-	rec *zed.Record
+	rec *zed.Value
 }
 
 func (c *Combiner) run() {
@@ -62,7 +62,7 @@ func (c *Combiner) finished() bool {
 	return true
 }
 
-func (c *Combiner) Read() (*zed.Record, error) {
+func (c *Combiner) Read() (*zed.Value, error) {
 	c.once.Do(c.run)
 	for {
 		select {

--- a/zio/counter.go
+++ b/zio/counter.go
@@ -21,7 +21,7 @@ func NewCounter(reader Reader, p *int64) *Counter {
 	return &Counter{Reader: reader, counter: p}
 }
 
-func (c *Counter) Read() (*zed.Record, error) {
+func (c *Counter) Read() (*zed.Value, error) {
 	rec, err := c.Reader.Read()
 	if rec != nil {
 		atomic.AddInt64(c.counter, 1)

--- a/zio/counter_test.go
+++ b/zio/counter_test.go
@@ -13,7 +13,7 @@ import (
 
 type Sink struct{}
 
-func (n *Sink) Write(rec *zed.Record) error {
+func (n *Sink) Write(rec *zed.Value) error {
 	return nil
 }
 

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -40,7 +40,7 @@ func NewReader(r io.Reader, zctx *zed.Context) *Reader {
 	}
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	for {
 		csvRec, err := r.reader.Read()
 		if err != nil {
@@ -72,7 +72,7 @@ func (r *Reader) init(hdr []string) {
 	r.vals = make([]interface{}, len(hdr))
 }
 
-func (r *Reader) translate(fields []string) (*zed.Record, error) {
+func (r *Reader) translate(fields []string) (*zed.Value, error) {
 	if len(fields) != len(r.vals) {
 		// This error shouldn't happen as it should be caught by the
 		// csv package but we check anyway.

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -42,7 +42,7 @@ func (w *Writer) Flush() error {
 	return w.encoder.Error()
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	rec, err := w.flattener.Flatten(rec)
 	if err != nil {
 		return err

--- a/zio/emitter/dir.go
+++ b/zio/emitter/dir.go
@@ -60,7 +60,7 @@ func NewDirWithEngine(ctx context.Context, engine storage.Engine, dir *storage.U
 	}, nil
 }
 
-func (d *Dir) Write(r *zed.Record) error {
+func (d *Dir) Write(r *zed.Value) error {
 	out, err := d.lookupOutput(r)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (d *Dir) Write(r *zed.Record) error {
 	return out.Write(r)
 }
 
-func (d *Dir) lookupOutput(rec *zed.Record) (zio.WriteCloser, error) {
+func (d *Dir) lookupOutput(rec *zed.Value) (zio.WriteCloser, error) {
 	typ := rec.Type
 	w, ok := d.writers[typ]
 	if ok {
@@ -85,7 +85,7 @@ func (d *Dir) lookupOutput(rec *zed.Record) (zio.WriteCloser, error) {
 // filename returns the name of the file for the specified path. This handles
 // the case of two tds one _path, adding a # in the filename for every _path that
 // has more than one td.
-func (d *Dir) filename(r *zed.Record) (*storage.URI, string) {
+func (d *Dir) filename(r *zed.Value) (*storage.URI, string) {
 	var _path string
 	base, err := r.AccessString("_path")
 	if err == nil {
@@ -97,7 +97,7 @@ func (d *Dir) filename(r *zed.Record) (*storage.URI, string) {
 	return d.dir.AppendPath(name), _path
 }
 
-func (d *Dir) newFile(rec *zed.Record) (zio.WriteCloser, error) {
+func (d *Dir) newFile(rec *zed.Value) (zio.WriteCloser, error) {
 	filename, path := d.filename(rec)
 	if w, ok := d.paths[path]; ok {
 		return w, nil

--- a/zio/jsonio/reader.go
+++ b/zio/jsonio/reader.go
@@ -36,7 +36,7 @@ func NewReader(r io.Reader, zctx *zed.Context) *Reader {
 	}
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	if !r.decoder.More() {
 		return nil, nil
 	}

--- a/zio/jsonio/writer.go
+++ b/zio/jsonio/writer.go
@@ -22,8 +22,8 @@ type Writer struct {
 }
 
 type describe struct {
-	Kind  string      `json:"kind"`
-	Value *zed.Record `json:"value"`
+	Kind  string     `json:"kind"`
+	Value *zed.Value `json:"value"`
 }
 
 func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
@@ -45,7 +45,7 @@ func (w *Writer) Close() error {
 	return err
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	if w.size > MaxWriteBuffer {
 		return fmt.Errorf("JSON output buffer size exceeded: %d", w.size)
 	}

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -56,7 +56,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
 	return writer
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	var v interface{}
 	if err := unmarshaler.Unmarshal(*rec, &v); err != nil {
 		return w.WriteZSON(rec)
@@ -71,7 +71,7 @@ func (w *Writer) Close() error {
 	return w.writer.Close()
 }
 
-func (w *Writer) WriteZSON(rec *zed.Record) error {
+func (w *Writer) WriteZSON(rec *zed.Value) error {
 	s, err := w.zson.FormatRecord(rec)
 	if err != nil {
 		return err

--- a/zio/mapper.go
+++ b/zio/mapper.go
@@ -16,7 +16,7 @@ func NewMapper(reader Reader, zctx *zed.Context) *Mapper {
 	}
 }
 
-func (m *Mapper) Read() (*zed.Record, error) {
+func (m *Mapper) Read() (*zed.Value, error) {
 	rec, err := m.Reader.Read()
 	if err != nil {
 		return nil, err

--- a/zio/ndjsonio/writer.go
+++ b/zio/ndjsonio/writer.go
@@ -24,6 +24,6 @@ func (w *Writer) Close() error {
 	return w.writer.Close()
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	return w.encoder.Encode(rec)
 }

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -34,7 +34,7 @@ func NewReader(r io.Reader, zctx *zed.Context) (*Reader, error) {
 	}, nil
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	data, err := r.fr.NextRow()
 	if err != nil {
 		if err == io.EOF {

--- a/zio/parquetio/writer.go
+++ b/zio/parquetio/writer.go
@@ -30,7 +30,7 @@ func (w *Writer) Close() error {
 	return err
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	recType := zed.AliasOf(rec.Type).(*zed.TypeRecord)
 	if w.typ == nil {
 		w.typ = recType

--- a/zio/peeker.go
+++ b/zio/peeker.go
@@ -6,14 +6,14 @@ import "github.com/brimdata/zed"
 // of the next item to be read without actually reading it.
 type Peeker struct {
 	Reader
-	cache *zed.Record
+	cache *zed.Value
 }
 
 func NewPeeker(reader Reader) *Peeker {
 	return &Peeker{Reader: reader}
 }
 
-func (p *Peeker) Peek() (*zed.Record, error) {
+func (p *Peeker) Peek() (*zed.Value, error) {
 	var err error
 	if p.cache == nil {
 		p.cache, err = p.Reader.Read()
@@ -21,7 +21,7 @@ func (p *Peeker) Peek() (*zed.Record, error) {
 	return p.cache, err
 }
 
-func (p *Peeker) Read() (*zed.Record, error) {
+func (p *Peeker) Read() (*zed.Value, error) {
 	v := p.cache
 	if v != nil {
 		p.cache = nil

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -37,7 +37,7 @@ func NewWriter(w io.WriteCloser, utf8 bool) *Writer {
 	}
 }
 
-func (w *Writer) Write(r *zed.Record) error {
+func (w *Writer) Write(r *zed.Value) error {
 	r, err := w.flattener.Flatten(r)
 	if err != nil {
 		return err

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -40,7 +40,7 @@ func (w *Writer) Close() error {
 	return w.writer.Close()
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	rec, err := w.flattener.Flatten(rec)
 	if err != nil {
 		return err

--- a/zio/tzngio/reader.go
+++ b/zio/tzngio/reader.go
@@ -61,7 +61,7 @@ func NewReader(reader io.Reader, zctx *zed.Context) *Reader {
 	}
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	for {
 		rec, b, err := r.ReadPayload()
 		if b != nil {
@@ -77,7 +77,7 @@ func (r *Reader) Read() (*zed.Record, error) {
 	}
 }
 
-func (r *Reader) ReadPayload() (*zed.Record, []byte, error) {
+func (r *Reader) ReadPayload() (*zed.Value, []byte, error) {
 again:
 	line, err := r.scanner.ScanLine()
 	if line == nil {
@@ -195,7 +195,7 @@ func (r *Reader) parseType(line []byte) (zed.Type, []byte, error) {
 	return typ, line[i+1:], nil
 }
 
-func (r *Reader) parseValue(line []byte) (*zed.Record, error) {
+func (r *Reader) parseValue(line []byte) (*zed.Value, error) {
 	// From the zng spec:
 	// A regular value is encoded on a line as type descriptor
 	// followed by ":" followed by a value encoding.

--- a/zio/tzngio/writer.go
+++ b/zio/tzngio/writer.go
@@ -37,7 +37,7 @@ func (w *Writer) WriteControl(b []byte) error {
 	return err
 }
 
-func (w *Writer) Write(r *zed.Record) error {
+func (w *Writer) Write(r *zed.Value) error {
 	inID := r.Type.ID()
 	name, ok := w.tracker[inID]
 	if !ok {

--- a/zio/warningreader.go
+++ b/zio/warningreader.go
@@ -22,7 +22,7 @@ func NewWarningReader(zr Reader, w Warner) Reader {
 	return &WarningReader{zr: zr, wn: w}
 }
 
-func (w *WarningReader) Read() (*zed.Record, error) {
+func (w *WarningReader) Read() (*zed.Value, error) {
 	rec, err := w.zr.Read()
 	if err != nil {
 		w.wn.Warn(fmt.Sprintf("%s: %s", w.zr, err))

--- a/zio/zeekio/builder.go
+++ b/zio/zeekio/builder.go
@@ -19,7 +19,7 @@ type builder struct {
 	reorderedFields [][]byte
 }
 
-func (b *builder) build(typ *zed.TypeRecord, sourceFields []int, path []byte, data []byte) (*zed.Record, error) {
+func (b *builder) build(typ *zed.TypeRecord, sourceFields []int, path []byte, data []byte) (*zed.Value, error) {
 	b.Reset()
 	b.Grow(len(data))
 	columns := typ.Columns

--- a/zio/zeekio/parser.go
+++ b/zio/zeekio/parser.go
@@ -313,7 +313,7 @@ func (p *Parser) Descriptor() (*zed.TypeRecord, bool) {
 
 }
 
-func (p *Parser) ParseValue(line []byte) (*zed.Record, error) {
+func (p *Parser) ParseValue(line []byte) (*zed.Value, error) {
 	if p.descriptor == nil {
 		if err := p.setDescriptor(); err != nil {
 			return nil, err

--- a/zio/zeekio/parser_test.go
+++ b/zio/zeekio/parser_test.go
@@ -62,7 +62,7 @@ func startLegacyTest(t *testing.T, fields, types []string, path string) *Parser 
 
 // sendLegacyValues() formats the array of values as a legacy zeek log line
 // and parses it.
-func sendLegacyValues(p *Parser, vals []string) (*zed.Record, error) {
+func sendLegacyValues(p *Parser, vals []string) (*zed.Value, error) {
 	return p.ParseValue([]byte(strings.Join(vals, "\t")))
 }
 

--- a/zio/zeekio/reader.go
+++ b/zio/zeekio/reader.go
@@ -34,7 +34,7 @@ func NewReader(reader io.Reader, zctx *zed.Context) (*Reader, error) {
 	}, nil
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	e := func(err error) error {
 		if err == nil {
 			return err

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -40,7 +40,7 @@ func (w *Writer) Close() error {
 	return w.writer.Close()
 }
 
-func (w *Writer) Write(r *zed.Record) error {
+func (w *Writer) Write(r *zed.Value) error {
 	r, err := w.flattener.Flatten(r)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func (w *Writer) Write(r *zed.Record) error {
 	return err
 }
 
-func (w *Writer) writeHeader(r *zed.Record, path string) error {
+func (w *Writer) writeHeader(r *zed.Value, path string) error {
 	d := r.Type
 	var s string
 	if w.separator != "\\x90" {
@@ -124,7 +124,7 @@ func isHighPrecision(ts nano.Ts) bool {
 
 // This returns the zeek strings for this record.  XXX We need to not use this.
 // XXX change to Pretty for output writers?... except zeek?
-func ZeekStrings(r *zed.Record, fmt tzngio.OutFmt) ([]string, error) {
+func ZeekStrings(r *zed.Value, fmt tzngio.OutFmt) ([]string, error) {
 	var ss []string
 	it := r.Bytes.Iter()
 	for _, col := range zed.TypeRecordOf(r.Type).Columns {

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -54,11 +54,11 @@ func NopCloser(w io.Writer) io.WriteCloser {
 // Read never returns a non-nil record and non-nil error together, and it never
 // returns io.EOF.
 type Reader interface {
-	Read() (*zed.Record, error)
+	Read() (*zed.Value, error)
 }
 
 type Writer interface {
-	Write(*zed.Record) error
+	Write(*zed.Value) error
 }
 
 type ReadCloser interface {
@@ -107,7 +107,7 @@ type concatReader struct {
 	readers []Reader
 }
 
-func (c *concatReader) Read() (*zed.Record, error) {
+func (c *concatReader) Read() (*zed.Value, error) {
 	for len(c.readers) > 0 {
 		rec, err := c.readers[0].Read()
 		if rec != nil || err != nil {
@@ -128,7 +128,7 @@ type multiWriter struct {
 	writers []Writer
 }
 
-func (m *multiWriter) Write(rec *zed.Record) error {
+func (m *multiWriter) Write(rec *zed.Value) error {
 	for _, w := range m.writers {
 		if err := w.Write(rec); err != nil {
 			return err

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -33,7 +33,7 @@ func NewReader(reader io.Reader, zctx *zed.Context) *Reader {
 	}
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	e := func(err error) error {
 		if err == nil {
 			return err

--- a/zio/zjsonio/stream.go
+++ b/zio/zjsonio/stream.go
@@ -23,7 +23,7 @@ func NewStream() *Stream {
 	}
 }
 
-func (s *Stream) Transform(r *zed.Record) (Object, error) {
+func (s *Stream) Transform(r *zed.Value) (Object, error) {
 	typ, err := s.zctx.TranslateType(r.Type)
 	if err != nil {
 		return Object{}, err

--- a/zio/zjsonio/writer.go
+++ b/zio/zjsonio/writer.go
@@ -64,7 +64,7 @@ func (w *Writer) Close() error {
 	return w.writer.Close()
 }
 
-func (w *Writer) Write(r *zed.Record) error {
+func (w *Writer) Write(r *zed.Value) error {
 	rec, err := w.stream.Transform(r)
 	if err != nil {
 		return err

--- a/zio/zng_test.go
+++ b/zio/zng_test.go
@@ -188,7 +188,7 @@ func TestStreams(t *testing.T) {
 		LZ4BlockSize: zngio.DefaultLZ4BlockSize,
 	})
 
-	var recs []*zed.Record
+	var recs []*zed.Value
 	for {
 		rec, err := r.Read()
 		require.NoError(t, err)

--- a/zio/zngio/batch.go
+++ b/zio/zngio/batch.go
@@ -9,7 +9,7 @@ import (
 
 type batch struct {
 	buf  *buffer
-	recs []zed.Record
+	recs []zed.Value
 	refs int32
 }
 
@@ -18,7 +18,7 @@ var batchPool sync.Pool
 func newBatch(buf *buffer) *batch {
 	b, ok := batchPool.Get().(*batch)
 	if !ok {
-		b = &batch{recs: make([]zed.Record, 200)}
+		b = &batch{recs: make([]zed.Value, 200)}
 	}
 	b.buf = buf
 	b.recs = b.recs[:0]
@@ -26,14 +26,14 @@ func newBatch(buf *buffer) *batch {
 	return b
 }
 
-func (b *batch) add(r *zed.Record) { b.recs = append(b.recs, *r) }
+func (b *batch) add(r *zed.Value) { b.recs = append(b.recs, *r) }
 
-func (b *batch) Index(i int) *zed.Record { return &b.recs[i] }
+func (b *batch) Index(i int) *zed.Value { return &b.recs[i] }
 
 func (b *batch) Length() int { return len(b.recs) }
 
-func (b *batch) Records() []*zed.Record {
-	var recs []*zed.Record
+func (b *batch) Records() []*zed.Value {
+	var recs []*zed.Value
 	for i := range b.recs {
 		recs = append(recs, &b.recs[i])
 	}

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -77,7 +77,7 @@ func (r *Reader) Position() int64 {
 // SkipStream skips over the records in the current stream and returns
 // the first record of the next stream and the start-of-stream position
 // of that record.
-func (r *Reader) SkipStream() (*zed.Record, int64, error) {
+func (r *Reader) SkipStream() (*zed.Value, int64, error) {
 	sos := r.sos
 	for {
 		rec, err := r.Read()
@@ -87,7 +87,7 @@ func (r *Reader) SkipStream() (*zed.Record, int64, error) {
 	}
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	for {
 		rec, msg, err := r.ReadPayload()
 		if err != nil {
@@ -100,7 +100,7 @@ func (r *Reader) Read() (*zed.Record, error) {
 	}
 }
 
-func (r *Reader) ReadPayload() (*zed.Record, *AppMessage, error) {
+func (r *Reader) ReadPayload() (*zed.Value, *AppMessage, error) {
 	for {
 		rec, msg, err := r.readPayload(nil)
 		if err != nil {
@@ -133,7 +133,7 @@ var startCompressed = errors.New("start of compressed value messaage block")
 // messages .  The record or message is volatile so they must be
 // copied (via copy for message's byte slice or zed.Record.Keep) as
 // subsequent calls to Read or ReadPayload will modify the referenced data.
-func (r *Reader) readPayload(rec *zed.Record) (*zed.Record, *AppMessage, error) {
+func (r *Reader) readPayload(rec *zed.Value) (*zed.Value, *AppMessage, error) {
 	for {
 		b, err := r.read(1)
 		if err != nil {
@@ -188,7 +188,7 @@ type reader interface {
 var _ reader = (*Reader)(nil)
 var _ reader = (*buffer)(nil)
 
-func readValue(r reader, code byte, m *zed.Mapper, validate bool, rec *zed.Record) (*zed.Record, error) {
+func readValue(r reader, code byte, m *zed.Mapper, validate bool, rec *zed.Value) (*zed.Value, error) {
 	id := int(code)
 	if code == zed.CtrlValueEscape {
 		var err error

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -198,7 +198,7 @@ func (w *worker) scanBatch(buf *buffer, mapper *zed.Mapper, streamZctx *zed.Cont
 	}
 	// Otherwise, build a batch by reading all records in the buffer.
 	batch := newBatch(buf)
-	var stackRec zed.Record
+	var stackRec zed.Value
 	var stats zbuf.ScannerStats
 	for buf.length() > 0 {
 		code, err := buf.ReadByte()
@@ -224,7 +224,7 @@ func (w *worker) scanBatch(buf *buffer, mapper *zed.Mapper, streamZctx *zed.Cont
 	return batch, nil
 }
 
-func (w *worker) wantRecord(rec *zed.Record, stats *zbuf.ScannerStats) bool {
+func (w *worker) wantRecord(rec *zed.Value, stats *zbuf.ScannerStats) bool {
 	stats.BytesRead += int64(len(rec.Bytes))
 	stats.RecordsRead++
 	// It's tempting to call w.bufferFilter.Eval on rec.Bytes here, but that

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -92,7 +92,7 @@ func (w *Writer) EndStream() error {
 	return nil
 }
 
-func (w *Writer) Write(r *zed.Record) error {
+func (w *Writer) Write(r *zed.Value) error {
 	// First send any typedefs for unsent types.
 	typ := w.encoder.Lookup(r.Type)
 	if typ == nil {

--- a/zio/zsonio/writer.go
+++ b/zio/zsonio/writer.go
@@ -29,7 +29,7 @@ func (w *Writer) Close() error {
 	return w.writer.Close()
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	s, err := w.formatter.FormatRecord(rec)
 	if err != nil {
 		return err

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -65,7 +65,7 @@ func (f *Formatter) pop() {
 	f.stack = f.stack[:n-1]
 }
 
-func (f *Formatter) FormatRecord(rec *zed.Record) (string, error) {
+func (f *Formatter) FormatRecord(rec *zed.Value) (string, error) {
 	f.builder.Reset()
 	// We reset tyepdefs so named types are emitted with their
 	// definition at first use in each record according to the

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -149,7 +149,7 @@ func (m *MarshalZNGContext) Marshal(v interface{}) (zed.Value, error) {
 	return zed.Value{typ, bytes}, nil
 }
 
-func (m *MarshalZNGContext) MarshalRecord(v interface{}) (*zed.Record, error) {
+func (m *MarshalZNGContext) MarshalRecord(v interface{}) (*zed.Value, error) {
 	m.Builder.Reset()
 	typ, err := m.encodeValue(reflect.ValueOf(v))
 	if err != nil {
@@ -165,7 +165,7 @@ func (m *MarshalZNGContext) MarshalRecord(v interface{}) (*zed.Record, error) {
 	return zed.NewRecord(typ, body), nil
 }
 
-func (m *MarshalZNGContext) MarshalCustom(names []string, fields []interface{}) (*zed.Record, error) {
+func (m *MarshalZNGContext) MarshalCustom(names []string, fields []interface{}) (*zed.Value, error) {
 	if len(names) != len(fields) {
 		return nil, errors.New("fields and columns don't match")
 	}
@@ -623,7 +623,7 @@ func UnmarshalZNG(zv zed.Value, v interface{}) error {
 	return NewZNGUnmarshaler().decodeAny(zv, reflect.ValueOf(v))
 }
 
-func UnmarshalZNGRecord(rec *zed.Record, v interface{}) error {
+func UnmarshalZNGRecord(rec *zed.Value, v interface{}) error {
 	return UnmarshalZNG(*rec, v)
 }
 

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -111,7 +111,7 @@ type SliceRecord struct {
 	S []IDSlice
 }
 
-func recToZSON(t *testing.T, rec *zed.Record) string {
+func recToZSON(t *testing.T, rec *zed.Value) string {
 	var b strings.Builder
 	w := zsonio.NewWriter(zio.NopCloser(&b), zsonio.WriterOpts{})
 	err := w.Write(rec)

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func toZSON(t *testing.T, rec *zed.Record) string {
+func toZSON(t *testing.T, rec *zed.Value) string {
 	var buf strings.Builder
 	require.NoError(t, zsonio.NewWriter(zio.NopCloser(&buf), zsonio.WriterOpts{}).Write(rec))
 	return strings.TrimRight(buf.String(), "\n")

--- a/zson/reader.go
+++ b/zson/reader.go
@@ -25,7 +25,7 @@ func NewReader(r io.Reader, zctx *zed.Context) *Reader {
 	}
 }
 
-func (r *Reader) Read() (*zed.Record, error) {
+func (r *Reader) Read() (*zed.Value, error) {
 	if r.parser == nil {
 		var err error
 		r.parser, err = NewParser(r.reader)

--- a/zson/reader_test.go
+++ b/zson/reader_test.go
@@ -15,7 +15,7 @@ func TestReadOneLineNoEOF(t *testing.T) {
 	const expected = `{msg:"record1"}`
 	type result struct {
 		err error
-		rec *zed.Record
+		rec *zed.Value
 	}
 	done := make(chan result)
 	go func() {

--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -15,7 +15,7 @@ var ErrBadSchemaID = errors.New("bad schema id in root reassembly column")
 type Assembly struct {
 	root    zed.Value
 	schemas []zed.Type
-	columns []*zed.Record
+	columns []*zed.Value
 }
 
 func NewAssembler(a *Assembly, seeker *storage.Seeker) (*Assembler, error) {
@@ -50,7 +50,7 @@ type Assembler struct {
 	err     error
 }
 
-func (a *Assembler) Read() (*zed.Record, error) {
+func (a *Assembler) Read() (*zed.Value, error) {
 	a.builder.Reset()
 	schemaID, err := a.root.Read()
 	if err == io.EOF {

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -116,7 +116,7 @@ func cutType(zctx *zed.Context, typ *zed.TypeRecord, fields []string) (*zed.Type
 	return wrapType, nwrap + 1, err
 }
 
-func (a *CutAssembler) Read() (*zed.Record, error) {
+func (a *CutAssembler) Read() (*zed.Value, error) {
 	a.builder.Reset()
 	for {
 		schemaID, err := a.root.Read()

--- a/zst/object.go
+++ b/zst/object.go
@@ -121,7 +121,7 @@ func (o *Object) IsEmpty() bool {
 func (o *Object) readAssembly() (*Assembly, error) {
 	reader := o.NewReassemblyReader()
 	assembly := &Assembly{}
-	var rec *zed.Record
+	var rec *zed.Value
 	for {
 		var err error
 		rec, err = reader.Read()

--- a/zst/trailer.go
+++ b/zst/trailer.go
@@ -37,7 +37,7 @@ type Trailer struct {
 
 var ErrNotZst = errors.New("not a zst object")
 
-func newTrailerRecord(zctx *zed.Context, skewThresh, segmentThresh int, sections []int64) (*zed.Record, error) {
+func newTrailerRecord(zctx *zed.Context, skewThresh, segmentThresh int, sections []int64) (*zed.Value, error) {
 	sectionsType := zctx.LookupTypeArray(zed.TypeInt64)
 	cols := []zed.Column{
 		{MagicField, zed.TypeString},
@@ -114,7 +114,7 @@ func readTrailer(r io.ReadSeeker, n int64) (*Trailer, error) {
 	return nil, errors.New("zst trailer not found")
 }
 
-func trailerVersion(rec *zed.Record) (int, error) {
+func trailerVersion(rec *zed.Value) (int, error) {
 	version, err := rec.AccessInt(VersionField)
 	if err != nil {
 		return -1, errors.New("zst version field is not a valid int32")
@@ -125,7 +125,7 @@ func trailerVersion(rec *zed.Record) (int, error) {
 	return int(version), nil
 }
 
-func recordToTrailer(rec *zed.Record) (*Trailer, error) {
+func recordToTrailer(rec *zed.Value) (*Trailer, error) {
 	var trailer Trailer
 	var err error
 	trailer.Magic, err = rec.AccessString(MagicField)
@@ -144,7 +144,7 @@ func recordToTrailer(rec *zed.Record) (*Trailer, error) {
 	return &trailer, nil
 }
 
-func decodeSections(rec *zed.Record) ([]int64, error) {
+func decodeSections(rec *zed.Value) ([]int64, error) {
 	v, err := rec.Access(SectionsField)
 	if err != nil {
 		return nil, err

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -101,7 +101,7 @@ func checkThresh(which string, max, thresh int) error {
 	return nil
 }
 
-func (w *Writer) Write(rec *zed.Record) error {
+func (w *Writer) Write(rec *zed.Value) error {
 	inputID := zed.TypeID(rec.Type)
 	schemaID, ok := w.schemaMap[inputID]
 	if !ok {


### PR DESCRIPTION
Generated automatically with the following script.

```sh
sed -i '' '/^type Record = Value/,+1d' recordval.go
gofmt -w -r 'Record -> Value' *.go
gofmt -w -r 'zed.Record -> zed.Value' .
```