### PR TITLE
allow cut of non-record value to root

### DIFF
--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/field"
-	"github.com/brimdata/zed/zcode"
 )
 
 type Cutter struct {
@@ -71,8 +70,8 @@ func (c *Cutter) FoundCut() bool {
 	return c.dirty
 }
 
-// Apply returns a new record comprising fields copied from in according to the
-// receiver's configuration.  If the resulting record would be empty, Apply
+// Apply returns a new value comprising fields copied from in according to the
+// receiver's configuration.  If the resulting value would be empty, Apply
 // returns nil.
 func (c *Cutter) Apply(in *zed.Value) (*zed.Value, error) {
 	if len(c.fieldRefs) == 1 && c.fieldRefs[0].IsRoot() {
@@ -83,15 +82,8 @@ func (c *Cutter) Apply(in *zed.Value) (*zed.Value, error) {
 			}
 			return nil, err
 		}
-		recType, ok := zed.AliasOf(zv.Type).(*zed.TypeRecord)
-		if !ok {
-			return nil, errors.New("cannot cut a non-record to .")
-		}
-		if zv.IsUnset() {
-			return nil, errors.New("cannot cut an unset value to .")
-		}
 		c.dirty = true
-		return zed.NewValue(recType, append(zcode.Bytes{}, zv.Bytes...)), nil
+		return &zv, nil
 	}
 	types := c.typeCache
 	b := c.builder

--- a/expr/ztests/cut-to-root-error-non-record.yaml
+++ b/expr/ztests/cut-to-root-error-non-record.yaml
@@ -1,8 +1,0 @@
-zed: 'cut this:=a'
-
-input: |
-  {a:1(int32)}
-
-warnings: |
-  cut: cannot cut a non-record to .
-  cut: no record found with columns a

--- a/expr/ztests/cut-to-root-error-unset-value.yaml
+++ b/expr/ztests/cut-to-root-error-unset-value.yaml
@@ -1,8 +1,0 @@
-zed: 'cut this:=a'
-
-input: |
-  {a:null({b:int32})}
-
-warnings: |
-  cut: cannot cut an unset value to .
-  cut: no record found with columns a

--- a/expr/ztests/cut-to-root.yaml
+++ b/expr/ztests/cut-to-root.yaml
@@ -1,9 +1,13 @@
 zed: 'cut this:=a'
 
 input: |
+  {a:1(int32)}
+  {a:null({b:int32})}
   {a:{b:null(int32)}}
   {a:{b:1(int32)}}
 
 output: |
+  1(int32)
+  null({b:int32})
   {b:null(int32)}
   {b:1(int32)}


### PR DESCRIPTION
Remove the restriction on cutting a non-record value to root left over
from when a top-level value was required to be a record.