### PR TITLE
reorient zbuf.Batch around []zed.Value

### DIFF
--- a/api/queryio/client.go
+++ b/api/queryio/client.go
@@ -46,7 +46,7 @@ type runner struct {
 }
 
 func (r *runner) Write(rec *zed.Value) error {
-	return r.driver.Write(r.cid, &zbuf.Array{rec})
+	return r.driver.Write(r.cid, &zbuf.Array{*rec})
 }
 
 func (r *runner) handleCtrl(ctrl interface{}) error {

--- a/api/queryio/driver.go
+++ b/api/queryio/driver.go
@@ -55,8 +55,9 @@ func (d *Driver) Write(cid int, batch zbuf.Batch) error {
 			return err
 		}
 	}
-	for i := 0; i < batch.Length(); i++ {
-		if err := d.writer.Write(batch.Index(i)); err != nil {
+	zvals := batch.Values()
+	for i := range zvals {
+		if err := d.writer.Write(&zvals[i]); err != nil {
 			return err
 		}
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -214,8 +214,9 @@ func (d *CLI) Write(cid int, batch zbuf.Batch) error {
 	if len(d.writers) == 1 {
 		cid = 0
 	}
-	for _, r := range batch.Records() {
-		if err := d.writers[cid].Write(r); err != nil {
+	zvals := batch.Values()
+	for i := range zvals {
+		if err := d.writers[cid].Write(&zvals[i]); err != nil {
 			return err
 		}
 	}
@@ -243,8 +244,9 @@ func (d *transformDriver) Write(cid int, batch zbuf.Batch) error {
 	if cid != 0 {
 		return errors.New("transform proc with multiple tails")
 	}
-	for i := 0; i < batch.Length(); i++ {
-		if err := d.w.Write(batch.Index(i)); err != nil {
+	zvals := batch.Values()
+	for i := range zvals {
+		if err := d.w.Write(&zvals[i]); err != nil {
 			return err
 		}
 	}
@@ -300,12 +302,13 @@ next:
 			return nil, r.err
 		}
 	}
-	if r.index >= r.batch.Length() {
+	zvals := r.batch.Values()
+	if r.index >= len(zvals) {
 		r.batch.Unref()
 		r.batch, r.index = nil, 0
 		goto next
 	}
-	rec := r.batch.Index(r.index)
+	rec := &zvals[r.index]
 	r.index++
 	return rec, nil
 }

--- a/expr/filter_test.go
+++ b/expr/filter_test.go
@@ -38,8 +38,8 @@ func runCasesHelper(t *testing.T, record string, cases []testcase, expectBufferF
 	zctx := zed.NewContext()
 	batch, err := zbuf.NewPuller(zson.NewReader(strings.NewReader(record), zctx), 2).Pull()
 	require.NoError(t, err, "record: %q", record)
-	require.Exactly(t, 1, batch.Length(), "record: %q", record)
-	rec := batch.Index(0)
+	require.Len(t, batch.Values(), 1, "record: %q", record)
+	rec := &batch.Values()[0]
 
 	lk := mock.NewLake()
 	for _, c := range cases {

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -164,13 +164,13 @@ func NewKeyCompareFn(key *zed.Value) (KeyCompareFn, error) {
 }
 
 // SortStable performs a stable sort on the provided records.
-func SortStable(records []*zed.Value, compare CompareFn) {
+func SortStable(records []zed.Value, compare CompareFn) {
 	slice := &RecordSlice{records, compare}
 	sort.Stable(slice)
 }
 
 type RecordSlice struct {
-	records []*zed.Value
+	records []zed.Value
 	compare CompareFn
 }
 
@@ -186,24 +186,24 @@ func (r *RecordSlice) Swap(i, j int) { r.records[i], r.records[j] = r.records[j]
 
 // Less implements sort.Interface for *Record slices.
 func (r *RecordSlice) Less(i, j int) bool {
-	return r.compare(r.records[i], r.records[j]) < 0
+	return r.compare(&r.records[i], &r.records[j]) < 0
 }
 
 // Push adds x as element Len(). Implements heap.Interface.
 func (r *RecordSlice) Push(rec interface{}) {
-	r.records = append(r.records, rec.(*zed.Value))
+	r.records = append(r.records, *rec.(*zed.Value))
 }
 
 // Pop removes the first element in the array. Implements heap.Interface.
 func (r *RecordSlice) Pop() interface{} {
 	rec := r.records[len(r.records)-1]
 	r.records = r.records[:len(r.records)-1]
-	return rec
+	return &rec
 }
 
 // Index returns the ith record.
 func (r *RecordSlice) Index(i int) *zed.Value {
-	return r.records[i]
+	return &r.records[i]
 }
 
 func LookupCompare(typ zed.Type) comparefn {

--- a/index/mem.go
+++ b/index/mem.go
@@ -13,7 +13,7 @@ import (
 type MemTable struct {
 	keys   field.List
 	table  map[string]*zed.Value
-	values []*zed.Value
+	values []zed.Value
 	sorted bool
 	zctx   *zed.Context
 }
@@ -33,7 +33,7 @@ func (t *MemTable) Read() (*zed.Value, error) {
 	if len(t.values) == 0 {
 		return nil, nil
 	}
-	rec := t.values[0]
+	rec := &t.values[0]
 	t.values = t.values[1:]
 	return rec, nil
 }
@@ -46,9 +46,9 @@ func (t *MemTable) open() {
 	n := len(t.table)
 	if n > 0 {
 		//XXX escaping to GC
-		t.values = make([]*zed.Value, 0, n)
+		t.values = make([]zed.Value, 0, n)
 		for _, value := range t.table {
-			t.values = append(t.values, value)
+			t.values = append(t.values, *value)
 		}
 		resolvers := make([]expr.Evaluator, 0, len(t.keys))
 		for _, key := range t.keys {

--- a/lake/api/querydriver.go
+++ b/lake/api/querydriver.go
@@ -17,9 +17,10 @@ func newQueryDriver(types ...interface{}) *queryDriver {
 }
 
 func (d *queryDriver) Write(channelID int, batch zbuf.Batch) error {
-	for _, rec := range batch.Records() {
+	zvals := batch.Values()
+	for i := range zvals {
 		var v interface{}
-		if err := d.unmarshaler.Unmarshal(*rec, &v); err != nil {
+		if err := d.unmarshaler.Unmarshal(zvals[i], &v); err != nil {
 			return err
 		}
 		d.results = append(d.results, v)

--- a/proc/apply.go
+++ b/proc/apply.go
@@ -38,10 +38,10 @@ func (a *applier) Pull() (zbuf.Batch, error) {
 			}
 			return nil, err
 		}
-		recs := make([]*zed.Value, 0, batch.Length())
-		for k := 0; k < batch.Length(); k++ {
-			in := batch.Index(k)
-			out, err := a.function.Apply(in)
+		zvals := batch.Values()
+		recs := make([]zed.Value, 0, len(zvals))
+		for i := range zvals {
+			out, err := a.function.Apply(&zvals[i])
 			if err != nil {
 				a.maybeWarn(err.Error())
 				continue
@@ -49,7 +49,7 @@ func (a *applier) Pull() (zbuf.Batch, error) {
 			if out != nil {
 				// Keep is necessary because Apply can return
 				// its argument.
-				recs = append(recs, out.Keep())
+				recs = append(recs, *out.Keep())
 			}
 		}
 		batch.Unref()

--- a/proc/explode/explode.go
+++ b/proc/explode/explode.go
@@ -38,16 +38,17 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		if proc.EOS(batch, err) {
 			return nil, err
 		}
-		recs := make([]*zed.Value, 0, batch.Length())
-		for _, rec := range batch.Records() {
+		zvals := batch.Values()
+		recs := make([]zed.Value, 0, len(zvals))
+		for i := range zvals {
 			for _, arg := range p.args {
-				zv, err := arg.Eval(rec)
+				zv, err := arg.Eval(&zvals[i])
 				if err != nil {
 					return nil, err
 				}
 				zed.Walk(zv.Type, zv.Bytes, func(typ zed.Type, body zcode.Bytes) error {
 					if typ == p.typ && body != nil {
-						recs = append(recs, p.builder.Build(body).Keep())
+						recs = append(recs, *p.builder.Build(body))
 						return zed.SkipContainer
 					}
 					return nil

--- a/proc/exprswitch/exprswitch.go
+++ b/proc/exprswitch/exprswitch.go
@@ -55,9 +55,9 @@ func (s *ExprSwitch) run() {
 			s.err = err
 			return
 		}
-		for i, n := 0, batch.Length(); i < n; i++ {
-			rec := batch.Index(i)
-			zv, err := s.evaluator.Eval(rec)
+		zvals := batch.Values()
+		for i := range zvals {
+			zv, err := s.evaluator.Eval(&zvals[i])
 			if err != nil {
 				s.err = err
 				return
@@ -71,7 +71,7 @@ func (s *ExprSwitch) run() {
 				continue
 			}
 			select {
-			case ch <- rec:
+			case ch <- &zvals[i]:
 			case doneCh := <-s.doneChCh:
 				s.handleDoneCh(doneCh)
 				if len(s.cases) == 0 && s.defaultCh == nil {
@@ -106,7 +106,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		go p.parent.run()
 	})
 	if rec, ok := <-p.ch; ok {
-		return zbuf.Array{rec}, nil
+		return zbuf.Array{*rec}, nil
 	}
 	return nil, p.parent.err
 }

--- a/proc/fuse/fuse.go
+++ b/proc/fuse/fuse.go
@@ -64,10 +64,9 @@ func (p *Proc) pullInput() error {
 
 func (p *Proc) writeBatch(batch zbuf.Batch) error {
 	defer batch.Unref()
-	l := batch.Length()
-	for i := 0; i < l; i++ {
-		rec := batch.Index(i)
-		if err := p.fuser.Write(rec); err != nil {
+	zvals := batch.Values()
+	for i := range zvals {
+		if err := p.fuser.Write(&zvals[i]); err != nil {
 			return err
 		}
 	}

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -259,9 +259,10 @@ type testGroupByDriver struct {
 }
 
 func (d *testGroupByDriver) Write(cid int, batch zbuf.Batch) error {
-	for _, r := range batch.Records() {
+	zvals := batch.Values()
+	for i := range zvals {
 		d.n++
-		if err := d.writer.Write(r); err != nil {
+		if err := d.writer.Write(&zvals[i]); err != nil {
 			return err
 		}
 	}

--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -61,7 +61,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		go p.left.run()
 		go p.right.Reader.(*puller).run()
 	})
-	var out []*zed.Value
+	var out []zed.Value
 	for {
 		leftRec, err := p.left.Read()
 		if err != nil {
@@ -91,7 +91,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 			// Nothing to add to the left join.
 			// Accumulate this record for an outer join.
 			if !p.inner {
-				out = append(out, leftRec.Keep())
+				out = append(out, *leftRec.Keep())
 			}
 			continue
 		}
@@ -116,7 +116,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 			if err != nil {
 				return nil, err
 			}
-			out = append(out, rec)
+			out = append(out, *rec)
 		}
 	}
 }

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -366,15 +366,15 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 	if proc.EOS(batch, err) {
 		return nil, err
 	}
-	recs := make([]*zed.Value, 0, batch.Length())
-	for k := 0; k < batch.Length(); k++ {
-		in := batch.Index(k)
-		rec, err := p.put(in)
+	zvals := batch.Values()
+	recs := make([]zed.Value, 0, len(zvals))
+	for i := range zvals {
+		rec, err := p.put(&zvals[i])
 		if err != nil {
 			return nil, err
 		}
 		// Keep is necessary because put can return its argument.
-		recs = append(recs, rec.Keep())
+		recs = append(recs, *rec.Keep())
 	}
 	batch.Unref()
 	return zbuf.Array(recs), nil

--- a/proc/shape/shape.go
+++ b/proc/shape/shape.go
@@ -61,10 +61,9 @@ func (p *Proc) pullInput() error {
 
 func (p *Proc) writeBatch(batch zbuf.Batch) error {
 	defer batch.Unref()
-	l := batch.Length()
-	for i := 0; i < l; i++ {
-		rec := batch.Index(i)
-		if err := p.shaper.Write(rec); err != nil {
+	zvals := batch.Values()
+	for i := range zvals {
+		if err := p.shaper.Write(&zvals[i]); err != nil {
 			return err
 		}
 	}

--- a/proc/spill/merge.go
+++ b/proc/spill/merge.go
@@ -59,7 +59,7 @@ func (r *MergeSort) Cleanup() {
 // temp directory.  Since we sort each chunk in memory before spilling, the
 // different chunks can be easily merged into sorted order when reading back
 // the chunks sequentially.
-func (r *MergeSort) Spill(ctx context.Context, recs []*zed.Value) error {
+func (r *MergeSort) Spill(ctx context.Context, recs []zed.Value) error {
 	// Sorting can be slow, so check for cancellation.
 	if err := goWithContext(ctx, func() {
 		expr.SortStable(recs, r.compareFn)

--- a/proc/spill/peeker.go
+++ b/proc/spill/peeker.go
@@ -14,12 +14,11 @@ type peeker struct {
 	ordinal    int
 }
 
-func newPeeker(ctx context.Context, filename string, ordinal int, recs []*zed.Value, zctx *zed.Context) (*peeker, error) {
+func newPeeker(ctx context.Context, filename string, ordinal int, arr zbuf.Array, zctx *zed.Context) (*peeker, error) {
 	f, err := NewFileWithPath(filename, zctx)
 	if err != nil {
 		return nil, err
 	}
-	arr := zbuf.Array(recs)
 	if err := zio.CopyWithContext(ctx, f, &arr); err != nil {
 		f.CloseAndRemove()
 		return nil, err

--- a/proc/switcher/switch.go
+++ b/proc/switcher/switch.go
@@ -61,7 +61,7 @@ func (s *Switcher) gather() {
 }
 
 func (s *Switcher) run() {
-	records := make([][]*zed.Value, s.n)
+	records := make([][]zed.Value, s.n)
 	results := make([]proc.Result, s.n)
 	for {
 		s.gather()
@@ -73,17 +73,18 @@ func (s *Switcher) run() {
 			s.sendEOS(proc.Result{batch, err})
 			continue
 		}
-		for _, rec := range batch.Records() {
-			if i := s.match(rec); i >= 0 {
-				if records[i] == nil {
-					records[i] = make([]*zed.Value, 0, batch.Length())
+		zvals := batch.Values()
+		for i := range zvals {
+			if j := s.match(&zvals[i]); j >= 0 {
+				if records[j] == nil {
+					records[j] = make([]zed.Value, 0, len(zvals))
 				}
-				records[i] = append(records[i], rec)
+				records[j] = append(records[j], zvals[i])
 			}
 		}
 		for i := range records {
 			if records[i] != nil {
-				results[i] = proc.Result{zbuf.Array(records[i]), nil}
+				results[i] = proc.Result{Batch: zbuf.Array(records[i])}
 				records[i] = nil
 			}
 		}

--- a/proc/tail/tail.go
+++ b/proc/tail/tail.go
@@ -11,7 +11,7 @@ type Proc struct {
 	limit  int
 	count  int
 	off    int
-	q      []*zed.Value
+	q      []zed.Value
 }
 
 func New(parent proc.Interface, limit int) *Proc {
@@ -19,7 +19,7 @@ func New(parent proc.Interface, limit int) *Proc {
 	return &Proc{
 		parent: parent,
 		limit:  limit,
-		q:      make([]*zed.Value, limit),
+		q:      make([]zed.Value, limit),
 	}
 }
 
@@ -31,7 +31,7 @@ func (p *Proc) tail() zbuf.Batch {
 	if p.count < p.limit {
 		start = 0
 	}
-	out := make([]*zed.Value, p.count)
+	out := make([]zed.Value, p.count)
 	for k := 0; k < p.count; k++ {
 		out[k] = p.q[(start+k)%p.limit]
 	}
@@ -47,8 +47,9 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		if proc.EOS(batch, err) {
 			return p.tail(), nil
 		}
-		for k := 0; k < batch.Length(); k++ {
-			p.q[p.off] = batch.Index(k).Keep()
+		zvals := batch.Values()
+		for i := range zvals {
+			p.q[p.off] = *zvals[i].Keep()
 			p.off = (p.off + 1) % p.limit
 			p.count++
 			if p.count >= p.limit {

--- a/proc/top/top.go
+++ b/proc/top/top.go
@@ -47,8 +47,9 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		if batch == nil {
 			return p.sorted(), nil
 		}
-		for k := 0; k < batch.Length(); k++ {
-			p.consume(batch.Index(k))
+		zvals := batch.Values()
+		for i := range zvals {
+			p.consume(&zvals[i])
 		}
 		batch.Unref()
 		if p.flushEvery {
@@ -84,10 +85,9 @@ func (t *Proc) sorted() zbuf.Batch {
 	if t.records == nil {
 		return nil
 	}
-	out := make([]*zed.Value, t.records.Len())
+	out := make([]zed.Value, t.records.Len())
 	for i := t.records.Len() - 1; i >= 0; i-- {
-		rec := heap.Pop(t.records).(*zed.Value)
-		out[i] = rec
+		out[i] = *heap.Pop(t.records).(*zed.Value)
 	}
 	// clear records
 	t.records = nil

--- a/proc/uniq/uniq.go
+++ b/proc/uniq/uniq.go
@@ -44,7 +44,7 @@ func (p *Proc) wrap(t *zed.Value) *zed.Value {
 	return t
 }
 
-func (p *Proc) appendUniq(out []*zed.Value, t *zed.Value) []*zed.Value {
+func (p *Proc) appendUniq(out []zed.Value, t *zed.Value) []zed.Value {
 	if p.count == 0 {
 		p.last = t.Keep()
 		p.count = 1
@@ -53,7 +53,7 @@ func (p *Proc) appendUniq(out []*zed.Value, t *zed.Value) []*zed.Value {
 		p.count++
 		return out
 	}
-	out = append(out, p.wrap(p.last))
+	out = append(out, *p.wrap(p.last))
 	p.last = t.Keep()
 	p.count = 1
 	return out
@@ -73,11 +73,12 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 			}
 			t := p.wrap(p.last)
 			p.last = nil
-			return zbuf.Array{t}, nil
+			return zbuf.Array{*t}, nil
 		}
-		var out []*zed.Value
-		for k := 0; k < batch.Length(); k++ {
-			out = p.appendUniq(out, batch.Index(k))
+		var out []zed.Value
+		zvals := batch.Values()
+		for i := range zvals {
+			out = p.appendUniq(out, &zvals[i])
 		}
 		batch.Unref()
 		if len(out) > 0 {

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -7,8 +7,9 @@ import (
 
 // Array is a slice of of records that implements the Batch and
 // the Reader interfaces.
-type Array []*zed.Value
+type Array []zed.Value
 
+var _ Batch = (*Array)(nil)
 var _ zio.Reader = (*Array)(nil)
 var _ zio.Writer = (*Array)(nil)
 
@@ -20,24 +21,12 @@ func (a Array) Unref() {
 	// do nothing... let the GC reclaim it
 }
 
-func (a Array) Length() int {
-	return len(a)
-}
-
-func (a Array) Records() []*zed.Value {
+func (a Array) Values() []zed.Value {
 	return a
 }
 
-//XXX should change this to Record()
-func (a Array) Index(k int) *zed.Value {
-	if k < len(a) {
-		return a[k]
-	}
-	return nil
-}
-
 func (a *Array) Append(r *zed.Value) {
-	*a = append(*a, r)
+	*a = append(*a, *r)
 }
 
 func (a *Array) Write(r *zed.Value) error {
@@ -50,7 +39,7 @@ func (a *Array) Write(r *zed.Value) error {
 func (a *Array) Read() (*zed.Value, error) {
 	var rec *zed.Value
 	if len(*a) > 0 {
-		rec = (*a)[0]
+		rec = &(*a)[0]
 		*a = (*a)[1:]
 	}
 	return rec, nil

--- a/zio/zngio/batch.go
+++ b/zio/zngio/batch.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zbuf"
 )
 
 type batch struct {
@@ -12,6 +13,8 @@ type batch struct {
 	recs []zed.Value
 	refs int32
 }
+
+var _ zbuf.Batch = (*batch)(nil)
 
 var batchPool sync.Pool
 
@@ -28,17 +31,7 @@ func newBatch(buf *buffer) *batch {
 
 func (b *batch) add(r *zed.Value) { b.recs = append(b.recs, *r) }
 
-func (b *batch) Index(i int) *zed.Value { return &b.recs[i] }
-
-func (b *batch) Length() int { return len(b.recs) }
-
-func (b *batch) Records() []*zed.Value {
-	var recs []*zed.Value
-	for i := range b.recs {
-		recs = append(recs, &b.recs[i])
-	}
-	return recs
-}
+func (b *batch) Values() []zed.Value { return b.recs }
 
 func (b *batch) Ref() { atomic.AddInt32(&b.refs, 1) }
 

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -217,7 +217,7 @@ func (w *worker) scanBatch(buf *buffer, mapper *zed.Mapper, streamZctx *zed.Cont
 		}
 	}
 	w.scanner.stats.Add(stats)
-	if batch.Length() == 0 {
+	if len(batch.Values()) == 0 {
 		batch.Unref()
 		return nil, nil
 	}


### PR DESCRIPTION
The zbuf.Batch interface is organized around slices of pointers to
zed.Values.  Reorient it around slices of zed.Values for better cache
locality and marginally better ergonomics.  Specifically, replace the
Index, Length, and Records methods with the new Values method.

This touches many fields, parameters, and variables whose names are
variations on "record". They should all be updated to variations on
"Zed value", but to keep this diff small, I've left that for a separate PR.

For #1762.

Depends on #3211.