### PR TITLE
remove -F and -T output flags

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -37,8 +37,6 @@ func (f *Flags) Options() anyio.WriterOpts {
 func (f *Flags) setFlags(fs *flag.FlagSet) {
 	// zio stuff
 	fs.BoolVar(&f.UTF8, "U", false, "display zeek strings as UTF-8")
-	fs.BoolVar(&f.Text.ShowTypes, "T", false, "display field types in text output")
-	fs.BoolVar(&f.Text.ShowFields, "F", false, "display field names in text output")
 	fs.BoolVar(&f.color, "color", true, "enable/disable color formatting for -Z and lake text output")
 	fs.IntVar(&f.ZNG.LZ4BlockSize, "znglz4blocksize", zngio.DefaultLZ4BlockSize,
 		"LZ4 block size in bytes for ZNG compression (nonpositive to disable)")

--- a/zio/anyio/writer.go
+++ b/zio/anyio/writer.go
@@ -25,7 +25,6 @@ type WriterOpts struct {
 	UTF8   bool
 	JSON   jsonio.WriterOpts
 	Lake   lakeio.WriterOpts
-	Text   textio.WriterOpts
 	ZNG    zngio.WriterOpts
 	ZSON   zsonio.WriterOpts
 	Zst    zstio.WriterOpts
@@ -50,7 +49,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) (zio.WriteCloser, error) {
 	case "zst":
 		return zstio.NewWriter(w, opts.Zst)
 	case "text":
-		return textio.NewWriter(w, opts.UTF8, opts.Text), nil
+		return textio.NewWriter(w, opts.UTF8), nil
 	case "table":
 		return tableio.NewWriter(w, opts.UTF8), nil
 	case "csv":

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -12,27 +12,20 @@ import (
 )
 
 type Writer struct {
-	WriterOpts
 	writer    io.WriteCloser
 	flattener *expr.Flattener
 	format    tzngio.OutFmt
 }
 
-type WriterOpts struct {
-	ShowTypes  bool
-	ShowFields bool
-}
-
-func NewWriter(w io.WriteCloser, utf8 bool, opts WriterOpts) *Writer {
+func NewWriter(w io.WriteCloser, utf8 bool) *Writer {
 	format := tzngio.OutFormatZeekAscii
 	if utf8 {
 		format = tzngio.OutFormatZeek
 	}
 	return &Writer{
-		WriterOpts: opts,
-		writer:     w,
-		flattener:  expr.NewFlattener(zed.NewContext()),
-		format:     format,
+		writer:    w,
+		flattener: expr.NewFlattener(zed.NewContext()),
+		format:    format,
 	}
 }
 
@@ -47,28 +40,22 @@ func (w *Writer) Write(rec *zed.Value) error {
 	}
 	var out []string
 	for k, col := range zed.TypeRecordOf(rec.Type).Columns {
-		var s, v string
+		var s string
 		value := rec.ValueByColumn(k)
 		if col.Type == zed.TypeTime {
 			if value.IsUnsetOrNil() {
-				v = "-"
+				s = "-"
 			} else {
 				ts, err := zed.DecodeTime(value.Bytes)
 				if err != nil {
 					return err
 				}
-				v = ts.Time().UTC().Format(time.RFC3339Nano)
+				s = ts.Time().UTC().Format(time.RFC3339Nano)
 			}
 		} else {
-			v = tzngio.FormatValue(value, w.format)
+			s = tzngio.FormatValue(value, w.format)
 		}
-		if w.ShowFields {
-			s = col.Name + ":"
-		}
-		if w.ShowTypes {
-			s = s + tzngio.TypeString(col.Type) + ":"
-		}
-		out = append(out, s+v)
+		out = append(out, s)
 	}
 	s := strings.Join(out, "\t")
 	_, err = fmt.Fprintf(w.writer, "%s\n", s)


### PR DESCRIPTION
The -F and -T output flags alter "-f text" output to include field names
and types, respectively, but they see no use.