### PR TITLE
remove expr.ValueCompareFn

### DIFF
--- a/expr/extent/span.go
+++ b/expr/extent/span.go
@@ -31,14 +31,14 @@ type Span interface {
 type Generic struct {
 	first zed.Value
 	last  zed.Value
-	cmp   expr.ValueCompareFn
+	cmp   expr.CompareFn
 }
 
 // CompareFunc returns a generic comparator suitable for use in a Range
 // based on the order of values in the range, i.e., when order is desc
 // then the first value is larger than the last value and Before is true
 // for larger values while After is true for smaller values, etc.
-func CompareFunc(o order.Which) expr.ValueCompareFn {
+func CompareFunc(o order.Which) expr.CompareFn {
 	// The values of nullsMax here (used during lake data reads) and in
 	// zbuf.NewCompareFn (used during lake data writes) must agree.
 	cmp := expr.NewValueCompareFn(o == order.Asc)
@@ -51,7 +51,7 @@ func CompareFunc(o order.Which) expr.ValueCompareFn {
 // Create a new Range from generic range of zed.Values according
 // to lower and upper.  The range is not sensitive to the absolute order
 // of lower and upper.
-func NewGeneric(lower, upper zed.Value, cmp expr.ValueCompareFn) *Generic {
+func NewGeneric(lower, upper zed.Value, cmp expr.CompareFn) *Generic {
 	if cmp(&lower, &upper) > 0 {
 		lower, upper = upper, lower
 	}

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -10,7 +10,6 @@ import (
 )
 
 type CompareFn func(a *zed.Value, b *zed.Value) int
-type ValueCompareFn func(a *zed.Value, b *zed.Value) int
 type KeyCompareFn func(Context, *zed.Value) int
 
 // Internal function that compares two values of compatible types.
@@ -63,7 +62,7 @@ func NewCompareFn(nullsMax bool, fields ...Evaluator) CompareFn {
 	}
 }
 
-func NewValueCompareFn(nullsMax bool) ValueCompareFn {
+func NewValueCompareFn(nullsMax bool) CompareFn {
 	var pair coerce.Pair
 	comparefns := make(map[zed.Type]comparefn)
 	return func(a, b *zed.Value) int {

--- a/lake/data/reader.go
+++ b/lake/data/reader.go
@@ -36,7 +36,7 @@ type Reader struct {
 // NewReader returns a Reader for this data object. If the object has a seek index
 // and if the provided span skips part of the object, the seek index will be used to
 // limit the reading window of the returned reader.
-func (o *ObjectScan) NewReader(ctx context.Context, engine storage.Engine, path *storage.URI, scanRange extent.Span, cmp expr.ValueCompareFn) (*Reader, error) {
+func (o *ObjectScan) NewReader(ctx context.Context, engine storage.Engine, path *storage.URI, scanRange extent.Span, cmp expr.CompareFn) (*Reader, error) {
 	objectPath := o.RowObjectPath(path)
 	reader, err := engine.Get(ctx, objectPath)
 	if err != nil {

--- a/lake/partition.go
+++ b/lake/partition.go
@@ -24,7 +24,7 @@ import (
 // to only the span involved.
 type Partition struct {
 	extent.Span
-	compare expr.ValueCompareFn
+	compare expr.CompareFn
 	Objects []*data.ObjectScan
 }
 
@@ -74,7 +74,7 @@ func PartitionObjects(objects []*data.Object, o order.Which) []Partition {
 
 type stack []Partition
 
-func (s *stack) pushObjectSpan(span objectSpan, cmp expr.ValueCompareFn) {
+func (s *stack) pushObjectSpan(span objectSpan, cmp expr.CompareFn) {
 	s.push(Partition{
 		Span:    span.Span,
 		compare: cmp,
@@ -102,7 +102,7 @@ type objectSpan struct {
 	object *data.Object
 }
 
-func sortedObjectSpans(objects []*data.Object, cmp expr.ValueCompareFn) []objectSpan {
+func sortedObjectSpans(objects []*data.Object, cmp expr.CompareFn) []objectSpan {
 	spans := make([]objectSpan, 0, len(objects))
 	for _, o := range objects {
 		spans = append(spans, objectSpan{

--- a/lake/seekindex/lookup.go
+++ b/lake/seekindex/lookup.go
@@ -11,7 +11,7 @@ import (
 	"github.com/brimdata/zed/zio"
 )
 
-func Lookup(r zio.Reader, from, to *zed.Value, cmp expr.ValueCompareFn) (Range, error) {
+func Lookup(r zio.Reader, from, to *zed.Value, cmp expr.CompareFn) (Range, error) {
 	return lookup(r, field.New("key"), from, to, cmp)
 }
 
@@ -19,7 +19,7 @@ func LookupByCount(r zio.Reader, from, to *zed.Value) (Range, error) {
 	return lookup(r, field.New("count"), from, to, extent.CompareFunc(order.Asc))
 }
 
-func lookup(r zio.Reader, path field.Path, from, to *zed.Value, cmp expr.ValueCompareFn) (Range, error) {
+func lookup(r zio.Reader, path field.Path, from, to *zed.Value, cmp expr.CompareFn) (Range, error) {
 	rg := Range{0, math.MaxInt64}
 	var rec *zed.Value
 	for {

--- a/lake/sorted.go
+++ b/lake/sorted.go
@@ -111,7 +111,7 @@ func (r *rangeWrapper) AsEvaluator() (expr.Evaluator, error) {
 type rangeFilter struct {
 	r       *rangeWrapper
 	filter  expr.Evaluator
-	compare expr.ValueCompareFn
+	compare expr.CompareFn
 }
 
 func (r *rangeFilter) Eval(ectx expr.Context, this *zed.Value) *zed.Value {
@@ -130,7 +130,7 @@ func (r *rangeFilter) Eval(ectx expr.Context, this *zed.Value) *zed.Value {
 	return r.filter.Eval(ectx, this)
 }
 
-func wrapRangeFilter(f zbuf.Filter, scan extent.Span, cmp expr.ValueCompareFn, first, last zed.Value, layout order.Layout) zbuf.Filter {
+func wrapRangeFilter(f zbuf.Filter, scan extent.Span, cmp expr.CompareFn, first, last zed.Value, layout order.Layout) zbuf.Filter {
 	scanFirst := scan.First()
 	scanLast := scan.Last()
 	if cmp(scanFirst, &first) <= 0 {

--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -51,9 +51,9 @@ type Aggregator struct {
 	recordTypes  map[int]*zed.TypeRecord
 	table        map[string]*Row
 	limit        int
-	valueCompare expr.ValueCompareFn // to compare primary group keys for early key output
-	keyCompare   expr.CompareFn      // compare the first key (used when input sorted)
-	keysCompare  expr.CompareFn      // compare all keys
+	valueCompare expr.CompareFn // to compare primary group keys for early key output
+	keyCompare   expr.CompareFn // compare the first key (used when input sorted)
+	keysCompare  expr.CompareFn // compare all keys
 	maxTableKey  *zed.Value
 	maxSpillKey  *zed.Value
 	inputDir     order.Direction
@@ -72,7 +72,7 @@ func NewAggregator(ctx context.Context, zctx *zed.Context, keyRefs, keyExprs, ag
 	if limit == 0 {
 		limit = DefaultLimit
 	}
-	var valueCompare expr.ValueCompareFn
+	var valueCompare expr.CompareFn
 	var keyCompare, keysCompare expr.CompareFn
 
 	nkeys := len(keyExprs)

--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -24,7 +24,7 @@ type Proc struct {
 	right       *zio.Peeker
 	getLeftKey  expr.Evaluator
 	getRightKey expr.Evaluator
-	compare     expr.ValueCompareFn
+	compare     expr.CompareFn
 	cutter      *expr.Cutter
 	joinKey     *zed.Value
 	joinSet     []*zed.Value


### PR DESCRIPTION
expr.ValueCompareFn is identical to CompareFn.  Remove the former and
use the latter instead.