### PR TITLE
enable ZNG compression in lake/api.RemoteSession.Load

### DIFF
--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -99,7 +99,7 @@ func (r *RemoteSession) RenamePool(ctx context.Context, pool ksuid.KSUID, name s
 
 func (r *RemoteSession) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, reader zio.Reader, commit api.CommitMessage) (ksuid.KSUID, error) {
 	pr, pw := io.Pipe()
-	w := zngio.NewWriter(pw, zngio.WriterOpts{})
+	w := zngio.NewWriter(pw, zngio.WriterOpts{LZ4BlockSize: zngio.DefaultLZ4BlockSize})
 	go func() {
 		zio.CopyWithContext(ctx, w, reader)
 		w.Close()


### PR DESCRIPTION
"zapi load" is slower than expected because the ZNG writer in
lake/api.RemoteSession.Load does lots of small writes to its
io.PipeWriter.  Speed it up by enabling compression for the ZNG writer.

(Wrapping the io.PipeWriter with a bufio.Writer is would also address
the problem, but we generally don't expect high-entropy data, so
compression should be beneficial.)