### PR TITLE
Enable streaming stats on query endpoint

### DIFF
--- a/api/queryio/zng.go
+++ b/api/queryio/zng.go
@@ -17,11 +17,11 @@ type ZNGWriter struct {
 	marshaler *zson.MarshalZNGContext
 }
 
-func NewZNGWriter(w io.WriteCloser) *ZNGWriter {
+func NewZNGWriter(w io.Writer) *ZNGWriter {
 	m := zson.NewZNGMarshaler()
 	m.Decorate(zson.StyleSimple)
 	return &ZNGWriter{
-		Writer: zngio.NewWriter(w, zngio.WriterOpts{
+		Writer: zngio.NewWriter(zio.NopCloser(w), zngio.WriterOpts{
 			LZ4BlockSize: zngio.DefaultLZ4BlockSize,
 		}),
 		marshaler: m,

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -21,9 +21,8 @@ import (
 	"github.com/brimdata/zed/zqe"
 )
 
-const queryStatsInterval = time.Second
-
 func handleQuery(c *Core, w *ResponseWriter, r *Request) {
+	const queryStatsInterval = time.Second
 	var req api.QueryRequest
 	if !r.Unmarshal(w, &req) {
 		return
@@ -46,13 +45,13 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 	if err != nil {
 		w.Error(err)
 	}
+	defer d.Close()
 	var statsTicker <-chan time.Time
 	if !noctrl {
 		t := time.NewTicker(queryStatsInterval)
-		statsTicker = t.C
 		defer t.Stop()
+		statsTicker = t.C
 	}
-	defer d.Close()
 	err = driver.RunWithLakeAndStats(r.Context(), d, query, zed.NewContext(), c.root, &req.Head, statsTicker, r.Logger, 0)
 	if err != nil && !errors.Is(err, journal.ErrEmpty) {
 		d.Error(err)


### PR DESCRIPTION
Stats were not getting sent on a periodic basis for the query endpoint.
This was causing long running queries on a service to time-out when
served behind an AWS load balancer: The load balancer would see no data
getting transmitted and time-out the connection.

Add a time Ticker in the query handler and also flush the response data
when a control message is sent.

Closes #3371