### PR TITLE
zed: auto refresh expired access tokens

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -76,14 +76,12 @@ func (c *Connection) SetAuthToken(token string) {
 }
 
 func (c *Connection) SetAuthStore(store *auth0.Store) error {
-	if store != nil {
-		c.auth = store
-		tokens, err := c.auth.Tokens(c.hostURL)
-		if err != nil || tokens == nil {
-			return err
-		}
-		c.SetAuthToken(tokens.Access)
+	tokens, err := store.Tokens(c.hostURL)
+	if err != nil || tokens == nil {
+		return err
 	}
+	c.auth = store
+	c.SetAuthToken(tokens.Access)
 	return nil
 }
 

--- a/api/client/connection_test.go
+++ b/api/client/connection_test.go
@@ -50,7 +50,7 @@ func TestClientRedirectReplay(t *testing.T) {
 		body <- string(b)
 	})
 	conn := NewConnectionTo(ts.URL)
-	store := auth0.NewStore(t.TempDir() + "/credentials.json")
+	store := auth0.NewStore(filepath.Join(t.TempDir(), "credentials.json"))
 	store.SetTokens(ts.URL, auth0.Tokens{
 		Access:  "012345",
 		Refresh: "98765",

--- a/api/client/connection_test.go
+++ b/api/client/connection_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/brimdata/zed/api"
+	"github.com/brimdata/zed/api/client/auth0"
+	"github.com/brimdata/zed/zngbytes"
+	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientRedirectReplay(t *testing.T) {
+	const expected = "hello world"
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	mux.HandleFunc("/auth/method", func(w http.ResponseWriter, r *http.Request) {
+		s := zngbytes.NewSerializer()
+		s.Write(api.AuthMethodResponse{
+			Kind: api.AuthMethodAuth0,
+			Auth0: &api.AuthMethodAuth0Details{
+				Domain: ts.URL,
+			},
+		})
+		w.Write(s.Bytes())
+	})
+	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(struct {
+			AccessToken string `json:"access_token"`
+		}{"12345"})
+	})
+	var requests int
+	body := make(chan string, 1)
+	mux.HandleFunc("/pool/", func(w http.ResponseWriter, r *http.Request) {
+		if requests == 0 {
+			requests++
+			w.WriteHeader(401)
+			io.WriteString(w, "invalid token")
+			return
+		}
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		body <- string(b)
+	})
+	conn := NewConnectionTo(ts.URL)
+	store := auth0.NewStore(t.TempDir() + "/credentials.json")
+	store.SetTokens(ts.URL, auth0.Tokens{
+		Access:  "012345",
+		Refresh: "98765",
+	})
+	conn.SetAuthStore(store)
+	_, err := conn.Load(context.Background(), ksuid.New(), "main", strings.NewReader(expected), api.CommitMessage{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, <-body)
+}

--- a/cli/lake.go
+++ b/cli/lake.go
@@ -45,13 +45,9 @@ func (l *LakeFlags) Connection() (*client.Connection, error) {
 	if !api.IsLakeService(uri) {
 		return nil, errors.New("cannot open connection on local lake")
 	}
-	tokens, err := l.AuthStore().Tokens(uri.String())
-	if err != nil {
-		return nil, err
-	}
 	conn := client.NewConnectionTo(uri.String())
-	if tokens != nil {
-		conn.SetAuthToken(tokens.Access)
+	if err := conn.SetAuthStore(l.AuthStore()); err != nil {
+		return nil, err
 	}
 	return conn, nil
 }

--- a/pkg/fs/jsonfile.go
+++ b/pkg/fs/jsonfile.go
@@ -12,7 +12,9 @@ import (
 // it with permissions perm.
 func MarshalJSONFile(v interface{}, filename string, perm os.FileMode) (err error) {
 	return ReplaceFile(filename, perm, func(w io.Writer) error {
-		return json.NewEncoder(w).Encode(v)
+		e := json.NewEncoder(w)
+		e.SetIndent("", "    ")
+		return e.Encode(v)
 	})
 }
 

--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -31,9 +31,8 @@ class Client():
         except FileNotFoundError:
             return None
         creds = json.loads(data)
-        for s in creds['services']:
-            if s['url'] == self.base_url:
-                return s['tokens']['access']
+        if self.base_url in creds['services']:
+            return creds['services'][self.base_url]['access']
         return None
 
     def create_pool(self, name, layout={'order': 'desc', 'keys': [['ts']]},


### PR DESCRIPTION
If a request fails due to using an expired access token, have the
client.Connection automatically retrieve a new access token from Auth0
and retry the request.