### PR TITLE
fix null handling in over operator

### DIFF
--- a/proc/traverse/over.go
+++ b/proc/traverse/over.go
@@ -78,10 +78,8 @@ func appendOver(vals []zed.Value, zv zed.Value) ([]zed.Value, error) {
 	for it := zv.Bytes.Iter(); !it.Done(); {
 		b, _ := it.Next()
 		// XXX when we do proper expr.Context, we can allocate
-		// this slice through the batch.
-		bc := make([]byte, len(b))
-		copy(bc, b)
-		vals = append(vals, zed.Value{typ, bc})
+		// this copy through the batch.
+		vals = append(vals, *zed.NewValue(typ, b).Copy())
 	}
 	return vals, nil
 }

--- a/proc/traverse/ztests/over-null.yaml
+++ b/proc/traverse/ztests/over-null.yaml
@@ -1,0 +1,11 @@
+zed: over this
+
+input: |
+  [null, 0]
+  [null, ""]
+
+output: |
+  null(int64)
+  0
+  null(string)
+  ""


### PR DESCRIPTION
The over operator changes null values to zero-length values of the same
type.  Fix this by preserving zed.Value.Bytes nil-ness in
proc/traverse.appendOver.