### PR TITLE
capitalize first letter of Zed where appropriate

### DIFF
--- a/cmd/zed/compile/command.go
+++ b/cmd/zed/compile/command.go
@@ -239,7 +239,7 @@ func (c *Command) compile(z string) (*compiler.Runtime, error) {
 const nodeProblem = `
 Failed to run node on ./compiler/parser/run.js.  The "-js" flag is for PEG
 development and should only be used when running "zed compile" in the root
-directory of the zed repository.`
+directory of the Zed repository.`
 
 func (c *Command) interactive() {
 	rl := liner.NewLiner()

--- a/cmd/zed/index/command.go
+++ b/cmd/zed/index/command.go
@@ -10,9 +10,9 @@ import (
 var Cmd = &charm.Spec{
 	Name:  "index",
 	Usage: "index <command> [options] [arguments...]",
-	Short: "create and search zed indexes",
+	Short: "create and search Zed indexes",
 	Long: `
-"zed index" is command-line utility for creating and manipulating zed indexes.
+"zed index" is command-line utility for creating and manipulating Zed indexes.
 `,
 	New: New,
 }

--- a/cmd/zed/index/convert/command.go
+++ b/cmd/zed/index/convert/command.go
@@ -19,9 +19,9 @@ import (
 var Convert = &charm.Spec{
 	Name:  "convert",
 	Usage: "convert [-f frametresh] [ -o file ] -k field[,field,...] file",
-	Short: "generate a zed index file from one or more zng files",
+	Short: "generate a Zed index file from one or more zng files",
 	Long: `
-The convert command generates a zed index containing keys and optional values
+The convert command generates a Zed index containing keys and optional values
 from the input file.  The required flag -k specifies one or more zng record
 field names that comprise the index search keys, in precedence order.
 The keys must be pre-sorted in ascending order with
@@ -47,7 +47,7 @@ type Command struct {
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedindex.Command)}
-	f.IntVar(&c.frameThresh, "f", 32*1024, "minimum frame size used in zed index file")
+	f.IntVar(&c.frameThresh, "f", 32*1024, "minimum frame size used in Zed index file")
 	f.StringVar(&c.order, "order", "asc", "specify data in ascending (asc) or descending (desc) order")
 	f.StringVar(&c.outputFile, "o", "index.zng", "name of index output file")
 	f.StringVar(&c.keys, "k", "", "comma-separated list of field names for keys")

--- a/cmd/zed/index/create/command.go
+++ b/cmd/zed/index/create/command.go
@@ -20,9 +20,9 @@ import (
 var Create = &charm.Spec{
 	Name:  "create",
 	Usage: "create [-f frameThresh] [ -o file ] -k field file",
-	Short: "create a key-only zed index from a zng file",
+	Short: "create a key-only Zed index from a zng file",
 	Long: `
-The create command generates a key-only zed index file comprising the values from the
+The create command generates a key-only Zed index file comprising the values from the
 input taken from the field specified by -k.  The output index will have a base layer
 with search key called "key".
 If a key appears more than once, the last value in the input takes precedence.

--- a/cmd/zed/index/lookup/command.go
+++ b/cmd/zed/index/lookup/command.go
@@ -16,10 +16,10 @@ import (
 var Lookup = &charm.Spec{
 	Name:  "lookup",
 	Usage: "lookup -k key[,key...] index",
-	Short: "lookup a key in a zed index file and print value as zng record",
+	Short: "lookup a key in a Zed index file and print value as zng record",
 	Long: `
 The lookup command locates the specified key(s) in the base layer of a
-zed index file and displays the result as a zng record.
+Zed index file and displays the result as a zng record.
 If the index has multiple keys, then multiple records may be returned for
 all the records that match the supplied keys.
 Each key argument specifies a value to look up in the table and must be parseable

--- a/cmd/zed/index/section/command.go
+++ b/cmd/zed/index/section/command.go
@@ -16,14 +16,14 @@ import (
 var Section = &charm.Spec{
 	Name:  "section",
 	Usage: "section [flags] path",
-	Short: "extract a section of a zed index file",
+	Short: "extract a section of a Zed index file",
 	Long: `
-The section command extracts a section from a zed index file and
+The section command extracts a section from a Zed index file and
 writes it to the output.  The -trailer option writes
-the zed index trailer to the output in addition to the section if the section
+the Zed index trailer to the output in addition to the section if the section
 number was specified.
 
-See the "zed index" command help for a description of a zed index file.`,
+See the "zed index" command help for a description of a Zed index file.`,
 	New: newCommand,
 }
 
@@ -40,7 +40,7 @@ type Command struct {
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*zedindex.Command)}
-	f.BoolVar(&c.trailer, "trailer", false, "include the zed index trailer in the output")
+	f.BoolVar(&c.trailer, "trailer", false, "include the Zed index trailer in the output")
 	f.IntVar(&c.section, "s", -1, "include the indicated section in the output")
 	c.outputFlags.SetFlags(f)
 	return c, nil

--- a/cmd/zed/lake/command.go
+++ b/cmd/zed/lake/command.go
@@ -24,7 +24,7 @@ The "zed lake" command
 operates on collections of Zed data files partitioned by and organized
 by a specified key and stored either on a filesystem or an S3 compatible object store.
 
-See the zed lake README in the zed repository for more information:
+See the Zed lake README in the Zed repository for more information:
 https://github.com/brimdata/zed/blob/main/docs/lake/README.md
 `,
 	New: New,

--- a/cmd/zed/query/command.go
+++ b/cmd/zed/query/command.go
@@ -27,11 +27,11 @@ import (
 var Cmd = &charm.Spec{
 	Name:        "query",
 	Usage:       "query [ options ] [ zed-query ] file [ file ... ]",
-	Short:       "apply zed queries to data files or streams",
+	Short:       "apply Zed queries to data files or streams",
 	HiddenFlags: "cpuprofile,memprofile,pathregexp",
 	Long: `
-"zed query" is a command for searching and analyzing data using the zed language
-(including the experimental SQL subset embedded in the zed language).
+"zed query" is a command for searching and analyzing data using the Zed language
+(including the experimental SQL subset embedded in the Zed language).
 If you have installed the shortcuts, "zq" is a shortcut for the "zed query" command.
 
 "zed query" applies boolean logic
@@ -56,21 +56,21 @@ beginning of stream will determine the format.
 
 The output format is binary ZNG by default, but can be overridden with -f.
 
-After the options, a zed "query" string may be specified as a
-single argument conforming to the zed language syntax;
+After the options, a Zed "query" string may be specified as a
+single argument conforming to the Zed language syntax;
 i.e., it should be quoted as a single string in the shell.
 
-If the first argument is a path to a valid file rather than a zed query,
-then the zed query is assumed to be "*", i.e., match and output all
-of the input.  If the first argument is both a valid zed query
+If the first argument is a path to a valid file rather than a Zed query,
+then the Zed query is assumed to be "*", i.e., match and output all
+of the input.  If the first argument is both a valid Zed query
 and an existing file, then the file overrides.
 
-The zed query text may include files using -I, which is particularly
+The Zed query text may include files using -I, which is particularly
 convenient when a large, complex query spans multiple lines.  In this case,
-these zed files are concatenated together along with the command-line zed query text
+these Zed files are concatenated together along with the command-line Zed query text
 in the order appearing on the command-line.
 
-See the zed source repository for more information:
+See the Zed source repository for more information:
 
 https://github.com/brimdata/zed
 `,

--- a/cmd/zed/root/command.go
+++ b/cmd/zed/root/command.go
@@ -13,7 +13,7 @@ import (
 var Zed = &charm.Spec{
 	Name:  "zed",
 	Usage: "zed <command> [options] [arguments...]",
-	Short: "run zed commands",
+	Short: "run Zed commands",
 	Long: `
 zed is a command-line tool for creating, configuring, ingesting into,
 querying, and orchestrating Zed data lakes.`,

--- a/cmd/zed/ztests/blank-help.yaml
+++ b/cmd/zed/ztests/blank-help.yaml
@@ -4,4 +4,4 @@ script: |
 outputs:
   - name: stderr
     regexp: |
-      run zed commands
+      run Zed commands

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -48,7 +48,7 @@ start = __ ast:Z __ EOF { RETURN(ast) }
 
 // A Zed script can be either a single operation or a chain of operations.
 // For a single operation, we do not need to wrap operator in a SequentialProc,
-// but we do for everything but FilterProc because the zed runtime is fragile
+// but we do for everything but FilterProc because the Zed runtime is fragile
 // to this difference right now.  See issue #1809.
 Z // = !(Operator / Aggregation / "(") op:Operation &EOF { RETURN(op) }
   = decls:Decl+ __ first:Operation rest:SequentialTail* {

--- a/index/index.go
+++ b/index/index.go
@@ -1,7 +1,7 @@
 // Package index provides an API for creating, merging, indexing, and querying
-// zed indexes.
+// Zed indexes.
 //
-// A zed index comprises a base index section followed by zero or more parent
+// A Zed index comprises a base index section followed by zero or more parent
 // section indexes followed by a trailer.  The sections are organized into a
 // B-tree-like data structure so keys can be looked up efficiently without
 // necessarily scanning the entire base index.
@@ -22,5 +22,5 @@ import (
 const MaxLevels = 20
 
 var (
-	ErrTooManyLevels = errors.New("zed index has too many levels (a larger frame threshold is needed)")
+	ErrTooManyLevels = errors.New("Zed index has too many levels (a larger frame threshold is needed)")
 )

--- a/index/writer.go
+++ b/index/writer.go
@@ -18,7 +18,7 @@ import (
 	"github.com/brimdata/zed/zson"
 )
 
-// Writer implements the zio.Writer interface. A Writer creates a zed index,
+// Writer implements the zio.Writer interface. A Writer creates a Zed index,
 // comprising the base zng file along with its related B-tree sections,
 // as zng records are consumed.
 //
@@ -72,7 +72,7 @@ type indexWriter struct {
 	frameKey   *zed.Value
 }
 
-// NewWriter returns a Writer ready to write a zed index or it returns
+// NewWriter returns a Writer ready to write a Zed index or it returns
 // an error.  The index is written to the URL provided in the path argument
 // while temporary file are written locally.  Calls to Write must
 // provide keys in increasing lexicographic order.  Duplicate keys are not
@@ -266,7 +266,7 @@ func (w *Writer) finalize() error {
 		}
 		if n != size {
 			f.Close()
-			return fmt.Errorf("internal zed index error: index file size (%d) does not equal zng size (%d)", n, size)
+			return fmt.Errorf("internal Zed index error: index file size (%d) does not equal zng size (%d)", n, size)
 		}
 		if err := f.Close(); err != nil {
 			return err

--- a/index/ztests/empty-index.yaml
+++ b/index/ztests/empty-index.yaml
@@ -1,5 +1,5 @@
 script: |
-  # b isn't in the input so this creates a valid zed index that is empty
+  # b isn't in the input so this creates a valid Zed index that is empty
   zed index create -o index.zng -k b in.zson
   zq -Z index.zng
   echo ===

--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -144,10 +144,10 @@ if __name__ == '__main__':
     import pprint
 
     parser = argparse.ArgumentParser(
-        description='Send a query to zed and pretty-print results.',
+        description='Query a Zed lake service and pretty-print results.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-u', dest='base_url', default=DEFAULT_BASE_URL,
-                        help='zed base URL')
+                        help='Zed lake service base URL')
     parser.add_argument('query')
     args = parser.parse_args()
 


### PR DESCRIPTION
Capitalize the first letter of Zed unless it's used as command name or
an identifier.