### PR TITLE
fix join when first left key value is non-null but zero-length

### DIFF
--- a/proc/join/ztests/first-key-is-zero.yaml
+++ b/proc/join/ztests/first-key-is-zero.yaml
@@ -1,0 +1,10 @@
+zed: |
+  split (
+    => pass;
+    => pass;
+  ) | join on a=a
+
+input: &input |
+  {a:0}
+
+output: *input

--- a/value.go
+++ b/value.go
@@ -154,6 +154,8 @@ func (v Value) IsUnsetOrNil() bool {
 	return v.Bytes == nil
 }
 
+// Copy returns a copy of v that does not share v.Bytes.  The copy's Bytes field
+// is nil if and only if v.Bytes is nil.
 func (v Value) Copy() *Value {
 	var b zcode.Bytes
 	if v.Bytes != nil {
@@ -161,6 +163,20 @@ func (v Value) Copy() *Value {
 		copy(b, v.Bytes)
 	}
 	return &Value{v.Type, b}
+}
+
+// CopyFrom copies from into v, reusing v.Bytes if possible and setting v.Bytes
+// to nil if and only if from.Bytes is nil.
+func (v *Value) CopyFrom(from *Value) {
+	v.Type = from.Type
+	if from.Bytes == nil {
+		v.Bytes = nil
+	} else if v.Bytes == nil {
+		v.Bytes = make(zcode.Bytes, len(from.Bytes))
+		copy(v.Bytes, from.Bytes)
+	} else {
+		v.Bytes = append(v.Bytes[:0], from.Bytes...)
+	}
 }
 
 func (v Value) IsStringy() bool {


### PR DESCRIPTION
The join operator ignores the first value encountered for the left join
key if its zed.Value.Bytes is non-null but zero-length.  Fix this by
preserving the nil-ness of that field when setting join.Proc.joinKey.