### PR TITLE
limit Markdown link check output

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: .github/workflows/markdown-link-check-config.json
+        use-quiet-mode: yes
     - name: Inform Slack users of link check failures
       uses: tiloio/slack-webhook-action@v1.1.2
       if: ${{ failure() && steps.extract_branch.outputs.branch == 'main' }}


### PR DESCRIPTION
When the Markdown link check CI action fails, finding the underlying
error is cumbersome because the action produces so much output.  Limit
its output to errors only.