### PR TITLE
fix "zapi drop" error handling

### DIFF
--- a/cmd/zed/lake/drop/command.go
+++ b/cmd/zed/lake/drop/command.go
@@ -60,7 +60,7 @@ func (c *Command) Run(args []string) error {
 	poolName := args[0]
 	poolID, err := lake.PoolID(ctx, poolName)
 	if err != nil {
-		return nil
+		return err
 	}
 	if err := c.confirm(poolName); err != nil {
 		return err

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/brimdata/zed/api"
@@ -11,7 +10,6 @@ import (
 	"github.com/brimdata/zed/api/queryio"
 	"github.com/brimdata/zed/driver"
 	"github.com/brimdata/zed/lake/index"
-	"github.com/brimdata/zed/lake/pools"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/zbuf"
@@ -39,7 +37,7 @@ func NewRemoteWithConnection(conn *client.Connection) *RemoteSession {
 func (r *RemoteSession) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error) {
 	config, err := LookupPoolByName(ctx, r, poolName)
 	if err != nil {
-		return ksuid.Nil, fmt.Errorf("%q: %w", poolName, pools.ErrNotFound)
+		return ksuid.Nil, err
 	}
 	return config.ID, nil
 }

--- a/service/ztests/drop.yaml
+++ b/service/ztests/drop.yaml
@@ -4,8 +4,11 @@ script: |
   zapi create -q p2
   zapi create -q p3
   zapi drop -f p3
-  echo ===
-  zapi ls -f zng | zq -f zson "pick name | sort name" -
+  echo === | tee /dev/stderr
+  zapi ls -f zng | zq -z "pick name | sort name" -
+  echo === | tee /dev/stderr
+  ! zapi drop p3
+  ! zapi -lake http://localhost:1 drop p3
 
 inputs:
   - name: service.sh
@@ -16,9 +19,12 @@ outputs:
     data: |
       pool deleted: p3
       ===
-      {
-          name: "p1"
-      }
-      {
-          name: "p2"
-      }
+      {name:"p1"}
+      {name:"p2"}
+      ===
+  - name: stderr
+    data: |
+      ===
+      ===
+      "p3": pool not found
+      Post "http://localhost:1/query": dial tcp [::1]:1: connect: connection refused


### PR DESCRIPTION
"zapi drop" exists with no output and a zero status when it fails to
connect to a lake service or to drop a nonexistent pool.  Exit with a
useful error message and a nonzero status instead.

Closes #3248.