### PR TITLE
change zbuf.Statser to Meter and ScannerStats to Progress

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -127,7 +127,7 @@ type QueryError struct {
 type QueryStats struct {
 	StartTime  nano.Ts `json:"start_time" zed:"start_time"`
 	UpdateTime nano.Ts `json:"update_time" zed:"update_time"`
-	zbuf.ScannerStats
+	zbuf.Progress
 }
 
 type QueryWarning struct {

--- a/api/queryio/client.go
+++ b/api/queryio/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimdata/zed/zio/zngio"
 )
 
-func RunClientResponse(ctx context.Context, d driver.Driver, res *client.Response) (zbuf.ScannerStats, error) {
+func RunClientResponse(ctx context.Context, d driver.Driver, res *client.Response) (zbuf.Progress, error) {
 	run := &runner{driver: d}
 	r := NewZNGReader(zngio.NewReader(res.Body, zed.NewContext()))
 	for ctx.Err() == nil {
@@ -41,7 +41,7 @@ func RunClientResponse(ctx context.Context, d driver.Driver, res *client.Respons
 type runner struct {
 	driver driver.Driver
 	cid    int
-	stats  zbuf.ScannerStats
+	stats  zbuf.Progress
 }
 
 func (r *runner) Write(rec *zed.Value) error {
@@ -55,8 +55,8 @@ func (r *runner) handleCtrl(ctrl interface{}) error {
 	case *api.QueryChannelEnd:
 		return r.driver.ChannelEnd(ctrl.ChannelID)
 	case *api.QueryStats:
-		r.stats = zbuf.ScannerStats(ctrl.ScannerStats)
-		return r.driver.Stats(ctrl.ScannerStats)
+		r.stats = zbuf.Progress(ctrl.Progress)
+		return r.driver.Stats(ctrl.Progress)
 	case *api.QueryWarning:
 		return r.driver.Warn(ctrl.Warning)
 	case *api.QueryError:

--- a/api/queryio/driver.go
+++ b/api/queryio/driver.go
@@ -63,11 +63,11 @@ func (d *Driver) ChannelEnd(channelID int) error {
 	return d.WriteControl(api.QueryChannelEnd{channelID})
 }
 
-func (d *Driver) Stats(stats zbuf.ScannerStats) error {
+func (d *Driver) Stats(stats zbuf.Progress) error {
 	v := api.QueryStats{
-		StartTime:    d.start,
-		UpdateTime:   nano.Now(),
-		ScannerStats: stats,
+		StartTime:  d.start,
+		UpdateTime: nano.Now(),
+		Progress:   stats,
 	}
 	return d.WriteControl(v)
 }

--- a/cli/queryflags/flags.go
+++ b/cli/queryflags/flags.go
@@ -58,7 +58,7 @@ func isURLWithKnownScheme(path string, schemes ...string) bool {
 	return false
 }
 
-func (f *Flags) PrintStats(stats zbuf.ScannerStats) {
+func (f *Flags) PrintStats(stats zbuf.Progress) {
 	if f.Stats {
 		out, err := zson.Marshal(stats)
 		if err != nil {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -144,8 +144,8 @@ func (r *Runtime) Entry() dag.Op {
 	return r.optimizer.Entry()
 }
 
-func (r *Runtime) Statser() zbuf.Statser {
-	return &statser{r.builder.Schedulers()}
+func (r *Runtime) Meter() zbuf.Meter {
+	return &meter{r.builder.Schedulers()}
 }
 
 // This must be called before the zbuf.Filter interface will work.
@@ -214,14 +214,14 @@ func CompileAssignments(dsts field.List, srcs field.List) (field.List, []expr.Ev
 	return kernel.CompileAssignments(dsts, srcs)
 }
 
-type statser struct {
+type meter struct {
 	schedulers []proc.Scheduler
 }
 
-func (s *statser) Stats() zbuf.ScannerStats {
-	var out zbuf.ScannerStats
+func (s *meter) Progress() zbuf.Progress {
+	var out zbuf.Progress
 	for _, sched := range s.schedulers {
-		out.Add(sched.Stats())
+		out.Add(sched.Progress())
 	}
 	return out
 }

--- a/compiler/kernel/proc.go
+++ b/compiler/kernel/proc.go
@@ -675,16 +675,16 @@ func evalAtCompileTime(zctx *zed.Context, scope *Scope, in dag.Expr) (zed.Value,
 }
 
 type readerScheduler struct {
-	ctx     context.Context
-	filter  *Filter
-	readers []zio.Reader
-	scanner zbuf.Scanner
-	stats   zbuf.ScannerStats
+	ctx      context.Context
+	filter   *Filter
+	readers  []zio.Reader
+	scanner  zbuf.Scanner
+	progress zbuf.Progress
 }
 
 func (r *readerScheduler) PullScanTask() (zbuf.PullerCloser, error) {
 	if r.scanner != nil {
-		r.stats.Add(r.scanner.Stats())
+		r.progress.Add(r.scanner.Progress())
 		r.scanner = nil
 	}
 	if len(r.readers) == 0 {
@@ -703,4 +703,4 @@ func (r *readerScheduler) PullScanTask() (zbuf.PullerCloser, error) {
 	return zbuf.ScannerNopCloser(s), nil
 }
 
-func (r *readerScheduler) Stats() zbuf.ScannerStats { return r.stats.Copy() }
+func (r *readerScheduler) Progress() zbuf.Progress { return r.scanner.Progress() }

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Interface interface {
-	Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ScannerStats, error)
+	Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.Progress, error)
 	PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error)
 	CreatePool(context.Context, string, order.Layout, int, int64) (ksuid.KSUID, error)

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -94,13 +94,13 @@ func (l *LocalSession) DeleteIndexRules(ctx context.Context, ids []ksuid.KSUID) 
 	return l.root.DeleteIndexRules(ctx, ids)
 }
 
-func (l *LocalSession) Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ScannerStats, error) {
+func (l *LocalSession) Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.Progress, error) {
 	query, err := compiler.ParseProc(src, srcfiles...)
 	if err != nil {
-		return zbuf.ScannerStats{}, err
+		return zbuf.Progress{}, err
 	}
 	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
-		return zbuf.ScannerStats{}, err
+		return zbuf.Progress{}, err
 	}
 	return driver.RunWithLake(ctx, d, query, zed.NewContext(), l.root, head)
 }

--- a/lake/api/querydriver.go
+++ b/lake/api/querydriver.go
@@ -36,6 +36,6 @@ func (*queryDriver) ChannelEnd(int) error {
 	return nil
 }
 
-func (*queryDriver) Stats(zbuf.ScannerStats) error {
+func (*queryDriver) Stats(zbuf.Progress) error {
 	return nil
 }

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -104,10 +104,10 @@ func (r *RemoteSession) Revert(ctx context.Context, poolID ksuid.KSUID, branchNa
 	return res.Commit, err
 }
 
-func (r *RemoteSession) Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ScannerStats, error) {
+func (r *RemoteSession) Query(ctx context.Context, d driver.Driver, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.Progress, error) {
 	res, err := r.conn.Query(ctx, head, src, srcfiles...)
 	if err != nil {
-		return zbuf.ScannerStats{}, err
+		return zbuf.Progress{}, err
 	}
 	defer res.Body.Close()
 	return queryio.RunClientResponse(ctx, d, res)

--- a/lake/sorted.go
+++ b/lake/sorted.go
@@ -42,7 +42,7 @@ func (s *statScanner) Pull() (zbuf.Batch, error) {
 	}
 	batch, err := s.puller.Pull()
 	if batch == nil || err != nil {
-		s.sched.AddStats(s.Scanner.Stats())
+		s.sched.AddProgress(s.Scanner.Progress())
 		s.puller = nil
 		s.err = err
 	}

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -271,8 +271,8 @@ func (d *testGroupByDriver) Warn(msg string) error {
 	panic("shouldn't warn")
 }
 
-func (d *testGroupByDriver) ChannelEnd(int) error          { return nil }
-func (d *testGroupByDriver) Stats(zbuf.ScannerStats) error { return nil }
+func (d *testGroupByDriver) ChannelEnd(int) error      { return nil }
+func (d *testGroupByDriver) Stats(zbuf.Progress) error { return nil }
 
 func TestGroupbyStreamingSpill(t *testing.T) {
 

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -40,7 +40,7 @@ type DataAdaptor interface {
 
 type Scheduler interface {
 	PullScanTask() (zbuf.PullerCloser, error)
-	Stats() zbuf.ScannerStats
+	Progress() zbuf.Progress
 }
 
 // Result is a convenient way to bundle the result of Proc.Pull() to


### PR DESCRIPTION
In working on the update for package driver, I realized the
"stats" terminology for scanner status could be improved by
clarifying the design intent of a "progress meter".  So this
commit changes Statser to Meter and ScannerStats to Progress.

This is just name changes and doesn't change any logic.
