### PR TITLE
add zed lake serve -rootcontentfile flag

### DIFF
--- a/service/ztests/rootcontentfile.yaml
+++ b/service/ztests/rootcontentfile.yaml
@@ -1,0 +1,13 @@
+script: |
+  LAKE_EXTRA_FLAGS=-rootcontentfile=f source service.sh
+  curl http://$ZED_LAKE_HOST
+
+inputs:
+  - name: f
+    data: &f |
+      Hello, world!
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: *f


### PR DESCRIPTION
The -rootcontentflag flag to "zed lake serve" specifies a file whose
contents are served for GET / requests (in place of the default content
in service.indexPage).