### PR TITLE
zed load: add fancy stats updates

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"sync/atomic"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli/auto"
@@ -66,67 +65,4 @@ func (f *Flags) Open(ctx context.Context, zctx *zed.Context, engine storage.Engi
 		readers = append(readers, file)
 	}
 	return readers, nil
-}
-
-func (f *Flags) OpenWithStats(ctx context.Context, zctx *zed.Context, engine storage.Engine, paths []string, stopOnErr bool) ([]*StatsReader, error) {
-	e := &engineWrap{Engine: engine}
-	readers, err := f.Open(ctx, zctx, e, paths, stopOnErr)
-	if err != nil {
-		return nil, err
-	}
-	statsers := make([]*StatsReader, len(readers))
-	for i, r := range readers {
-		sr := e.readers[i]
-		size, err := storage.Size(sr.Reader)
-		if err != nil && !errors.Is(err, storage.ErrNotSupported) {
-			zio.CloseReaders(readers)
-			return nil, err
-		}
-		statsers[i] = &StatsReader{
-			Reader:     r,
-			BytesTotal: size,
-			counter:    sr,
-		}
-	}
-	return statsers, nil
-}
-
-type engineWrap struct {
-	storage.Engine
-	readers []*byteCounter
-}
-
-func (e *engineWrap) Get(ctx context.Context, u *storage.URI) (storage.Reader, error) {
-	r, err := e.Engine.Get(ctx, u)
-	if err != nil {
-		return nil, err
-	}
-	counter := &byteCounter{Reader: r}
-	e.readers = append(e.readers, counter)
-	return counter, nil
-}
-
-type StatsReader struct {
-	zio.Reader
-	BytesTotal int64
-	counter    *byteCounter
-}
-
-func (r *StatsReader) BytesRead() int64 {
-	return r.counter.BytesRead()
-}
-
-type byteCounter struct {
-	storage.Reader
-	n int64
-}
-
-func (r *byteCounter) Read(b []byte) (int, error) {
-	n, err := r.Reader.Read(b)
-	atomic.AddInt64(&r.n, int64(n))
-	return n, err
-}
-
-func (r *byteCounter) BytesRead() int64 {
-	return atomic.LoadInt64(&r.n)
 }

--- a/cmd/zed/load/command.go
+++ b/cmd/zed/load/command.go
@@ -1,9 +1,13 @@
 package load
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"os"
+	"time"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/cli"
@@ -12,9 +16,13 @@ import (
 	"github.com/brimdata/zed/cli/procflags"
 	"github.com/brimdata/zed/cmd/zed/root"
 	"github.com/brimdata/zed/pkg/charm"
+	"github.com/brimdata/zed/pkg/display"
 	"github.com/brimdata/zed/pkg/rlimit"
 	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/pkg/units"
 	"github.com/brimdata/zed/zio"
+	"github.com/paulbellamy/ratecounter"
+	"golang.org/x/term"
 )
 
 var Cmd = &charm.Spec{
@@ -35,6 +43,12 @@ type Command struct {
 	procFlags  procflags.Flags
 	inputFlags inputflags.Flags
 	lakeFlags  lakeflags.Flags
+
+	// status output
+	ctx       context.Context
+	rate      *ratecounter.RateCounter
+	statsers  []*inputflags.StatsReader
+	totalRead int64
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
@@ -67,9 +81,13 @@ func (c *Command) Run(args []string) error {
 	}
 	paths := args
 	local := storage.NewLocalEngine()
-	readers, err := c.inputFlags.Open(ctx, zed.NewContext(), local, paths, false)
+	c.statsers, err = c.inputFlags.OpenWithStats(ctx, zed.NewContext(), local, paths, false)
 	if err != nil {
 		return err
+	}
+	readers := make([]zio.Reader, len(c.statsers))
+	for i, r := range c.statsers {
+		readers[i] = r
 	}
 	defer zio.CloseReaders(readers)
 	head, err := c.lakeFlags.HEAD()
@@ -83,7 +101,17 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	var d *display.Display
+	if !c.lakeFlags.Quiet && term.IsTerminal(int(os.Stderr.Fd())) {
+		c.ctx = ctx
+		c.rate = ratecounter.NewRateCounter(time.Second)
+		d = display.New(c, time.Second/2, os.Stderr)
+		go d.Run()
+	}
 	commitID, err := lake.Load(ctx, poolID, head.Branch, zio.ConcatReader(readers...), c.CommitMessage())
+	if d != nil {
+		d.Close()
+	}
 	if err != nil {
 		return err
 	}
@@ -91,4 +119,41 @@ func (c *Command) Run(args []string) error {
 		fmt.Printf("%s committed\n", commitID)
 	}
 	return nil
+}
+
+type displayer struct {
+	statsers  []*inputflags.StatsReader
+	totalRead int64
+	rate      *ratecounter.RateCounter
+	ctx       context.Context
+}
+
+// (1/1) 1GB/4GB 87%
+
+func (c *Command) Display(w io.Writer) bool {
+	var completed int
+	var totalBytes, readBytes units.Bytes
+	for _, statser := range c.statsers {
+		total, read := statser.BytesTotal, statser.BytesRead()
+		if total == read {
+			completed++
+		}
+		totalBytes += units.Bytes(total)
+		readBytes += units.Bytes(read)
+	}
+	fmt.Fprintf(w, "(%d/%d) ", completed, len(c.statsers))
+	rate := c.incrRate(readBytes)
+	if totalBytes == 0 {
+		fmt.Fprintf(w, "%s %s/s\n", readBytes.Abbrev(), rate.Abbrev())
+	} else {
+		fmt.Fprintf(w, "%s/%s %s/s %.2f%%\n", readBytes.Abbrev(), totalBytes.Abbrev(), rate.Abbrev(), float64(readBytes)/float64(totalBytes)*100)
+	}
+	return c.ctx.Err() == nil
+
+}
+
+func (c *Command) incrRate(readBytes units.Bytes) units.Bytes {
+	c.rate.Incr(int64(readBytes) - c.totalRead)
+	c.totalRead = int64(readBytes)
+	return units.Bytes(c.rate.Rate())
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/kr/text v0.2.0
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/paulbellamy/ratecounter v0.2.0
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
 	github.com/peterh/liner v1.1.0
 	github.com/pierrec/lz4/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.4 h1:NiTx7EEvBzu9sFOD1zORteLSt3o8gnlvZZwSE9TnY9U=
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
+github.com/paulbellamy/ratecounter v0.2.0 h1:2L/RhJq+HA8gBQImDXtLPrDXK5qAj6ozWVK/zFXVJGs=
+github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4 h1:MfIUBZ1bz7TgvQLVa/yPJZOGeKEgs6eTKUjz3zB4B+U=
 github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4/go.mod h1:RMU2gJXhratVxBDTFeOdNhd540tG57lt9FIUV0YLvIQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -26,9 +26,7 @@ type Display struct {
 
 func New(updater Displayer, interval time.Duration, out io.Writer) *Display {
 	live := uilive.New()
-	if out != nil {
-		live.Out = out
-	}
+	live.Out = out
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Display{
 		ctx:      ctx,


### PR DESCRIPTION
Add stats updates to zed load if -q is not enabled and the current shell
is a tty.

Closes #3354