### PR TITLE
fix bug with joining record unions

### DIFF
--- a/expr/dot.go
+++ b/expr/dot.go
@@ -33,7 +33,7 @@ func NewDottedExpr(f field.Path) Evaluator {
 	return ret
 }
 
-func valOf(val *zed.Value) *zed.Value {
+func ValueOf(val *zed.Value) *zed.Value {
 	typ := val.Type
 	if _, ok := typ.(*zed.TypeAlias); !ok {
 		if _, ok := typ.(*zed.TypeUnion); !ok {
@@ -58,7 +58,7 @@ func valOf(val *zed.Value) *zed.Value {
 
 func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 	rec := d.record.Eval(ectx, this)
-	val := valOf(rec)
+	val := ValueOf(rec)
 	recType, ok := val.Type.(*zed.TypeRecord)
 	if !ok {
 		return zed.Missing

--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -241,6 +241,8 @@ func (p *Proc) splice(left, right *zed.Value) (*zed.Value, error) {
 		// stream.
 		return left, nil
 	}
+	left = expr.ValueOf(left)
+	right = expr.ValueOf(right)
 	typ, err := p.combinedType(zed.TypeRecordOf(left.Type), zed.TypeRecordOf(right.Type))
 	if err != nil {
 		return nil, err

--- a/proc/join/ztests/join-union.yaml
+++ b/proc/join/ztests/join-union.yaml
@@ -1,21 +1,18 @@
 script: |
-  zq -z 'split ( => sort a => sort b ) | inner join on a=b hit:=c | sort a' a.zson b.zson
-
+  zq -z 'inner join on a=b' a.zson b.zson
 inputs:
   - name: a.zson
     data: |
       {a:1}(({a:int64},{a:string}))
       {a:2}(({a:int64},{a:string}))
       {a:"bar"}(({a:int64},{a:string}))
-
   - name: b.zson
     data: |
-      {b:1,c:"hit"}
-      {b:"bar",c:"hit"}
-      {b:3,c:"hit"}
-
+      {b:1}
+      {b:3}
+      {b:"bar"}
 outputs:
   - name: stdout
     data: |
-      {a:1,hit:"hit"}
-      {a:"bar",hit:"hit"}
+      {a:1}
+      {a:"bar"}

--- a/proc/join/ztests/join-union.yaml
+++ b/proc/join/ztests/join-union.yaml
@@ -1,0 +1,21 @@
+script: |
+  zq -z 'split ( => sort a => sort b ) | inner join on a=b hit:=c | sort a' a.zson b.zson
+
+inputs:
+  - name: a.zson
+    data: |
+      {a:1}(({a:int64},{a:string}))
+      {a:2}(({a:int64},{a:string}))
+      {a:"bar"}(({a:int64},{a:string}))
+
+  - name: b.zson
+    data: |
+      {b:1,c:"hit"}
+      {b:"bar",c:"hit"}
+      {b:3,c:"hit"}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1,hit:"hit"}
+      {a:"bar",hit:"hit"}


### PR DESCRIPTION
This commit fixes a bug in the join logic to handle unions by
simply extracting the union-tagged value from the input before
processing.