### PR TITLE
Add SeekStride to pool configuration

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -36,9 +36,10 @@ type VersionResponse struct {
 }
 
 type PoolPostRequest struct {
-	Name   string       `json:"name"`
-	Layout order.Layout `json:"layout"`
-	Thresh int64        `json:"thresh"`
+	Name       string       `json:"name"`
+	Layout     order.Layout `json:"layout"`
+	Thresh     int64        `json:"thresh"`
+	SeekStride int          `json:"seek_stride"`
 }
 
 type PoolPutRequest struct {

--- a/api/api.go
+++ b/api/api.go
@@ -38,8 +38,8 @@ type VersionResponse struct {
 type PoolPostRequest struct {
 	Name       string       `json:"name"`
 	Layout     order.Layout `json:"layout"`
-	Thresh     int64        `json:"thresh"`
 	SeekStride int          `json:"seek_stride"`
+	Thresh     int64        `json:"thresh"`
 }
 
 type PoolPutRequest struct {

--- a/cmd/zed/create/command.go
+++ b/cmd/zed/create/command.go
@@ -78,7 +78,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	poolName := args[0]
-	id, err := lake.CreatePool(ctx, poolName, layout, int64(c.thresh), int(c.seekStride))
+	id, err := lake.CreatePool(ctx, poolName, layout, int(c.seekStride), int64(c.thresh))
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/load/command.go
+++ b/cmd/zed/load/command.go
@@ -11,11 +11,9 @@ import (
 	"github.com/brimdata/zed/cli/lakeflags"
 	"github.com/brimdata/zed/cli/procflags"
 	"github.com/brimdata/zed/cmd/zed/root"
-	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/rlimit"
 	"github.com/brimdata/zed/pkg/storage"
-	"github.com/brimdata/zed/pkg/units"
 	"github.com/brimdata/zed/zio"
 )
 
@@ -32,8 +30,7 @@ The load command adds data to a pool and commits it to a branch.
 type Command struct {
 	*root.Command
 	cli.LakeFlags
-	seekStride units.Bytes
-	commit     bool
+	commit bool
 	cli.CommitFlags
 	procFlags  procflags.Flags
 	inputFlags inputflags.Flags
@@ -42,10 +39,8 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{
-		Command:    parent.(*root.Command),
-		seekStride: units.Bytes(lake.SeekIndexStride),
+		Command: parent.(*root.Command),
 	}
-	f.Var(&c.seekStride, "seekstride", "size of seek-index unit for ZNG data, as '32KB', '1MB', etc.")
 	c.CommitFlags.SetFlags(f)
 	c.LakeFlags.SetFlags(f)
 	c.inputFlags.SetFlags(f, true)
@@ -63,7 +58,6 @@ func (c *Command) Run(args []string) error {
 	if len(args) == 0 {
 		return errors.New("zed load: at least one input file must be specified (- for stdin)")
 	}
-	lake.SeekIndexStride = int(c.seekStride)
 	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
 		return err
 	}

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -22,7 +22,7 @@ type Interface interface {
 	Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ScannerStats, error)
 	PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error)
-	CreatePool(context.Context, string, order.Layout, int64, int) (ksuid.KSUID, error)
+	CreatePool(context.Context, string, order.Layout, int, int64) (ksuid.KSUID, error)
 	RemovePool(context.Context, ksuid.KSUID) error
 	RenamePool(context.Context, ksuid.KSUID, string) error
 	CreateBranch(ctx context.Context, pool ksuid.KSUID, name string, parent ksuid.KSUID) error

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -22,7 +22,7 @@ type Interface interface {
 	Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ScannerStats, error)
 	PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error)
-	CreatePool(context.Context, string, order.Layout, int64) (ksuid.KSUID, error)
+	CreatePool(context.Context, string, order.Layout, int64, int) (ksuid.KSUID, error)
 	RemovePool(context.Context, ksuid.KSUID) error
 	RenamePool(context.Context, ksuid.KSUID, string) error
 	CreateBranch(ctx context.Context, pool ksuid.KSUID, name string, parent ksuid.KSUID) error

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -50,11 +50,11 @@ func CreateLocalLake(ctx context.Context, lakePath *storage.URI) (*LocalSession,
 	}, nil
 }
 
-func (l *LocalSession) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64, seekStride int) (ksuid.KSUID, error) {
+func (l *LocalSession) CreatePool(ctx context.Context, name string, layout order.Layout, seekStride int, thresh int64) (ksuid.KSUID, error) {
 	if name == "" {
 		return ksuid.Nil, errors.New("no pool name provided")
 	}
-	pool, err := l.root.CreatePool(ctx, name, layout, thresh, seekStride)
+	pool, err := l.root.CreatePool(ctx, name, layout, seekStride, thresh)
 	if err != nil {
 		return ksuid.Nil, err
 	}

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -50,11 +50,11 @@ func CreateLocalLake(ctx context.Context, lakePath *storage.URI) (*LocalSession,
 	}, nil
 }
 
-func (l *LocalSession) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64) (ksuid.KSUID, error) {
+func (l *LocalSession) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64, seekStride int) (ksuid.KSUID, error) {
 	if name == "" {
 		return ksuid.Nil, errors.New("no pool name provided")
 	}
-	pool, err := l.root.CreatePool(ctx, name, layout, thresh)
+	pool, err := l.root.CreatePool(ctx, name, layout, thresh, seekStride)
 	if err != nil {
 		return ksuid.Nil, err
 	}

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -47,11 +47,12 @@ func (r *RemoteSession) CommitObject(ctx context.Context, poolID ksuid.KSUID, br
 	return res.Commit, err
 }
 
-func (r *RemoteSession) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64) (ksuid.KSUID, error) {
+func (r *RemoteSession) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64, seekStride int) (ksuid.KSUID, error) {
 	res, err := r.conn.CreatePool(ctx, api.PoolPostRequest{
-		Name:   name,
-		Layout: layout,
-		Thresh: thresh,
+		Name:       name,
+		Layout:     layout,
+		SeekStride: seekStride,
+		Thresh:     thresh,
 	})
 	if err != nil {
 		return ksuid.Nil, err

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -47,7 +47,7 @@ func (r *RemoteSession) CommitObject(ctx context.Context, poolID ksuid.KSUID, br
 	return res.Commit, err
 }
 
-func (r *RemoteSession) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64, seekStride int) (ksuid.KSUID, error) {
+func (r *RemoteSession) CreatePool(ctx context.Context, name string, layout order.Layout, seekStride int, thresh int64) (ksuid.KSUID, error) {
 	res, err := r.conn.CreatePool(ctx, api.PoolPostRequest{
 		Name:       name,
 		Layout:     layout,

--- a/lake/data/object.go
+++ b/lake/data/object.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	DefaultThreshold  = 500 * 1024 * 1024
 	DefaultSeekStride = 64 * 1024
+	DefaultThreshold  = 500 * 1024 * 1024
 )
 
 // A FileKind is the first part of a file name, used to differentiate files

--- a/lake/data/object.go
+++ b/lake/data/object.go
@@ -14,7 +14,10 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
-const DefaultThreshold = 500 * 1024 * 1024
+const (
+	DefaultThreshold  = 500 * 1024 * 1024
+	DefaultSeekStride = 64 * 1024
+)
 
 // A FileKind is the first part of a file name, used to differentiate files
 // when they are listed from the archive's backing store.

--- a/lake/pools/config.go
+++ b/lake/pools/config.go
@@ -10,25 +10,30 @@ import (
 )
 
 type Config struct {
-	Ts        nano.Ts      `zed:"ts"`
-	Name      string       `zed:"name"`
-	ID        ksuid.KSUID  `zed:"id"`
-	Layout    order.Layout `zed:"layout"`
-	Threshold int64        `zed:"threshold"`
+	Ts         nano.Ts      `zed:"ts"`
+	Name       string       `zed:"name"`
+	ID         ksuid.KSUID  `zed:"id"`
+	Layout     order.Layout `zed:"layout"`
+	SeekStride int          `zed:"seek_stride"`
+	Threshold  int64        `zed:"threshold"`
 }
 
 var _ journal.Entry = (*Config)(nil)
 
-func NewConfig(name string, layout order.Layout, thresh int64) *Config {
+func NewConfig(name string, layout order.Layout, thresh int64, seekStride int) *Config {
 	if thresh == 0 {
 		thresh = data.DefaultThreshold
 	}
+	if seekStride == 0 {
+		seekStride = data.DefaultSeekStride
+	}
 	return &Config{
-		Ts:        nano.Now(),
-		Name:      name,
-		ID:        ksuid.New(),
-		Layout:    layout,
-		Threshold: thresh,
+		Ts:         nano.Now(),
+		Name:       name,
+		ID:         ksuid.New(),
+		Layout:     layout,
+		SeekStride: seekStride,
+		Threshold:  thresh,
 	}
 }
 

--- a/lake/root.go
+++ b/lake/root.go
@@ -299,7 +299,7 @@ func (r *Root) RenamePool(ctx context.Context, id ksuid.KSUID, newName string) e
 	return r.pools.Rename(ctx, id, newName)
 }
 
-func (r *Root) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64) (*Pool, error) {
+func (r *Root) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64, seekStride int) (*Pool, error) {
 	if name == "HEAD" {
 		return nil, fmt.Errorf("pool cannot be named %q", name)
 	}
@@ -309,7 +309,7 @@ func (r *Root) CreatePool(ctx context.Context, name string, layout order.Layout,
 	if thresh == 0 {
 		thresh = data.DefaultThreshold
 	}
-	config := pools.NewConfig(name, layout, thresh)
+	config := pools.NewConfig(name, layout, thresh, seekStride)
 	if err := CreatePool(ctx, config, r.engine, r.path); err != nil {
 		return nil, err
 	}

--- a/lake/root.go
+++ b/lake/root.go
@@ -299,7 +299,7 @@ func (r *Root) RenamePool(ctx context.Context, id ksuid.KSUID, newName string) e
 	return r.pools.Rename(ctx, id, newName)
 }
 
-func (r *Root) CreatePool(ctx context.Context, name string, layout order.Layout, thresh int64, seekStride int) (*Pool, error) {
+func (r *Root) CreatePool(ctx context.Context, name string, layout order.Layout, seekStride int, thresh int64) (*Pool, error) {
 	if name == "HEAD" {
 		return nil, fmt.Errorf("pool cannot be named %q", name)
 	}

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var SeekIndexStride = 64 * 1024
-
 // Writer is a zio.Writer that consumes records into memory according to
 // the pools data object threshold, sorts each resulting buffer, and writes
 // it as an immutable object to the storage system.  The presumption is that
@@ -130,7 +128,7 @@ func (w *Writer) writeObject(object *data.Object, recs []zed.Value) error {
 	if err != nil {
 		object.Last = zed.Value{zed.TypeNull, nil}
 	}
-	writer, err := object.NewWriter(w.ctx, w.pool.engine, w.pool.DataPath, w.pool.Layout.Order, key, SeekIndexStride)
+	writer, err := object.NewWriter(w.ctx, w.pool.engine, w.pool.DataPath, w.pool.Layout.Order, key, w.pool.SeekStride)
 	if err != nil {
 		return err
 	}

--- a/lake/ztests/consecutive-ts.yaml
+++ b/lake/ztests/consecutive-ts.yaml
@@ -1,8 +1,8 @@
 script: |
   export ZED_LAKE=test
   zed init -q
-  zed create -q -orderby ts:desc logs
-  zed load -use logs@main -q -seekstride 11B in.zson
+  zed create -q -seekstride 11B -orderby ts:desc logs
+  zed load -use logs@main -q in.zson
   zq -z test/*/data/*-seek.zng
 
 inputs:

--- a/lake/ztests/ls.yaml
+++ b/lake/ztests/ls.yaml
@@ -26,6 +26,7 @@ outputs:
                   ] (=field.Path)
               ] (=field.List)
           } (=order.Layout),
+          seek_stride: 65536,
           threshold: 524288000
       }
       ===

--- a/lake/ztests/meta.yaml
+++ b/lake/ztests/meta.yaml
@@ -37,6 +37,7 @@ outputs:
                   ] (=field.Path)
               ] (=field.List)
           } (=order.Layout),
+          seek_stride: 65536,
           threshold: 524288000
       }
       {
@@ -49,6 +50,7 @@ outputs:
                   ] (=field.Path)
               ] (=field.List)
           } (=order.Layout),
+          seek_stride: 65536,
           threshold: 524288000
       }
       ===

--- a/lake/ztests/seek-index-null.yaml
+++ b/lake/ztests/seek-index-null.yaml
@@ -3,8 +3,8 @@ script: |
   zed init -q
   for o in asc desc; do
     echo // $o | tee /dev/stderr
-    zed create -q -orderby ts:$o $o
-    zed load -q -seekstride=2KB -use $o@main babble.zson null.zson
+    zed create -q -seekstride 2KB -orderby ts:$o $o
+    zed load -q -use $o@main babble.zson null.zson
     zed query -z -s "from $o range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
   done
 

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -116,7 +116,7 @@ func handlePoolPost(c *Core, w *ResponseWriter, r *Request) {
 	if !r.Unmarshal(w, &req) {
 		return
 	}
-	pool, err := c.root.CreatePool(r.Context(), req.Name, req.Layout, req.Thresh)
+	pool, err := c.root.CreatePool(r.Context(), req.Name, req.Layout, req.Thresh, req.SeekStride)
 	if err != nil {
 		w.Error(err)
 		return

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -116,7 +116,7 @@ func handlePoolPost(c *Core, w *ResponseWriter, r *Request) {
 	if !r.Unmarshal(w, &req) {
 		return
 	}
-	pool, err := c.root.CreatePool(r.Context(), req.Name, req.Layout, req.Thresh, req.SeekStride)
+	pool, err := c.root.CreatePool(r.Context(), req.Name, req.Layout, req.SeekStride, req.Thresh)
 	if err != nil {
 		w.Error(err)
 		return

--- a/service/ztests/curl-create.yaml
+++ b/service/ztests/curl-create.yaml
@@ -12,4 +12,4 @@ inputs:
 outputs:
   - name: stdout
     regexp: |
-      \{"kind":"lake.BranchMeta","value":\{"branch":\{"commit":"\w{42}","name":"main","ts":"[0-9TZ:.\-]+"\},"pool":\{"id":"\w{42}","layout":\{"keys":\[\["ts"\]\],"order":"desc"\},"name":"test","threshold":524288000,"ts":"[0-9TZ:.\-]+"\}\}\}
+      \{"kind":"lake.BranchMeta","value":\{"branch":\{"commit":"\w{42}","name":"main","ts":"[0-9TZ:.\-]+"\},"pool":\{"id":"\w{42}","layout":\{"keys":\[\["ts"\]\],"order":"desc"\},"name":"test","seek_stride":65536,"threshold":524288000,"ts":"[0-9TZ:.\-]+"\}\}\}

--- a/service/ztests/curl-pool-rename.yaml
+++ b/service/ztests/curl-pool-rename.yaml
@@ -19,4 +19,4 @@ inputs:
 outputs:
   - name: stdout
     regexp: |
-      \[\{"kind":"pools.Config","value":\{"id":"\w{42}","layout":\{"keys":\[\["ts"\]\],"order":"desc"\},"name":"new_test","threshold":524288000,"ts":"[0-9TZ:.\-]+"\}\}\]
+      \[\{"kind":"pools.Config","value":\{"id":"\w{42}","layout":\{"keys":\[\["ts"\]\],"order":"desc"\},"name":"new_test","seek_stride":65536,"threshold":524288000,"ts":"[0-9TZ:.\-]+"\}\}\]

--- a/service/ztests/seek-index-null.yaml
+++ b/service/ztests/seek-index-null.yaml
@@ -1,30 +1,34 @@
 script: |
-  export ZED_LAKE=test
-  zed init -q
-  zed create -seekstride 2KB -orderby ts:asc -q asc
-  zed load -q -use asc@main babble.zson
-  zed query -z -s "from asc range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
-  echo === | tee /dev/stderr
-  zed create -seekstride 2KB -orderby ts:desc -q desc
-  zed load -q -use desc@main babble.zson
-  zed query -z -s "from desc range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
+  source service.sh
+  for o in asc desc; do
+    echo // $o | tee /dev/stderr
+    zed create -q -seekstride=2KB -orderby ts:$o $o
+    zed load -q -use $o@main babble.zson null.zson
+    zed query -z -s "from $o range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
+  done
 
 inputs:
+  - name: service.sh
   - name: babble.zson
     source: ../../testdata/babble.zson
+  - name: null.zson
+    data: |
+      {ts:null(time),s:"foo-bar",v:1}
 
 outputs:
   - name: stdout
     data: |
+      // asc
       {ts:2020-04-21T23:59:26.06326664Z,s:"potbellied-Dedanim",v:230}
       {ts:2020-04-21T23:59:29.06985813Z,s:"areek-ashless",v:266}
       {ts:2020-04-21T23:59:38.0687693Z,s:"topcoating-rhexis",v:415}
-      ===
+      // desc
       {ts:2020-04-21T23:59:38.0687693Z,s:"topcoating-rhexis",v:415}
       {ts:2020-04-21T23:59:29.06985813Z,s:"areek-ashless",v:266}
       {ts:2020-04-21T23:59:26.06326664Z,s:"potbellied-Dedanim",v:230}
   - name: stderr
     data: |
+      // asc
       {bytes_read:16401,bytes_matched:87,records_read:500,records_matched:3}
-      ===
+      // desc
       {bytes_read:16404,bytes_matched:87,records_read:500,records_matched:3}

--- a/service/ztests/seek-index-overlap.yaml
+++ b/service/ztests/seek-index-overlap.yaml
@@ -1,6 +1,5 @@
 script: |
-  export ZED_LAKE=test
-  zed init -q
+  source service.sh
   zed create -seekstride 2KB -orderby ts:asc -q asc
   zed create -seekstride 2KB -orderby ts:desc -q desc
   zed use -q asc@main
@@ -14,6 +13,7 @@ script: |
   zed query -z -s "from desc | count()"
 
 inputs:
+  - name: service.sh
   - name: babble.zson
     source: ../../testdata/babble.zson
 

--- a/service/ztests/seek-index.yaml
+++ b/service/ztests/seek-index.yaml
@@ -1,6 +1,5 @@
 script: |
-  export ZED_LAKE=test
-  zed init -q
+  source service.sh
   zed create -seekstride 2KB -orderby ts:asc -q asc
   zed load -q -use asc@main babble.zson
   zed query -z -s "from asc range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
@@ -10,6 +9,7 @@ script: |
   zed query -z -s "from desc range 2020-04-21T23:59:26.063Z to 2020-04-21T23:59:38.069Z"
 
 inputs:
+  - name: service.sh
   - name: babble.zson
     source: ../../testdata/babble.zson
 


### PR DESCRIPTION
Instead of having SeekStride as a global variable, move this to an
option in pools.Config. Drop -seekstride as a flag in zed command load
and add -seekstride as a hidden flag in zed create.