### PR TITLE
fix lake/ztests/delete.yaml

### DIFF
--- a/lake/ztests/delete.yaml
+++ b/lake/ztests/delete.yaml
@@ -4,10 +4,10 @@ script: |
   zed lake create -q test
   zed lake use -q test@main
   zed lake load -q 1.zson
+  id=$(zed lake query -f text "from test@main:objects | cut id:=ksuid(id) | tail 1")
   zed lake load -q 2.zson
   zed lake query -z "*"
   echo ===
-  id=$(zed lake query -f text "from test@main:objects | cut id:=ksuid(id) | tail 1")
   zed lake delete -q $id
   zed lake query -z "*"
 inputs:
@@ -22,4 +22,4 @@ outputs:
       {x:2}
       {x:1}
       ===
-      {x:1}
+      {x:2}


### PR DESCRIPTION
This applies the change to service/ztests/delete.yaml in #3227 to the
similar test in lake/ztests/delete.yaml.

The test in lake/ztests/delete.yaml is flaky because it expects
"from pool@branch:objects" to emit objects in creation order, but the
actual order is undefined.  Fix it by grabbing the first object ID
immediately after creation.