### PR TITLE
Add record number to seek index

### DIFF
--- a/lake/seekindex/seekindex_test.go
+++ b/lake/seekindex/seekindex_test.go
@@ -98,9 +98,9 @@ func newTestSeekIndex(t *testing.T, entries []entry) *testSeekIndex {
 func build(t *testing.T, entries entries) *bytes.Buffer {
 	var buffer bytes.Buffer
 	w := NewWriter(zngio.NewWriter(zio.NopCloser(&buffer), zngio.WriterOpts{}))
-	for _, entry := range entries {
+	for i, entry := range entries {
 		zv := zed.Value{zed.TypeTime, zed.EncodeTime(entry.ts)}
-		err := w.Write(zv, entry.offset)
+		err := w.Write(zv, uint64(i), entry.offset)
 		require.NoError(t, err)
 	}
 	return &buffer

--- a/lake/seekindex/writer.go
+++ b/lake/seekindex/writer.go
@@ -22,7 +22,7 @@ func NewWriter(w zio.Writer) *Writer {
 	}
 }
 
-func (w *Writer) Write(key zed.Value, offset int64) error {
+func (w *Writer) Write(key zed.Value, count uint64, offset int64) error {
 	b := w.builder
 	b.Reset()
 	if zed.IsContainerType(key.Type) {
@@ -30,10 +30,12 @@ func (w *Writer) Write(key zed.Value, offset int64) error {
 	} else {
 		b.AppendPrimitive(key.Bytes)
 	}
+	b.AppendPrimitive(zed.EncodeUint(count))
 	b.AppendPrimitive(zed.EncodeInt(offset))
 	if w.typ != key.Type {
 		var schema = []zed.Column{
 			{"key", key.Type},
+			{"count", zed.TypeUint64},
 			{"offset", zed.TypeInt64},
 		}
 		w.recType = w.zctx.MustLookupTypeRecord(schema)

--- a/lake/ztests/consecutive-ts.yaml
+++ b/lake/ztests/consecutive-ts.yaml
@@ -33,7 +33,7 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {key:1970-01-01T00:00:08Z,offset:0}
-      {key:1970-01-01T00:00:06Z,offset:23}
-      {key:1970-01-01T00:00:02Z,offset:72}
-      {key:1970-01-01T00:00:00Z,offset:108}
+      {key:1970-01-01T00:00:08Z,count:0(uint64),offset:0}
+      {key:1970-01-01T00:00:06Z,count:2(uint64),offset:23}
+      {key:1970-01-01T00:00:02Z,count:10(uint64),offset:72}
+      {key:1970-01-01T00:00:00Z,count:15(uint64),offset:108}


### PR DESCRIPTION
Add the unique record number to each entry in a lake's data object seek index.

Part of #3018 