### PR TITLE
make fuse() output deterministic

### DIFF
--- a/expr/agg/fuse.go
+++ b/expr/agg/fuse.go
@@ -7,14 +7,12 @@ import (
 )
 
 type fuse struct {
-	shapes   map[*zed.TypeRecord]struct{}
+	shapes   map[*zed.TypeRecord]int
 	partials []zed.Value
 }
 
 func newFuse() *fuse {
-	return &fuse{
-		shapes: make(map[*zed.TypeRecord]struct{}),
-	}
+	return &fuse{shapes: make(map[*zed.TypeRecord]int)}
 }
 
 func (f *fuse) Consume(v zed.Value) error {
@@ -23,7 +21,7 @@ func (f *fuse) Consume(v zed.Value) error {
 	if !ok {
 		return nil
 	}
-	f.shapes[typ] = struct{}{}
+	f.shapes[typ] = len(f.shapes)
 	return nil
 }
 
@@ -44,7 +42,11 @@ func (f *fuse) Result(zctx *zed.Context) (zed.Value, error) {
 		}
 		schema.Mixin(recType)
 	}
-	for typ := range f.shapes {
+	shapes := make([]*zed.TypeRecord, len(f.shapes))
+	for typ, i := range f.shapes {
+		shapes[i] = typ
+	}
+	for _, typ := range shapes {
 		schema.Mixin(typ)
 	}
 	typ, err := schema.Type()

--- a/expr/agg/ztests/fuse-container.yaml
+++ b/expr/agg/ztests/fuse-container.yaml
@@ -1,6 +1,4 @@
-skip: Enable after fixing https://github.com/brimdata/zed/issues/2145.
-
-zed: all=fuse(.),r=fuse(r)
+zed: all:=fuse(.),r:=fuse(r)
 
 input: |
   {a:"hello",r:{x:1(int32),y:2(int32)}}


### PR DESCRIPTION
Output from fuse() is nondeterministic because the order in which
expr/agg.fuse.Result mixes fuse.shapes into its schema depends on map
iteration order, which is unspecified.  Make fuse() output determinstic
by recording the order in which types are added to fuse.shapes and
mixing them into the schema in that order.

With the updated `expr/agg/ztests/fuse-container.yaml` here, `go test -count=100 -run=TestZed/expr/agg/ztests/fuse-container -short .` passes with the `expr/agg/fuse.go` changes and fails without them.

Closes #3184.