### PR TITLE
fix failing query in scripts/perf-compare.sh

### DIFF
--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -46,7 +46,7 @@ declare -a ZED_QUERIES=(
     '*'
     'cut ts'
     'count()'
-    'count() by id.orig_h'
+    'count() by quiet(id.orig_h)'
     'id.resp_h==52.85.83.116'
 )
 


### PR DESCRIPTION
As of #3368, the command "zq -f zeek 'count() by id.orig_h' ..." in
scripts/perf-compare.sh fails because its output now includes Zed error
values, on which the Zeek writer chokes.  Fix by wrapping id.orig_h with
quiet() in that command.