### PR TITLE
handle primitives in mapper to fix ZNG bug

### DIFF
--- a/zio/anyio/ztests/fake-zng.yaml
+++ b/zio/anyio/ztests/fake-zng.yaml
@@ -9,12 +9,4 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      stdio:stdin: format detection error
-      	zeek: line 1: bad types/fields definition in zeek header
-      	zjson: line 1: invalid character '\x00' looking for beginning of value
-      	zson: zson syntax error
-      	zng: zng type ID out of range
-      	csv: line 1: EOF
-      	json: invalid character '\x00' looking for beginning of value
-      	parquet: auto-detection not supported
-      	zst: auto-detection not supported
+      stdio:stdin: malformed zng record

--- a/zio/zngio/ztests/primitive.yaml
+++ b/zio/zngio/ztests/primitive.yaml
@@ -1,0 +1,16 @@
+script: |
+  zq -i zson - | zq -i zng -z -
+
+inputs:
+  - name: stdin
+    data: |
+      1
+      "hello"
+      "foo"(error)
+
+outputs:
+  - name: stdout
+    data: |
+      1
+      "hello"
+      "foo"(error)


### PR DESCRIPTION
The zngio reader applies the type mapper to all top-level values
but the type mapper presumes types are complex.  This commit changes
the type mapper to check for primitives and do nothing so that
any code that uses a mapper doesn't have to special-case primitives.

Fixes #3391