### PR TITLE
Enable embedding custom metadata in the commit journal

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"

--- a/api/api.go
+++ b/api/api.go
@@ -54,9 +54,9 @@ type BranchMergeRequest struct {
 }
 
 type CommitMessage struct {
-	Author string    `zed:"author"`
-	Body   string    `zed:"body"`
-	Meta   string 	 `zed:"meta"`
+	Author string `zed:"author"`
+	Body   string `zed:"body"`
+	Meta   string `zed:"meta"`
 }
 
 type CommitResponse struct {

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"context"
-	
+
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
@@ -55,8 +54,9 @@ type BranchMergeRequest struct {
 }
 
 type CommitMessage struct {
-	Author string `zed:"author"`
-	Body   string `zed:"body"`
+	Author string    `zed:"author"`
+	Body   string    `zed:"body"`
+	Meta   string 	 `zed:"meta"`
 }
 
 type CommitResponse struct {

--- a/cmd/zed/lake/commitflags.go
+++ b/cmd/zed/lake/commitflags.go
@@ -34,16 +34,19 @@ func username() string {
 type CommitFlags struct {
 	User    string
 	Message string
+	Meta    string
 }
 
 func (c *CommitFlags) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&c.User, "user", username(), "user name for commit message")
 	f.StringVar(&c.Message, "message", "", "commit message")
+	f.StringVar(&c.Meta, "meta", "", "application metadata")
 }
 
 func (c *CommitFlags) CommitMessage() api.CommitMessage {
 	return api.CommitMessage{
 		Author: c.User,
 		Body:   c.Message,
+		Meta: 	c.Meta,
 	}
 }

--- a/cmd/zed/lake/commitflags.go
+++ b/cmd/zed/lake/commitflags.go
@@ -47,6 +47,6 @@ func (c *CommitFlags) CommitMessage() api.CommitMessage {
 	return api.CommitMessage{
 		Author: c.User,
 		Body:   c.Message,
-		Meta: 	c.Meta,
+		Meta:   c.Meta,
 	}
 }

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -133,7 +133,7 @@ func (l *LocalSession) Load(ctx context.Context, poolID ksuid.KSUID, branchName 
 	if err != nil {
 		return ksuid.Nil, err
 	}
-	return branch.Load(ctx, r, message.Author, message.Body)
+	return branch.Load(ctx, r, message.Author, message.Body, message.Meta)
 }
 
 func (l *LocalSession) Delete(ctx context.Context, poolID ksuid.KSUID, branchName string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	ErrCommitFailed      = fmt.Errorf("exceeded max update attempts (%d) to branch tip: commit failed", maxCommitRetries)
-	ErrInvalidCommitMeta = errors.New("cannot parse zson string")
+	ErrInvalidCommitMeta = errors.New("cannot parse ZSON string")
 )
 
 type Branch struct {

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	ErrCommitFailed = fmt.Errorf("exceeded max update attempts (%d) to branch tip: commit failed", maxCommitRetries)
+	ErrCommitFailed      = fmt.Errorf("exceeded max update attempts (%d) to branch tip: commit failed", maxCommitRetries)
 	ErrInvalidCommitMeta = errors.New("cannot parse zson string")
 )
 

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -26,7 +26,10 @@ const (
 	maxMessageObjects = 10
 )
 
-var ErrCommitFailed = fmt.Errorf("exceeded max update attempts (%d) to branch tip: commit failed", maxCommitRetries)
+var (
+	ErrCommitFailed = fmt.Errorf("exceeded max update attempts (%d) to branch tip: commit failed", maxCommitRetries)
+	ErrInvalidCommitMeta = errors.New("cannot parse zson string")
+)
 
 type Branch struct {
 	branches.Config
@@ -100,7 +103,7 @@ func loadMeta(meta string) (zed.Value, error) {
 	}
 	zv, err := zson.ParseValue(zed.NewContext(), meta)
 	if err != nil {
-		return zed.Missing, fmt.Errorf("cannot parse zson string %s: %v", zv, err)
+		return zed.Missing, fmt.Errorf("%w %s: %v", ErrInvalidCommitMeta, zv, err)
 	}
 	return zv, nil
 }

--- a/lake/commits/actions.go
+++ b/lake/commits/actions.go
@@ -57,7 +57,7 @@ type Commit struct {
 	Author  string      `zed:"author"`
 	Date    nano.Ts     `zed:"date"`
 	Message string      `zed:"message"`
-	Meta 	zed.Value	`zed:"meta"`
+	Meta    zed.Value   `zed:"meta"`
 }
 
 func (c *Commit) String() string {

--- a/lake/commits/actions.go
+++ b/lake/commits/actions.go
@@ -69,10 +69,6 @@ func (c *Commit) String() string {
 	return fmt.Sprintf("COMMIT %s -> %s %s %s %s", c.ID, c.Parent, c.Date, c.Author, c.Message)
 }
 
-func (c *Commit) AppMeta() zed.Value {
-	return c.Meta
-}
-
 type Delete struct {
 	Commit ksuid.KSUID `zed:"commit"`
 	ID     ksuid.KSUID `zed:"id"`

--- a/lake/commits/actions.go
+++ b/lake/commits/actions.go
@@ -60,13 +60,13 @@ type Commit struct {
 	Meta    zed.Value   `zed:"meta"`
 }
 
+func (c *Commit) CommitID() ksuid.KSUID {
+	return c.ID
+}
+
 func (c *Commit) String() string {
 	//XXX need to format Message field for single line
 	return fmt.Sprintf("COMMIT %s -> %s %s %s %s", c.ID, c.Parent, c.Date, c.Author, c.Message)
-}
-
-func (c *Commit) CommitID() ksuid.KSUID {
-	return c.ID
 }
 
 func (c *Commit) AppMeta() zed.Value {

--- a/lake/commits/actions.go
+++ b/lake/commits/actions.go
@@ -3,6 +3,7 @@ package commits
 import (
 	"fmt"
 
+	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/pkg/nano"
@@ -56,15 +57,20 @@ type Commit struct {
 	Author  string      `zed:"author"`
 	Date    nano.Ts     `zed:"date"`
 	Message string      `zed:"message"`
+	Meta 	zed.Value	`zed:"meta"`
+}
+
+func (c *Commit) String() string {
+	//XXX need to format Message field for single line
+	return fmt.Sprintf("COMMIT %s -> %s %s %s %s", c.ID, c.Parent, c.Date, c.Author, c.Message)
 }
 
 func (c *Commit) CommitID() ksuid.KSUID {
 	return c.ID
 }
 
-func (c *Commit) String() string {
-	//XXX need to format Message field for single line
-	return fmt.Sprintf("COMMIT %s -> %s %s %s %s", c.ID, c.Parent, c.Date, c.Author, c.Message)
+func (c *Commit) AppMeta() zed.Value {
+	return c.Meta
 }
 
 type Delete struct {

--- a/lake/commits/object.go
+++ b/lake/commits/object.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/pkg/nano"
@@ -21,7 +22,7 @@ type Object struct {
 	Actions []Action    `zed:"actions"`
 }
 
-func NewObject(parent ksuid.KSUID, author, message string, retries int) *Object {
+func NewObject(parent ksuid.KSUID, author, message string, retries int, meta zed.Value) *Object {
 	commit := ksuid.New()
 	o := &Object{
 		Commit: commit,
@@ -34,12 +35,13 @@ func NewObject(parent ksuid.KSUID, author, message string, retries int) *Object 
 		Date:    nano.Now(),
 		Author:  author,
 		Message: message,
+		Meta:    meta,
 	})
 	return o
 }
 
-func NewAddsObject(parent ksuid.KSUID, retries int, author, message string, objects []data.Object) *Object {
-	o := NewObject(parent, author, message, retries)
+func NewAddsObject(parent ksuid.KSUID, retries int, author, message string, meta zed.Value, objects []data.Object) *Object {
+	o := NewObject(parent, author, message, retries, meta)
 	for _, dataObject := range objects {
 		o.append(&Add{Commit: o.Commit, Object: dataObject})
 	}
@@ -47,7 +49,7 @@ func NewAddsObject(parent ksuid.KSUID, retries int, author, message string, obje
 }
 
 func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, ids []ksuid.KSUID) *Object {
-	o := NewObject(parent, author, message, retries)
+	o := NewObject(parent, author, message, retries, zed.Value{zed.TypeNull, nil})
 	for _, id := range ids {
 		o.appendDelete(id)
 	}
@@ -55,7 +57,7 @@ func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, i
 }
 
 func NewAddIndexesObject(parent ksuid.KSUID, author, message string, retries int, indexes []*index.Object) *Object {
-	o := NewObject(parent, author, message, retries)
+	o := NewObject(parent, author, message, retries, zed.Value{zed.TypeNull, nil})
 	for _, index := range indexes {
 		o.appendAddIndex(index)
 	}

--- a/lake/commits/object.go
+++ b/lake/commits/object.go
@@ -22,7 +22,7 @@ type Object struct {
 	Actions []Action    `zed:"actions"`
 }
 
-func NewObject(parent ksuid.KSUID, author, message string, retries int, meta zed.Value) *Object {
+func NewObject(parent ksuid.KSUID, author, message string, meta zed.Value, retries int) *Object {
 	commit := ksuid.New()
 	o := &Object{
 		Commit: commit,
@@ -41,7 +41,7 @@ func NewObject(parent ksuid.KSUID, author, message string, retries int, meta zed
 }
 
 func NewAddsObject(parent ksuid.KSUID, retries int, author, message string, meta zed.Value, objects []data.Object) *Object {
-	o := NewObject(parent, author, message, retries, meta)
+	o := NewObject(parent, author, message, meta, retries)
 	for _, dataObject := range objects {
 		o.append(&Add{Commit: o.Commit, Object: dataObject})
 	}
@@ -49,7 +49,7 @@ func NewAddsObject(parent ksuid.KSUID, retries int, author, message string, meta
 }
 
 func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, ids []ksuid.KSUID) *Object {
-	o := NewObject(parent, author, message, retries, zed.Value{zed.TypeNull, nil})
+	o := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
 	for _, id := range ids {
 		o.appendDelete(id)
 	}
@@ -57,7 +57,7 @@ func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, i
 }
 
 func NewAddIndexesObject(parent ksuid.KSUID, author, message string, retries int, indexes []*index.Object) *Object {
-	o := NewObject(parent, author, message, retries, zed.Value{zed.TypeNull, nil})
+	o := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
 	for _, index := range indexes {
 		o.appendAddIndex(index)
 	}

--- a/lake/commits/patch.go
+++ b/lake/commits/patch.go
@@ -124,7 +124,7 @@ func (p *Patch) DeleteIndexObject(ruleID ksuid.KSUID, id ksuid.KSUID) error {
 }
 
 func (p *Patch) NewCommitObject(parent ksuid.KSUID, retries int, author, message string, meta zed.Value) *Object {
-	o := NewObject(parent, author, message, retries, meta)
+	o := NewObject(parent, author, message, meta, retries)
 	for _, id := range p.deletedObjects {
 		o.appendDelete(id)
 	}
@@ -141,7 +141,7 @@ func (p *Patch) NewCommitObject(parent ksuid.KSUID, retries int, author, message
 }
 
 func (p *Patch) Revert(tip *Snapshot, commit, parent ksuid.KSUID, retries int, author, message string) (*Object, error) {
-	object := NewObject(parent, author, message, retries, zed.Value{zed.TypeNull, nil})
+	object := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
 	// For each data object in the patch that is also in the tip, we do a delete.
 	for _, dataObject := range p.diff.SelectAll() {
 		if Exists(tip, dataObject.ID) {

--- a/lake/commits/patch.go
+++ b/lake/commits/patch.go
@@ -3,6 +3,7 @@ package commits
 import (
 	"errors"
 
+	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/expr/extent"
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/lake/index"
@@ -122,8 +123,8 @@ func (p *Patch) DeleteIndexObject(ruleID ksuid.KSUID, id ksuid.KSUID) error {
 	return nil
 }
 
-func (p *Patch) NewCommitObject(parent ksuid.KSUID, retries int, author, message string) *Object {
-	o := NewObject(parent, author, message, retries)
+func (p *Patch) NewCommitObject(parent ksuid.KSUID, retries int, author, message string, meta zed.Value) *Object {
+	o := NewObject(parent, author, message, retries, meta)
 	for _, id := range p.deletedObjects {
 		o.appendDelete(id)
 	}
@@ -140,7 +141,7 @@ func (p *Patch) NewCommitObject(parent ksuid.KSUID, retries int, author, message
 }
 
 func (p *Patch) Revert(tip *Snapshot, commit, parent ksuid.KSUID, retries int, author, message string) (*Object, error) {
-	object := NewObject(parent, author, message, retries)
+	object := NewObject(parent, author, message, retries, zed.Value{zed.TypeNull, nil})
 	// For each data object in the patch that is also in the tip, we do a delete.
 	for _, dataObject := range p.diff.SelectAll() {
 		if Exists(tip, dataObject.ID) {

--- a/lake/ztests/appmeta.yaml
+++ b/lake/ztests/appmeta.yaml
@@ -1,0 +1,18 @@
+script: |
+  export ZED_LAKE_ROOT=test
+  zed lake init -q
+  zed lake create -q logs
+  zed lake load -q -use logs@main -meta '"original"' babble.zson
+  zed lake load -q -use logs@main -meta '"normalized-v1"' babble.zson
+  zed lake load -q -use logs@main -meta '"normalized-v2"' babble.zson
+  zed lake query "from logs@main:log | meta matches normalized* | sort date | cut meta" | zq -z -
+
+inputs:
+  - name: babble.zson
+    source: ../../testdata/babble.zson
+
+outputs:
+  - name: stdout
+    data: |
+      {meta:"normalized-v1"}
+      {meta:"normalized-v2"}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -375,6 +375,9 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 		if errors.Is(err, commits.ErrEmptyTransaction) {
 			err = zqe.ErrInvalid("no records in request")
 		}
+		if errors.Is(err, lake.ErrInvalidCommitMeta) {
+			err = zqe.ErrInvalid("invalid commit metadata in request")
+		}
 		w.Error(err)
 		return
 	}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -370,7 +370,7 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 	}
 	warnings := warningCollector{}
 	zr = zio.NewWarningReader(zr, &warnings)
-	kommit, err := branch.Load(r.Context(), zr, message.Author, message.Body)
+	kommit, err := branch.Load(r.Context(), zr, message.Author, message.Body, message.Meta)
 	if err != nil {
 		if errors.Is(err, commits.ErrEmptyTransaction) {
 			err = zqe.ErrInvalid("no records in request")


### PR DESCRIPTION
This PR allows embedding a metadata field (`meta`) in the commit object at `zed lake load`. The `meta` field can include any ZSON/ZNG data such that external applications can embed any custom metadata in the commit journal and implement arbitrary data provenance and governance capabilities later.

For example,

Load data with `-meta` option:
`zed lake load -meta '{class: "sensitive"}' in.zson`

Filter commits by metadata:
`zed lake query "from pool@main:log | meta.class=='sensitive'"`

One can embed any ZSON/ZNG data, e.g.,
`zed lake load -meta '[{a:1}, {b:"hi there"}]' in.zson`

This PR does not do/check: allowing data to be arbitrarily large (that it can't fit in an HTTP header over the load endpoint with remote driver).