### PR TITLE
replace lake.ErrPoolNotFound with lake/pools.ErrNotFound

### DIFF
--- a/lake/root.go
+++ b/lake/root.go
@@ -33,8 +33,6 @@ const (
 	LakeMagicString = "ZED LAKE"
 )
 
-var ErrPoolNotFound = errors.New("pool not found")
-
 // The Root of the lake represents the path prefix and configuration state
 // for all of the data pools in the lake.
 type Root struct {
@@ -234,7 +232,7 @@ func (r *Root) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	if err != nil {
 		poolRef = r.pools.LookupByName(ctx, poolName)
 		if poolRef == nil {
-			return ksuid.Nil, fmt.Errorf("%s: %w", poolName, ErrPoolNotFound)
+			return ksuid.Nil, fmt.Errorf("%s: %w", poolName, pools.ErrNotFound)
 		}
 		poolID = poolRef.ID
 	}

--- a/service/request.go
+++ b/service/request.go
@@ -60,8 +60,8 @@ func (r *Request) PoolID(w *ResponseWriter, root *lake.Root) (ksuid.KSUID, bool)
 	id, err := lakeparse.ParseID(s)
 	if err != nil {
 		id, err = root.PoolID(r.Context(), s)
-		if errors.Is(err, lake.ErrPoolNotFound) {
-			w.Error(zqe.ErrNotFound(err))
+		if errors.Is(err, pools.ErrNotFound) {
+			w.Error(err)
 			return ksuid.Nil, false
 		}
 		if err != nil {


### PR DESCRIPTION
ErrPoolNotFound is redundant with pools.ErrNotFound.  Remove the former
and use the latter instead.