### PR TITLE
remove zed.Value.Ts and zbuf.MergeByTs

### DIFF
--- a/lake/sorted.go
+++ b/lake/sorted.go
@@ -77,12 +77,9 @@ func newSortedScanner(ctx context.Context, pool *Pool, zctx *zed.Context, filter
 			sched:   sched,
 		})
 	}
-	keys := pool.Layout.Keys
 	var merger zbuf.Puller
 	if len(pullers) == 1 {
 		merger = pullers[0]
-	} else if len(keys) > 0 && len(keys[0]) == 1 && keys[0][0] == "ts" {
-		merger = zbuf.MergeByTs(ctx, pullers, pool.Layout.Order)
 	} else {
 		merger = zbuf.NewMerger(ctx, pullers, importCompareFn(pool))
 	}

--- a/recordval.go
+++ b/recordval.go
@@ -276,10 +276,3 @@ func (r *Value) AccessTimeByColumn(colno int) (nano.Ts, error) {
 	}
 	return DecodeTime(zv)
 }
-
-// Ts returns the value of the receiver's "ts" field.  If the field is absent,
-// is null, or has a type other than TypeOfTime, Ts returns nano.MinTs.
-func (r *Value) Ts() nano.Ts {
-	ts, _ := r.AccessTime("ts")
-	return ts
-}

--- a/recordval_test.go
+++ b/recordval_test.go
@@ -3,10 +3,8 @@ package zed_test
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zson"
 	"github.com/stretchr/testify/assert"
@@ -85,23 +83,4 @@ func TestRecordAccessAlias(t *testing.T) {
 	b, err := rec.AccessBool("bar")
 	require.NoError(t, err)
 	assert.Equal(t, b, true)
-}
-
-func TestRecordTs(t *testing.T) {
-	cases := []struct {
-		input    string
-		expected nano.Ts
-	}{
-		{"{ts:1970-01-01T00:00:01Z}", nano.Ts(time.Second)},
-		{"{notts:1970-01-01T00:00:01Z}", nano.MinTs}, // No ts field.
-		{"{ts:null (time)}", nano.MinTs},             // Null ts field.
-		{"{ts:1}", nano.MinTs},                       // Type of ts field is not TypeOfTime.
-	}
-	for _, c := range cases {
-		zr := zson.NewReader(strings.NewReader(c.input), zed.NewContext())
-		rec, err := zr.Read()
-		assert.NoError(t, err)
-		require.NotNil(t, rec)
-		assert.Exactly(t, c.expected, rec.Ts(), "input: %q", c.input)
-	}
 }

--- a/zbuf/merger.go
+++ b/zbuf/merger.go
@@ -75,23 +75,6 @@ func NewMerger(ctx context.Context, pullers []Puller, cmp expr.CompareFn) *Merge
 	return m
 }
 
-func MergeByTs(ctx context.Context, pullers []Puller, o order.Which) *Merger {
-	cmp := func(a, b *zed.Value) int {
-		if o == order.Desc {
-			a, b = b, a
-		}
-		aTs, bTs := a.Ts(), b.Ts()
-		if aTs < bTs {
-			return -1
-		}
-		if aTs > bTs {
-			return 1
-		}
-		return bytes.Compare(a.Bytes, b.Bytes)
-	}
-	return NewMerger(ctx, pullers, cmp)
-}
-
 func (m *Merger) run() {
 	for _, p := range m.pullers {
 		m.wg.Add(1)

--- a/zio/zeekio/parser_test.go
+++ b/zio/zeekio/parser_test.go
@@ -79,7 +79,9 @@ func TestLegacyZeekValid(t *testing.T) {
 	record, err := sendLegacyValues(parser, values)
 	require.NoError(t, err)
 
-	assert.Equal(t, record.Ts(), nano.MinTs, "Record has MinTs")
+	ts, err := record.AccessTime("ts")
+	assert.ErrorIs(t, err, zed.ErrMissing)
+	assert.Equal(t, nano.MinTs, ts)
 	// XXX check contents of other fields?
 
 	// Test standard headers with a timestamp in records
@@ -92,9 +94,11 @@ func TestLegacyZeekValid(t *testing.T) {
 	record, err = sendLegacyValues(parser, valsWithTs)
 	require.NoError(t, err)
 
-	ts, err := nano.Parse([]byte(timestamp))
+	expectedTs, err := nano.Parse([]byte(timestamp))
 	require.NoError(t, err)
-	assert.Equal(t, record.Ts(), ts, "Timestamp is correct")
+	ts, err = record.AccessTime("ts")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTs, ts, "Timestamp is correct")
 
 	// Test the #path header
 	parser = startLegacyTest(t, fieldsWithTs, typesWithTs, "testpath")


### PR DESCRIPTION
A holdover from zed.Record, zed.Value.Ts offers no benefit over
zed.Value.AccessTime.  And without zed.Value.Ts, zbuf.MergeByTs offers
no benefit over zbuf.NewMerger.