### PR TITLE
panic on error in zcode.Iter.Next, NextTagAndBody

### DIFF
--- a/array.go
+++ b/array.go
@@ -29,10 +29,7 @@ func (t *TypeArray) Marshal(zv zcode.Bytes) (interface{}, error) {
 	vals := []Value{}
 	it := zv.Iter()
 	for !it.Done() {
-		val, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		val, _ := it.Next()
 		vals = append(vals, Value{t.Type, val})
 	}
 	return vals, nil
@@ -44,12 +41,8 @@ func (t *TypeArray) Format(zv zcode.Bytes) string {
 	b.WriteByte('[')
 	it := zv.Iter()
 	for !it.Done() {
-		val, _, err := it.Next()
-		if err != nil {
-			return badZNG(err, t, zv)
-		}
 		b.WriteString(sep)
-		if val == nil {
+		if val, _ := it.Next(); val == nil {
 			b.WriteString("null")
 		} else {
 			b.WriteString(t.Type.Format(val))

--- a/expr/agg/collect.go
+++ b/expr/agg/collect.go
@@ -108,11 +108,7 @@ func (c *Collect) ConsumeAsPartial(val *zed.Value) {
 	typ := arrayType.Type
 	elem := zed.Value{Type: typ}
 	for it := val.Iter(); !it.Done(); {
-		b, _, err := it.Next()
-		if err != nil {
-			panic(err)
-		}
-		elem.Bytes = b
+		elem.Bytes, _ = it.Next()
 		c.update(&elem)
 	}
 }

--- a/expr/agg/union.go
+++ b/expr/agg/union.go
@@ -79,10 +79,7 @@ func (u *Union) ConsumeAsPartial(val *zed.Value) {
 		u.typ = typ.Type
 	}
 	for it := val.Iter(); !it.Done(); {
-		elem, _, err := it.Next()
-		if err != nil {
-			panic(err)
-		}
+		elem, _ := it.Next()
 		u.update(elem)
 	}
 }

--- a/expr/boolean.go
+++ b/expr/boolean.go
@@ -397,11 +397,7 @@ func Contains(compare Boolean) Boolean {
 			return false
 		}
 		for it := val.Iter(); !it.Done(); {
-			var err error
-			el.Bytes, _, err = it.Next()
-			if err != nil {
-				return false
-			}
+			el.Bytes, _ = it.Next()
 			if compare(&el) {
 				return true
 			}

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -166,10 +166,7 @@ func (i *In) inContainer(typ zed.Type, elem, container *zed.Value) *zed.Value {
 		if iter.Done() {
 			return zed.False
 		}
-		zv, _, err := iter.Next()
-		if err != nil {
-			panic(err)
-		}
+		zv, _ := iter.Next()
 		if _, errVal := i.vals.Coerce(elem, &zed.Value{typ, zv}); errVal != nil {
 			if errVal != coerce.IncompatibleTypes {
 				return errVal
@@ -185,10 +182,7 @@ func (i *In) inMap(typ *zed.TypeMap, elem, container *zed.Value) *zed.Value {
 	valType := zed.AliasOf(typ.ValType)
 	iter := container.Bytes.Iter()
 	for !iter.Done() {
-		zv, _, err := iter.Next()
-		if err != nil {
-			panic(err)
-		}
+		zv, _ := iter.Next()
 		if _, errVal := i.vals.Coerce(elem, &zed.Value{keyType, zv}); errVal != nil {
 			if errVal != coerce.IncompatibleTypes {
 				return errVal
@@ -196,10 +190,7 @@ func (i *In) inMap(typ *zed.TypeMap, elem, container *zed.Value) *zed.Value {
 		} else if i.vals.Equal() {
 			return zed.True
 		}
-		zv, _, err = iter.Next()
-		if err != nil {
-			panic(err)
-		}
+		zv, _ = iter.Next()
 		if _, errVal := i.vals.Coerce(elem, &zed.Value{valType, zv}); errVal != nil {
 			if errVal != coerce.IncompatibleTypes {
 				return errVal
@@ -607,10 +598,7 @@ func getNthFromContainer(container zcode.Bytes, idx uint) zcode.Bytes {
 	iter := container.Iter()
 	var i uint = 0
 	for ; !iter.Done(); i++ {
-		zv, _, err := iter.Next()
-		if err != nil {
-			panic(err)
-		}
+		zv, _ := iter.Next()
 		if i == idx {
 			return zv
 		}
@@ -621,14 +609,8 @@ func getNthFromContainer(container zcode.Bytes, idx uint) zcode.Bytes {
 func lookupKey(mapBytes, target zcode.Bytes) (zcode.Bytes, bool) {
 	iter := mapBytes.Iter()
 	for !iter.Done() {
-		key, _, err := iter.Next()
-		if err != nil {
-			return nil, false
-		}
-		val, _, err := iter.Next()
-		if err != nil {
-			return nil, false
-		}
+		key, _ := iter.Next()
+		val, _ := iter.Next()
 		if bytes.Compare(key, target) == 0 {
 			return val, true
 		}

--- a/expr/flattener.go
+++ b/expr/flattener.go
@@ -44,13 +44,11 @@ func recode(dst zcode.Bytes, typ *zed.TypeRecord, in zcode.Bytes) (zcode.Bytes, 
 	it := in.Iter()
 	colno := 0
 	for !it.Done() {
-		val, container, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		val, container := it.Next()
 		col := typ.Columns[colno]
 		colno++
 		if childType, ok := zed.AliasOf(col.Type).(*zed.TypeRecord); ok {
+			var err error
 			dst, err = recode(dst, childType, val)
 			if err != nil {
 				return nil, err

--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -179,10 +179,7 @@ func (j *Join) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	it := zsplits.Bytes.Iter()
 	var sep string
 	for !it.Done() {
-		bytes, _, err := it.Next()
-		if err != nil {
-			panic(err)
-		}
+		bytes, _ := it.Next()
 		s, err := zed.DecodeString(bytes)
 		if err != nil {
 			panic(err)

--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -454,10 +454,7 @@ func (s *step) build(ectx Context, in zcode.Bytes, b *zcode.Builder) *zed.Value 
 		b.BeginContainer()
 		iter := in.Iter()
 		for !iter.Done() {
-			zv, _, err := iter.Next()
-			if err != nil {
-				panic(err)
-			}
+			zv, _ := iter.Next()
 			if zerr := s.children[0].build(ectx, zv, b); zerr != nil {
 				return zerr
 			}

--- a/expr/slice.go
+++ b/expr/slice.go
@@ -84,9 +84,7 @@ func (s *Slice) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if k == from {
 			bytes = zcode.Bytes(it)
 		}
-		if _, _, err := it.Next(); err != nil {
-			panic(err)
-		}
+		it.Next()
 	}
 	return ectx.NewValue(elem.Type, bytes[:len(bytes)-len(it)])
 }

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -232,13 +232,13 @@ func LookupCompare(typ zed.Type) comparefn {
 				if ib.Done() {
 					return 1
 				}
-				va, container, err := ia.Next()
-				if container || err != nil {
+				va, container := ia.Next()
+				if container {
 					return -1
 				}
 
-				vb, container, err := ib.Next()
-				if container || err != nil {
+				vb, container := ib.Next()
+				if container {
 					return 1
 				}
 				if v := compare(va, vb); v != 0 {

--- a/expr/unflattener.go
+++ b/expr/unflattener.go
@@ -70,10 +70,7 @@ func (u *Unflattener) Eval(ectx Context, this *zed.Value) *zed.Value {
 	}
 	b.Reset()
 	for iter := this.Bytes.Iter(); !iter.Done(); {
-		zv, con, err := iter.Next()
-		if err != nil {
-			panic(err)
-		}
+		zv, con := iter.Next()
 		b.Append(zv, con)
 	}
 	zbytes, err := b.Encode()

--- a/fielditer.go
+++ b/fielditer.go
@@ -31,15 +31,9 @@ func (r *fieldIter) Next() ([]string, Value, error) {
 		return nil, Value{}, ErrExhausted
 	}
 	info := &r.stack[len(r.stack)-1]
-
-	zv, container, err := info.iter.Next()
-	if err != nil {
-		return nil, Value{}, err
-	}
-
 	col := info.typ.Columns[info.offset]
 	fullname := append(info.field, col.Name)
-
+	zv, container := info.iter.Next()
 	recType, isRecord := AliasOf(col.Type).(*TypeRecord)
 	if isRecord {
 		if !container {

--- a/map.go
+++ b/map.go
@@ -32,18 +32,11 @@ func (t *TypeMap) Decode(zv zcode.Bytes) (Value, Value, error) {
 		return Value{}, Value{}, nil
 	}
 	it := zv.Iter()
-	key, container, err := it.Next()
-	if err != nil {
-		return Value{}, Value{}, err
-	}
+	key, container := it.Next()
 	if container != IsContainerType(t.KeyType) {
 		return Value{}, Value{}, ErrMismatch
 	}
-	var val zcode.Bytes
-	val, container, err = it.Next()
-	if err != nil {
-		return Value{}, Value{}, err
-	}
+	val, container := it.Next()
 	if container != IsContainerType(t.ValType) {
 		return Value{}, Value{}, ErrMismatch
 	}
@@ -55,15 +48,9 @@ func (t *TypeMap) Marshal(zv zcode.Bytes) (interface{}, error) {
 	vals := []Value{}
 	it := zv.Iter()
 	for !it.Done() {
-		val, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		val, _ := it.Next()
 		vals = append(vals, Value{t.KeyType, val})
-		val, _, err = it.Next()
-		if err != nil {
-			return nil, err
-		}
+		val, _ = it.Next()
 		vals = append(vals, Value{t.ValType, val})
 	}
 	return vals, nil
@@ -81,14 +68,8 @@ type keyval struct {
 func NormalizeMap(zv zcode.Bytes) zcode.Bytes {
 	elements := make([]keyval, 0, 8)
 	for it := zv.Iter(); !it.Done(); {
-		key, _, err := it.NextTagAndBody()
-		if err != nil {
-			panic(err)
-		}
-		val, _, err := it.NextTagAndBody()
-		if err != nil {
-			panic(err)
-		}
+		key, _ := it.NextTagAndBody()
+		val, _ := it.NextTagAndBody()
 		elements = append(elements, keyval{key, val})
 	}
 	if len(elements) < 2 {
@@ -116,18 +97,12 @@ func (t *TypeMap) Format(zv zcode.Bytes) string {
 	b.WriteString("|{")
 	sep := ""
 	for !it.Done() {
-		val, _, err := it.Next()
-		if err != nil {
-			return badZNG(err, t, zv)
-		}
+		val, _ := it.Next()
 		b.WriteString(sep)
 		b.WriteByte('{')
 		b.WriteString(t.KeyType.Format(val))
 		b.WriteByte(',')
-		val, _, err = it.Next()
-		if err != nil {
-			return badZNG(err, t, zv)
-		}
+		val, _ = it.Next()
 		b.WriteString(t.ValType.Format(val))
 		b.WriteByte('}')
 		b.WriteString(sep)

--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -489,10 +489,7 @@ func (a *Aggregator) readTable(flush, partialsOut bool) (zbuf.Batch, error) {
 		it := zcode.Bytes(key).Iter()
 		a.builder.Reset()
 		for _, typ := range a.keyTypes.Types(row.keyType) {
-			flatVal, _, err := it.Next()
-			if err != nil {
-				panic(err)
-			}
+			flatVal, _ := it.Next()
 			a.builder.Append(flatVal, zed.IsContainerType(typ))
 			types = append(types, typ)
 		}

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -183,10 +183,7 @@ func (ig *getter) nth(n int) (zcode.Bytes, error) {
 		ig.iter = ig.container.Iter()
 	}
 	for !ig.iter.Done() {
-		zv, _, err := ig.iter.Next()
-		if err != nil {
-			return nil, err
-		}
+		zv, _ := ig.iter.Next()
 		ig.cursor++
 		if ig.cursor == n {
 			return zv, nil

--- a/proc/shape/shaper.go
+++ b/proc/shape/shaper.go
@@ -86,10 +86,7 @@ func (i *integer) check(zv zed.Value) {
 func (a *anchor) updateInts(rec *zed.Value) error {
 	it := rec.Bytes.Iter()
 	for k, c := range rec.Columns() {
-		bytes, _, err := it.Next()
-		if err != nil {
-			return err
-		}
+		bytes, _ := it.Next()
 		zv := zed.Value{c.Type, bytes}
 		a.integers[k].check(zv)
 	}
@@ -280,10 +277,7 @@ func recode(from, to []zed.Column, bytes zcode.Bytes) (zcode.Bytes, error) {
 	out := make(zcode.Bytes, 0, len(bytes))
 	it := bytes.Iter()
 	for k, fromCol := range from {
-		b, container, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		b, container := it.Next()
 		toType := to[k].Type
 		if fromCol.Type != toType && b != nil {
 			if fromCol.Type != zed.TypeFloat64 {

--- a/proc/traverse/over.go
+++ b/proc/traverse/over.go
@@ -5,7 +5,6 @@ import (
 	"github.com/brimdata/zed/expr"
 	"github.com/brimdata/zed/proc"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zcode"
 )
 
 type Over struct {
@@ -76,19 +75,13 @@ func appendOver(vals []zed.Value, zv zed.Value) ([]zed.Value, error) {
 		// XXX Issue #3324: need to support records and maps.
 		return vals, nil
 	}
-	iter := zcode.Iter(zv.Bytes)
-	for {
-		b, _, err := iter.Next()
-		if b == nil {
-			return vals, nil
-		}
-		if err != nil {
-			return nil, err
-		}
+	for it := zv.Bytes.Iter(); !it.Done(); {
+		b, _ := it.Next()
 		// XXX when we do proper expr.Context, we can allocate
 		// this slice through the batch.
 		bc := make([]byte, len(b))
 		copy(bc, b)
 		vals = append(vals, zed.Value{typ, bc})
 	}
+	return vals, nil
 }

--- a/record.go
+++ b/record.go
@@ -36,10 +36,7 @@ func (t *TypeRecord) Decode(zv zcode.Bytes) ([]Value, error) {
 	}
 	var vals []Value
 	for i, it := 0, zv.Iter(); !it.Done(); i++ {
-		val, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		val, _ := it.Next()
 		if i >= len(t.Columns) {
 			return nil, fmt.Errorf("too many values for record element %s", val)
 		}
@@ -53,10 +50,7 @@ func (t *TypeRecord) Marshal(zv zcode.Bytes) (interface{}, error) {
 	m := make(map[string]Value)
 	it := zv.Iter()
 	for _, col := range t.Columns {
-		zv, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		zv, _ := it.Next()
 		m[col.Name] = Value{col.Type, zv}
 	}
 	return m, nil
@@ -108,14 +102,10 @@ func (t *TypeRecord) Format(zv zcode.Bytes) string {
 	sep := ""
 	it := zv.Iter()
 	for _, c := range t.Columns {
-		val, _, err := it.Next()
-		if err != nil {
-			return badZNG(err, t, zv)
-		}
 		b.WriteString(sep)
 		b.WriteString(QuotedName(c.Name))
 		b.WriteByte(':')
-		if val == nil {
+		if val, _ := it.Next(); val == nil {
 			b.WriteString("null")
 		} else {
 			b.WriteString(c.Type.Format(val))

--- a/recordval.go
+++ b/recordval.go
@@ -82,10 +82,7 @@ func checkSet(typ *TypeSet, body zcode.Bytes) error {
 	it := body.Iter()
 	var prev zcode.Bytes
 	for !it.Done() {
-		tagAndBody, _, err := it.NextTagAndBody()
-		if err != nil {
-			return err
-		}
+		tagAndBody, _ := it.NextTagAndBody()
 		if prev != nil {
 			switch bytes.Compare(prev, tagAndBody) {
 			case 0:
@@ -123,11 +120,7 @@ func (r *Value) Slice(column int) (zcode.Bytes, error) {
 		if it.Done() {
 			return nil, ErrMissing
 		}
-		var err error
-		zv, _, err = it.Next()
-		if err != nil {
-			return nil, err
-		}
+		zv, _ = it.Next()
 	}
 	return zv, nil
 }

--- a/set.go
+++ b/set.go
@@ -31,10 +31,7 @@ func (t *TypeSet) Marshal(zv zcode.Bytes) (interface{}, error) {
 	vals := []Value{}
 	it := zv.Iter()
 	for !it.Done() {
-		val, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		val, _ := it.Next()
 		vals = append(vals, Value{t.Type, val})
 	}
 	return vals, nil
@@ -46,12 +43,8 @@ func (t *TypeSet) Format(zv zcode.Bytes) string {
 	sep := ""
 	it := zv.Iter()
 	for !it.Done() {
-		val, _, err := it.Next()
-		if err != nil {
-			return badZNG(err, t, zv)
-		}
 		b.WriteString(sep)
-		if val == nil {
+		if val, _ := it.Next(); val == nil {
 			b.WriteString("null")
 		} else {
 			b.WriteString(t.Type.Format(val))
@@ -69,10 +62,7 @@ func (t *TypeSet) Format(zv zcode.Bytes) string {
 func NormalizeSet(zv zcode.Bytes) zcode.Bytes {
 	elements := make([]zcode.Bytes, 0, 8)
 	for it := zv.Iter(); !it.Done(); {
-		elem, _, err := it.NextTagAndBody()
-		if err != nil {
-			panic(err)
-		}
+		elem, _ := it.NextTagAndBody()
 		elements = append(elements, elem)
 	}
 	if len(elements) < 2 {

--- a/split.go
+++ b/split.go
@@ -1,8 +1,6 @@
 package zed
 
 import (
-	"fmt"
-
 	"github.com/brimdata/zed/zcode"
 )
 
@@ -15,10 +13,7 @@ func Split(elemType Type, b zcode.Bytes) ([]Value, error) {
 	}
 	vals := []Value{}
 	for it := b.Iter(); !it.Done(); {
-		zv, _, err := it.Next()
-		if err != nil {
-			return nil, fmt.Errorf("parsing element type '%s' value %q: %w", elemType, b, err)
-		}
+		zv, _ := it.Next()
 		vals = append(vals, Value{elemType, zv})
 	}
 	return vals, nil

--- a/union.go
+++ b/union.go
@@ -32,10 +32,7 @@ func (t *TypeUnion) Type(selector int) (Type, error) {
 // returns the concrete type of the value, its selector, and the value encoding.
 func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	it := zv.Iter()
-	v, container, err := it.Next()
-	if err != nil {
-		return nil, -1, nil, err
-	}
+	v, container := it.Next()
 	if container {
 		return nil, -1, nil, ErrBadValue
 	}
@@ -47,10 +44,7 @@ func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	if err != nil {
 		return nil, -1, nil, err
 	}
-	v, _, err = it.Next()
-	if err != nil {
-		return nil, -1, nil, err
-	}
+	v, _ = it.Next()
 	if !it.Done() {
 		return nil, -1, nil, ErrBadValue
 	}

--- a/value.go
+++ b/value.go
@@ -103,10 +103,7 @@ func (v Value) ArrayIndex(idx int64) (Value, error) {
 		return Value{}, ErrIndex
 	}
 	for i, it := 0, v.Iter(); !it.Done(); i++ {
-		zv, _, err := it.Next()
-		if err != nil {
-			return Value{}, err
-		}
+		zv, _ := it.Next()
 		if i == int(idx) {
 			return Value{vec.Type, zv}, nil
 		}
@@ -123,10 +120,7 @@ func (v Value) Elements() ([]Value, error) {
 	}
 	var elements []Value
 	for it := v.Iter(); !it.Done(); {
-		zv, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		zv, _ := it.Next()
 		elements = append(elements, Value{innerType, zv})
 	}
 	return elements, nil
@@ -140,9 +134,7 @@ func (v Value) ContainerLength() (int, error) {
 		}
 		var n int
 		for it := v.Iter(); !it.Done(); {
-			if _, _, err := it.Next(); err != nil {
-				return -1, err
-			}
+			it.Next()
 			n++
 		}
 		return n, nil
@@ -152,12 +144,8 @@ func (v Value) ContainerLength() (int, error) {
 		}
 		var n int
 		for it := v.Iter(); !it.Done(); {
-			if _, _, err := it.Next(); err != nil {
-				return -1, err
-			}
-			if _, _, err := it.Next(); err != nil {
-				return -1, err
-			}
+			it.Next()
+			it.Next()
 			n++
 		}
 		return n, nil

--- a/walk.go
+++ b/walk.go
@@ -67,10 +67,7 @@ func walkRecord(typ *TypeRecord, body zcode.Bytes, visit Visitor) error {
 		if it.Done() {
 			return &RecordTypeError{Name: string(col.Name), Type: col.Type.String(), Err: ErrMissingField}
 		}
-		body, container, err := it.Next()
-		if err != nil {
-			return err
-		}
+		body, container := it.Next()
 		if err := checkKind(col.Name, col.Type, body, container); err != nil {
 			return err
 		}
@@ -88,10 +85,7 @@ func walkArray(typ *TypeArray, body zcode.Bytes, visit Visitor) error {
 	inner := InnerType(typ)
 	it := body.Iter()
 	for !it.Done() {
-		body, container, err := it.Next()
-		if err != nil {
-			return err
-		}
+		body, container := it.Next()
 		if err := checkKind("<array element>", inner, body, container); err != nil {
 			return err
 		}
@@ -111,10 +105,7 @@ func walkUnion(typ *TypeUnion, body zcode.Bytes, visit Visitor) error {
 		return &RecordTypeError{Name: "<union type>", Type: typ.String(), Err: err}
 	}
 	it := body.Iter()
-	v, container, err := it.Next()
-	if err != nil {
-		return err
-	}
+	v, container := it.Next()
 	if container {
 		return ErrBadValue
 	}
@@ -126,10 +117,7 @@ func walkUnion(typ *TypeUnion, body zcode.Bytes, visit Visitor) error {
 	if err != nil {
 		return err
 	}
-	body, container, err = it.Next()
-	if err != nil {
-		return err
-	}
+	body, container = it.Next()
 	if !it.Done() {
 		err := errors.New("union value container has more than two items")
 		return &RecordTypeError{Name: "<union>", Type: typ.String(), Err: err}
@@ -147,10 +135,7 @@ func walkSet(typ *TypeSet, body zcode.Bytes, visit Visitor) error {
 	inner := AliasOf(InnerType(typ))
 	it := body.Iter()
 	for !it.Done() {
-		body, container, err := it.Next()
-		if err != nil {
-			return err
-		}
+		body, container := it.Next()
 		if err := checkKind("<set element>", inner, body, container); err != nil {
 			return err
 		}
@@ -169,20 +154,14 @@ func walkMap(typ *TypeMap, body zcode.Bytes, visit Visitor) error {
 	valType := AliasOf(typ.ValType)
 	it := body.Iter()
 	for !it.Done() {
-		body, container, err := it.Next()
-		if err != nil {
-			return err
-		}
+		body, container := it.Next()
 		if err := checkKind("<map key>", keyType, body, container); err != nil {
 			return err
 		}
 		if err := Walk(keyType, body, visit); err != nil {
 			return err
 		}
-		body, container, err = it.Next()
-		if err != nil {
-			return err
-		}
+		body, container = it.Next()
 		if err := checkKind("<map value>", valType, body, container); err != nil {
 			return err
 		}

--- a/zcode/bytes.go
+++ b/zcode/bytes.go
@@ -57,16 +57,13 @@ func appendBytes(b, v []byte) []byte {
 
 func (b Bytes) build(dst []byte) ([]byte, error) {
 	for it := b.Iter(); !it.Done(); {
-		v, container, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
-		if container {
+		if v, container := it.Next(); container {
 			if v == nil {
 				dst = append(dst, "(*)"...)
 				continue
 			}
 			dst = append(dst, '[')
+			var err error
 			dst, err = v.build(dst)
 			if err != nil {
 				return nil, err
@@ -86,10 +83,7 @@ func (b Bytes) build(dst []byte) ([]byte, error) {
 // If the receiver is not a single container, ErrNotSingleton is returned.
 func (b Bytes) ContainerBody() (Bytes, error) {
 	it := b.Iter()
-	body, container, err := it.Next()
-	if err != nil {
-		return nil, err
-	}
+	body, container := it.Next()
 	if !container {
 		return nil, ErrNotContainer
 	}

--- a/zcode/iter.go
+++ b/zcode/iter.go
@@ -15,37 +15,38 @@ func (i *Iter) Done() bool {
 
 // Next returns the body of the next value along with a boolean that is true if
 // the value is a container.  It returns an empty slice for an empty or
-// zero-length value and nil for a Zed null value.  The container boolean is
-// not meaningful if the returned Bytes slice is nil.
-func (i *Iter) Next() (Bytes, bool, error) {
+// zero-length value and nil for a Zed null value.  The container boolean is not
+// meaningful if the returned Bytes slice is nil.  Next panics if the next value
+// is malformed.
+func (i *Iter) Next() (Bytes, bool) {
 	// The tag is zero for a null value; otherwise, it is the value's
 	// length plus one.
 	u64, n := binary.Uvarint(*i)
 	if n <= 0 {
-		return nil, false, fmt.Errorf("bad uvarint: %d", n)
+		panic(fmt.Sprintf("bad uvarint: %d", n))
 	}
 	if tagIsNull(u64) {
 		*i = (*i)[n:]
-		return nil, false, nil
+		return nil, false
 	}
 	end := n + tagLength(u64)
 	val := (*i)[n:end]
 	*i = (*i)[end:]
-	return Bytes(val), tagIsContainer(u64), nil
+	return Bytes(val), tagIsContainer(u64)
 }
 
 // NextTagAndBody returns the next value as a slice containing the value's
 // undecoded tag followed by its body along with a boolean that is true if the
-// value is a container.
-func (i *Iter) NextTagAndBody() (Bytes, bool, error) {
+// value is a container.  NextTagAndBody panics if the next value is malformed.
+func (i *Iter) NextTagAndBody() (Bytes, bool) {
 	u64, n := binary.Uvarint(*i)
 	if n <= 0 {
-		return nil, false, fmt.Errorf("bad uvarint: %d", n)
+		panic(fmt.Sprintf("bad uvarint: %d", n))
 	}
 	if !tagIsNull(u64) {
 		n += tagLength(u64)
 	}
 	val := (*i)[:n]
 	*i = (*i)[n:]
-	return Bytes(val), tagIsContainer(u64), nil
+	return Bytes(val), tagIsContainer(u64)
 }

--- a/zcode/zcode_test.go
+++ b/zcode/zcode_test.go
@@ -30,8 +30,7 @@ func TestAppendContainer(t *testing.T) {
 		it := Iter(buf)
 		for _, expected := range c {
 			assert.False(t, it.Done())
-			val, container, err := it.Next()
-			assert.NoError(t, err)
+			val, container := it.Next()
 			assert.True(t, val == nil || container)
 			assert.Exactly(t, expected, []byte(val))
 		}
@@ -48,8 +47,7 @@ func TestAppendPrimitive(t *testing.T) {
 		it := Iter(buf)
 		for _, expected := range c {
 			assert.False(t, it.Done())
-			val, container, err := it.Next()
-			assert.NoError(t, err)
+			val, container := it.Next()
 			assert.False(t, container)
 			assert.Exactly(t, expected, []byte(val))
 		}

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -62,12 +62,8 @@ func (w *Writer) Write(rec *zed.Value) error {
 	w.strings = w.strings[:0]
 	cols := rec.Columns()
 	for i, it := 0, rec.Bytes.Iter(); i < len(cols) && !it.Done(); i++ {
-		zb, _, err := it.Next()
-		if err != nil {
-			return err
-		}
 		var s string
-		if zb != nil {
+		if zb, _ := it.Next(); zb != nil {
 			typ := cols[i].Type
 			id := typ.ID()
 			switch {

--- a/zio/parquetio/data.go
+++ b/zio/parquetio/data.go
@@ -73,10 +73,7 @@ func newData(typ zed.Type, zb zcode.Bytes) (interface{}, error) {
 func newListData(typ zed.Type, zb zcode.Bytes) (map[string]interface{}, error) {
 	var elements []map[string]interface{}
 	for it := zb.Iter(); !it.Done(); {
-		zb2, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		zb2, _ := it.Next()
 		v, err := newData(typ, zb2)
 		if err != nil {
 			return nil, err
@@ -89,18 +86,12 @@ func newListData(typ zed.Type, zb zcode.Bytes) (map[string]interface{}, error) {
 func newMapData(keyType, valType zed.Type, zb zcode.Bytes) (map[string]interface{}, error) {
 	var elements []map[string]interface{}
 	for i, it := 0, zb.Iter(); !it.Done(); i++ {
-		keyBytes, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		keyBytes, _ := it.Next()
 		key, err := newData(keyType, keyBytes)
 		if err != nil {
 			return nil, err
 		}
-		valBytes, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		valBytes, _ := it.Next()
 		val, err := newData(valType, valBytes)
 		if err != nil {
 			return nil, err
@@ -116,10 +107,7 @@ func newMapData(keyType, valType zed.Type, zb zcode.Bytes) (map[string]interface
 func newRecordData(typ *zed.TypeRecord, zb zcode.Bytes) (map[string]interface{}, error) {
 	m := make(map[string]interface{}, len(typ.Columns))
 	for i, it := 0, zb.Iter(); !it.Done(); i++ {
-		zb2, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		zb2, _ := it.Next()
 		v, err := newData(typ.Columns[i].Type, zb2)
 		if err != nil {
 			return nil, err

--- a/zio/tzngio/stringof.go
+++ b/zio/tzngio/stringof.go
@@ -122,18 +122,12 @@ func StringOfArray(t *zed.TypeArray, zv zcode.Bytes, fmt OutFmt, _ bool) string 
 	first := true
 	it := zv.Iter()
 	for !it.Done() {
-		val, _, err := it.Next()
-		if err != nil {
-			//XXX
-			b.WriteString("ERR")
-			break
-		}
 		if first {
 			first = false
 		} else {
 			b.WriteByte(separator)
 		}
-		if val == nil {
+		if val, _ := it.Next(); val == nil {
 			b.WriteByte('-')
 		} else {
 			b.WriteString(StringOf(zed.Value{t.Type, val}, fmt, true))
@@ -208,22 +202,12 @@ func StringOfMap(t *zed.TypeMap, zv zcode.Bytes, fmt OutFmt, _ bool) string {
 	it := zv.Iter()
 	b.WriteByte('[')
 	for !it.Done() {
-		val, container, err := it.Next()
-		if err != nil {
-			//XXX
-			b.WriteString("ERR")
-			break
-		}
+		val, container := it.Next()
 		b.WriteString(StringOf(zed.Value{t.KeyType, val}, fmt, true))
 		if !container {
 			b.WriteByte(';')
 		}
-		val, container, err = it.Next()
-		if err != nil {
-			//XXX
-			b.WriteString("ERR")
-			break
-		}
+		val, container = it.Next()
 		b.WriteString(StringOf(zed.Value{t.ValType, val}, fmt, true))
 		if !container {
 			b.WriteByte(';')
@@ -253,18 +237,12 @@ func StringOfRecord(t *zed.TypeRecord, zv zcode.Bytes, fmt OutFmt, _ bool) strin
 	first := true
 	it := zv.Iter()
 	for _, col := range t.Columns {
-		val, _, err := it.Next()
-		if err != nil {
-			//XXX
-			b.WriteString("ERR")
-			break
-		}
 		if first {
 			first = false
 		} else {
 			b.WriteByte(separator)
 		}
-		if val == nil {
+		if val, _ := it.Next(); val == nil {
 			b.WriteByte('-')
 		} else {
 			b.WriteString(StringOf(zed.Value{col.Type, val}, fmt, false))
@@ -295,17 +273,12 @@ func StringOfSet(t *zed.TypeSet, zv zcode.Bytes, fmt OutFmt, _ bool) string {
 	first := true
 	it := zv.Iter()
 	for !it.Done() {
-		val, _, err := it.Next()
-		if err != nil {
-			//XXX
-			b.WriteString("ERR")
-			break
-		}
 		if first {
 			first = false
 		} else {
 			b.WriteByte(separator)
 		}
+		val, _ := it.Next()
 		b.WriteString(StringOf(zed.Value{t.Type, val}, fmt, true))
 	}
 

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -120,12 +120,8 @@ func ZeekStrings(r *zed.Value, fmt tzngio.OutFmt) ([]string, error) {
 	var ss []string
 	it := r.Bytes.Iter()
 	for _, col := range zed.TypeRecordOf(r.Type).Columns {
-		val, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
 		var field string
-		if val == nil {
+		if val, _ := it.Next(); val == nil {
 			field = "-"
 		} else if col.Type == zed.TypeTime {
 			ts, err := zed.DecodeTime(val)

--- a/zio/zjsonio/values.go
+++ b/zio/zjsonio/values.go
@@ -36,19 +36,14 @@ func encodeMap(zctx *zed.Context, typ *zed.TypeMap, v zcode.Bytes) (interface{},
 	var out []interface{}
 	it := zcode.Bytes(v).Iter()
 	for !it.Done() {
-		key, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		key, _ := it.Next()
 		pair := make([]interface{}, 2)
+		var err error
 		pair[0], err = encodeValue(zctx, typ.KeyType, key)
 		if err != nil {
 			return nil, err
 		}
-		val, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		val, _ := it.Next()
 		pair[1], err = encodeValue(zctx, typ.ValType, val)
 		if err != nil {
 			return nil, err
@@ -114,10 +109,7 @@ func encodeRecord(zctx *zed.Context, typ *zed.TypeRecord, val zcode.Bytes) (inte
 	out := []interface{}{}
 	k := 0
 	for it := val.Iter(); !it.Done(); k++ {
-		zv, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		zv, _ := it.Next()
 		v, err := encodeValue(zctx, typ.Columns[k].Type, zv)
 		if err != nil {
 			return nil, err
@@ -135,10 +127,7 @@ func encodeContainer(zctx *zed.Context, typ zed.Type, bytes zcode.Bytes) (interf
 	// so that an empty container encodes as a JSON empty array [].
 	out := []interface{}{}
 	for it := bytes.Iter(); !it.Done(); {
-		b, _, err := it.Next()
-		if err != nil {
-			return nil, err
-		}
+		b, _ := it.Next()
 		v, err := encodeValue(zctx, typ, b)
 		if err != nil {
 			return nil, err

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -21,10 +21,7 @@ func Build(b *zcode.Builder, val Value) (zed.Value, error) {
 		return zed.Value{}, err
 	}
 	it := b.Bytes().Iter()
-	bytes, _, err := it.Next()
-	if err != nil {
-		return zed.Value{}, err
-	}
+	bytes, _ := it.Next()
 	return zed.Value{val.TypeOf(), bytes}, nil
 }
 

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -235,10 +235,7 @@ func (f *Formatter) formatRecord(indent int, typ *zed.TypeRecord, bytes zcode.By
 		if it.Done() {
 			return &zed.RecordTypeError{Name: string(field.Name), Type: field.Type.String(), Err: zed.ErrMissingField}
 		}
-		bytes, _, err := it.Next()
-		if err != nil {
-			return err
-		}
+		bytes, _ := it.Next()
 		f.build(sep)
 		f.startColor(color.Blue)
 		f.indent(indent, zed.QuotedName(field.Name))
@@ -271,12 +268,9 @@ func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type,
 	sep := f.newline
 	it := zv.Iter()
 	for !it.Done() {
-		bytes, _, err := it.Next()
-		if err != nil {
-			return true, err
-		}
 		f.build(sep)
 		f.indent(indent, "")
+		bytes, _ := it.Next()
 		if err := f.formatValue(indent, inner, bytes, known, parentImplied, true); err != nil {
 			return true, err
 		}
@@ -311,18 +305,12 @@ func (f *Formatter) formatMap(indent int, typ *zed.TypeMap, bytes zcode.Bytes, k
 	indent += f.tab
 	sep := f.newline
 	for it := bytes.Iter(); !it.Done(); {
-		keyBytes, _, err := it.Next()
-		if err != nil {
-			return empty, err
-		}
+		keyBytes, _ := it.Next()
 		if it.Done() {
 			return empty, errors.New("truncated map value")
 		}
 		empty = false
-		valBytes, _, err := it.Next()
-		if err != nil {
-			return empty, err
-		}
+		valBytes, _ := it.Next()
 		f.build(sep)
 		f.indent(indent, "")
 		if err := f.formatValue(indent, typ.KeyType, keyBytes, known, parentImplied, true); err != nil {

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -139,10 +139,7 @@ func (m *MarshalZNGContext) Marshal(v interface{}) (zed.Value, error) {
 	if it.Done() {
 		return zed.Value{}, errors.New("no value found")
 	}
-	bytes, _, err = it.Next()
-	if err != nil {
-		return zed.Value{}, err
-	}
+	bytes, _ = it.Next()
 	return zed.Value{typ, bytes}, nil
 }
 
@@ -854,18 +851,12 @@ func (u *UnmarshalZNGContext) decodeMap(zv zed.Value, mapVal reflect.Value) erro
 	keyType := mapVal.Type().Key()
 	valType := mapVal.Type().Elem()
 	for it := zv.Iter(); !it.Done(); {
-		keyzb, _, err := it.Next()
-		if err != nil {
-			return err
-		}
+		keyzb, _ := it.Next()
 		key := reflect.New(keyType).Elem()
 		if err := u.decodeAny(zed.Value{typ.KeyType, keyzb}, key); err != nil {
 			return err
 		}
-		valzb, _, err := it.Next()
-		if err != nil {
-			return err
-		}
+		valzb, _ := it.Next()
 		val := reflect.New(valType).Elem()
 		if err := u.decodeAny(zed.Value{typ.ValType, valzb}, val); err != nil {
 			return err
@@ -891,10 +882,7 @@ func (u *UnmarshalZNGContext) decodeRecord(zv zed.Value, sval reflect.Value) err
 		if i >= len(recType.Columns) {
 			return zed.ErrMismatch
 		}
-		itzv, _, err := it.Next()
-		if err != nil {
-			return err
-		}
+		itzv, _ := it.Next()
 		name := recType.Columns[i].Name
 		if fieldIdx, ok := nameToField[name]; ok {
 			typ := recType.Columns[i].Type
@@ -928,10 +916,7 @@ func (u *UnmarshalZNGContext) decodeArray(zv zed.Value, arrVal reflect.Value) er
 	}
 	i := 0
 	for it := zv.Iter(); !it.Done(); i++ {
-		itzv, _, err := it.Next()
-		if err != nil {
-			return err
-		}
+		itzv, _ := it.Next()
 		if i >= arrVal.Cap() {
 			newcap := arrVal.Cap() + arrVal.Cap()/2
 			if newcap < 4 {

--- a/zson/parser-values.go
+++ b/zson/parser-values.go
@@ -581,6 +581,6 @@ func ParsePrimitive(typeText, valText string) (zed.Value, error) {
 		return zed.Value{}, err
 	}
 	it := b.Bytes().Iter()
-	bytes, _, _ := it.Next()
+	bytes, _ := it.Next()
 	return zed.Value{typ, bytes}, nil
 }

--- a/zst/column/array.go
+++ b/zst/column/array.go
@@ -26,10 +26,7 @@ func (a *ArrayWriter) Write(body zcode.Bytes) error {
 	it := body.Iter()
 	var len int32
 	for !it.Done() {
-		body, _, err := it.Next()
-		if err != nil {
-			return err
-		}
+		body, _ := it.Next()
 		if err := a.values.Write(body); err != nil {
 			return err
 		}

--- a/zst/column/primitive.go
+++ b/zst/column/primitive.go
@@ -80,8 +80,8 @@ func (p *Primitive) read() (zcode.Bytes, error) {
 			return nil, err
 		}
 	}
-	zv, _, err := p.iter.Next()
-	return zv, err
+	zv, _ := p.iter.Next()
+	return zv, nil
 }
 
 func (p *Primitive) next() error {

--- a/zst/column/record.go
+++ b/zst/column/record.go
@@ -31,10 +31,7 @@ func (r RecordWriter) Write(body zcode.Bytes) error {
 		if it.Done() {
 			return ErrColumnMismatch
 		}
-		body, _, err := it.Next()
-		if err != nil {
-			return err
-		}
+		body, _ := it.Next()
 		if err := f.write(body); err != nil {
 			return err
 		}
@@ -78,16 +75,13 @@ func (r *Record) UnmarshalZNG(typ *zed.TypeRecord, in zed.Value, reader io.Reade
 	}
 	k := 0
 	for it := in.Bytes.Iter(); !it.Done(); k++ {
-		zv, _, err := it.Next()
-		if err != nil {
-			return err
-		}
 		if k >= len(typ.Columns) {
 			return errors.New("mismatch between record type and record_column") //XXX
 		}
 		fieldType := typ.Columns[k].Type
+		zv, _ := it.Next()
 		f := &Field{}
-		if err = f.UnmarshalZNG(fieldType, zed.Value{rtype.Columns[k].Type, zv}, reader); err != nil {
+		if err := f.UnmarshalZNG(fieldType, zed.Value{rtype.Columns[k].Type, zv}, reader); err != nil {
 			return err
 		}
 		*r = append(*r, f)

--- a/zst/column/segment.go
+++ b/zst/column/segment.go
@@ -23,10 +23,7 @@ var ErrCorruptSegment = errors.New("segmap value corrupt")
 
 func UnmarshalSegment(zv zcode.Bytes, s *Segment) error {
 	it := zv.Iter()
-	zv, isContainer, err := it.Next()
-	if err != nil {
-		return err
-	}
+	zv, isContainer := it.Next()
 	if isContainer {
 		return ErrCorruptSegment
 	}
@@ -35,10 +32,7 @@ func UnmarshalSegment(zv zcode.Bytes, s *Segment) error {
 		return err
 	}
 	s.Offset = v
-	zv, isContainer, err = it.Next()
-	if err != nil {
-		return err
-	}
+	zv, isContainer = it.Next()
 	if isContainer {
 		return ErrCorruptSegment
 	}
@@ -65,10 +59,7 @@ func UnmarshalSegmap(in zed.Value, s *[]Segment) error {
 	*s = []Segment{}
 	it := in.Bytes.Iter()
 	for !it.Done() {
-		zv, isContainer, err := it.Next()
-		if err != nil {
-			return err
-		}
+		zv, isContainer := it.Next()
 		if !isContainer {
 			return ErrCorruptSegment
 		}


### PR DESCRIPTION
Errors from zcode.Iter's Next and NextTagAndBody methods are generally
unrecoverable and simply propagate to the top level.  With that in mind,
simplify these methods' signatures by removing their error return
parameter and panicking instead.  (A proc.Catcher usually will recover
any panic and convert it to a top-level error.)