### PR TITLE
index.Finder.Nearest: support lt and gt

### DIFF
--- a/cmd/zed/index/lookup/command.go
+++ b/cmd/zed/index/lookup/command.go
@@ -80,7 +80,7 @@ func (c *LookupCommand) Run(args []string) error {
 	go func() {
 		if c.closest {
 			var rec *zed.Value
-			rec, searchErr = finder.ClosestLTE(keys...)
+			rec, searchErr = finder.Nearest("<=", keys...)
 			if rec != nil {
 				hits <- rec
 			}

--- a/index/finder.go
+++ b/index/finder.go
@@ -76,8 +76,7 @@ func lookupAsc(reader zio.Reader, fn expr.KeyCompareFn, op Operator) (*zed.Value
 			}
 			return prev, err
 		}
-		cmp := fn(rec)
-		if cmp >= 0 {
+		if cmp := fn(rec); cmp >= 0 {
 			if cmp == 0 && op.hasEqual() {
 				return rec, nil
 			}

--- a/index/finder.go
+++ b/index/finder.go
@@ -215,7 +215,7 @@ func compareFn(kvs []KeyValue) expr.KeyCompareFn {
 }
 
 // Nearest finds the zed.Value in the index that is nearest to kvs according to
-// the provided operator.
+// operator.
 func (f *Finder) Nearest(operator string, kvs ...KeyValue) (*zed.Value, error) {
 	op := Operator(operator)
 	if !op.valid() {

--- a/index/finder.go
+++ b/index/finder.go
@@ -273,7 +273,6 @@ func (o Operator) valid() bool {
 	switch o {
 	case EQL, GT, GTE, LT, LTE:
 		return true
-	default:
-		return false
 	}
+	return false
 }

--- a/index/finder.go
+++ b/index/finder.go
@@ -264,9 +264,8 @@ func (o Operator) hasEqual() bool {
 	switch o {
 	case EQL, GTE, LTE:
 		return true
-	default:
-		return false
 	}
+	return false
 }
 
 func (o Operator) valid() bool {

--- a/index/finder.go
+++ b/index/finder.go
@@ -14,6 +14,16 @@ import (
 	"github.com/brimdata/zed/zson"
 )
 
+type Operator string
+
+const (
+	EQL Operator = "="
+	GT  Operator = ">"
+	GTE Operator = ">="
+	LT  Operator = "<"
+	LTE Operator = "<="
+)
+
 var ErrNotFound = errors.New("key not found")
 
 // Finder looks up values in a microindex using its embedded index.
@@ -45,72 +55,69 @@ func NewFinder(ctx context.Context, zctx *zed.Context, engine storage.Engine, ur
 	}, nil
 }
 
-type operator int
-
-const (
-	eql operator = iota
-	gte
-	lte
-)
-
 // lookup searches for a match of the given key compared to the
 // key values in the records read from the reader.  If the op argument is eql
 // then only exact matches are returned.  Otherwise, the record with the
 // largest key smaller (or larger) than the key argument is returned.
-func lookup(reader zio.Reader, compare expr.KeyCompareFn, o order.Which, op operator) (*zed.Value, error) {
+func lookup(reader zio.Reader, compare expr.KeyCompareFn, o order.Which, op Operator) (*zed.Value, error) {
 	if o == order.Asc {
 		return lookupAsc(reader, compare, op)
 	}
 	return lookupDesc(reader, compare, op)
 }
 
-func lookupAsc(reader zio.Reader, fn expr.KeyCompareFn, op operator) (*zed.Value, error) {
+func lookupAsc(reader zio.Reader, fn expr.KeyCompareFn, op Operator) (*zed.Value, error) {
 	var prev *zed.Value
 	for {
 		rec, err := reader.Read()
 		if rec == nil || err != nil {
-			if op == eql || op == gte {
+			if op == EQL || op == GTE || op == GT {
 				prev = nil
 			}
 			return prev, err
 		}
-		if cmp := fn(rec); cmp >= 0 {
-			if cmp == 0 {
+		cmp := fn(rec)
+		if cmp >= 0 {
+			if cmp == 0 && op.hasEqual() {
 				return rec, nil
 			}
-			if op == eql {
-				rec = nil
-			}
-			if op == lte {
+			if op == LTE || op == LT {
 				return prev, nil
 			}
-			return rec, nil
+			if op == EQL {
+				rec = nil
+			}
+			if !(op == GT && cmp == 0) {
+				return rec, nil
+			}
 		}
 		prev = rec
 	}
 }
 
-func lookupDesc(reader zio.Reader, fn expr.KeyCompareFn, op operator) (*zed.Value, error) {
+func lookupDesc(reader zio.Reader, fn expr.KeyCompareFn, op Operator) (*zed.Value, error) {
 	var prev *zed.Value
 	for {
 		rec, err := reader.Read()
 		if rec == nil || err != nil {
-			if op == eql || op == lte {
+			if op == EQL || op == LTE || op == LT {
 				prev = nil
 			}
 			return prev, err
 		}
 		if cmp := fn(rec); cmp <= 0 {
-			if cmp == 0 {
+			if cmp == 0 && op.hasEqual() {
 				return rec, nil
 			}
-			if op == eql {
-				rec = nil
-			}
-			if op == gte {
+			if op == GTE || op == GT {
 				return prev, nil
 			}
-			return rec, nil
+			if op == EQL {
+				return nil, nil
+			}
+			if !(op == LT && cmp == 0) {
+				return rec, nil
+			}
 		}
 		prev = rec
 	}
@@ -132,9 +139,9 @@ func (f *Finder) search(compare expr.KeyCompareFn) (zio.Reader, error) {
 		if err != nil {
 			return nil, err
 		}
-		op := lte
+		op := LTE
 		if f.trailer.Order == order.Desc {
-			op = gte
+			op = GTE
 		}
 		rec, err := lookup(reader, compare, f.trailer.Order, op)
 		if err != nil {
@@ -154,19 +161,7 @@ func (f *Finder) search(compare expr.KeyCompareFn) (zio.Reader, error) {
 }
 
 func (f *Finder) Lookup(kvs ...KeyValue) (*zed.Value, error) {
-	if f.IsEmpty() {
-		return nil, nil
-	}
-	compare := compareFn(kvs)
-	reader, err := f.search(compare)
-	if err != nil {
-		if err == ErrNotFound {
-			// Return nil/success when exact-match lookup fails
-			err = nil
-		}
-		return nil, err
-	}
-	return lookup(reader, compare, f.trailer.Order, eql)
+	return f.Nearest("=", kvs...)
 }
 
 func (f *Finder) LookupAll(ctx context.Context, hits chan<- *zed.Value, kvs []KeyValue) error {
@@ -182,7 +177,7 @@ func (f *Finder) LookupAll(ctx context.Context, hits chan<- *zed.Value, kvs []Ke
 		// As long as we have an exact key-match, where unset key
 		// columns are "don't care", keep reading records and return
 		// them via the channel.
-		rec, err := lookup(reader, compare, f.trailer.Order, eql)
+		rec, err := lookup(reader, compare, f.trailer.Order, EQL)
 		if err != nil {
 			return err
 		}
@@ -195,18 +190,6 @@ func (f *Finder) LookupAll(ctx context.Context, hits chan<- *zed.Value, kvs []Ke
 			return ctx.Err()
 		}
 	}
-}
-
-// ClosestGTE returns the closest record that is greater than or equal to the
-// provided key values.
-func (f *Finder) ClosestGTE(kvs ...KeyValue) (*zed.Value, error) {
-	return f.closest(kvs, gte)
-}
-
-// ClosestLTE returns the closest record that is less than or equal to the
-// provided key values.
-func (f *Finder) ClosestLTE(kvs ...KeyValue) (*zed.Value, error) {
-	return f.closest(kvs, lte)
 }
 
 func compareFn(kvs []KeyValue) expr.KeyCompareFn {
@@ -231,7 +214,13 @@ func compareFn(kvs []KeyValue) expr.KeyCompareFn {
 	}
 }
 
-func (f *Finder) closest(kvs []KeyValue, op operator) (*zed.Value, error) {
+// Nearest finds the zed.Value in the index that is nearest to kvs according to
+// the provided operator.
+func (f *Finder) Nearest(operator string, kvs ...KeyValue) (*zed.Value, error) {
+	op := Operator(operator)
+	if !op.valid() {
+		return nil, fmt.Errorf("unsupported operator: %s", operator)
+	}
 	if f.IsEmpty() {
 		return nil, nil
 	}
@@ -269,4 +258,22 @@ func (f *Finder) ParseKeys(inputs ...string) ([]KeyValue, error) {
 		}
 	}
 	return kvs, nil
+}
+
+func (o Operator) hasEqual() bool {
+	switch o {
+	case EQL, GTE, LTE:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o Operator) valid() bool {
+	switch o {
+	case EQL, GT, GTE, LT, LTE:
+		return true
+	default:
+		return false
+	}
 }

--- a/index/finder.go
+++ b/index/finder.go
@@ -84,7 +84,7 @@ func lookupAsc(reader zio.Reader, fn expr.KeyCompareFn, op Operator) (*zed.Value
 				return prev, nil
 			}
 			if op == EQL {
-				rec = nil
+				return nil, nil
 			}
 			if !(op == GT && cmp == 0) {
 				return rec, nil

--- a/index/findreader.go
+++ b/index/findreader.go
@@ -48,7 +48,7 @@ func (f *FinderReader) Read() (*zed.Value, error) {
 			return nil, err
 		}
 	}
-	return lookup(f.reader, f.compare, f.finder.trailer.Order, eql)
+	return lookup(f.reader, f.compare, f.finder.trailer.Order, EQL)
 }
 
 func (f *FinderReader) Close() error {

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -100,7 +100,7 @@ func TestNearest(t *testing.T) {
 			require.NoError(t, err)
 			rec, err := finder.Nearest(op, kvs...)
 			require.NoError(t, err)
-			var v int64 = -1
+			v := int64(-1)
 			if rec != nil {
 				v, err = rec.AccessInt("ts")
 				require.NoError(t, err)


### PR DESCRIPTION
Change the name of closet to nearest, make it a public method and
support > and < operations. Get rid of ClosetGTE/LTE and have users just
call nearest with the correct operator.

Part of #3183