### PR TITLE
fix proc/exprswitch/ztests/switch-default.yaml

### DIFF
--- a/proc/exprswitch/ztests/switch-default.yaml
+++ b/proc/exprswitch/ztests/switch-default.yaml
@@ -1,5 +1,5 @@
 zed: |
-  switch (
+  switch a (
      2 => put v:='two';
      1 => put v:='one';
      3 => filter null;


### PR DESCRIPTION
This test is intended to exercise the "switch expr (literal => ...;)"
form of the switch operator but lacks "expr".  Add it.