### PR TITLE
Move zst, compile and index into dev subcommand

### DIFF
--- a/cmd/zc/main.go
+++ b/cmd/zc/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/brimdata/zed/cmd/zed/compile"
+	"github.com/brimdata/zed/cmd/zed/dev/compile"
 	"github.com/brimdata/zed/cmd/zed/root"
 )
 

--- a/cmd/zed/dev/command.go
+++ b/cmd/zed/dev/command.go
@@ -1,0 +1,26 @@
+package dev
+
+import (
+	"flag"
+
+	"github.com/brimdata/zed/cmd/zed/root"
+	"github.com/brimdata/zed/pkg/charm"
+)
+
+var Cmd = &charm.Spec{
+	Name:  "dev",
+	Usage: "dev sub-command [arguments...]",
+	Short: "run specified zed development tool",
+	Long: `
+dev runs the Zed dev command identified by the arguments. With no arguments it
+prints the list of known dev tools.`,
+	New: New,
+}
+
+type Command struct {
+	*root.Command
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return parent.(*root.Command), nil
+}

--- a/cmd/zed/dev/compile/command.go
+++ b/cmd/zed/dev/compile/command.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/brimdata/zed/cmd/zed/dev"
 	"github.com/brimdata/zed/cmd/zed/root"
 	"github.com/brimdata/zed/compiler"
 	"github.com/brimdata/zed/compiler/ast"
@@ -28,11 +29,11 @@ var Cmd = &charm.Spec{
 	Usage: "compile [ options ] zed",
 	Short: "inspect Zed language abstract syntax trees and compiler stages",
 	Long: `
-The "zed compile" command parses a Zed expression and prints the resulting abstract syntax
+The "zed dev compile" command parses a Zed expression and prints the resulting abstract syntax
 tree as JSON object to standard output.  If you have installed the
-shortcuts, "zc" is a short cut for the "zed compile" command.
+shortcuts, "zc" is a short cut for the "zed dev compile" command.
 
-"zed compile" is a tool for dev and test,
+"zed dev compile" is a tool for dev and test,
 and is also useful to advanced users for understanding how Zed syntax is
 translated into an analytics requests sent to the "zed server" search endpoint.
 
@@ -45,6 +46,10 @@ how the parsed AST is transformed into a runtime object comprised of the
 Zed kernel operators.
 `,
 	New: New,
+}
+
+func init() {
+	dev.Cmd.Add(Cmd)
 }
 
 type Command struct {
@@ -238,7 +243,7 @@ func (c *Command) compile(z string) (*compiler.Runtime, error) {
 
 const nodeProblem = `
 Failed to run node on ./compiler/parser/run.js.  The "-js" flag is for PEG
-development and should only be used when running "zed compile" in the root
+development and should only be used when running "zed dev compile" in the root
 directory of the Zed repository.`
 
 func (c *Command) interactive() {

--- a/cmd/zed/dev/indexfile/command.go
+++ b/cmd/zed/dev/indexfile/command.go
@@ -1,20 +1,25 @@
-package index
+package indexfile
 
 import (
 	"flag"
 
+	"github.com/brimdata/zed/cmd/zed/dev"
 	"github.com/brimdata/zed/cmd/zed/root"
 	"github.com/brimdata/zed/pkg/charm"
 )
 
 var Cmd = &charm.Spec{
-	Name:  "index",
-	Usage: "index <command> [options] [arguments...]",
+	Name:  "indexfile",
+	Usage: "indexfile <command> [options] [arguments...]",
 	Short: "create and search Zed indexes",
 	Long: `
-"zed index" is command-line utility for creating and manipulating Zed indexes.
+"zed dev indexfile" is command-line utility for creating and manipulating Zed indexes.
 `,
 	New: New,
+}
+
+func init() {
+	dev.Cmd.Add(Cmd)
 }
 
 type Command struct {

--- a/cmd/zed/dev/indexfile/convert/command.go
+++ b/cmd/zed/dev/indexfile/convert/command.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/inputflags"
-	zedindex "github.com/brimdata/zed/cmd/zed/index"
+	"github.com/brimdata/zed/cmd/zed/dev/indexfile"
 	"github.com/brimdata/zed/field"
 	"github.com/brimdata/zed/index"
 	"github.com/brimdata/zed/order"
@@ -33,11 +33,11 @@ It is an error if the key or value fields are not of uniform type.`,
 }
 
 func init() {
-	zedindex.Cmd.Add(Convert)
+	indexfile.Cmd.Add(Convert)
 }
 
 type Command struct {
-	*zedindex.Command
+	*indexfile.Command
 	frameThresh int
 	order       string
 	outputFile  string
@@ -46,7 +46,7 @@ type Command struct {
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &Command{Command: parent.(*zedindex.Command)}
+	c := &Command{Command: parent.(*indexfile.Command)}
 	f.IntVar(&c.frameThresh, "f", 32*1024, "minimum frame size used in Zed index file")
 	f.StringVar(&c.order, "order", "asc", "specify data in ascending (asc) or descending (desc) order")
 	f.StringVar(&c.outputFile, "o", "index.zng", "name of index output file")

--- a/cmd/zed/dev/indexfile/create/command.go
+++ b/cmd/zed/dev/indexfile/create/command.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/inputflags"
-	zedindex "github.com/brimdata/zed/cmd/zed/index"
+	"github.com/brimdata/zed/cmd/zed/dev/indexfile"
 	"github.com/brimdata/zed/compiler"
 	"github.com/brimdata/zed/expr"
 	"github.com/brimdata/zed/field"
@@ -31,11 +31,11 @@ It is an error if the key fields are not of uniform type.`,
 }
 
 func init() {
-	zedindex.Cmd.Add(Create)
+	indexfile.Cmd.Add(Create)
 }
 
 type Command struct {
-	*zedindex.Command
+	*indexfile.Command
 	frameThresh int
 	outputFile  string
 	keys        field.List
@@ -45,7 +45,7 @@ type Command struct {
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &Command{Command: parent.(*zedindex.Command)}
+	c := &Command{Command: parent.(*indexfile.Command)}
 	f.IntVar(&c.frameThresh, "f", 32*1024, "minimum frame size used in index file")
 	f.StringVar(&c.outputFile, "o", "index.zng", "name of index output file")
 	f.Func("k", "field name of search keys", c.parseKey)

--- a/cmd/zed/dev/indexfile/lookup/command.go
+++ b/cmd/zed/dev/indexfile/lookup/command.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/outputflags"
-	zedindex "github.com/brimdata/zed/cmd/zed/index"
+	"github.com/brimdata/zed/cmd/zed/dev/indexfile"
 	"github.com/brimdata/zed/index"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
@@ -30,18 +30,18 @@ of any nested records.`,
 }
 
 func init() {
-	zedindex.Cmd.Add(Lookup)
+	indexfile.Cmd.Add(Lookup)
 }
 
 type LookupCommand struct {
-	*zedindex.Command
+	*indexfile.Command
 	keys        string
 	outputFlags outputflags.Flags
 	closest     bool
 }
 
 func newLookupCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &LookupCommand{Command: parent.(*zedindex.Command)}
+	c := &LookupCommand{Command: parent.(*indexfile.Command)}
 	f.StringVar(&c.keys, "k", "", "key(s) to search")
 	f.BoolVar(&c.closest, "c", false, "find closest insead of exact match")
 	c.outputFlags.SetFlags(f)
@@ -55,7 +55,7 @@ func (c *LookupCommand) Run(args []string) error {
 	}
 	defer cleanup()
 	if len(args) != 1 {
-		return errors.New("zed index lookup: must be run with a single file argument")
+		return errors.New("zed dev indexfile lookup: must be run with a single file argument")
 	}
 	path := args[0]
 	if c.keys == "" {

--- a/cmd/zed/dev/indexfile/section/command.go
+++ b/cmd/zed/dev/indexfile/section/command.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/outputflags"
-	zedindex "github.com/brimdata/zed/cmd/zed/index"
+	"github.com/brimdata/zed/cmd/zed/dev/indexfile"
 	"github.com/brimdata/zed/index"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
@@ -23,23 +23,23 @@ writes it to the output.  The -trailer option writes
 the Zed index trailer to the output in addition to the section if the section
 number was specified.
 
-See the "zed index" command help for a description of a Zed index file.`,
+See the "zed dev indexfile" command help for a description of a Zed index file.`,
 	New: newCommand,
 }
 
 func init() {
-	zedindex.Cmd.Add(Section)
+	indexfile.Cmd.Add(Section)
 }
 
 type Command struct {
-	*zedindex.Command
+	*indexfile.Command
 	outputFlags outputflags.Flags
 	trailer     bool
 	section     int
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &Command{Command: parent.(*zedindex.Command)}
+	c := &Command{Command: parent.(*indexfile.Command)}
 	f.BoolVar(&c.trailer, "trailer", false, "include the Zed index trailer in the output")
 	f.IntVar(&c.section, "s", -1, "include the indicated section in the output")
 	c.outputFlags.SetFlags(f)
@@ -53,7 +53,7 @@ func (c *Command) Run(args []string) error {
 	}
 	defer cleanup()
 	if len(args) != 1 {
-		return errors.New("zed index section: must be run with a single path argument")
+		return errors.New("zed dev indexfine section: must be run with a single path argument")
 	}
 	path := args[0]
 	local := storage.NewLocalEngine()

--- a/cmd/zed/dev/zst/command.go
+++ b/cmd/zed/dev/zst/command.go
@@ -3,6 +3,7 @@ package zst
 import (
 	"flag"
 
+	"github.com/brimdata/zed/cmd/zed/dev"
 	"github.com/brimdata/zed/cmd/zed/root"
 	"github.com/brimdata/zed/pkg/charm"
 )
@@ -14,6 +15,10 @@ var Cmd = &charm.Spec{
 	Long: `
 zst is a command-line tool for creating and manipulating zst columnar objects.`,
 	New: New,
+}
+
+func init() {
+	dev.Cmd.Add(Cmd)
 }
 
 type Command struct {

--- a/cmd/zed/dev/zst/create/command.go
+++ b/cmd/zed/dev/zst/create/command.go
@@ -7,7 +7,7 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/inputflags"
 	"github.com/brimdata/zed/cli/outputflags"
-	"github.com/brimdata/zed/cmd/zed/zst"
+	devzst "github.com/brimdata/zed/cmd/zed/dev/zst"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
@@ -38,11 +38,11 @@ taken here to control the amount of row skew that can arise.`,
 }
 
 func init() {
-	zst.Cmd.Add(Create)
+	devzst.Cmd.Add(Create)
 }
 
 type Command struct {
-	*zst.Command
+	*devzst.Command
 	outputFlags outputflags.Flags
 	inputFlags  inputflags.Flags
 }
@@ -52,7 +52,7 @@ func MibToBytes(mib float64) int {
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &Command{Command: parent.(*zst.Command)}
+	c := &Command{Command: parent.(*devzst.Command)}
 	c.inputFlags.SetFlags(f, true)
 	c.outputFlags.SetFlagsWithFormat(f, "zst")
 	return c, nil

--- a/cmd/zed/dev/zst/cut/command.go
+++ b/cmd/zed/dev/zst/cut/command.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/outputflags"
-	zstcmd "github.com/brimdata/zed/cmd/zed/zst"
+	devzst "github.com/brimdata/zed/cmd/zed/dev/zst"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
@@ -35,17 +35,17 @@ to scan all of the zng row data.
 }
 
 func init() {
-	zstcmd.Cmd.Add(Cut)
+	devzst.Cmd.Add(Cut)
 }
 
 type Command struct {
-	*zstcmd.Command
+	*devzst.Command
 	outputFlags outputflags.Flags
 	fieldExpr   string
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &Command{Command: parent.(*zstcmd.Command)}
+	c := &Command{Command: parent.(*devzst.Command)}
 	f.StringVar(&c.fieldExpr, "k", "", "dotted field expression of field to cut")
 	c.outputFlags.SetFlags(f)
 	return c, nil

--- a/cmd/zed/dev/zst/inspect/command.go
+++ b/cmd/zed/dev/zst/inspect/command.go
@@ -6,8 +6,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/outputflags"
-	zedzst "github.com/brimdata/zed/cmd/zed/zst"
-	zstcmd "github.com/brimdata/zed/cmd/zed/zst"
+	devzst "github.com/brimdata/zed/cmd/zed/dev/zst"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
@@ -31,18 +30,18 @@ the -trailer option (off by defaulut) indicates that the trailer should be inclu
 }
 
 func init() {
-	zedzst.Cmd.Add(Inspect)
+	devzst.Cmd.Add(Inspect)
 }
 
 type Command struct {
-	*zedzst.Command
+	*devzst.Command
 	outputFlags outputflags.Flags
 	trailer     bool
 	reassembly  bool
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &Command{Command: parent.(*zstcmd.Command)}
+	c := &Command{Command: parent.(*devzst.Command)}
 	f.BoolVar(&c.trailer, "trailer", false, "include the zst trailer in the output")
 	f.BoolVar(&c.reassembly, "R", true, "include the zst reassembly section in the output")
 	c.outputFlags.SetFlags(f)

--- a/cmd/zed/dev/zst/read/command.go
+++ b/cmd/zed/dev/zst/read/command.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/outputflags"
-	zstcmd "github.com/brimdata/zed/cmd/zed/zst"
+	devzst "github.com/brimdata/zed/cmd/zed/dev/zst"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
@@ -29,16 +29,16 @@ read zst objects with zq.
 }
 
 func init() {
-	zstcmd.Cmd.Add(Read)
+	devzst.Cmd.Add(Read)
 }
 
 type Command struct {
-	*zstcmd.Command
+	*devzst.Command
 	outputFlags outputflags.Flags
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &Command{Command: parent.(*zstcmd.Command)}
+	c := &Command{Command: parent.(*devzst.Command)}
 	c.outputFlags.SetFlags(f)
 	return c, nil
 }

--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -5,12 +5,18 @@ import (
 	"os"
 
 	"github.com/brimdata/zed/cmd/zed/api"
-	"github.com/brimdata/zed/cmd/zed/compile"
-	"github.com/brimdata/zed/cmd/zed/index"
-	_ "github.com/brimdata/zed/cmd/zed/index/convert"
-	_ "github.com/brimdata/zed/cmd/zed/index/create"
-	_ "github.com/brimdata/zed/cmd/zed/index/lookup"
-	_ "github.com/brimdata/zed/cmd/zed/index/section"
+	"github.com/brimdata/zed/cmd/zed/dev"
+	_ "github.com/brimdata/zed/cmd/zed/dev/compile"
+	_ "github.com/brimdata/zed/cmd/zed/dev/indexfile"
+	_ "github.com/brimdata/zed/cmd/zed/dev/indexfile/convert"
+	_ "github.com/brimdata/zed/cmd/zed/dev/indexfile/create"
+	_ "github.com/brimdata/zed/cmd/zed/dev/indexfile/lookup"
+	_ "github.com/brimdata/zed/cmd/zed/dev/indexfile/section"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst/create"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst/cut"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst/inspect"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst/read"
 	"github.com/brimdata/zed/cmd/zed/lake"
 	_ "github.com/brimdata/zed/cmd/zed/lake/auth"
 	_ "github.com/brimdata/zed/cmd/zed/lake/branch"
@@ -32,21 +38,14 @@ import (
 	_ "github.com/brimdata/zed/cmd/zed/lake/vacate"
 	"github.com/brimdata/zed/cmd/zed/query"
 	"github.com/brimdata/zed/cmd/zed/root"
-	"github.com/brimdata/zed/cmd/zed/zst"
-	_ "github.com/brimdata/zed/cmd/zed/zst/create"
-	_ "github.com/brimdata/zed/cmd/zed/zst/cut"
-	_ "github.com/brimdata/zed/cmd/zed/zst/inspect"
-	_ "github.com/brimdata/zed/cmd/zed/zst/read"
 )
 
 func main() {
 	zed := root.Zed
 	zed.Add(api.Cmd)
-	zed.Add(compile.Cmd)
+	zed.Add(dev.Cmd)
 	zed.Add(query.Cmd)
-	zed.Add(zst.Cmd)
 	zed.Add(lake.Cmd)
-	zed.Add(index.Cmd)
 	if err := zed.ExecRoot(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)

--- a/cmd/zst/command.go
+++ b/cmd/zst/command.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/brimdata/zed/cmd/zed/dev/zst"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst/create"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst/cut"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst/inspect"
+	_ "github.com/brimdata/zed/cmd/zed/dev/zst/read"
 	"github.com/brimdata/zed/cmd/zed/root"
-	"github.com/brimdata/zed/cmd/zed/zst"
-	_ "github.com/brimdata/zed/cmd/zed/zst/create"
-	_ "github.com/brimdata/zed/cmd/zed/zst/cut"
-	_ "github.com/brimdata/zed/cmd/zed/zst/inspect"
-	_ "github.com/brimdata/zed/cmd/zed/zst/read"
 )
 
 func main() {

--- a/compiler/parser/README.md
+++ b/compiler/parser/README.md
@@ -31,7 +31,7 @@ pigeon and pegjs to create the two parsers.
 
 ## Testing
 
-The [zed compile command](../../cmd/zc) can be used for easily testing the output of
+The [zed dev compile command](../../cmd/zc) can be used for easily testing the output of
 the Zed parser.
 
 ## Development

--- a/compiler/ztests/par-count.yaml
+++ b/compiler/ztests/par-count.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2 "from 'pool-ts' | count() by y"
+script: zc -C -P 2 "from 'pool-ts' | count() by y"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-cut-put-rename.yaml
+++ b/compiler/ztests/par-cut-put-rename.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2  "from 'pool-ts' | cut ts, y, z | put x := y | rename y := z"
+script: zc -C -P 2  "from 'pool-ts' | cut ts, y, z | put x := y | rename y := z"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-cut-uniq.yaml
+++ b/compiler/ztests/par-cut-uniq.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2  "from 'pool-ts' | cut ts, foo:=x | uniq"
+script: zc -C -P 2  "from 'pool-ts' | cut ts, foo:=x | uniq"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-drop-uniq.yaml
+++ b/compiler/ztests/par-drop-uniq.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2 "from 'pool-ts' | drop x | uniq"
+script: zc -C -P 2 "from 'pool-ts' | drop x | uniq"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-every-count.yaml
+++ b/compiler/ztests/par-every-count.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2 "from 'pool-ts' | every 1h count() by y"
+script: zc -C -P 2 "from 'pool-ts' | every 1h count() by y"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-put-dist-uniq.yaml
+++ b/compiler/ztests/par-put-dist-uniq.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2  "from 'pool-ts' | put x:=y | countdistinct(x) by y | uniq"
+script: zc -C -P 2  "from 'pool-ts' | put x:=y | countdistinct(x) by y | uniq"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-put-rename-uniq.yaml
+++ b/compiler/ztests/par-put-rename-uniq.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2  "from 'pool-ts' | put x:=foo | rename foo:=boo | uniq"
+script: zc -C -P 2  "from 'pool-ts' | put x:=foo | rename foo:=boo | uniq"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-put-tail.yaml
+++ b/compiler/ztests/par-put-tail.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2 "from 'pool-ts' | put a:=1 | tail"
+script: zc -C -P 2 "from 'pool-ts' | put a:=1 | tail"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-put-ts-rename-count.yaml
+++ b/compiler/ztests/par-put-ts-rename-count.yaml
@@ -1,6 +1,6 @@
 skip: we no longer parallelize now when we clobber the sort key.  issue 2756
 
-script: zed compile -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo | count()"
+script: zc -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo | count()"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-put-ts-rename-sort.yaml
+++ b/compiler/ztests/par-put-ts-rename-sort.yaml
@@ -1,6 +1,6 @@
 skip: we no longer parallelize now when we clobber the sort key.  issue 2756
 
-script: zed compile -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo | sort"
+script: zc -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo | sort"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-put-ts-rename.yaml
+++ b/compiler/ztests/par-put-ts-rename.yaml
@@ -1,6 +1,6 @@
 skip: we no longer parallelize now when we clobber the sort key.  issue 2756
 
-script: zed compile -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo"
+script: zc -C -P 2  "from 'pool-ts' | put ts:=foo | rename foo:=boo"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-sort-uniq.yaml
+++ b/compiler/ztests/par-sort-uniq.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2 "from 'pool-ts' | sort | uniq"
+script: zc -C -P 2 "from 'pool-ts' | sort | uniq"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-sort-x-uniq.yaml
+++ b/compiler/ztests/par-sort-x-uniq.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2 "from 'pool-ts' | sort x | uniq"
+script: zc -C -P 2 "from 'pool-ts' | sort x | uniq"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-uniq.yaml
+++ b/compiler/ztests/par-uniq.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -P 2 "from 'pool-ts' | uniq"
+script: zc -C -P 2 "from 'pool-ts' | uniq"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/pushdown-index.yaml
+++ b/compiler/ztests/pushdown-index.yaml
@@ -1,11 +1,11 @@
 script: |
-  zed compile -C -O "from 'pool-ts'| x=='hello' or x==1.0"
+  zc -C -O "from 'pool-ts'| x=='hello' or x==1.0"
   echo ===
-  zed compile -C -O "from 'pool-ts'| x > 1 y <= 1.0"
+  zc -C -O "from 'pool-ts'| x > 1 y <= 1.0"
   echo ===
-  zed compile -C -O "from 'pool-ts'| x=='hello' or x!=1.0"
+  zc -C -O "from 'pool-ts'| x=='hello' or x!=1.0"
   echo ===
-  zed compile -C -O "from 'pool-ts'| x=='hello' or !(y==2 or y==3)"
+  zc -C -O "from 'pool-ts'| x=='hello' or !(y==2 or y==3)"
 
 outputs:
   - name: stdout

--- a/compiler/ztests/sem-groupby-input-dir.yaml
+++ b/compiler/ztests/sem-groupby-input-dir.yaml
@@ -1,4 +1,4 @@
-script: zed compile -C -O "from 'pool-ts'| every 1h count()"
+script: zc -C -O "from 'pool-ts'| every 1h count()"
 
 outputs:
   - name: stdout

--- a/index/ztests/bad-version.yaml
+++ b/index/ztests/bad-version.yaml
@@ -3,7 +3,7 @@ script: |
   zq -o in1.zng in.zson
   zq -o trailer.zng trailer.zson
   cat in1.zng trailer.zng > index.zng
-  ! zed index lookup -z -k hello index.zng
+  ! zed dev indexfile lookup -z -k hello index.zng
 
 inputs:
   - name: in.zson

--- a/index/ztests/btree-clash.yaml
+++ b/index/ztests/btree-clash.yaml
@@ -1,6 +1,6 @@
 script: |
-  zed index convert -f 50 -o index.zng -k _child -
-  zed index section -z -trailer index.zng
+  zed dev indexfile convert -f 50 -o index.zng -k _child -
+  zed dev indexfile section -z -trailer index.zng
 
 inputs:
   - name: stdin

--- a/index/ztests/create.yaml
+++ b/index/ztests/create.yaml
@@ -1,5 +1,5 @@
 script: |
-  zed index create -o index.zng -k a in.zson
+  zed dev indexfile create -o index.zng -k a in.zson
   zq -z index.zng
 
 inputs:

--- a/index/ztests/different-types.yaml
+++ b/index/ztests/different-types.yaml
@@ -1,9 +1,9 @@
 script: |
-  zed index create -o index.zng -k a in.zson
-  zed index lookup -z -k 127.0.0.1 index.zng
-  zed index lookup -z -k 1.4 index.zng
-  zed index lookup -z -k 1 index.zng
-  zed index lookup -z -k '"hello"' index.zng
+  zed dev indexfile create -o index.zng -k a in.zson
+  zed dev indexfile lookup -z -k 127.0.0.1 index.zng
+  zed dev indexfile lookup -z -k 1.4 index.zng
+  zed dev indexfile lookup -z -k 1 index.zng
+  zed dev indexfile lookup -z -k '"hello"' index.zng
 
 inputs:
   - name: in.zson

--- a/index/ztests/empty-file.yaml
+++ b/index/ztests/empty-file.yaml
@@ -1,6 +1,6 @@
 script: |
   echo -n "" > empty.zng
-  ! zed index lookup -k none empty.zng
+  ! zed dev indexfile lookup -k none empty.zng
 
 outputs:
   - name: stderr

--- a/index/ztests/empty-index.yaml
+++ b/index/ztests/empty-index.yaml
@@ -1,9 +1,9 @@
 script: |
   # b isn't in the input so this creates a valid Zed index that is empty
-  zed index create -o index.zng -k b in.zson
+  zed dev indexfile create -o index.zng -k b in.zson
   zq -Z index.zng
   echo ===
-  zed index lookup -z -k hello index.zng
+  zed dev indexfile lookup -z -k hello index.zng
   echo ===
 
 inputs:

--- a/index/ztests/flexkey.yaml
+++ b/index/ztests/flexkey.yaml
@@ -1,13 +1,13 @@
 script: |
   zq -o tmp.zng "sum(v) by s | put key:=s | sort key"  babble.zson
   # -x says input keys already sorted and don't create new base records
-  zed index convert -f 20000 -o index.zng -k key tmp.zng
+  zed dev indexfile convert -f 20000 -o index.zng -k key tmp.zng
   # 50 not in index
-  zed index section -z -s 1 index.zng
+  zed dev indexfile section -z -s 1 index.zng
   echo ===
-  zed index lookup -z -k \"wailer-strick\" index.zng
+  zed dev indexfile lookup -z -k \"wailer-strick\" index.zng
   echo ===
-  zed index lookup -z -k \"Anatinacea-bestrew\" index.zng
+  zed dev indexfile lookup -z -k \"Anatinacea-bestrew\" index.zng
 
 inputs:
   - name: babble.zson

--- a/index/ztests/levels.yaml
+++ b/index/ztests/levels.yaml
@@ -1,8 +1,8 @@
 script: |
-  zed index create -o index.zng -k s -f 200 babble.zson
-  zed index section -z -trailer index.zng
+  zed dev indexfile create -o index.zng -k s -f 200 babble.zson
+  zed dev indexfile section -z -trailer index.zng
   echo ===
-  zed index section -z -s 2 index.zng
+  zed dev indexfile section -z -s 2 index.zng
 
 inputs:
   - name: babble.zson

--- a/index/ztests/manual.yaml
+++ b/index/ztests/manual.yaml
@@ -1,8 +1,8 @@
 script: |
-  zed index create -o index.zng -k s babble.zson
+  zed dev indexfile create -o index.zng -k s babble.zson
   zq -z index.zng > index.zson
   zq -o sorted.zng "by s | sort s" babble.zson
-  zed index convert -o manual.zng -k s sorted.zng
+  zed dev indexfile convert -o manual.zng -k s sorted.zng
   zq -z manual.zng > manual.zson
   diff index.zson manual.zson
 

--- a/index/ztests/maxframe.yaml
+++ b/index/ztests/maxframe.yaml
@@ -1,5 +1,5 @@
 script: |
-  ! zed index create -f 1000000000 -o index.zng -k a in.zson
+  ! zed dev indexfile create -f 1000000000 -o index.zng -k a in.zson
 
 inputs:
   - name: in.zson

--- a/index/ztests/maxlevels.yaml
+++ b/index/ztests/maxlevels.yaml
@@ -1,5 +1,5 @@
 script: |
-  ! zed index create -o index.zng -k s -f 20 babble.zson
+  ! zed dev indexfile create -o index.zng -k s -f 20 babble.zson
 
 inputs:
   - name: babble.zson

--- a/index/ztests/multikey-desc.yaml
+++ b/index/ztests/multikey-desc.yaml
@@ -4,14 +4,14 @@ script: |
   # in the base zng index.
   zq -o sorted.zng "sum(v) by s | sort -r sum,s"  babble.zson
   # convert assumes input keys already sorted and doesn't create new base records
-  zed index convert -f 200 -order desc -o index.zng -k sum,s sorted.zng
-  zed index section -z -s 1 index.zng
+  zed dev indexfile convert -f 200 -order desc -o index.zng -k sum,s sorted.zng
+  zed dev indexfile section -z -s 1 index.zng
   echo ===
   # exact lookup of the one record
-  zed index lookup -z -k 149,\"wailer-strick\" index.zng
+  zed dev indexfile lookup -z -k 149,\"wailer-strick\" index.zng
   echo ===
   # don't cares for secondary key... returns multiple matches
-  zed index lookup -z -k 100 index.zng
+  zed dev indexfile lookup -z -k 100 index.zng
 
 inputs:
   - name: babble.zson

--- a/index/ztests/multikey.yaml
+++ b/index/ztests/multikey.yaml
@@ -4,14 +4,14 @@ script: |
   # in the base zng index.
   zq -o sorted.zng "sum(v) by s | sort sum,s"  babble.zson
   # convert assumes input keys already sorted and doesn't create new base records
-  zed index convert -f 200 -o index.zng -k sum,s sorted.zng
-  zed index section -z -s 1 index.zng
+  zed dev indexfile convert -f 200 -o index.zng -k sum,s sorted.zng
+  zed dev indexfile section -z -s 1 index.zng
   echo ===
   # exact lookup of the one record
-  zed index lookup -z -k 149,\"wailer-strick\" index.zng
+  zed dev indexfile lookup -z -k 149,\"wailer-strick\" index.zng
   echo ===
   # don't cares for secondary key... returns multiple matches
-  zed index lookup --z -k 100 index.zng
+  zed dev indexfile lookup --z -k 100 index.zng
 
 inputs:
   - name: babble.zson

--- a/index/ztests/no-trailer.yaml
+++ b/index/ztests/no-trailer.yaml
@@ -1,6 +1,6 @@
 script: |
   zq -o tmp.zng babble.zson
-  ! zed index lookup -z -k 469 tmp.zng
+  ! zed dev indexfile lookup -z -k 469 tmp.zng
 
 inputs:
   - name: babble.zson

--- a/index/ztests/ready.yaml
+++ b/index/ztests/ready.yaml
@@ -1,6 +1,6 @@
 script: |
-  zed index create -x -f 20 -o index.zng -k key -
-  zed index section -z -s 2 index.zng
+  zed dev indexfile create -x -f 20 -o index.zng -k key -
+  zed dev indexfile section -z -s 2 index.zng
 
 inputs:
   - name: stdin

--- a/zfmt/ztests/parallel.yaml
+++ b/zfmt/ztests/parallel.yaml
@@ -1,5 +1,5 @@
 script: |
-  zed compile -s -C 'file bar | foo | split (=> count() by x:=this["@foo"]; => sum(x); => put a:=b*c;) | cut cake | sort -r x'
+  zc -s -C 'file bar | foo | split (=> count() by x:=this["@foo"]; => sum(x); => put a:=b*c;) | cut cake | sort -r x'
 
 outputs:
   - name: stdout


### PR DESCRIPTION
In preparation for the upcoming zed cli migration move the zst, compile
and index commands into a new dev subcommand. Rename index to indexfile.