### PR TITLE
add zbuf.WriteBatch

### DIFF
--- a/api/queryio/driver.go
+++ b/api/queryio/driver.go
@@ -55,14 +55,8 @@ func (d *Driver) Write(cid int, batch zbuf.Batch) error {
 			return err
 		}
 	}
-	zvals := batch.Values()
-	for i := range zvals {
-		if err := d.writer.Write(&zvals[i]); err != nil {
-			return err
-		}
-	}
-	batch.Unref()
-	return nil
+	defer batch.Unref()
+	return zbuf.WriteBatch(d.writer, batch)
 }
 
 func (d *Driver) ChannelEnd(channelID int) error {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -214,14 +214,8 @@ func (d *CLI) Write(cid int, batch zbuf.Batch) error {
 	if len(d.writers) == 1 {
 		cid = 0
 	}
-	zvals := batch.Values()
-	for i := range zvals {
-		if err := d.writers[cid].Write(&zvals[i]); err != nil {
-			return err
-		}
-	}
-	batch.Unref()
-	return nil
+	defer batch.Unref()
+	return zbuf.WriteBatch(d.writers[cid], batch)
 }
 
 func (d *CLI) Warn(msg string) error {
@@ -244,14 +238,8 @@ func (d *transformDriver) Write(cid int, batch zbuf.Batch) error {
 	if cid != 0 {
 		return errors.New("transform proc with multiple tails")
 	}
-	zvals := batch.Values()
-	for i := range zvals {
-		if err := d.w.Write(&zvals[i]); err != nil {
-			return err
-		}
-	}
-	batch.Unref()
-	return nil
+	defer batch.Unref()
+	return zbuf.WriteBatch(d.w, batch)
 }
 
 func (d *transformDriver) Warn(warning string) error           { return nil }

--- a/proc/fuse/fuse.go
+++ b/proc/fuse/fuse.go
@@ -56,21 +56,11 @@ func (p *Proc) pullInput() error {
 		if batch == nil {
 			return nil
 		}
-		if err := p.writeBatch(batch); err != nil {
+		if err := zbuf.WriteBatch(p.fuser, batch); err != nil {
 			return err
 		}
+		batch.Unref()
 	}
-}
-
-func (p *Proc) writeBatch(batch zbuf.Batch) error {
-	defer batch.Unref()
-	zvals := batch.Values()
-	for i := range zvals {
-		if err := p.fuser.Write(&zvals[i]); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (p *Proc) pushOutput() error {

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -253,20 +253,15 @@ func (cr *countReader) Read() (*zed.Value, error) {
 }
 
 type testGroupByDriver struct {
-	n      int
 	writer zio.Writer
 	cb     func(n int)
 }
 
 func (d *testGroupByDriver) Write(cid int, batch zbuf.Batch) error {
-	zvals := batch.Values()
-	for i := range zvals {
-		d.n++
-		if err := d.writer.Write(&zvals[i]); err != nil {
-			return err
-		}
+	if err := zbuf.WriteBatch(d.writer, batch); err != nil {
+		return err
 	}
-	d.cb(d.n)
+	d.cb(len(batch.Values()))
 	return nil
 }
 

--- a/proc/shape/shape.go
+++ b/proc/shape/shape.go
@@ -53,21 +53,11 @@ func (p *Proc) pullInput() error {
 		if err != nil || batch == nil {
 			return err
 		}
-		if err := p.writeBatch(batch); err != nil {
+		if err := zbuf.WriteBatch(p.shaper, batch); err != nil {
 			return err
 		}
+		batch.Unref()
 	}
-}
-
-func (p *Proc) writeBatch(batch zbuf.Batch) error {
-	defer batch.Unref()
-	zvals := batch.Values()
-	for i := range zvals {
-		if err := p.shaper.Write(&zvals[i]); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (p *Proc) pushOutput() error {


### PR DESCRIPTION
We have seven copies of the loop that writes values from a zbuf.Batch to
a zio.Writer.  Add zbuf.WriteBatch to do that and replace the loops.