### PR TITLE
service request/response: Make zson the default

### DIFF
--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -17,6 +17,7 @@ class Client():
     def __init__(self, base_url=DEFAULT_BASE_URL):
         self.base_url = base_url
         self.session = requests.Session()
+        self.session.headers.update({'Accept': 'application/x-zjson'})
 
     def create_pool(self, name, layout={'order': 'desc', 'keys': [['ts']]},
                     thresh=0):

--- a/service/core.go
+++ b/service/core.go
@@ -20,6 +20,11 @@ import (
 	"go.uber.org/zap"
 )
 
+// DefaultZedFormat is the default Zed format that the server will assume if the
+// value for a request's "Accept" or "Content-Type" headers are not set or set
+// to "*/*".
+const DefaultZedFormat = "zson"
+
 const indexPage = `
 <!DOCTYPE html>
 <html>

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -34,13 +34,10 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 	if !ok {
 		return
 	}
-	format, err := api.MediaTypeToFormat(r.Header.Get("Accept"))
+	format, err := api.MediaTypeToFormat(r.Header.Get("Accept"), DefaultZedFormat)
 	if err != nil {
-		if !errors.Is(err, api.ErrMediaTypeUnspecified) {
-			w.Error(zqe.ErrInvalid(err))
-			return
-		}
-		format = "zjson"
+		w.Error(zqe.ErrInvalid(err))
+		return
 	}
 	d, err := queryio.NewDriver(zio.NopCloser(w), format, !noctrl)
 	if err != nil {

--- a/service/ztests/curl-query.yaml
+++ b/service/ztests/curl-query.yaml
@@ -2,7 +2,7 @@ script: |
   source service.sh
   zapi create -q test
   zapi load -q -use test@main -
-  for accept in text/csv application/{json,x-ndjson,x-zjson,x-zson}; do
+  for accept in text/csv application/{json,x-ndjson,x-zjson,x-zson} ""; do
     echo === $accept ===
     curl -H "Accept: $accept" -d '{"query":"from test"}' http://${ZED_LAKE_HOST}/query |
       sed -E '/QueryStats/s/[0-9]{3,}/xxx/g'  # for ZJSON
@@ -34,5 +34,8 @@ outputs:
       {"kind":"QueryChannelEnd","value":{"channel_id":0}}
       {"kind":"QueryStats","value":{"start_time":{"sec":xxx,"ns":xxx},"update_time":{"sec":xxx,"ns":xxx},"bytes_read":36,"bytes_matched":36,"records_read":2,"records_matched":2}}
       === application/x-zson ===
+      {a:"hello",b:{c:"world",d:"goodbye"}}
+      {a:"one",b:{c:"two",d:"three"}}
+      === ===
       {a:"hello",b:{c:"world",d:"goodbye"}}
       {a:"one",b:{c:"two",d:"three"}}


### PR DESCRIPTION
Change the service handlers to return zson if requested media type is
any or unset. Augment api.MediaTypeToFormat to accept a default format
that is returned if the media type header is any or unset.