### PR TITLE
Rename function trunc to bucket

### DIFF
--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -126,7 +126,7 @@ func orderPreservingCall(e dag.Expr, key field.Path) bool {
 		// There are probably other functions we could cover.
 		// It would be good if the function declaration included
 		// the info we need here.  See issue #2660.
-		case "ceil", "floor", "round", "trunc":
+		case "bucket", "ceil", "floor", "round":
 			if len(call.Args) >= 1 && fieldOf(call.Args[0]).Equal(key) {
 				return true
 			}

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -232,7 +232,7 @@ func semSequential(ctx context.Context, scope *Scope, seq *ast.Sequential, adapt
 // semProc does a semantic analysis on a flowgraph to an
 // intermediate representation that can be compiled into the runtime
 // object.  Currently, it only replaces the group-by duration with
-// a truncation call on the ts and replaces FunctionCall's in proc context
+// a bucket call on the ts and replaces FunctionCall's in proc context
 // with either a group-by or filter-proc based on the function's name.
 func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAdaptor, head *lakeparse.Commitish) (dag.Op, error) {
 	switch p := p.(type) {
@@ -256,7 +256,7 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 				},
 				RHS: &dag.Call{
 					Kind: "Call",
-					Name: "trunc",
+					Name: "bucket",
 					Args: []dag.Expr{
 						&dag.Path{
 							Kind: "Path",
@@ -291,7 +291,7 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 		// so this code path isn't hit yet, but it uses this same entry point
 		// and it will soon do other stuff so we need to put in place the
 		// separation... see issue #2163.  Also, we copy Duration even though
-		// above we changed duration to the a trunc(ts) group-by key as the
+		// above we changed duration to the a bucket(ts) group-by key as the
 		// Duration field is used later by the parallelization operator.
 		return &dag.Summarize{
 			Kind:     "Summarize",

--- a/compiler/ztests/par-every-count.yaml
+++ b/compiler/ztests/par-every-count.yaml
@@ -6,10 +6,10 @@ outputs:
       from (
         pool G2eDzBUfU6IEmUSGCa5kHyXMhoO =>
           summarize every 1h partials-out sort-dir 1
-              count:=count() by ts:=trunc(ts, 1h),y:=y
+              count:=count() by ts:=bucket(ts, 1h),y:=y
         pool G2eDzBUfU6IEmUSGCa5kHyXMhoO =>
           summarize every 1h partials-out sort-dir 1
-              count:=count() by ts:=trunc(ts, 1h),y:=y
+              count:=count() by ts:=bucket(ts, 1h),y:=y
       )
       | merge ts:asc
       | summarize every 1h partials-in sort-dir 1

--- a/compiler/ztests/sem-groupby-input-dir.yaml
+++ b/compiler/ztests/sem-groupby-input-dir.yaml
@@ -7,4 +7,4 @@ outputs:
         pool G2eDzBUfU6IEmUSGCa5kHyXMhoO
       )
       | summarize every 1h sort-dir 1
-          count:=count() by ts:=trunc(ts, 1h)
+          count:=count() by ts:=bucket(ts, 1h)

--- a/docs/language/data-types.md
+++ b/docs/language/data-types.md
@@ -45,7 +45,7 @@ zq -z 'every 1d sum(quantity) | sort ts' shipments.ndjson
 
 #### Output:
 ```mdtest-output
-{ts:"trunc: time arg required"(error),sum:9158}
+{ts:"bucket: time arg required"(error),sum:9158}
 ```
 
 However, if we cast the `ts` field to the Zed `time` type, now the

--- a/docs/language/functions.md
+++ b/docs/language/functions.md
@@ -34,7 +34,7 @@
   - [`to_upper`](#to_upper)
   - [`trim`](#trim)
 - [Time](#time)
-  - [`trunc`](#trunc)
+  - [`bucket`](#bucket)
 - [Types](#types)
   - [`is`](#is)
   - [`iserr`](#iserr)
@@ -598,19 +598,19 @@ echo '{}' | zq -z 'yield now()' -
 2021-12-16T23:33:41.680643Z
 ```
 
-### `trunc`
+### `bucket`
 
 ```
-trunc(t <timey>, m (duration,<number>)) -> time
+bucket(t (<timey>,duration), m (duration,<number>)) -> (time,duration)
 ```
 
 <!-- XXX document time coercion rules  and link below-->
 
-`trunc` returns time `t` (or value that can be coerced to time) rounded down to
+`bucket` returns time or duration `t` (or value that can be coerced to time) rounded down to
 the nearest multiple of duration `m`.
 
 ```mdtest-command
-echo '{ts:2020-05-26T15:27:47Z}' | zq -z 'ts := trunc(ts, 1h)' -
+echo '{ts:2020-05-26T15:27:47Z}' | zq -z 'ts := bucket(ts, 1h)' -
 ```
 
 **Output:**

--- a/docs/language/grouping.md
+++ b/docs/language/grouping.md
@@ -132,7 +132,7 @@ If a data source includes a field named `ts` of the `time` type, the shorthand
 `every <duration>` can be used before invoking your aggregate function(s) to
 create batches of records that are close together in time. If your data has
 a differently-named field of the `time` type, the same can be achieved with
-a grouping `by <name>:=trunc(<field-name>, <duration>)`.
+a grouping `by <name>:=bucket(<field-name>, <duration>)`.
 
 The `<duration>` may be expressed as a combination of one or more of the
 following units of time. An integer or decimal value must precede the
@@ -191,7 +191,7 @@ which collections of schools opened during each week after the start of year
 2014:
 
 ```mdtest-command dir=testdata/edu
-zq -Z 'OpenDate >= 2014-01-01T00:00:00Z | OpenedThisWeek:=collect(School) by OpenWeek:=trunc(OpenDate, 1w) | sort OpenWeek' schools.zson
+zq -Z 'OpenDate >= 2014-01-01T00:00:00Z | OpenedThisWeek:=collect(School) by OpenWeek:=bucket(OpenDate, 1w) | sort OpenWeek' schools.zson
 ```
 
 #### Output:

--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -77,10 +77,10 @@ func New(zctx *zed.Context, name string, narg int) (Interface, bool, error) {
 		argmin = 2
 		argmax = 2
 		f = newSplit(zctx)
-	case "trunc":
+	case "bucket":
 		argmin = 2
 		argmax = 2
-		f = &Trunc{}
+		f = &Bucket{}
 	case "typename":
 		argmax = 2
 		f = &typeName{zctx: zctx}

--- a/expr/function/time.go
+++ b/expr/function/time.go
@@ -36,7 +36,7 @@ func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 		bin = nano.Duration(d) * nano.Second
 	}
-	if tsArg.Type == zed.TypeDuration {
+	if zed.TypeUnder(tsArg.Type) == zed.TypeDuration {
 		dur, err := zed.DecodeDuration(tsArg.Bytes)
 		if err != nil {
 			panic(err)

--- a/expr/function/ztests/bucket.yaml
+++ b/expr/function/ztests/bucket.yaml
@@ -1,9 +1,11 @@
-zed: cut t := trunc(t, bin)
+zed: cut t := bucket(t, bin)
 
 input: |
   {t:1590506867.967,bin:1}
   {t:2020-05-26T15:27:47Z,bin:1h}
+  {t:3s,bin:2s}
 
 output: |
   {t:2020-05-26T15:27:47Z}
   {t:2020-05-26T15:00:00Z}
+  {t:2s}

--- a/pkg/nano/duration.go
+++ b/pkg/nano/duration.go
@@ -102,6 +102,10 @@ func writeFixedPoint(b *strings.Builder, ns, scale int64) {
 	}
 }
 
+func (d Duration) Trunc(bin Duration) Duration {
+	return d / bin * bin
+}
+
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(Ts(d))
 }


### PR DESCRIPTION
This change also makes it so if first argument is a duration, the
duration type is kept and is truncated by the second duration argument.

Part of #2213