### PR TITLE
load -seekStride: Don't set global var

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -271,8 +271,9 @@ func (c *Connection) Query(ctx context.Context, head *lakeparse.Commitish, src s
 	return res, err
 }
 
-func (c *Connection) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, r io.Reader, message api.CommitMessage) (api.CommitResponse, error) {
+func (c *Connection) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, r io.Reader, message api.CommitMessage, seekIndexStride int) (api.CommitResponse, error) {
 	path := urlPath("pool", poolID.String(), "branch", branchName)
+	path += fmt.Sprintf("?seekStride=%d", seekIndexStride)
 	req := c.NewRequest(ctx, http.MethodPost, path, r)
 	if err := encodeCommitMessage(req, message); err != nil {
 		return api.CommitResponse{}, err

--- a/cmd/zed/load/command.go
+++ b/cmd/zed/load/command.go
@@ -43,7 +43,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{
 		Command:    parent.(*root.Command),
-		seekStride: units.Bytes(lake.SeekIndexStride),
+		seekStride: units.Bytes(lake.DefaultSeekStride),
 	}
 	f.Var(&c.seekStride, "seekstride", "size of seek-index unit for ZNG data, as '32KB', '1MB', etc.")
 	c.CommitFlags.SetFlags(f)
@@ -63,7 +63,6 @@ func (c *Command) Run(args []string) error {
 	if len(args) == 0 {
 		return errors.New("zed load: at least one input file must be specified (- for stdin)")
 	}
-	lake.SeekIndexStride = int(c.seekStride)
 	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
 		return err
 	}
@@ -89,7 +88,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	commitID, err := lake.Load(ctx, poolID, head.Branch, zio.ConcatReader(readers...), c.CommitMessage())
+	commitID, err := lake.Load(ctx, poolID, head.Branch, zio.ConcatReader(readers...), c.CommitMessage(), int(c.seekStride))
 	if err != nil {
 		return err
 	}

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -28,7 +28,7 @@ type Interface interface {
 	CreateBranch(ctx context.Context, pool ksuid.KSUID, name string, parent ksuid.KSUID) error
 	RemoveBranch(ctx context.Context, pool ksuid.KSUID, branchName string) error
 	MergeBranch(ctx context.Context, pool ksuid.KSUID, childBranch, parentBranch string, message api.CommitMessage) (ksuid.KSUID, error)
-	Load(ctx context.Context, pool ksuid.KSUID, branch string, r zio.Reader, message api.CommitMessage) (ksuid.KSUID, error)
+	Load(ctx context.Context, pool ksuid.KSUID, branch string, r zio.Reader, message api.CommitMessage, seekIndexStride int) (ksuid.KSUID, error)
 	Delete(ctx context.Context, pool ksuid.KSUID, branchName string, tags []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
 	Revert(ctx context.Context, poolID ksuid.KSUID, branch string, commitID ksuid.KSUID, commit api.CommitMessage) (ksuid.KSUID, error)
 	AddIndexRules(context.Context, []index.Rule) error

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -128,12 +128,12 @@ func (l *LocalSession) lookupBranch(ctx context.Context, poolID ksuid.KSUID, bra
 	return pool, branch, nil
 }
 
-func (l *LocalSession) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, r zio.Reader, message api.CommitMessage) (ksuid.KSUID, error) {
+func (l *LocalSession) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, r zio.Reader, message api.CommitMessage, seekIndexStride int) (ksuid.KSUID, error) {
 	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
 	if err != nil {
 		return ksuid.Nil, err
 	}
-	return branch.Load(ctx, r, message.Author, message.Body, message.Meta)
+	return branch.Load(ctx, r, message.Author, message.Body, message.Meta, seekIndexStride)
 }
 
 func (l *LocalSession) Delete(ctx context.Context, poolID ksuid.KSUID, branchName string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -87,14 +87,14 @@ func (r *RemoteSession) RenamePool(ctx context.Context, pool ksuid.KSUID, name s
 	return r.conn.RenamePool(ctx, pool, api.PoolPutRequest{Name: name})
 }
 
-func (r *RemoteSession) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, reader zio.Reader, commit api.CommitMessage) (ksuid.KSUID, error) {
+func (r *RemoteSession) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, reader zio.Reader, commit api.CommitMessage, seekIndexStride int) (ksuid.KSUID, error) {
 	pr, pw := io.Pipe()
 	w := zngio.NewWriter(pw, zngio.WriterOpts{LZ4BlockSize: zngio.DefaultLZ4BlockSize})
 	go func() {
 		zio.CopyWithContext(ctx, w, reader)
 		w.Close()
 	}()
-	res, err := r.conn.Load(ctx, poolID, branchName, pr, commit)
+	res, err := r.conn.Load(ctx, poolID, branchName, pr, commit, seekIndexStride)
 	return res.Commit, err
 }
 

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -46,8 +46,8 @@ func OpenBranch(ctx context.Context, config *branches.Config, engine storage.Eng
 	}, nil
 }
 
-func (b *Branch) Load(ctx context.Context, r zio.Reader, author, message, meta string) (ksuid.KSUID, error) {
-	w, err := NewWriter(ctx, b.pool)
+func (b *Branch) Load(ctx context.Context, r zio.Reader, author, message, meta string, seekIndexStride int) (ksuid.KSUID, error) {
+	w, err := NewWriter(ctx, b.pool, seekIndexStride)
 	if err != nil {
 		return ksuid.Nil, err
 	}

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -89,7 +89,7 @@ func (c *testClient) TestQuery(query string) string {
 }
 
 func (c *testClient) TestLoad(poolID ksuid.KSUID, branchName string, r io.Reader) {
-	_, err := c.Connection.Load(context.Background(), poolID, branchName, r, api.CommitMessage{})
+	_, err := c.Connection.Load(context.Background(), poolID, branchName, r, api.CommitMessage{}, lake.DefaultSeekStride)
 	require.NoError(c, err)
 }
 

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -277,6 +277,13 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 	if !ok {
 		return
 	}
+	seekStride, isset, ok := r.IntFromQuery("seekStride", w)
+	if !ok {
+		return
+	}
+	if !isset {
+		seekStride = lake.DefaultSeekStride
+	}
 	message, ok := r.decodeCommitMessage(w)
 	if !ok {
 		return
@@ -301,7 +308,7 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 	}
 	warnings := warningCollector{}
 	zr = zio.NewWarningReader(zr, &warnings)
-	kommit, err := branch.Load(r.Context(), zr, message.Author, message.Body, message.Meta)
+	kommit, err := branch.Load(r.Context(), zr, message.Author, message.Body, message.Meta, seekStride)
 	if err != nil {
 		if errors.Is(err, commits.ErrEmptyTransaction) {
 			err = zqe.ErrInvalid("no records in request")

--- a/service/request.go
+++ b/service/request.go
@@ -127,6 +127,19 @@ func (r *Request) JournalIDFromQuery(param string, w *ResponseWriter) (journal.I
 	return journal.ID(id), true
 }
 
+func (r *Request) IntFromQuery(param string, w *ResponseWriter) (int, bool, bool) {
+	s := r.URL.Query().Get(param)
+	if s == "" {
+		return 0, false, true
+	}
+	i, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		w.Error(zqe.ErrInvalid("invalid query param %q: %w", s, err))
+		return 0, true, false
+	}
+	return int(i), true, true
+}
+
 func (r *Request) BoolFromQuery(param string, w *ResponseWriter) (bool, bool) {
 	s := r.URL.Query().Get(param)
 	if s == "" {

--- a/service/ztests/seek-index-null.yaml
+++ b/service/ztests/seek-index-null.yaml
@@ -1,0 +1,34 @@
+script: |
+  source service.sh
+  for o in asc desc; do
+    echo // $o | tee /dev/stderr
+    zed create -q -orderby ts:$o $o
+    zed load -q -seekstride=2KB -use $o@main babble.zson null.zson
+    zed query -z -s "from $o range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
+  done
+
+inputs:
+  - name: service.sh
+  - name: babble.zson
+    source: ../../testdata/babble.zson
+  - name: null.zson
+    data: |
+      {ts:null(time),s:"foo-bar",v:1}
+
+outputs:
+  - name: stdout
+    data: |
+      // asc
+      {ts:2020-04-21T23:59:26.06326664Z,s:"potbellied-Dedanim",v:230}
+      {ts:2020-04-21T23:59:29.06985813Z,s:"areek-ashless",v:266}
+      {ts:2020-04-21T23:59:38.0687693Z,s:"topcoating-rhexis",v:415}
+      // desc
+      {ts:2020-04-21T23:59:38.0687693Z,s:"topcoating-rhexis",v:415}
+      {ts:2020-04-21T23:59:29.06985813Z,s:"areek-ashless",v:266}
+      {ts:2020-04-21T23:59:26.06326664Z,s:"potbellied-Dedanim",v:230}
+  - name: stderr
+    data: |
+      // asc
+      {bytes_read:16401,bytes_matched:87,records_read:500,records_matched:3}
+      // desc
+      {bytes_read:16404,bytes_matched:87,records_read:500,records_matched:3}

--- a/service/ztests/seek-index-overlap.yaml
+++ b/service/ztests/seek-index-overlap.yaml
@@ -1,0 +1,30 @@
+script: |
+  source service.sh
+  zed create -orderby ts:asc -q asc
+  zed create -orderby ts:desc -q desc
+  zed use -q asc@main
+  zq "tail 900" babble.zson | zed load -seekstride=2000B -q -
+  zq "head 250" babble.zson | zed load -seekstride=2000B -q -
+  zed query -z -s "from asc | count()"
+  echo === | tee /dev/stderr
+  zed use -q desc@main
+  zq "tail 900" babble.zson | zed load -seekstride=2000B -q -
+  zq "head 250" babble.zson | zed load -seekstride=2000B -q -
+  zed query -z -s "from desc | count()"
+
+inputs:
+  - name: service.sh
+  - name: babble.zson
+    source: ../../testdata/babble.zson
+
+outputs:
+  - name: stdout
+    data: |
+      {count:1150(uint64)}
+      ===
+      {count:1150(uint64)}
+  - name: stderr
+    data: |
+      {bytes_read:37833,bytes_matched:37833,records_read:1150,records_matched:1150}
+      ===
+      {bytes_read:37833,bytes_matched:37833,records_read:1150,records_matched:1150}

--- a/service/ztests/seek-index.yaml
+++ b/service/ztests/seek-index.yaml
@@ -1,0 +1,30 @@
+script: |
+  source service.sh
+  zed create -orderby ts:asc -q asc
+  zed load -q -seekstride=2KB -use asc@main babble.zson
+  zed query -z -s "from asc range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
+  echo === | tee /dev/stderr
+  zed create -orderby ts:desc -q desc
+  zed load -q -seekstride=2KB -use desc@main babble.zson
+  zed query -z -s "from desc range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
+
+inputs:
+  - name: service.sh
+  - name: babble.zson
+    source: ../../testdata/babble.zson
+
+outputs:
+  - name: stdout
+    data: |
+      {ts:2020-04-21T23:59:26.06326664Z,s:"potbellied-Dedanim",v:230}
+      {ts:2020-04-21T23:59:29.06985813Z,s:"areek-ashless",v:266}
+      {ts:2020-04-21T23:59:38.0687693Z,s:"topcoating-rhexis",v:415}
+      ===
+      {ts:2020-04-21T23:59:38.0687693Z,s:"topcoating-rhexis",v:415}
+      {ts:2020-04-21T23:59:29.06985813Z,s:"areek-ashless",v:266}
+      {ts:2020-04-21T23:59:26.06326664Z,s:"potbellied-Dedanim",v:230}
+  - name: stderr
+    data: |
+      {bytes_read:16401,bytes_matched:87,records_read:500,records_matched:3}
+      ===
+      {bytes_read:16404,bytes_matched:87,records_read:500,records_matched:3}


### PR DESCRIPTION
In the zed load command setting the global SeekIndexStride variable to the
value of the -seekStride flag made it so this value was ignored for
service load requests. Instead add seekStride option to the lake Load
command and propagate this value to the object writers. Add seekStride
query parameter for load requests.