### PR TITLE
fix sort for empty input

### DIFF
--- a/lake/ztests/revert-index.yaml
+++ b/lake/ztests/revert-index.yaml
@@ -30,7 +30,6 @@ outputs:
       {name:"IPs",count:1(uint64)}
       {name:"Ys",count:1(uint64)}
       ===
-      "warning: sort field \"name\" not present in input"(error)
       ===
       {name:"IPs",count:1(uint64)}
       {name:"Ys",count:1(uint64)}

--- a/proc/sort/unseen.go
+++ b/proc/sort/unseen.go
@@ -12,7 +12,7 @@ type unseenFieldTracker struct {
 
 func newUnseenFieldTracker(fields []expr.Evaluator) *unseenFieldTracker {
 	unseen := make(map[expr.Evaluator]struct{})
-	// We start out withe unseen map full of all the fields and take
+	// We start with the unseen map full of all the fields and take
 	// them out for each record type we encounter.
 	for _, f := range fields {
 		unseen[f] = struct{}{}
@@ -26,7 +26,7 @@ func newUnseenFieldTracker(fields []expr.Evaluator) *unseenFieldTracker {
 func (u *unseenFieldTracker) update(ectx expr.Context, rec *zed.Value) {
 	recType := zed.TypeRecordOf(rec.Type)
 	if len(u.unseenFields) == 0 || u.seenTypes[recType] {
-		// Either have seen this type or nothing to unsee anymore.
+		// We've already seen every field or seen this type.
 		return
 	}
 	u.seenTypes[recType] = true
@@ -39,6 +39,10 @@ func (u *unseenFieldTracker) update(ectx expr.Context, rec *zed.Value) {
 }
 
 func (u *unseenFieldTracker) unseen() []expr.Evaluator {
+	if len(u.seenTypes) == 0 {
+		// We haven't seen any input.
+		return nil
+	}
 	var fields []expr.Evaluator
 	for f := range u.unseenFields {
 		fields = append(fields, f)

--- a/proc/sort/ztests/empty-input.yaml
+++ b/proc/sort/ztests/empty-input.yaml
@@ -1,0 +1,6 @@
+# Sort with empty input should produce no output or warning.
+zed: sort foo
+
+input: ''
+
+output: ''


### PR DESCRIPTION
The sort operator warns about missing fields when its input is empty.
It shouldn't, so fix it to warn only after seeing at least one value.