### PR TITLE
Peeker: fill at least until min

### DIFF
--- a/pkg/peeker/reader.go
+++ b/pkg/peeker/reader.go
@@ -47,22 +47,14 @@ func (r *Reader) fill(min int) error {
 	r.buffer = r.buffer[:cap(r.buffer)]
 	copy(r.buffer, r.cursor)
 	clen := len(r.cursor)
-	space := len(r.buffer) - clen
-	for space > 0 {
-		cc, err := r.Reader.Read(r.buffer[clen:])
-		if cc > 0 {
-			clen += cc
-			space -= cc
-		}
-		if err != nil {
-			if err == io.EOF {
-				r.eof = true
-				break
-			}
+	n, err := io.ReadAtLeast(r.Reader, r.buffer[clen:], min)
+	if err != nil {
+		if err != io.EOF && err != io.ErrUnexpectedEOF {
 			return err
 		}
+		r.eof = true
 	}
-	r.buffer = r.buffer[:clen]
+	r.buffer = r.buffer[:clen+n]
 	r.cursor = r.buffer
 	return nil
 }


### PR DESCRIPTION
Peeker was previously holding up reads until it had been able to
completely fill up its entire buffer. This caused a problem when reading
from slow drip streams of data- you wouldn't see any data until the
buffer was full which may take a while when the buffer is large. Change
this behavior so Peeker.fill reads until it has at least enough data to
meet the min argument.