### PR TITLE
remove -U flag and always emit UTF-8 for "-f table/text/zeek"

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -36,7 +36,6 @@ func (f *Flags) Options() anyio.WriterOpts {
 
 func (f *Flags) setFlags(fs *flag.FlagSet) {
 	// zio stuff
-	fs.BoolVar(&f.UTF8, "U", false, "display zeek strings as UTF-8")
 	fs.BoolVar(&f.color, "color", true, "enable/disable color formatting for -Z and lake text output")
 	fs.IntVar(&f.ZNG.LZ4BlockSize, "znglz4blocksize", zngio.DefaultLZ4BlockSize,
 		"LZ4 block size in bytes for ZNG compression (nonpositive to disable)")

--- a/zeek/Data-Type-Compatibility.md
+++ b/zeek/Data-Type-Compatibility.md
@@ -90,7 +90,7 @@ cat zeek_types.log
 #unset_field	-
 #fields	my_bool	my_count	my_int	my_double	my_time	my_interval	my_printable_string	my_bytes_string	my_port	my_addr	my_subnet	my_enum	my_set	my_vector	my_record.name	my_record.age
 #types	bool	count	int	double	time	interval	string	string	port	addr	subnet	enum	set[string]	vector[string]	string	count
-T	123	456	123.4560	1592502151.123456	123.456	smile\xf0\x9f\x98\x81smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	things,in,a,set	order,is,important	Jeanne	122
+T	123	456	123.4560	1592502151.123456	123.456	smile😁smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	things,in,a,set	order,is,important	Jeanne	122
 ```
 
 #### Reading the TSV log, outputting as ZSON, and saving a copy:
@@ -147,7 +147,7 @@ zq -f zeek zeek_types.zson
 #unset_field	-
 #fields	my_bool	my_count	my_int	my_double	my_time	my_interval	my_printable_string	my_bytes_string	my_port	my_addr	my_subnet	my_enum	my_set	my_vector	my_record.name	my_record.age
 #types	bool	count	int	double	time	interval	string	string	port	addr	subnet	enum	set[string]	vector[string]	string	count
-T	123	456	123.456	1592502151.123456	123.456	smile\xf0\x9f\x98\x81smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	a,in,set,things	order,is,important	Jeanne	122
+T	123	456	123.456	1592502151.123456	123.456	smile😁smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	a,in,set,things	order,is,important	Jeanne	122
 ```
 
 ## Type-Specific Details

--- a/zio/anyio/writer.go
+++ b/zio/anyio/writer.go
@@ -22,7 +22,6 @@ import (
 
 type WriterOpts struct {
 	Format string
-	UTF8   bool
 	JSON   jsonio.WriterOpts
 	Lake   lakeio.WriterOpts
 	ZNG    zngio.WriterOpts
@@ -37,7 +36,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) (zio.WriteCloser, error) {
 	case "zng":
 		return zngio.NewWriter(w, opts.ZNG), nil
 	case "zeek":
-		return zeekio.NewWriter(w, opts.UTF8), nil
+		return zeekio.NewWriter(w), nil
 	case "ndjson":
 		return ndjsonio.NewWriter(w), nil
 	case "json":
@@ -49,9 +48,9 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) (zio.WriteCloser, error) {
 	case "zst":
 		return zstio.NewWriter(w, opts.Zst)
 	case "text":
-		return textio.NewWriter(w, opts.UTF8), nil
+		return textio.NewWriter(w), nil
 	case "table":
-		return tableio.NewWriter(w, opts.UTF8), nil
+		return tableio.NewWriter(w), nil
 	case "csv":
 		return csvio.NewWriter(w), nil
 	case "parquet":

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -19,21 +19,15 @@ type Writer struct {
 	typ       *zed.TypeRecord
 	limit     int
 	nline     int
-	format    tzngio.OutFmt
 }
 
-func NewWriter(w io.WriteCloser, utf8 bool) *Writer {
+func NewWriter(w io.WriteCloser) *Writer {
 	table := tabwriter.NewWriter(w, 0, 8, 1, ' ', 0)
-	format := tzngio.OutFormatZeekAscii
-	if utf8 {
-		format = tzngio.OutFormatZeek
-	}
 	return &Writer{
 		writer:    w,
 		flattener: expr.NewFlattener(zed.NewContext()),
 		table:     table,
 		limit:     1000,
-		format:    format,
 	}
 }
 
@@ -70,7 +64,7 @@ func (w *Writer) Write(r *zed.Value) error {
 				v = ts.Time().UTC().Format(time.RFC3339Nano)
 			}
 		} else {
-			v = tzngio.FormatValue(value, w.format)
+			v = tzngio.FormatValue(value, tzngio.OutFormatZeek)
 		}
 		out = append(out, v)
 	}

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -14,18 +14,12 @@ import (
 type Writer struct {
 	writer    io.WriteCloser
 	flattener *expr.Flattener
-	format    tzngio.OutFmt
 }
 
-func NewWriter(w io.WriteCloser, utf8 bool) *Writer {
-	format := tzngio.OutFormatZeekAscii
-	if utf8 {
-		format = tzngio.OutFormatZeek
-	}
+func NewWriter(w io.WriteCloser) *Writer {
 	return &Writer{
 		writer:    w,
 		flattener: expr.NewFlattener(zed.NewContext()),
-		format:    format,
 	}
 }
 
@@ -53,7 +47,7 @@ func (w *Writer) Write(rec *zed.Value) error {
 				s = ts.Time().UTC().Format(time.RFC3339Nano)
 			}
 		} else {
-			s = tzngio.FormatValue(value, w.format)
+			s = tzngio.FormatValue(value, tzngio.OutFormatZeek)
 		}
 		out = append(out, s)
 	}

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -19,20 +19,12 @@ type Writer struct {
 	header
 	flattener *expr.Flattener
 	typ       *zed.TypeRecord
-	format    tzngio.OutFmt
 }
 
-func NewWriter(w io.WriteCloser, utf8 bool) *Writer {
-	var format tzngio.OutFmt
-	if utf8 {
-		format = tzngio.OutFormatZeek
-	} else {
-		format = tzngio.OutFormatZeekAscii
-	}
+func NewWriter(w io.WriteCloser) *Writer {
 	return &Writer{
 		writer:    w,
 		flattener: expr.NewFlattener(zed.NewContext()),
-		format:    format,
 	}
 }
 
@@ -52,7 +44,7 @@ func (w *Writer) Write(r *zed.Value) error {
 		}
 		w.typ = zed.TypeRecordOf(r.Type)
 	}
-	values, err := ZeekStrings(r, w.format)
+	values, err := ZeekStrings(r, tzngio.OutFormatZeek)
 	if err != nil {
 		return err
 	}
@@ -146,7 +138,7 @@ func ZeekStrings(r *zed.Value, fmt tzngio.OutFmt) ([]string, error) {
 			}
 			field = string(ts.AppendFloat(nil, precision))
 		} else {
-			field = tzngio.StringOf(zed.Value{col.Type, val}, fmt, false)
+			field = tzngio.StringOf(zed.Value{col.Type, val}, tzngio.OutFormatZeek, false)
 		}
 		ss = append(ss, field)
 	}

--- a/zio/zeekio/ztests/utf8.yaml
+++ b/zio/zeekio/ztests/utf8.yaml
@@ -1,23 +1,21 @@
-script: zq -f zeek -U in.zson
+zed: '*'
 
-inputs:
-  - name: in.zson
-    data: |
-      {_path:"",foo:"😁"(bstring)}
-      {_path:"magic",foo:"😁"(bstring)}
-      {_path:"",foo:"foo😁bar\x00\x01baz"(bstring)}
+input: |
+  {_path:"",foo:"😁"(bstring)}
+  {_path:"magic",foo:"😁"(bstring)}
+  {_path:"",foo:"foo😁bar\x00\x01baz"(bstring)}
 
-outputs:
-  - name: stdout
-    data: |
-      #separator \x09
-      #set_separator	,
-      #empty_field	(empty)
-      #unset_field	-
-      #fields	foo
-      #types	string
-      😁
-      #path	magic
-      😁
-      #path	-
-      foo😁bar\x00\x01baz
+output-flags: -f zeek
+
+output: |
+  #separator \x09
+  #set_separator	,
+  #empty_field	(empty)
+  #unset_field	-
+  #fields	foo
+  #types	string
+  😁
+  #path	magic
+  😁
+  #path	-
+  foo😁bar\x00\x01baz

--- a/zson/ztests/zson-to-zeek.yaml
+++ b/zson/ztests/zson-to-zeek.yaml
@@ -45,4 +45,4 @@ outputs:
       #unset_field	-
       #fields	my_bool	my_count	my_int	my_double	my_time	my_interval	my_printable_string	my_bytes_string	my_port	my_addr	my_subnet	my_enum	my_set	my_vector	my_record.name	my_record.age
       #types	bool	count	int	double	time	interval	string	string	port	addr	subnet	enum	set[string]	vector[string]	string	count
-      T	123	456	123.456	1592502151.123456	123.456	smile\xf0\x9f\x98\x81smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	a,in,set,things	order,is,important	Jeanne	122
+      T	123	456	123.456	1592502151.123456	123.456	smile😁smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	a,in,set,things	order,is,important	Jeanne	122


### PR DESCRIPTION
Output from "-f table/text/zeek" is ASCII with Zeek-style \xhh escaping
for invalid bytes.  UTF-8 is usually preferable but requires the -U
flag.  Remove the flag and always emit UTF-8.  (It's easily transformed
to ASCII with, say, "iconv -f ASCII --byte-subst '\x%02x'".)