### PR TITLE
fix join when first left key value is null

### DIFF
--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -134,7 +134,8 @@ func (p *Proc) setJoinKey(key zed.Value) {
 }
 
 func (p *Proc) getJoinSet(leftKey zed.Value) ([]*zed.Value, error) {
-	if p.compare(leftKey, p.joinKey) == 0 {
+	if p.joinKey.Type != nil && p.compare(leftKey, p.joinKey) == 0 {
+		// If p.joinKey.Type is nil, p.joinKey hasn't been set.
 		return p.joinSet, nil
 	}
 	for {

--- a/proc/join/ztests/first-key-is-null.yaml
+++ b/proc/join/ztests/first-key-is-null.yaml
@@ -1,0 +1,10 @@
+zed: |
+  split (
+    => pass;
+    => pass;
+  ) | join on a=a
+
+input: &input |
+  {a:null(int64)}
+
+output: *input


### PR DESCRIPTION
The join operator hangs if the first value encountered for the left join
key is null.  Fix this by checking that join.Proc.joinKey has been set
before using it.