### PR TITLE
Change prepack to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zed",
   "version": "0.33.0-dev",
   "scripts": {
-      "prepack": "node npm/build"
+      "prepare": "node npm/build"
   },
   "files": [
       "dist/**",


### PR DESCRIPTION
The prepack command stopped working when upgrading from npm version 6 to version 7. Changing it to prepare works in both versions.