### PR TITLE
shorten sleep time to speed up some ztests

### DIFF
--- a/cmd/zq/ztests/http.bash
+++ b/cmd/zq/ztests/http.bash
@@ -8,8 +8,8 @@ i=0
 while :; do
     python3 -c "from urllib.request import *; urlopen('$http_base_url')" &&
         break
-    sleep 0.5
-    if ((i++ >= 10)); then
+    sleep 0.1
+    if ((i++ >= 50)); then
         echo "timed out waiting for HTTP server"
         echo "http.log:"
         cat http.log

--- a/service/ztests/mockbrim.sh
+++ b/service/ztests/mockbrim.sh
@@ -8,11 +8,11 @@ function awaitdeadservice {
   function servicealive { kill -0 $LAKE_PID 2> /dev/null; }
   while servicealive ; do
     let i+=1
-    if [ $i -gt 5 ]; then
+    if [ $i -gt 50 ]; then
       echo "timed out waiting for service to exit" 
       exit 1
     fi
-    sleep 1
+    sleep 0.1
   done
 }
 
@@ -21,11 +21,11 @@ function awaitfile {
   i=0
   until [ -f $file ]; do
     let i+=1
-    if [ $i -gt 5 ]; then
+    if [ $i -gt 50 ]; then
       echo "timed out waiting for file \"$file\" to appear"
       exit 1
     fi
-    sleep 1
+    sleep 0.1
   done
 }
 

--- a/service/ztests/service.sh
+++ b/service/ztests/service.sh
@@ -5,12 +5,12 @@ function awaitfile {
   i=0
   until [ -f $file ]; do
     let i+=1
-    if [ $i -gt 5 ]; then
+    if [ $i -gt 50 ]; then
       echo "lake serve log:"
       cat lake.log
       exit 1
     fi
-    sleep 1
+    sleep 0.1
   done
 }
 

--- a/testdata/minio.sh
+++ b/testdata/minio.sh
@@ -10,11 +10,11 @@ trap "rm -rf $portdir; kill -9 $!" EXIT
 i=0
 until [ -f $portdir/port ]; do
   let i+=1
-  if [ $i -gt 5 ]; then
+  if [ $i -gt 50 ]; then
     echo "timed out waiting for minio to start"
     exit 1
   fi
-  sleep 1
+  sleep 0.1
 done
 
 port=$(cat $portdir/port)


### PR DESCRIPTION
"make test-system" runs a number of script-style ztests that poll for a
service to be ready, sleeping for 500 or 1000 milliseconds between
attempts.  Reduce that to 100 milliseconds to speed things up.  (This
shaves at least two seconds off "make test-system" for me.)