### PR TITLE
Use seek index to narrow index lookups

### DIFF
--- a/lake/index/filter.go
+++ b/lake/index/filter.go
@@ -2,13 +2,25 @@ package index
 
 import (
 	"context"
+	"math"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/compiler/ast/dag"
+	zedexpr "github.com/brimdata/zed/expr"
+	"github.com/brimdata/zed/expr/extent"
+	"github.com/brimdata/zed/field"
 	"github.com/brimdata/zed/index"
+	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/segmentio/ksuid"
+	"go.uber.org/multierr"
 	"golang.org/x/sync/semaphore"
+)
+
+var (
+	minExpr = zedexpr.NewDottedExpr(field.Dotted("seek.min"))
+	maxExpr = zedexpr.NewDottedExpr(field.Dotted("seek.max"))
+	MaxSpan = extent.NewGenericFromOrder(*zed.NewUint64(0), *zed.NewUint64(math.MaxUint64), order.Asc)
 )
 
 type Filter struct {
@@ -31,27 +43,42 @@ func NewFilter(engine storage.Engine, path *storage.URI, dag *dag.Filter) (*Filt
 	}, nil
 }
 
-func (f *Filter) Apply(ctx context.Context, oid ksuid.KSUID, rules []Rule) (bool, error) {
+func (f *Filter) Apply(ctx context.Context, oid ksuid.KSUID, rules []Rule) (extent.Span, error) {
 	ch := f.expr(ctx, f, oid, rules)
 	if ch == nil {
-		return true, nil
+		return MaxSpan, nil
 	}
 	r := <-ch
-	return r.hit, r.err
+	return r.span, r.err
 }
 
-func (f *Filter) find(ctx context.Context, oid, rid ksuid.KSUID, kv index.KeyValue, op string) (bool, error) {
+func (f *Filter) find(ctx context.Context, oid, rid ksuid.KSUID, kv index.KeyValue, op string) (extent.Span, error) {
 	u := ObjectPath(f.path, rid, oid)
 	finder, err := index.NewFinder(ctx, zed.NewContext(), f.engine, u)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	rec, err := finder.Nearest(op, kv)
+	val, err := finder.Nearest(op, kv)
+	if val == nil || err != nil {
+		return nil, err
+	}
+	return getSpan(val, finder.Order())
+}
+
+func getSpan(val *zed.Value, o order.Which) (extent.Span, error) {
+	ectx := zedexpr.NewContext()
+	min := minExpr.Eval(ectx, val)
+	max := maxExpr.Eval(ectx, val)
+	var err error
+	if min.Type == zed.TypeError {
+		err, _ = zed.DecodeError(min.Bytes)
+	}
+	if max.Type == zed.TypeError {
+		err2, _ := zed.DecodeError(max.Bytes)
+		err = multierr.Combine(err, err2)
+	}
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if rec != nil {
-		return true, nil
-	}
-	return false, nil
+	return extent.NewGenericFromOrder(*min, *max, o), nil
 }

--- a/lake/index/rule.go
+++ b/lake/index/rule.go
@@ -96,15 +96,14 @@ func Equivalent(a, b Rule) bool {
 	return false
 }
 
+const fieldZed = `
+cut %s
+| put key := this, count := count() - 1
+| count := count(), seek.min := min(count), seek.max := max(count) by key
+| sort %s`
+
 func (f *FieldRule) Zed() string {
-	var fields string
-	for i, field := range f.Fields {
-		if i > 0 {
-			fields += ", "
-		}
-		fields += field.String()
-	}
-	return fmt.Sprintf("cut %s | count() by %s | sort %s", fields, fields, fields)
+	return fmt.Sprintf(fieldZed, f.Fields, f.RuleKeys())
 }
 
 func (t *TypeRule) Zed() string {
@@ -165,7 +164,11 @@ func (a *AggRule) RuleID() ksuid.KSUID {
 }
 
 func (f *FieldRule) RuleKeys() field.List {
-	return f.Fields
+	keys := make(field.List, len(f.Fields))
+	for i, path := range f.Fields {
+		keys[i] = append(field.Path{"key"}, path...)
+	}
+	return keys
 }
 
 func (t *TypeRule) RuleKeys() field.List {

--- a/lake/partition.go
+++ b/lake/partition.go
@@ -25,7 +25,7 @@ import (
 type Partition struct {
 	extent.Span
 	compare expr.ValueCompareFn
-	Objects []*data.Object
+	Objects []*data.ObjectScan
 }
 
 func (p Partition) IsZero() bool {
@@ -63,7 +63,7 @@ func PartitionObjects(objects []*data.Object, o order.Which) []Partition {
 		if span.Before(tos.Last()) {
 			s.pushObjectSpan(span, cmp)
 		} else {
-			tos.Objects = append(tos.Objects, span.object)
+			tos.Objects = append(tos.Objects, data.NewObjectScan(*span.object))
 			tos.Extend(span.Last())
 		}
 	}
@@ -78,7 +78,7 @@ func (s *stack) pushObjectSpan(span objectSpan, cmp expr.ValueCompareFn) {
 	s.push(Partition{
 		Span:    span.Span,
 		compare: cmp,
-		Objects: []*data.Object{span.object},
+		Objects: []*data.ObjectScan{data.NewObjectScan(*span.object)},
 	})
 }
 

--- a/lake/seekindex/lookup.go
+++ b/lake/seekindex/lookup.go
@@ -5,10 +5,21 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/expr"
+	"github.com/brimdata/zed/expr/extent"
+	"github.com/brimdata/zed/field"
+	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/zio"
 )
 
 func Lookup(r zio.Reader, from, to *zed.Value, cmp expr.ValueCompareFn) (Range, error) {
+	return lookup(r, field.New("key"), from, to, cmp)
+}
+
+func LookupByCount(r zio.Reader, from, to *zed.Value) (Range, error) {
+	return lookup(r, field.New("count"), from, to, extent.CompareFunc(order.Asc))
+}
+
+func lookup(r zio.Reader, path field.Path, from, to *zed.Value, cmp expr.ValueCompareFn) (Range, error) {
 	rg := Range{0, math.MaxInt64}
 	var rec *zed.Value
 	for {
@@ -20,7 +31,7 @@ func Lookup(r zio.Reader, from, to *zed.Value, cmp expr.ValueCompareFn) (Range, 
 		if rec == nil {
 			return rg, nil
 		}
-		key, err := rec.Access("key")
+		key, err := rec.Deref(path)
 		if err != nil {
 			return Range{}, err
 		}
@@ -40,7 +51,7 @@ func Lookup(r zio.Reader, from, to *zed.Value, cmp expr.ValueCompareFn) (Range, 
 		}
 	}
 	for {
-		key, err := rec.Access("key")
+		key, err := rec.Deref(path)
 		if err != nil {
 			return Range{}, err
 		}

--- a/lake/seekindex/range.go
+++ b/lake/seekindex/range.go
@@ -13,8 +13,22 @@ func (r Range) TrimEnd(end int64) Range {
 	return r
 }
 
+func (r Range) Crop(r2 Range) Range {
+	if r.Start < r2.Start {
+		r.Start = r2.Start
+	}
+	if r.End > r2.End {
+		r.End = r2.End
+	}
+	return r
+}
+
 func (r Range) Size() int64 {
 	return r.End - r.Start
+}
+
+func (r Range) IsZero() bool {
+	return r.Start == 0 && r.End == 0
 }
 
 func (r Range) Reader(reader io.ReaderAt) (io.Reader, error) {

--- a/lake/ztests/index/query-with-seek.yaml
+++ b/lake/ztests/index/query-with-seek.yaml
@@ -9,8 +9,6 @@ script: |
   zed index create -q AvgScrMath field AvgScrMath
   zed index update -q AvgScrMath
   zed query -s -z 'AvgScrMath == 306 | cut dname'
-
-
 inputs:
   - name: testscores.zson
     source: ../../../testdata/edu/testscores.zson

--- a/lake/ztests/index/query-with-seek.yaml
+++ b/lake/ztests/index/query-with-seek.yaml
@@ -1,0 +1,30 @@
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create -q -seekstride 1KiB -orderby dname:asc test
+  zed use -q test@main
+  zed load -q  testscores.zson
+  zed query -s -z 'AvgScrMath == 306 | cut dname'
+  echo === | tee >(cat >&2)
+  zed index create -q AvgScrMath field AvgScrMath
+  zed index update -q AvgScrMath
+  zed query -s -z 'AvgScrMath == 306 | cut dname'
+
+
+inputs:
+  - name: testscores.zson
+    source: ../../../testdata/edu/testscores.zson
+
+outputs:
+  - name: stdout
+    data: |
+      {dname:"SBE - Lifeline Education Charter"}
+      {dname:"SBE - Lifeline Education Charter"}
+      ===
+      {dname:"SBE - Lifeline Education Charter"}
+      {dname:"SBE - Lifeline Education Charter"}
+  - name: stderr
+    data: |
+      {bytes_read:127768,bytes_matched:136,records_read:2331,records_matched:2}
+      ===
+      {bytes_read:3500,bytes_matched:136,records_read:58,records_matched:2}

--- a/lake/ztests/index/query.yaml
+++ b/lake/ztests/index/query.yaml
@@ -8,13 +8,13 @@ script: |
   zed load -q 1.zson
   zed load -q 2.zson
   zed load -q 3.zson
-  zed query -s -o /dev/null 's==127.0.0.1' 2> stats.zson
+  zed query -s -o /dev/null 's==127.0.0.1'
   zed index update -q
-  zed query -s -o /dev/null 's==127.0.0.1' 2>> stats.zson
-  zed query -s -o /dev/null 's==1' 2>> stats.zson
-  zed query -s -o /dev/null 's=="hello"' 2>> stats.zson
-  zed query -s -o /dev/null 's=="hello" or s==1 or s==127.0.0.1' 2>> stats.zson
-  zq -z 'cut records_read, records_matched' stats.zson
+  zed query -s -o /dev/null 's==127.0.0.1'
+  zed query -s -o /dev/null 's==1'
+  zed query -s -o /dev/null 's=="hello"'
+  zed query -s -o /dev/null 's=="hello" or s==1 or s==127.0.0.1'
+  zed query -s -o /dev/null 's=="missing"'
 inputs:
   - name: 1.zson
     data: |
@@ -27,10 +27,11 @@ inputs:
       {s:"hello"}
 
 outputs:
-  - name: stdout
+  - name: stderr
     data: |
-      {records_read:3,records_matched:1}
-      {records_read:1,records_matched:1}
-      {records_read:1,records_matched:1}
-      {records_read:1,records_matched:1}
-      {records_read:3,records_matched:3}
+      {bytes_read:13,bytes_matched:5,records_read:3,records_matched:1}
+      {bytes_read:5,bytes_matched:5,records_read:1,records_matched:1}
+      {bytes_read:2,bytes_matched:2,records_read:1,records_matched:1}
+      {bytes_read:6,bytes_matched:6,records_read:1,records_matched:1}
+      {bytes_read:13,bytes_matched:13,records_read:3,records_matched:3}
+      {bytes_read:0,bytes_matched:0,records_read:0,records_matched:0}

--- a/service/ztests/index/query-with-seek.yaml
+++ b/service/ztests/index/query-with-seek.yaml
@@ -8,8 +8,6 @@ script: |
   zed index create -q AvgScrMath field AvgScrMath
   zed index update -q AvgScrMath
   zed query -s -z 'AvgScrMath == 306 | cut dname'
-
-
 inputs:
   - name: service.sh
     source: ../service.sh

--- a/service/ztests/index/query-with-seek.yaml
+++ b/service/ztests/index/query-with-seek.yaml
@@ -1,0 +1,31 @@
+script: |
+  source service.sh
+  zed create -q -seekstride 1KiB -orderby dname:asc test
+  zed use -q test@main
+  zed load -q  testscores.zson
+  zed query -s -z 'AvgScrMath == 306 | cut dname'
+  echo === | tee >(cat >&2)
+  zed index create -q AvgScrMath field AvgScrMath
+  zed index update -q AvgScrMath
+  zed query -s -z 'AvgScrMath == 306 | cut dname'
+
+
+inputs:
+  - name: service.sh
+    source: ../service.sh
+  - name: testscores.zson
+    source: ../../../testdata/edu/testscores.zson
+
+outputs:
+  - name: stdout
+    data: |
+      {dname:"SBE - Lifeline Education Charter"}
+      {dname:"SBE - Lifeline Education Charter"}
+      ===
+      {dname:"SBE - Lifeline Education Charter"}
+      {dname:"SBE - Lifeline Education Charter"}
+  - name: stderr
+    data: |
+      {bytes_read:127768,bytes_matched:136,records_read:2331,records_matched:2}
+      ===
+      {bytes_read:3500,bytes_matched:136,records_read:58,records_matched:2}

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -180,7 +180,7 @@ func formatPartition(b *bytes.Buffer, p lake.Partition) {
 	b.WriteString(zson.String(*p.Last()))
 	b.WriteByte('\n')
 	for _, o := range p.Objects {
-		formatDataObject(b, o, "", 2)
+		formatDataObject(b, &o.Object, "", 2)
 	}
 }
 


### PR DESCRIPTION

 Store the value count range for each key when creating indexes and use these use
 this range to narrow the scan of an index optimized query.

 This pr also plumbs the SeekIndexStride option into the branch.Load api
 which was necessary in order to get server tests working for this
 feature.

 Closes #3018