### PR TITLE
Zedify events handler

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -98,7 +98,7 @@ type EventBranchCommit struct {
 }
 
 type EventPool struct {
-	PoolID ksuid.KSUID `json:"pool_id"`
+	PoolID ksuid.KSUID `zed:"pool_id"`
 }
 
 type EventBranch struct {

--- a/api/api.go
+++ b/api/api.go
@@ -91,19 +91,19 @@ type IndexUpdateRequest struct {
 }
 
 type EventBranchCommit struct {
-	CommitID string `json:"commit_id"`
-	PoolID   string `json:"pool_id"`
-	Branch   string `json:"branch"`
-	Parent   string `json:"parent"`
+	CommitID ksuid.KSUID `json:"commit_id"`
+	PoolID   ksuid.KSUID `json:"pool_id"`
+	Branch   string      `json:"branch"`
+	Parent   string      `json:"parent"`
 }
 
 type EventPool struct {
-	PoolID string `json:"pool_id"`
+	PoolID ksuid.KSUID `json:"pool_id"`
 }
 
 type EventBranch struct {
-	PoolID string `json:"pool_id"`
-	Branch string `json:"branch"`
+	PoolID ksuid.KSUID `json:"pool_id"`
+	Branch string      `json:"branch"`
 }
 
 type QueryRequest struct {

--- a/api/api.go
+++ b/api/api.go
@@ -91,10 +91,10 @@ type IndexUpdateRequest struct {
 }
 
 type EventBranchCommit struct {
-	CommitID ksuid.KSUID `json:"commit_id"`
-	PoolID   ksuid.KSUID `json:"pool_id"`
-	Branch   string      `json:"branch"`
-	Parent   string      `json:"parent"`
+	CommitID ksuid.KSUID `zed:"commit_id"`
+	PoolID   ksuid.KSUID `zed:"pool_id"`
+	Branch   string      `zed:"branch"`
+	Parent   string      `zed:"parent"`
 }
 
 type EventPool struct {

--- a/api/api.go
+++ b/api/api.go
@@ -102,8 +102,8 @@ type EventPool struct {
 }
 
 type EventBranch struct {
-	PoolID ksuid.KSUID `json:"pool_id"`
-	Branch string      `json:"branch"`
+	PoolID ksuid.KSUID `zed:"pool_id"`
+	Branch string      `zed:"branch"`
 }
 
 type QueryRequest struct {

--- a/service/core.go
+++ b/service/core.go
@@ -234,7 +234,7 @@ func (c *Core) publishEvent(w *ResponseWriter, name string, data interface{}) {
 		return
 	}
 	go func() {
-		ev := event{name: name, value: zv}
+		ev := event{name: name, value: &zv}
 		c.subscriptionsMu.RLock()
 		for sub := range c.subscriptions {
 			sub <- ev

--- a/service/core.go
+++ b/service/core.go
@@ -230,7 +230,7 @@ func (c *Core) requestLogger(r *http.Request) *zap.Logger {
 func (c *Core) publishEvent(w *ResponseWriter, name string, data interface{}) {
 	zv, err := zson.MarshalZNG(data)
 	if err != nil {
-		w.Logger.Error("error marshaling published event", zap.Error(err))
+		w.Logger.Error("Error marshaling published event", zap.Error(err))
 		return
 	}
 	go func() {

--- a/service/core.go
+++ b/service/core.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brimdata/zed/api"
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zson"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -54,7 +55,7 @@ type Core struct {
 	routerAPI       *mux.Router
 	routerAux       *mux.Router
 	taskCount       int64
-	subscriptions   map[chan []byte]struct{}
+	subscriptions   map[chan event]struct{}
 	subscriptionsMu sync.RWMutex
 }
 
@@ -129,7 +130,7 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 		registry:      registry,
 		routerAPI:     routerAPI,
 		routerAux:     routerAux,
-		subscriptions: make(map[chan []byte]struct{}),
+		subscriptions: make(map[chan event]struct{}),
 	}
 
 	c.addAPIServerRoutes()
@@ -226,17 +227,17 @@ func (c *Core) requestLogger(r *http.Request) *zap.Logger {
 	return c.logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
 }
 
-func (c *Core) publishEvent(event string, data interface{}) {
+func (c *Core) publishEvent(w *ResponseWriter, name string, data interface{}) {
+	zv, err := zson.MarshalZNG(data)
+	if err != nil {
+		w.Logger.Error("error marshaling published event", zap.Error(err))
+		return
+	}
 	go func() {
-		b, err := json.Marshal(data)
-		if err != nil {
-			c.logger.Error("Marshal error", zap.Error(err))
-			return
-		}
-		payload := []byte(fmt.Sprintf("event: %s\ndata: %s\n\n", event, b))
+		ev := event{name: name, value: zv}
 		c.subscriptionsMu.RLock()
 		for sub := range c.subscriptions {
-			sub <- payload
+			sub <- ev
 		}
 		c.subscriptionsMu.RUnlock()
 	}()

--- a/service/eventstream.go
+++ b/service/eventstream.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/anyio"
+)
+
+type event struct {
+	name  string
+	value zed.Value
+}
+
+type eventStreamWriter struct {
+	body   io.Writer
+	format string
+}
+
+func (e *eventStreamWriter) WriteEvent(ev event) error {
+	buf := bytes.NewBuffer(nil)
+	w, err := anyio.NewWriter(zio.NopCloser(buf), anyio.WriterOpts{Format: e.format})
+	if err != nil {
+		return err
+	}
+	if err := w.Write(&ev.value); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(e.body, "event: %s\ndata: %s\n\n", ev.name, buf)
+	return err
+}

--- a/service/eventstream.go
+++ b/service/eventstream.go
@@ -20,7 +20,7 @@ type eventStreamWriter struct {
 	format string
 }
 
-func (e *eventStreamWriter) WriteEvent(ev event) error {
+func (e *eventStreamWriter) writeEvent(ev event) error {
 	buf := bytes.NewBuffer(nil)
 	w, err := anyio.NewWriter(zio.NopCloser(buf), anyio.WriterOpts{Format: e.format})
 	if err != nil {

--- a/service/eventstream.go
+++ b/service/eventstream.go
@@ -12,7 +12,7 @@ import (
 
 type event struct {
 	name  string
-	value zed.Value
+	value *zed.Value
 }
 
 type eventStreamWriter struct {
@@ -26,12 +26,12 @@ func (e *eventStreamWriter) writeEvent(ev event) error {
 	if err != nil {
 		return err
 	}
-	if err := w.Write(&ev.value); err != nil {
+	if err := w.Write(ev.value); err != nil {
 		return err
 	}
 	if err := w.Close(); err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(e.body, "event: %s\ndata: %s\n\n", ev.name, buf)
+	_, err = fmt.Fprintf(e.body, "event: %s\ndata: %s\n\n", ev.name, &buf)
 	return err
 }

--- a/service/eventstream.go
+++ b/service/eventstream.go
@@ -21,8 +21,8 @@ type eventStreamWriter struct {
 }
 
 func (e *eventStreamWriter) writeEvent(ev event) error {
-	buf := bytes.NewBuffer(nil)
-	w, err := anyio.NewWriter(zio.NopCloser(buf), anyio.WriterOpts{Format: e.format})
+	var buf bytes.Buffer
+	w, err := anyio.NewWriter(zio.NopCloser(&buf), anyio.WriterOpts{Format: e.format})
 	if err != nil {
 		return err
 	}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -143,8 +143,8 @@ func handlePoolPut(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
-	c.publishEvent(w, "pool-update", api.EventPool{PoolID: id})
 	w.WriteHeader(http.StatusNoContent)
+	c.publishEvent(w, "pool-update", api.EventPool{PoolID: id})
 }
 
 func handleBranchPost(c *Core, w *ResponseWriter, r *Request) {
@@ -166,8 +166,8 @@ func handleBranchPost(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
-	c.publishEvent(w, "branch-update", api.EventBranch{PoolID: poolID, Branch: branchRef.Name})
 	w.Respond(http.StatusOK, branchRef)
+	c.publishEvent(w, "branch-update", api.EventBranch{PoolID: poolID, Branch: branchRef.Name})
 }
 
 func handleRevertPost(c *Core, w *ResponseWriter, r *Request) {
@@ -192,12 +192,12 @@ func handleRevertPost(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
+	w.Respond(http.StatusOK, api.CommitResponse{Commit: commit})
 	c.publishEvent(w, "branch-revert", api.EventBranchCommit{
 		CommitID: commit,
 		PoolID:   poolID,
 		Branch:   branch,
 	})
-	w.Respond(http.StatusOK, api.CommitResponse{Commit: commit})
 }
 
 func handleBranchMerge(c *Core, w *ResponseWriter, r *Request) {
@@ -222,13 +222,13 @@ func handleBranchMerge(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
+	w.Respond(http.StatusOK, api.CommitResponse{Commit: commit})
 	c.publishEvent(w, "branch-merge", api.EventBranchCommit{
 		CommitID: commit,
 		PoolID:   poolID,
 		Branch:   childBranch,
 		Parent:   parentBranch,
 	})
-	w.Respond(http.StatusOK, api.CommitResponse{Commit: commit})
 }
 
 func handlePoolDelete(c *Core, w *ResponseWriter, r *Request) {
@@ -240,8 +240,8 @@ func handlePoolDelete(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
-	c.publishEvent(w, "pool-delete", api.EventPool{PoolID: id})
 	w.WriteHeader(http.StatusNoContent)
+	c.publishEvent(w, "pool-delete", api.EventPool{PoolID: id})
 }
 
 func handleBranchDelete(c *Core, w *ResponseWriter, r *Request) {
@@ -257,8 +257,8 @@ func handleBranchDelete(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
-	c.publishEvent(w, "branch-delete", api.EventBranch{PoolID: poolID, Branch: branchName})
 	w.WriteHeader(http.StatusNoContent)
+	c.publishEvent(w, "branch-delete", api.EventBranch{PoolID: poolID, Branch: branchName})
 }
 
 type warningCollector []string
@@ -312,14 +312,14 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
+	w.Respond(http.StatusOK, api.CommitResponse{
+		Warnings: warnings,
+		Commit:   kommit,
+	})
 	c.publishEvent(w, "branch-commit", api.EventBranchCommit{
 		CommitID: kommit,
 		PoolID:   pool.ID,
 		Branch:   branch.Name,
-	})
-	w.Respond(http.StatusOK, api.CommitResponse{
-		Warnings: warnings,
-		Commit:   kommit,
 	})
 }
 

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -126,8 +126,8 @@ func handlePoolPost(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
-	c.publishEvent(w, "pool-new", api.EventPool{PoolID: pool.ID})
 	w.Respond(http.StatusOK, meta)
+	c.publishEvent(w, "pool-new", api.EventPool{PoolID: pool.ID})
 }
 
 func handlePoolPut(c *Core, w *ResponseWriter, r *Request) {
@@ -473,7 +473,7 @@ func handleEvents(c *Core, w *ResponseWriter, r *Request) {
 	for {
 		select {
 		case ev := <-subscription:
-			if err := writer.WriteEvent(ev); err != nil {
+			if err := writer.writeEvent(ev); err != nil {
 				w.Error(err)
 				continue
 			}


### PR DESCRIPTION
Zedify objects fed into the events handler. This fixes an issue where ksuids where getting formatted differently for the /events endpoint vs the other endpoints in the app.