### PR TITLE
allow leading split operator

### DIFF
--- a/compiler/ast/dag/operator.go
+++ b/compiler/ast/dag/operator.go
@@ -261,8 +261,21 @@ func (seq *Sequential) IsEntry() bool {
 	if len(seq.Ops) == 0 {
 		return false
 	}
-	_, ok := seq.Ops[0].(*From)
-	return ok
+	switch op := seq.Ops[0].(type) {
+	case *From:
+		return true
+	case *Parallel:
+		if len(op.Ops) == 0 {
+			return false
+		}
+		for _, o := range op.Ops {
+			if s, ok := o.(*Sequential); !ok || !s.IsEntry() {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func (seq *Sequential) Prepend(front Op) {

--- a/compiler/kernel/proc.go
+++ b/compiler/kernel/proc.go
@@ -281,6 +281,17 @@ func (b *Builder) compileSequential(seq *dag.Sequential, parents []proc.Interfac
 }
 
 func (b *Builder) compileParallel(parallel *dag.Parallel, parents []proc.Interface) ([]proc.Interface, error) {
+	if len(parents) == 0 {
+		var procs []proc.Interface
+		for _, op := range parallel.Ops {
+			proc, err := b.compile(op, nil)
+			if err != nil {
+				return nil, err
+			}
+			procs = append(procs, proc...)
+		}
+		return procs, nil
+	}
 	n := len(parallel.Ops)
 	if len(parents) == 1 {
 		// Single parent: insert a splitter and wire to each branch.

--- a/compiler/semantic/ast.go
+++ b/compiler/semantic/ast.go
@@ -2,7 +2,6 @@ package semantic
 
 import (
 	"context"
-	"errors"
 
 	"github.com/brimdata/zed/compiler/ast"
 	"github.com/brimdata/zed/compiler/ast/dag"
@@ -12,9 +11,6 @@ import (
 
 // Analyze analysis the AST and prepares it for runtime compilation.
 func Analyze(ctx context.Context, seq *ast.Sequential, constsAST []ast.Proc, adaptor proc.DataAdaptor, head *lakeparse.Commitish) (*dag.Sequential, []dag.Op, error) {
-	if !isFrom(seq) {
-		return nil, nil, errors.New("Zed program does not begin with a data source")
-	}
 	scope := NewScope()
 	scope.Enter()
 	consts, err := semConsts(scope, constsAST)

--- a/compiler/ztests/split-err.yaml
+++ b/compiler/ztests/split-err.yaml
@@ -1,0 +1,13 @@
+script: |
+  ! zq '
+    split (
+      => pass;
+      => from (file /dev/null => pass;);
+    )
+  ' /dev/null
+
+
+outputs:
+  - name: stderr
+    data: |
+      upstream data source blocked by 'from operator'

--- a/compiler/ztests/split-from.yaml
+++ b/compiler/ztests/split-from.yaml
@@ -1,0 +1,22 @@
+script: |
+  zq -z -I query.zed
+
+inputs:
+  - name: query.zed
+    data: |
+      split (
+        => from (file a.zson => pass;);
+        => from (file b.zson => pass;);
+      ) | sort a
+  - name: a.zson
+    data: |
+      {a:1}
+  - name: b.zson
+    data: |
+      {a:2}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1}
+      {a:2}

--- a/compiler/ztests/split.yaml
+++ b/compiler/ztests/split.yaml
@@ -1,0 +1,8 @@
+zed: split (=> pass; => pass;)
+
+input: |
+  {a:1}
+
+output: |
+  {a:1}
+  {a:1}

--- a/expr/ztests/type-map.yaml
+++ b/expr/ztests/type-map.yaml
@@ -5,7 +5,7 @@ zed: |
     "conn": conn,
     "dns": dns
   }|
-  * | split (
+  split (
     => cut schema:=schemas[_path];
     => missing(schemas[_path]) | put _UNCLASSIFIED:=true;
   ) | sort .

--- a/proc/ztests/rename-share.yaml
+++ b/proc/ztests/rename-share.yaml
@@ -1,5 +1,5 @@
 # tests that a rename isn't visible to other procs operating on same records.
-zed: '* | split (=>rename id2:=id; =>cut id.orig_h;) | sort id'
+zed: 'split (=> rename id2:=id; => cut id.orig_h;) | sort id'
 
 input: |
   {id:{orig_h:39681(port=(uint16)),resp_h:3389(port)}}


### PR DESCRIPTION
Allow a leading split operator, including one whose branches all have a
leading from operator, as in "split (=> from (...); => from (...);)".