### PR TITLE
rename zed.AliasOf to TypeUnder

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -40,10 +40,10 @@ func (t *TypeAlias) Format(zv zcode.Bytes) string {
 	return t.Type.Format(zv)
 }
 
-func AliasOf(typ Type) Type {
+func TypeUnder(typ Type) Type {
 	alias, ok := typ.(*TypeAlias)
 	if ok {
-		return AliasOf(alias.Type)
+		return TypeUnder(alias.Type)
 	}
 	return typ
 }

--- a/compiler/kernel/bufferfilter.go
+++ b/compiler/kernel/bufferfilter.go
@@ -57,7 +57,7 @@ func CompileBufferFilter(zctx *zed.Context, e dag.Expr) (*expr.BufferFilter, err
 		if err != nil {
 			return nil, err
 		}
-		switch zed.AliasOf(literal.Type) {
+		switch zed.TypeUnder(literal.Type) {
 		case zed.TypeNet:
 			return nil, nil
 		case zed.TypeString:

--- a/compiler/kernel/filter.go
+++ b/compiler/kernel/filter.go
@@ -95,7 +95,7 @@ func compileSearch(zctx *zed.Context, search *dag.Search) (expr.Evaluator, error
 	if err != nil {
 		return nil, err
 	}
-	switch zed.AliasOf(val.Type) {
+	switch zed.TypeUnder(val.Type) {
 	case zed.TypeNet:
 		match, err := expr.Comparison("=", &val)
 		if err != nil {

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -289,7 +289,7 @@ func isIndexOfThis(scope *Scope, lhs, rhs dag.Expr) *dag.Path {
 
 func isStringConst(scope *Scope, e dag.Expr) (field string, ok bool) {
 	val, err := kernel.EvalAtCompileTime(scope.zctx, e)
-	if err == nil && val != nil && zed.AliasOf(val.Type) == zed.TypeString {
+	if err == nil && val != nil && zed.TypeUnder(val.Type) == zed.TypeString {
 		return string(val.Bytes), true
 	}
 	return "", false

--- a/expr/agg/logical.go
+++ b/expr/agg/logical.go
@@ -11,7 +11,7 @@ type And struct {
 var _ Function = (*And)(nil)
 
 func (a *And) Consume(val *zed.Value) {
-	if val.IsNull() || zed.AliasOf(val.Type) != zed.TypeBool {
+	if val.IsNull() || zed.TypeUnder(val.Type) != zed.TypeBool {
 		return
 	}
 	if a.val == nil {
@@ -49,7 +49,7 @@ type Or struct {
 var _ Function = (*Or)(nil)
 
 func (o *Or) Consume(val *zed.Value) {
-	if val.IsNull() || zed.AliasOf(val.Type) != zed.TypeBool {
+	if val.IsNull() || zed.TypeUnder(val.Type) != zed.TypeBool {
 		return
 	}
 	if o.val == nil {

--- a/expr/agg/schema.go
+++ b/expr/agg/schema.go
@@ -70,9 +70,9 @@ func columnOfField(cols []zed.Column, name string) (int, bool) {
 }
 
 func unify(zctx *zed.Context, a, b zed.Type) zed.Type {
-	if ua, ok := zed.AliasOf(a).(*zed.TypeUnion); ok {
+	if ua, ok := zed.TypeUnder(a).(*zed.TypeUnion); ok {
 		types := ua.Types
-		if ub, ok := zed.AliasOf(b).(*zed.TypeUnion); ok {
+		if ub, ok := zed.TypeUnder(b).(*zed.TypeUnion); ok {
 			for _, t := range ub.Types {
 				types = appendIfAbsent(types, t)
 			}
@@ -81,7 +81,7 @@ func unify(zctx *zed.Context, a, b zed.Type) zed.Type {
 		}
 		return zctx.LookupTypeUnion(types)
 	}
-	if _, ok := zed.AliasOf(b).(*zed.TypeUnion); ok {
+	if _, ok := zed.TypeUnder(b).(*zed.TypeUnion); ok {
 		return unify(zctx, b, a)
 	}
 	return zctx.LookupTypeUnion([]zed.Type{a, b})

--- a/expr/boolean.go
+++ b/expr/boolean.go
@@ -410,7 +410,7 @@ func Contains(compare Boolean) Boolean {
 // of this method as some types limit the operand to equality and
 // the various types handle coercion in different ways.
 func Comparison(op string, val *zed.Value) (Boolean, error) {
-	switch zed.AliasOf(val.Type).(type) {
+	switch zed.TypeUnder(val.Type).(type) {
 	case *zed.TypeOfNull:
 		return CompareNull(op)
 	case *zed.TypeOfIP:

--- a/expr/cast.go
+++ b/expr/cast.go
@@ -118,7 +118,7 @@ func castToFloat64(ectx Context, val *zed.Value) *zed.Value {
 }
 
 func castToIP(ectx Context, val *zed.Value) *zed.Value {
-	if _, ok := zed.AliasOf(val.Type).(*zed.TypeOfIP); ok {
+	if _, ok := zed.TypeUnder(val.Type).(*zed.TypeOfIP); ok {
 		return val
 	}
 	if !val.IsStringy() {

--- a/expr/dot.go
+++ b/expr/dot.go
@@ -43,7 +43,7 @@ func valOf(val *zed.Value) *zed.Value {
 	}
 	bytes := val.Bytes
 	for {
-		typ = zed.AliasOf(typ)
+		typ = zed.TypeUnder(typ)
 		union, ok := typ.(*zed.TypeUnion)
 		if !ok {
 			return &zed.Value{typ, bytes}

--- a/expr/dropper.go
+++ b/expr/dropper.go
@@ -82,7 +82,7 @@ func complementFields(drops field.List, prefix field.Path, typ *zed.TypeRecord) 
 			match = true
 			continue
 		}
-		if typ, ok := zed.AliasOf(c.Type).(*zed.TypeRecord); ok {
+		if typ, ok := zed.TypeUnder(c.Type).(*zed.TypeRecord); ok {
 			if fs, ts, m := complementFields(drops, append(prefix, c.Name), typ); m {
 				fields = append(fields, fs...)
 				types = append(types, ts...)

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -61,7 +61,7 @@ func NewLogicalOr(lhs, rhs Evaluator) *Or {
 // are returned.
 func EvalBool(ectx Context, this *zed.Value, e Evaluator) (*zed.Value, bool) {
 	val := e.Eval(ectx, this)
-	if zed.AliasOf(val.Type) == zed.TypeBool {
+	if zed.TypeUnder(val.Type) == zed.TypeBool {
 		return val, true
 	}
 	if val.IsError() {
@@ -128,13 +128,13 @@ func (i *In) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if container.IsError() {
 		return container
 	}
-	switch typ := zed.AliasOf(container.Type).(type) {
+	switch typ := zed.TypeUnder(container.Type).(type) {
 	case *zed.TypeOfNet:
 		return inNet(ectx, elem, container)
 	case *zed.TypeArray:
-		return i.inContainer(zed.AliasOf(typ.Type), elem, container)
+		return i.inContainer(zed.TypeUnder(typ.Type), elem, container)
 	case *zed.TypeSet:
-		return i.inContainer(zed.AliasOf(typ.Type), elem, container)
+		return i.inContainer(zed.TypeUnder(typ.Type), elem, container)
 	case *zed.TypeMap:
 		return i.inMap(typ, elem, container)
 	default:
@@ -147,7 +147,7 @@ func inNet(ectx Context, elem, net *zed.Value) *zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	if typ := zed.AliasOf(elem.Type); typ != zed.TypeIP {
+	if typ := zed.TypeUnder(elem.Type); typ != zed.TypeIP {
 		return ectx.CopyValue(*zed.NewErrorf("'in' operator applied to non-container type"))
 	}
 	a, err := zed.DecodeIP(elem.Bytes)
@@ -178,8 +178,8 @@ func (i *In) inContainer(typ zed.Type, elem, container *zed.Value) *zed.Value {
 }
 
 func (i *In) inMap(typ *zed.TypeMap, elem, container *zed.Value) *zed.Value {
-	keyType := zed.AliasOf(typ.KeyType)
-	valType := zed.AliasOf(typ.ValType)
+	keyType := zed.TypeUnder(typ.KeyType)
+	valType := zed.TypeUnder(typ.ValType)
 	iter := container.Bytes.Iter()
 	for !iter.Done() {
 		zv, _ := iter.Next()

--- a/expr/flattener.go
+++ b/expr/flattener.go
@@ -29,7 +29,7 @@ func NewFlattener(zctx *zed.Context) *Flattener {
 func recode(dst zcode.Bytes, typ *zed.TypeRecord, in zcode.Bytes) (zcode.Bytes, error) {
 	if in == nil {
 		for _, col := range typ.Columns {
-			if typ, ok := zed.AliasOf(col.Type).(*zed.TypeRecord); ok {
+			if typ, ok := zed.TypeUnder(col.Type).(*zed.TypeRecord); ok {
 				var err error
 				dst, err = recode(dst, typ, nil)
 				if err != nil {
@@ -47,7 +47,7 @@ func recode(dst zcode.Bytes, typ *zed.TypeRecord, in zcode.Bytes) (zcode.Bytes, 
 		val, container := it.Next()
 		col := typ.Columns[colno]
 		colno++
-		if childType, ok := zed.AliasOf(col.Type).(*zed.TypeRecord); ok {
+		if childType, ok := zed.TypeUnder(col.Type).(*zed.TypeRecord); ok {
 			var err error
 			dst, err = recode(dst, childType, val)
 			if err != nil {
@@ -75,7 +75,7 @@ func (f *Flattener) Flatten(r *zed.Value) (*zed.Value, error) {
 	// Since we are mapping the input context to itself we can do a
 	// pointer comparison to see if the types are the same and there
 	// is no need to record.
-	if zed.AliasOf(r.Type) == flatType {
+	if zed.TypeUnder(r.Type) == flatType {
 		return r, nil
 	}
 	zv, err := recode(nil, zed.TypeRecordOf(r.Type), r.Bytes)
@@ -90,7 +90,7 @@ func (f *Flattener) Flatten(r *zed.Value) (*zed.Value, error) {
 func FlattenColumns(cols []zed.Column) []zed.Column {
 	ret := []zed.Column{}
 	for _, c := range cols {
-		if recType, ok := zed.AliasOf(c.Type).(*zed.TypeRecord); ok {
+		if recType, ok := zed.TypeUnder(c.Type).(*zed.TypeRecord); ok {
 			inners := FlattenColumns(recType.Columns)
 			for i := range inners {
 				inners[i].Name = fmt.Sprintf("%s.%s", c.Name, inners[i].Name)

--- a/expr/function/fields.go
+++ b/expr/function/fields.go
@@ -21,7 +21,7 @@ func NewFields(zctx *zed.Context) *Fields {
 func fieldNames(typ *zed.TypeRecord) []string {
 	var out []string
 	for _, c := range typ.Columns {
-		if typ, ok := zed.AliasOf(c.Type).(*zed.TypeRecord); ok {
+		if typ, ok := zed.TypeUnder(c.Type).(*zed.TypeRecord); ok {
 			for _, subfield := range fieldNames(typ) {
 				out = append(out, c.Name+"."+subfield)
 			}
@@ -47,7 +47,7 @@ func (f *Fields) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 }
 
 func isRecordType(zv zed.Value, zctx *zed.Context) *zed.TypeRecord {
-	if typ, ok := zed.AliasOf(zv.Type).(*zed.TypeRecord); ok {
+	if typ, ok := zed.TypeUnder(zv.Type).(*zed.TypeRecord); ok {
 		return typ
 	}
 	if zv.Type == zed.TypeType {
@@ -55,7 +55,7 @@ func isRecordType(zv zed.Value, zctx *zed.Context) *zed.TypeRecord {
 		if err != nil {
 			return nil
 		}
-		if typ, ok := zed.AliasOf(typ).(*zed.TypeRecord); ok {
+		if typ, ok := zed.TypeUnder(typ).(*zed.TypeRecord); ok {
 			return typ
 		}
 	}

--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -146,7 +146,7 @@ var _ Interface = (*LenFn)(nil)
 func (l *LenFn) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	val := args[0]
 	var length int
-	switch typ := zed.AliasOf(args[0].Type).(type) {
+	switch typ := zed.TypeUnder(args[0].Type).(type) {
 	case *zed.TypeOfNull:
 	case *zed.TypeRecord:
 		length = len(typ.Columns)
@@ -178,7 +178,7 @@ type typeUnder struct {
 }
 
 func (t *typeUnder) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	typ := zed.AliasOf(args[0].Type)
+	typ := zed.TypeUnder(args[0].Type)
 	return ctx.CopyValue(*t.zctx.LookupTypeValue(typ))
 }
 
@@ -199,7 +199,7 @@ type typeName struct {
 }
 
 func (t *typeName) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
-	if zed.AliasOf(args[0].Type) != zed.TypeString {
+	if zed.TypeUnder(args[0].Type) != zed.TypeString {
 		return newErrorf(ectx, "typename: first argument not a string")
 	}
 	name := string(args[0].Bytes)
@@ -210,7 +210,7 @@ func (t *typeName) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 		return t.zctx.LookupTypeValue(typ)
 	}
-	if zed.AliasOf(args[1].Type) != zed.TypeType {
+	if zed.TypeUnder(args[1].Type) != zed.TypeType {
 		return newErrorf(ectx, "typename: second argument not a type value")
 	}
 	typ, err := t.zctx.LookupByValue(args[1].Bytes)

--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -155,7 +155,7 @@ type Join struct {
 
 func (j *Join) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	zsplits := args[0]
-	typ, ok := zed.AliasOf(zsplits.Type).(*zed.TypeArray)
+	typ, ok := zed.TypeUnder(zsplits.Type).(*zed.TypeArray)
 	if !ok {
 		return newErrorf(ctx, "join: array of string args required")
 	}

--- a/expr/slice.go
+++ b/expr/slice.go
@@ -52,7 +52,7 @@ func (s *Slice) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if elem.IsError() {
 		return elem
 	}
-	if _, ok := zed.AliasOf(elem.Type).(*zed.TypeArray); !ok {
+	if _, ok := zed.TypeUnder(elem.Type).(*zed.TypeArray); !ok {
 		// XXX use structured error
 		return zed.NewErrorf("sliced value is not an array: %s", zson.MustFormatValue(*elem))
 	}

--- a/fielditer.go
+++ b/fielditer.go
@@ -34,7 +34,7 @@ func (r *fieldIter) Next() ([]string, Value, error) {
 	col := info.typ.Columns[info.offset]
 	fullname := append(info.field, col.Name)
 	zv, container := info.iter.Next()
-	recType, isRecord := AliasOf(col.Type).(*TypeRecord)
+	recType, isRecord := TypeUnder(col.Type).(*TypeRecord)
 	if isRecord {
 		if !container {
 			return nil, Value{}, ErrMismatch

--- a/pkg/stringsearch/fieldnamefinder.go
+++ b/pkg/stringsearch/fieldnamefinder.go
@@ -54,7 +54,7 @@ func (f *FieldNameFinder) Find(zctx *zed.Context, buf []byte) bool {
 		if err != nil {
 			return true
 		}
-		tr, ok := zed.AliasOf(t).(*zed.TypeRecord)
+		tr, ok := zed.TypeUnder(t).(*zed.TypeRecord)
 		if !ok {
 			return true
 		}
@@ -96,7 +96,7 @@ func (f *FieldNameIter) Next() []byte {
 		info := &f.stack[len(f.stack)-1]
 		col := info.columns[info.offset]
 		f.buf = append(f.buf, "."+col.Name...)
-		t, ok := zed.AliasOf(col.Type).(*zed.TypeRecord)
+		t, ok := zed.TypeUnder(col.Type).(*zed.TypeRecord)
 		if !ok || len(t.Columns) == 0 {
 			break
 		}

--- a/proc/shape/shaper.go
+++ b/proc/shape/shaper.go
@@ -36,7 +36,7 @@ type integer struct {
 }
 
 func nulltype(t zed.Type) bool {
-	return zed.AliasOf(t) == zed.TypeNull
+	return zed.TypeUnder(t) == zed.TypeNull
 }
 
 func (a *anchor) match(cols []zed.Column) bool {

--- a/recordval.go
+++ b/recordval.go
@@ -181,7 +181,7 @@ func (r *Value) AccessString(field string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	switch AliasOf(v.Type).(type) {
+	switch TypeUnder(v.Type).(type) {
 	case *TypeOfString, *TypeOfBstring:
 		return DecodeString(v.Bytes)
 	default:
@@ -194,7 +194,7 @@ func (r *Value) AccessBool(field string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if _, ok := AliasOf(v.Type).(*TypeOfBool); !ok {
+	if _, ok := TypeUnder(v.Type).(*TypeOfBool); !ok {
 		return false, ErrTypeMismatch
 	}
 	return DecodeBool(v.Bytes)
@@ -205,7 +205,7 @@ func (r *Value) AccessInt(field string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	switch AliasOf(v.Type).(type) {
+	switch TypeUnder(v.Type).(type) {
 	case *TypeOfUint8:
 		b, err := DecodeUint(v.Bytes)
 		return int64(b), err
@@ -229,7 +229,7 @@ func (r *Value) AccessIP(field string) (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := AliasOf(v.Type).(*TypeOfIP); !ok {
+	if _, ok := TypeUnder(v.Type).(*TypeOfIP); !ok {
 		return nil, ErrTypeMismatch
 	}
 	return DecodeIP(v.Bytes)
@@ -240,7 +240,7 @@ func (r *Value) AccessTime(field string) (nano.Ts, error) {
 	if err != nil {
 		return 0, err
 	}
-	if _, ok := AliasOf(v.Type).(*TypeOfTime); !ok {
+	if _, ok := TypeUnder(v.Type).(*TypeOfTime); !ok {
 		return 0, ErrTypeMismatch
 	}
 	return DecodeTime(v.Bytes)

--- a/type.go
+++ b/type.go
@@ -278,7 +278,7 @@ func LookupPrimitiveByID(id int) Type {
 // InnerType returns the element type for the underlying set or array type or
 // nil if the underlying type is not a set or array.
 func InnerType(typ Type) Type {
-	switch typ := AliasOf(typ).(type) {
+	switch typ := TypeUnder(typ).(type) {
 	case *TypeSet:
 		return typ.Type
 	case *TypeArray:
@@ -312,12 +312,12 @@ func IsUnionType(typ Type) bool {
 }
 
 func IsRecordType(typ Type) bool {
-	_, ok := AliasOf(typ).(*TypeRecord)
+	_, ok := TypeUnder(typ).(*TypeRecord)
 	return ok
 }
 
 func TypeRecordOf(typ Type) *TypeRecord {
-	t, _ := AliasOf(typ).(*TypeRecord)
+	t, _ := TypeUnder(typ).(*TypeRecord)
 	return t
 }
 

--- a/value.go
+++ b/value.go
@@ -186,7 +186,7 @@ func (v *Value) IsStringy() bool {
 }
 
 func (v *Value) IsError() bool {
-	return AliasOf(v.Type) == TypeError
+	return TypeUnder(v.Type) == TypeError
 }
 
 func (v *Value) IsMissing() bool {

--- a/walk.go
+++ b/walk.go
@@ -132,7 +132,7 @@ func walkSet(typ *TypeSet, body zcode.Bytes, visit Visitor) error {
 	if body == nil {
 		return nil
 	}
-	inner := AliasOf(InnerType(typ))
+	inner := TypeUnder(InnerType(typ))
 	it := body.Iter()
 	for !it.Done() {
 		body, container := it.Next()
@@ -150,8 +150,8 @@ func walkMap(typ *TypeMap, body zcode.Bytes, visit Visitor) error {
 	if body == nil {
 		return nil
 	}
-	keyType := AliasOf(typ.KeyType)
-	valType := AliasOf(typ.ValType)
+	keyType := TypeUnder(typ.KeyType)
+	valType := TypeUnder(typ.ValType)
 	it := body.Iter()
 	for !it.Done() {
 		body, container := it.Next()

--- a/zio/parquetio/builder.go
+++ b/zio/parquetio/builder.go
@@ -40,7 +40,7 @@ func (b *builder) appendValue(typ zed.Type, v interface{}) {
 		b.buf = zed.AppendUint(b.buf[:0], v)
 		b.AppendPrimitive(b.buf)
 	case map[string]interface{}:
-		switch typ := zed.AliasOf(typ).(type) {
+		switch typ := zed.TypeUnder(typ).(type) {
 		case *zed.TypeArray:
 			switch v := v["list"].(type) {
 			case nil:

--- a/zio/parquetio/data.go
+++ b/zio/parquetio/data.go
@@ -11,7 +11,7 @@ func newData(typ zed.Type, zb zcode.Bytes) (interface{}, error) {
 	if zb == nil {
 		return nil, nil
 	}
-	switch typ := zed.AliasOf(typ).(type) {
+	switch typ := zed.TypeUnder(typ).(type) {
 	case *zed.TypeOfUint8:
 		v, err := zed.DecodeUint(zb)
 		return uint32(v), err

--- a/zio/parquetio/writer.go
+++ b/zio/parquetio/writer.go
@@ -31,7 +31,7 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) Write(rec *zed.Value) error {
-	recType := zed.AliasOf(rec.Type).(*zed.TypeRecord)
+	recType := zed.TypeUnder(rec.Type).(*zed.TypeRecord)
 	if w.typ == nil {
 		w.typ = recType
 		sd, err := newSchemaDefinition(recType)

--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -134,7 +134,7 @@ func (a Analyzer) convertValue(zctx *zed.Context, val astzed.Value, parent zed.T
 			return nil, err
 		}
 		var v Value
-		if union, ok := zed.AliasOf(cast).(*zed.TypeUnion); ok {
+		if union, ok := zed.TypeUnder(cast).(*zed.TypeUnion); ok {
 			v, err = a.convertValue(zctx, val.Of, nil)
 			if err != nil {
 				return nil, err
@@ -146,7 +146,7 @@ func (a Analyzer) convertValue(zctx *zed.Context, val astzed.Value, parent zed.T
 		if err != nil {
 			return nil, err
 		}
-		if union, ok := zed.AliasOf(parent).(*zed.TypeUnion); ok {
+		if union, ok := zed.TypeUnder(parent).(*zed.TypeUnion); ok {
 			v, err = a.convertUnion(zctx, v, union, parent)
 		}
 		return v, err
@@ -158,7 +158,7 @@ func (a Analyzer) typeCheck(cast, parent zed.Type) error {
 	if parent == nil || cast == parent {
 		return nil
 	}
-	if _, ok := zed.AliasOf(parent).(*zed.TypeUnion); ok {
+	if _, ok := zed.TypeUnder(parent).(*zed.TypeUnion); ok {
 		// We let unions through this type check with no further checking
 		// as any union incompability will be caught in convertAnyValue().
 		return nil
@@ -183,7 +183,7 @@ func (a Analyzer) convertAny(zctx *zed.Context, val astzed.Any, cast zed.Type) (
 	// If we're casting something to a union, then the thing inside needs to
 	// describe itself and we can convert the inner value to a union value when
 	// we know its type (so we can code the selector).
-	if union, ok := zed.AliasOf(cast).(*zed.TypeUnion); ok {
+	if union, ok := zed.TypeUnder(cast).(*zed.TypeUnion); ok {
 		v, err := a.convertAny(zctx, val, nil)
 		if err != nil {
 			return nil, err
@@ -261,7 +261,7 @@ func (a Analyzer) convertRecord(zctx *zed.Context, val *astzed.Record, cast zed.
 	var fields []Value
 	var err error
 	if cast != nil {
-		recType, ok := zed.AliasOf(cast).(*zed.TypeRecord)
+		recType, ok := zed.TypeUnder(cast).(*zed.TypeRecord)
 		if !ok {
 			return nil, fmt.Errorf("record decorator not of type record: %T", cast)
 		}
@@ -314,7 +314,7 @@ func arrayElemCast(cast zed.Type) (zed.Type, error) {
 	if cast == nil {
 		return nil, nil
 	}
-	if arrayType, ok := zed.AliasOf(cast).(*zed.TypeArray); ok {
+	if arrayType, ok := zed.TypeUnder(cast).(*zed.TypeArray); ok {
 		return arrayType.Type, nil
 	}
 	return nil, errors.New("array decorator not of type array")
@@ -428,7 +428,7 @@ func differentTypes(vals []Value) []zed.Type {
 func (a Analyzer) convertSet(zctx *zed.Context, set *astzed.Set, cast zed.Type) (Value, error) {
 	var elemType zed.Type
 	if cast != nil {
-		setType, ok := zed.AliasOf(cast).(*zed.TypeSet)
+		setType, ok := zed.TypeUnder(cast).(*zed.TypeSet)
 		if !ok {
 			return nil, fmt.Errorf("set decorator not of type set: %T", cast)
 		}
@@ -485,7 +485,7 @@ func (a Analyzer) convertEnum(zctx *zed.Context, val *astzed.Enum, cast zed.Type
 	if cast == nil {
 		return nil, fmt.Errorf("identifier %q must be enum and requires decorator", val.Name)
 	}
-	enum, ok := zed.AliasOf(cast).(*zed.TypeEnum)
+	enum, ok := zed.TypeUnder(cast).(*zed.TypeEnum)
 	if !ok {
 		return nil, fmt.Errorf("identifier %q is enum and incompatible with type %q", val.Name, cast)
 	}
@@ -503,7 +503,7 @@ func (a Analyzer) convertEnum(zctx *zed.Context, val *astzed.Enum, cast zed.Type
 func (a Analyzer) convertMap(zctx *zed.Context, m *astzed.Map, cast zed.Type) (Value, error) {
 	var keyType, valType zed.Type
 	if cast != nil {
-		typ, ok := zed.AliasOf(cast).(*zed.TypeMap)
+		typ, ok := zed.TypeUnder(cast).(*zed.TypeMap)
 		if !ok {
 			return nil, errors.New("map decorator not of type map")
 		}
@@ -543,7 +543,7 @@ func (a Analyzer) convertMap(zctx *zed.Context, m *astzed.Map, cast zed.Type) (V
 
 func (a Analyzer) convertTypeValue(zctx *zed.Context, tv *astzed.TypeValue, cast zed.Type) (Value, error) {
 	if cast != nil {
-		if _, ok := zed.AliasOf(cast).(*zed.TypeOfType); !ok {
+		if _, ok := zed.TypeUnder(cast).(*zed.TypeOfType); !ok {
 			return nil, fmt.Errorf("cannot apply decorator (%q) to a type value", cast)
 		}
 	}

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -51,7 +51,7 @@ func buildValue(b *zcode.Builder, val Value) error {
 }
 
 func BuildPrimitive(b *zcode.Builder, val Primitive) error {
-	switch zed.AliasOf(val.Type).(type) {
+	switch zed.TypeUnder(val.Type).(type) {
 	case *zed.TypeOfUint8, *zed.TypeOfUint16, *zed.TypeOfUint32, *zed.TypeOfUint64:
 		v, err := strconv.ParseUint(val.Text, 10, 64)
 		if err != nil {

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -316,7 +316,7 @@ func (f *Formatter) formatMap(indent int, typ *zed.TypeMap, bytes zcode.Bytes, k
 		if err := f.formatValue(indent, typ.KeyType, keyBytes, known, parentImplied, true); err != nil {
 			return empty, err
 		}
-		if zed.AliasOf(typ.KeyType) == zed.TypeIP && len(keyBytes) == 16 {
+		if zed.TypeUnder(typ.KeyType) == zed.TypeIP && len(keyBytes) == 16 {
 			// To avoid ambiguity, whitespace must separate an IPv6
 			// map key from the colon that follows it.
 			f.build(" ")
@@ -463,7 +463,7 @@ var colors = map[zed.Type]color.Code{
 
 func (f *Formatter) startColorPrimitive(typ zed.Type) {
 	if f.tab > 0 {
-		c, ok := colors[zed.AliasOf(typ)]
+		c, ok := colors[zed.TypeUnder(typ)]
 		if !ok {
 			c = color.Reset
 		}

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -744,7 +744,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 	case reflect.String:
 		// XXX We bundle string, bstring, type, error all into string.
 		// See issue #1853.
-		switch zed.AliasOf(zv.Type) {
+		switch zed.TypeUnder(zv.Type) {
 		case zed.TypeString, zed.TypeBstring, zed.TypeType, zed.TypeError:
 		default:
 			return incompatTypeError(zv.Type, v)
@@ -757,7 +757,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 		v.SetString(x)
 		return err
 	case reflect.Bool:
-		if zed.AliasOf(zv.Type) != zed.TypeBool {
+		if zed.TypeUnder(zv.Type) != zed.TypeBool {
 			return incompatTypeError(zv.Type, v)
 		}
 		if zv.Bytes == nil {
@@ -768,7 +768,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 		v.SetBool(x)
 		return err
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		switch zed.AliasOf(zv.Type) {
+		switch zed.TypeUnder(zv.Type) {
 		case zed.TypeInt8, zed.TypeInt16, zed.TypeInt32, zed.TypeInt64:
 		default:
 			return incompatTypeError(zv.Type, v)
@@ -781,7 +781,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 		v.SetInt(x)
 		return err
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		switch zed.AliasOf(zv.Type) {
+		switch zed.TypeUnder(zv.Type) {
 		case zed.TypeUint8, zed.TypeUint16, zed.TypeUint32, zed.TypeUint64:
 		default:
 			return incompatTypeError(zv.Type, v)
@@ -794,7 +794,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 		v.SetUint(x)
 		return err
 	case reflect.Float32:
-		if zed.AliasOf(zv.Type) != zed.TypeFloat32 {
+		if zed.TypeUnder(zv.Type) != zed.TypeFloat32 {
 			return incompatTypeError(zv.Type, v)
 		}
 		if zv.Bytes == nil {
@@ -805,7 +805,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 		v.SetFloat(float64(x))
 		return err
 	case reflect.Float64:
-		if zed.AliasOf(zv.Type) != zed.TypeFloat64 {
+		if zed.TypeUnder(zv.Type) != zed.TypeFloat64 {
 			return incompatTypeError(zv.Type, v)
 		}
 		if zv.Bytes == nil {
@@ -825,7 +825,7 @@ func isIP(typ reflect.Type) bool {
 }
 
 func (u *UnmarshalZNGContext) decodeIP(zv zed.Value, v reflect.Value) error {
-	if zed.AliasOf(zv.Type) != zed.TypeIP {
+	if zed.TypeUnder(zv.Type) != zed.TypeIP {
 		return incompatTypeError(zv.Type, v)
 	}
 	if zv.Bytes == nil {
@@ -838,7 +838,7 @@ func (u *UnmarshalZNGContext) decodeIP(zv zed.Value, v reflect.Value) error {
 }
 
 func (u *UnmarshalZNGContext) decodeMap(zv zed.Value, mapVal reflect.Value) error {
-	typ, ok := zed.AliasOf(zv.Type).(*zed.TypeMap)
+	typ, ok := zed.TypeUnder(zv.Type).(*zed.TypeMap)
 	if !ok {
 		return errors.New("not a map")
 	}
@@ -867,7 +867,7 @@ func (u *UnmarshalZNGContext) decodeMap(zv zed.Value, mapVal reflect.Value) erro
 }
 
 func (u *UnmarshalZNGContext) decodeRecord(zv zed.Value, sval reflect.Value) error {
-	recType, ok := zed.AliasOf(zv.Type).(*zed.TypeRecord)
+	recType, ok := zed.TypeUnder(zv.Type).(*zed.TypeRecord)
 	if !ok {
 		return fmt.Errorf("cannot unmarshal Zed type %q into Go struct", FormatType(zv.Type))
 	}
@@ -895,7 +895,7 @@ func (u *UnmarshalZNGContext) decodeRecord(zv zed.Value, sval reflect.Value) err
 }
 
 func (u *UnmarshalZNGContext) decodeArray(zv zed.Value, arrVal reflect.Value) error {
-	typ := zed.AliasOf(zv.Type)
+	typ := zed.TypeUnder(zv.Type)
 	if typ == zed.TypeBytes && arrVal.Type().Elem().Kind() == reflect.Uint8 {
 		if zv.Bytes == nil {
 			return nil
@@ -907,7 +907,7 @@ func (u *UnmarshalZNGContext) decodeArray(zv zed.Value, arrVal reflect.Value) er
 		arrVal.SetBytes(zv.Bytes)
 		return nil
 	}
-	arrType, ok := zed.AliasOf(zv.Type).(*zed.TypeArray)
+	arrType, ok := zed.TypeUnder(zv.Type).(*zed.TypeArray)
 	if !ok {
 		return errors.New("not an array")
 	}


### PR DESCRIPTION
The new name matches Zed's typeunder(), which behaves similarly.