### PR TITLE
improve zbuf.Merger performance with a heap

### DIFF
--- a/zbuf/merger.go
+++ b/zbuf/merger.go
@@ -2,12 +2,15 @@ package zbuf
 
 import (
 	"bytes"
+	"container/heap"
 	"context"
 	"sync"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/expr"
 	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/zio"
+	"golang.org/x/sync/errgroup"
 )
 
 // A Merger merges multiple upstream Pullers into one downstream Puller.
@@ -17,25 +20,20 @@ import (
 // would otherwise block waiting for an adjacent puller to finish but the
 // Merger is waiting on the upstream puller.
 type Merger struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
 	cmp     expr.CompareFn
-	once    sync.Once
-	pullers []*mergerPuller
-	wg      sync.WaitGroup
+	pullers []Puller
+
+	cancel context.CancelFunc
+	ctx    context.Context
+	group  *errgroup.Group
+	once   sync.Once
+	// Maintained as a min-heap on cmp of mergerUpstream.zvals[0] (see Less)
+	// so that the next Read always returns upstreams[0].zvals[0].
+	upstreams []*mergerUpstream
 }
 
-type mergerPuller struct {
-	Puller
-	ch    chan batch
-	batch Batch
-	zvals []zed.Value
-}
-
-type batch struct {
-	Batch
-	err error
-}
+var _ Puller = (*Merger)(nil)
+var _ zio.Reader = (*Merger)(nil)
 
 func NewCompareFn(layout order.Layout) expr.CompareFn {
 	nullsMax := layout.Order == order.Asc
@@ -63,127 +61,113 @@ func totalOrderCompare(fn expr.CompareFn) expr.CompareFn {
 
 func NewMerger(ctx context.Context, pullers []Puller, cmp expr.CompareFn) *Merger {
 	ctx, cancel := context.WithCancel(ctx)
-	m := &Merger{
-		ctx:    ctx,
-		cmp:    cmp,
-		cancel: cancel,
+	group, ctx := errgroup.WithContext(ctx)
+	return &Merger{
+		cmp:     cmp,
+		pullers: append([]Puller(nil), pullers...),
+		cancel:  cancel,
+		ctx:     ctx,
+		group:   group,
 	}
-	m.pullers = make([]*mergerPuller, 0, len(pullers))
-	for _, p := range pullers {
-		m.pullers = append(m.pullers, &mergerPuller{Puller: p, ch: make(chan batch)})
-	}
-	return m
-}
-
-func (m *Merger) run() {
-	for _, p := range m.pullers {
-		m.wg.Add(1)
-		puller := p
-		go func() {
-			defer m.wg.Done()
-			for {
-				b, err := puller.Pull()
-				select {
-				case puller.ch <- batch{Batch: b, err: err}:
-					if b == nil && err == nil {
-						// EOS
-						return
-					}
-				case <-m.ctx.Done():
-					return
-				}
-			}
-		}()
-	}
-}
-
-// Read fulfills Reader so that we can use ReadBatch or
-// use Merger as a Reader directly.
-func (m *Merger) Read() (*zed.Value, error) {
-	m.once.Do(m.run)
-	leader, err := m.findLeader()
-	if leader < 0 || err != nil {
-		m.Cancel()
-		m.wg.Wait()
-		return nil, err
-	}
-	return m.pullers[leader].next(), nil
-}
-
-func (m *mergerPuller) next() *zed.Value {
-	rec := m.zvals[0]
-	m.zvals = m.zvals[1:]
-	m.batch = nil
-	return &rec
-}
-
-func (m *Merger) findLeader() (int, error) {
-	leader := -1
-	for k, p := range m.pullers {
-		if p == nil {
-			continue
-		}
-		if len(p.zvals) == 0 {
-			select {
-			case b := <-p.ch:
-				if b.err != nil {
-					return -1, b.err
-				}
-				if b.Batch == nil {
-					// EOS
-					m.pullers[k] = nil
-					continue
-				}
-				// We're keeping records owned by res.Batch so don't call Unref.
-				// XXX this means the batch won't be returned to
-				// the pool and instead will run through GC.
-				p.zvals = b.Batch.Values()
-				p.batch = b.Batch
-			case <-m.ctx.Done():
-				return -1, m.ctx.Err()
-			}
-		}
-		if leader == -1 || m.cmp(&p.zvals[0], &m.pullers[leader].zvals[0]) < 0 {
-			leader = k
-		}
-	}
-	return leader, nil
-}
-
-func (m *Merger) overlaps(leader int) bool {
-	hol := m.pullers[leader]
-	if hol.batch == nil {
-		return true
-	}
-	last := &hol.zvals[len(hol.zvals)-1]
-	for k, p := range m.pullers {
-		if k == leader || p == nil {
-			continue
-		}
-		if m.cmp(last, &p.zvals[0]) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func (m *Merger) Pull() (Batch, error) {
-	m.once.Do(m.run)
-	leader, err := m.findLeader()
-	if leader < 0 || err != nil {
-		m.Cancel()
-		m.wg.Wait()
-		return nil, err
-	}
-	if !m.overlaps(leader) {
-		b := m.pullers[leader].batch
-		m.pullers[leader].zvals = nil
-		return b, nil
-	}
-	const batchLen = 100 // XXX
-	return readBatch(m, batchLen)
 }
 
 func (m *Merger) Cancel() {
 	m.cancel()
+}
+
+func (m *Merger) Pull() (Batch, error) {
+	m.once.Do(m.run)
+	if m.Len() == 0 {
+		return nil, m.group.Wait()
+	}
+	min := heap.Pop(m).(*mergerUpstream)
+	if m.Len() == 0 || m.cmp(&min.zvals[len(min.zvals)-1], &m.upstreams[0].zvals[0]) <= 0 {
+		// Either min is the only upstreams or min's last value is less
+		// than or equal to the next upstream's first value.  Either
+		// way, it's safe to return min's remaining values as a batch.
+		batch := min.batch
+		if len(min.zvals) < len(batch.Values()) {
+			batch = Array(min.zvals)
+		}
+		if min.receive() {
+			heap.Push(m, min)
+		}
+		return batch, nil
+	}
+	heap.Push(m, min)
+	const batchLen = 100 // XXX
+	return readBatch(m, batchLen)
+}
+
+func (m *Merger) Read() (*zed.Value, error) {
+	if m.Len() == 0 {
+		return nil, m.group.Wait()
+	}
+	u := m.upstreams[0]
+	zv := &u.zvals[0]
+	u.zvals = u.zvals[1:]
+	if len(u.zvals) > 0 || u.receive() {
+		heap.Fix(m, 0)
+	} else {
+		heap.Pop(m)
+	}
+	return zv, nil
+}
+
+func (m *Merger) run() {
+	for _, p := range m.pullers {
+		p := p
+		ch := make(chan Batch)
+		m.group.Go(func() error {
+			defer close(ch)
+			for {
+				batch, err := p.Pull()
+				if batch == nil || err != nil {
+					return err
+				}
+				select {
+				case ch <- batch:
+				case <-m.ctx.Done():
+					return m.ctx.Err()
+				}
+			}
+		})
+		if u := (&mergerUpstream{ch: ch}); u.receive() {
+			m.upstreams = append(m.upstreams, u)
+		}
+	}
+	heap.Init(m)
+}
+
+func (m *Merger) Len() int { return len(m.upstreams) }
+
+func (m *Merger) Less(i, j int) bool {
+	return m.cmp(&m.upstreams[i].zvals[0], &m.upstreams[j].zvals[0]) < 0
+}
+
+func (m *Merger) Swap(i, j int) { m.upstreams[i], m.upstreams[j] = m.upstreams[j], m.upstreams[i] }
+
+func (m *Merger) Push(x interface{}) { m.upstreams = append(m.upstreams, x.(*mergerUpstream)) }
+
+func (m *Merger) Pop() interface{} {
+	x := m.upstreams[len(m.upstreams)-1]
+	m.upstreams = m.upstreams[:len(m.upstreams)-1]
+	return x
+}
+
+type mergerUpstream struct {
+	ch    <-chan Batch
+	batch Batch
+	zvals []zed.Value
+}
+
+// receive tries to receive the next batch.  It returns false when no batches
+// remain.
+func (m *mergerUpstream) receive() bool {
+	batch, ok := <-m.ch
+	m.batch = batch
+	if m.batch != nil {
+		m.zvals = batch.Values()
+	}
+	return ok
 }


### PR DESCRIPTION
In zbuf.Merger, findLeader and overlaps both do a linear search over
pullers.  If pullers is large and cmp is expensive, these searches are
slow.  Improve performance by replacing them with a heap using
container/heap.

---

Some performance measurements follow. They cover two scenarios for three commits.

**Scenarios**, both with pool key `ts`:
1. Scan a pool containing a single data object comprising the 26 files in `zed-sample-data/zeek-default/`
2. Scan a pool containing 26 data objects, each comprising one file in `zed-sample-data/zeek-default/`

**Commits**:
- 76ba623f75d3b2c251cc765620fc8eee5248f042: last commit before #3186, which removed caching from zed.Record.Ts
- 9e8e6b759dc05699c734beb467d90368f13d6cd9: tip of `main`
- c9d6af7ee8001a67b8b5c79f97a30a2d8dc2ddfe: tip of this branch, `zbuf.Merger-heap`

**Summary**, using the fastest times for each scenario and commit and showing the time ratio of this branch to the other commits:
- 0.15 / 0.17 ≈ 0.9 for both other commits in scenario 1,
- 1.41 / 0.52 ≈ 2.7 for 76ba623f75d3b2c251cc765620fc8eee5248f042 in scenario 2, and
- 1.41 / 8.17 ≈ 0.2 for main in scenario 2.

**Data**:
```sh
$ bash -e <<'EOF'
PATH=$PWD/dist:$PATH
export ZED_LAKE_ROOT=root
for c in \
  'zed lake load -q zed-sample-data/zeek-default/*' \
  'for f in zed-sample-data/zeek-default/*; do zed lake load -q $f; done' \
; do
  rm -rf $ZED_LAKE_ROOT
  mkdir $ZED_LAKE_ROOT
  zed lake init -q $ZED_LAKE_ROOT
  zed lake create -q pool
  zed lake use -q pool@main
  echo === $c
  eval $c
  for r in 76ba623f75d3b2c251cc765620fc8eee5248f042 main zbuf.Merger-heap; do
    git checkout -q $r
    git describe --all --long
    make build
    for _ in 1 2 3 4 5; do
      /usr/bin/time zed lake query -f null '*'
    done
  done
done
EOF
=== zed lake load -q zed-sample-data/zeek-default/capture_loss.log.gz zed-sample-data/zeek-default/conn.log.gz zed-sample-data/zeek-default/dce_rpc.log.gz zed-sample-data/zeek-default/dns.log.gz zed-sample-data/zeek-default/dpd.log.gz zed-sample-data/zeek-default/files.log.gz zed-sample-data/zeek-default/ftp.log.gz zed-sample-data/zeek-default/http.log.gz zed-sample-data/zeek-default/kerberos.log.gz zed-sample-data/zeek-default/modbus.log.gz zed-sample-data/zeek-default/notice.log.gz zed-sample-data/zeek-default/ntlm.log.gz zed-sample-data/zeek-default/ntp.log.gz zed-sample-data/zeek-default/pe.log.gz zed-sample-data/zeek-default/rdp.log.gz zed-sample-data/zeek-default/rfb.log.gz zed-sample-data/zeek-default/smb_files.log.gz zed-sample-data/zeek-default/smb_mapping.log.gz zed-sample-data/zeek-default/smtp.log.gz zed-sample-data/zeek-default/snmp.log.gz zed-sample-data/zeek-default/ssh.log.gz zed-sample-data/zeek-default/ssl.log.gz zed-sample-data/zeek-default/stats.log.gz zed-sample-data/zeek-default/syslog.log.gz zed-sample-data/zeek-default/weird.log.gz zed-sample-data/zeek-default/x509.log.gz
tags/v0.31.0-19-g76ba623f
        0.40 real         0.64 user         0.11 sys
        0.18 real         0.67 user         0.12 sys
        0.26 real         0.77 user         0.14 sys
        0.17 real         0.67 user         0.12 sys
        0.18 real         0.67 user         0.12 sys
heads/main-0-g9e8e6b75
        0.40 real         0.51 user         0.09 sys
        0.17 real         0.55 user         0.09 sys
        0.18 real         0.52 user         0.09 sys
        0.19 real         0.50 user         0.08 sys
        0.19 real         0.52 user         0.09 sys
heads/zbuf.Merger-heap-0-gc9d6af7e
        0.41 real         0.55 user         0.09 sys
        0.15 real         0.58 user         0.09 sys
        0.14 real         0.58 user         0.08 sys
        0.15 real         0.54 user         0.08 sys
        0.15 real         0.55 user         0.08 sys
=== for f in zed-sample-data/zeek-default/*; do zed lake load -q $f; done
tags/v0.31.0-19-g76ba623f
        0.78 real         1.06 user         0.23 sys
        0.52 real         1.05 user         0.23 sys
        0.54 real         1.05 user         0.22 sys
        0.62 real         1.12 user         0.24 sys
        0.65 real         1.18 user         0.26 sys
heads/main-0-g9e8e6b75
        9.26 real         9.37 user         0.42 sys
        8.25 real         8.80 user         0.31 sys
        8.17 real         8.71 user         0.30 sys
        8.36 real         8.91 user         0.30 sys
        8.51 real         9.06 user         0.31 sys
heads/zbuf.Merger-heap-0-gc9d6af7e
        1.87 real         2.00 user         0.29 sys
        1.43 real         1.88 user         0.21 sys
        1.41 real         1.86 user         0.21 sys
        1.39 real         1.84 user         0.21 sys
        1.39 real         1.84 user         0.21 sys
```
