### PR TITLE
propagate arithmetic expression errors properly

### DIFF
--- a/expr/ztests/nested-error.yaml
+++ b/expr/ztests/nested-error.yaml
@@ -1,0 +1,7 @@
+zed: yield {x:'a'+(1+'b')}
+
+input: |
+  {}
+
+output: |
+  {x:"incompatible types"(error)}


### PR DESCRIPTION
Errors were not propagated properly where error values could
be used incorrectly as actual values in expressions like string
concatenation.  This fixes arithmetic expressions to detect and
propagate errors correctly.

We will improve the error message for "incompatible types" in a 
subsequent PR.  See #3224.

This should fix the "bstring" problem in #3377.
