### PR TITLE
Query endpoint: default to ZSON response

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -36,13 +36,14 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 	if !ok {
 		return
 	}
-	format, err := api.MediaTypeToFormat(r.Header.Get("Accept"))
-	if err != nil {
-		if !errors.Is(err, api.ErrMediaTypeUnspecified) {
-			w.Error(zqe.ErrInvalid(err))
-			return
-		}
-		format = "zjson"
+	accept := r.Header.Get("Accept")
+	if accept == "" || accept == api.MediaTypeAny {
+		accept = api.MediaTypeZSON
+	}
+	format, err := api.MediaTypeToFormat(accept)
+	if err != nil && !errors.Is(err, api.ErrMediaTypeUnspecified) {
+		w.Error(zqe.ErrInvalid(err))
+		return
 	}
 	d, err := queryio.NewDriver(zio.NopCloser(w), format, !noctrl)
 	if err != nil {

--- a/service/ztests/curl-query-default-zson.yaml
+++ b/service/ztests/curl-query-default-zson.yaml
@@ -1,0 +1,12 @@
+script: |
+  source service.sh
+  zapi create -q test
+  curl -H "Accept: " -d '{"query":"from :pools | cut name"}' http://${ZED_LAKE_HOST}/query?noctrl=T
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      {name:"test"}


### PR DESCRIPTION
For the query endpoint, if the "Accept" endpoint is not specified
default to ZSON.

Part of brimdata/brim#1905