### PR TITLE
remove leading "* |" from Zed queries where possible

### DIFF
--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -97,7 +97,7 @@ func (o *Optimizer) parallelizeTrunk(seq *dag.Sequential, trunk *dag.Trunk, repl
 			// If the inbound layout doesn't match up here then the
 			// every operator won't work right so we flag
 			// a compilation error..., e.g., it's like saying
-			//   * | sort x | every 1h count() by _path
+			//   sort x | every 1h count() by _path
 			// Actually, this could work it just can't stream the
 			// every's as they finish.  We should work out this logic.
 			// Otherwise, the runtime builder will insert a simple combiner.

--- a/compiler/parser/invalid.zed
+++ b/compiler/parser/invalid.zed
@@ -1,3 +1,3 @@
-* | count() by _path; count() by addr
-* | sort -r -r,-r,-r
-* | sort -r a a, b, c
+count() by _path; count() by addr
+sort -r -r,-r,-r
+sort -r a a, b, c

--- a/compiler/parser/valid.zed
+++ b/compiler/parser/valid.zed
@@ -1,20 +1,20 @@
 foo
 foo | count()
-* | count() with -limit 10
-* | count() by _path with -limit 10
-* | every 1h count() by _path with -limit 10
-* | filter x==1
+count() with -limit 10
+count() by _path with -limit 10
+every 1h count() by _path with -limit 10
+filter x==1
 _path=='conn'
 _path=='conn' id.resp_p==80
-* | count(), sum(foo)
-* | split (=>count() by _path; =>count() by addr;)
-* | switch (foo => count() by _path; field==1 => count() by addr;)
-* | count() by _path | count() by addr
-* | split (=>count() by _path; =>sort;) | split (=>count() by addr;)
-* | switch (foo => count() by _path; field==1 => sort;) | switch (* =>count() by addr;)
-* | sort -r
-* | sort -r a, b, c
-* | sort -r a, b, c
+count(), sum(foo)
+split (=>count() by _path; =>count() by addr;)
+switch (foo => count() by _path; field==1 => count() by addr;)
+count() by _path | count() by addr
+split (=>count() by _path; =>sort;) | split (=>count() by addr;)
+switch (foo => count() by _path; field==1 => sort;) | switch (* =>count() by addr;)
+sort -r
+sort -r a, b, c
+sort -r a, b, c
 count() | sort
 top 1
 top 1 -flush

--- a/compiler/parser/ztests/proc-search.yaml
+++ b/compiler/parser/ztests/proc-search.yaml
@@ -1,4 +1,4 @@
-zed: '* | bar'
+zed: bar
 
 input: |
   {s1:"foo",s2:"bar"}

--- a/docs/language/expr-TODO.md
+++ b/docs/language/expr-TODO.md
@@ -293,13 +293,13 @@ count() where acme.com or google.com
 ```
 Consider another examples
 ```
-* | put isConn=_path=conn, isSSL=_path=ssl, portsMatch=id.orig_h=id.orig_p | ...
+put isConn=_path=conn, isSSL=_path=ssl, portsMatch=id.orig_h=id.orig_p | ...
 ```
 Here, `=` means two different things (assignment and comparison).  The parse
 knows by context which is which but it can look a bit funny.  This might
 make more sense:
 ```
-* | put isConn=_path==conn, isSSL=_path==ssl, portsMatch=id.orig_h==id.orig_p | ...
+put isConn=_path==conn, isSSL=_path==ssl, portsMatch=id.orig_h==id.orig_p | ...
 ```
 But now, we don't want to have to say this...
 ```
@@ -360,18 +360,18 @@ search predicates.
 That said, keyword search does not appear in expression context.
 e.g.,
 ```
-* | put x=foo
+put x=foo
 ```
 means assign the field foo to x.  The RHS is never a keyword search resulting
 in a boolean for matches to the word "foo".   That said, search syntax can
 appear inside of an expression with the explicit use of the `match` function,
 e.g.,
 ```
-* | put foundIt=match(foo)
+put foundIt=match(foo)
 ```
 or from our example above...
 ```
-* | put foundIt=match("John Smith" (acme.com OR gmail.com))
+put foundIt=match("John Smith" (acme.com OR gmail.com))
 ```
 
 > Note: we may want to make `put x=foo==bar` treat bar as a string to be
@@ -650,7 +650,7 @@ in the Zed:
 ```
 let port = uint16
 let socket = {orig_h:ip,orig_p:port,resp_h:ip,resp_p:port}
-* | put hasSocket=id.is(socket)
+put hasSocket=id.is(socket)
 ```
 
 We should have methods for all of this so we could say `.is(string)`

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -162,7 +162,7 @@ func New(name, input, output, cmd string) test.Internal {
 	output = strings.ReplaceAll(output, "\n\n", "\n")
 	return test.Internal{
 		Name:         name,
-		Query:        "* | " + cmd,
+		Query:        cmd,
 		Input:        input,
 		OutputFormat: "zson",
 		Expected:     test.Trim(output),


### PR DESCRIPTION
It still appears in cmd/zed/README.md and docs/language/search-syntax.md
as documentation and in compiler/ztests/from-pass.yaml because the
compiler requires it.