### PR TITLE
panic on failure when decoding Zed primitive

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -28,7 +28,7 @@ func (t *TypeAlias) AliasID() int {
 	return t.id
 }
 
-func (t *TypeAlias) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeAlias) Marshal(zv zcode.Bytes) interface{} {
 	return t.Type.Marshal(zv)
 }
 

--- a/array.go
+++ b/array.go
@@ -24,7 +24,7 @@ func (t *TypeArray) String() string {
 	return fmt.Sprintf("[%s]", t.Type)
 }
 
-func (t *TypeArray) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeArray) Marshal(zv zcode.Bytes) interface{} {
 	// start out with zero-length container so we get "[]" instead of nil
 	vals := []*Value{}
 	it := zv.Iter()
@@ -32,7 +32,7 @@ func (t *TypeArray) Marshal(zv zcode.Bytes) (interface{}, error) {
 		val, _ := it.Next()
 		vals = append(vals, &Value{t.Type, val})
 	}
-	return vals, nil
+	return vals
 }
 
 func (t *TypeArray) Format(zv zcode.Bytes) string {

--- a/bool.go
+++ b/bool.go
@@ -36,14 +36,8 @@ func EncodeBool(b bool) zcode.Bytes {
 	return AppendBool(nil, b)
 }
 
-func DecodeBool(zv zcode.Bytes) (bool, error) {
-	if zv == nil {
-		return false, nil
-	}
-	if zv[0] != 0 {
-		return true, nil
-	}
-	return false, nil
+func DecodeBool(zv zcode.Bytes) bool {
+	return zv != nil && zv[0] != 0
 }
 
 func (t *TypeOfBool) ID() int {
@@ -54,16 +48,12 @@ func (t *TypeOfBool) String() string {
 	return "bool"
 }
 
-func (t *TypeOfBool) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfBool) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeBool(zv)
 }
 
 func (t *TypeOfBool) Format(zv zcode.Bytes) string {
-	b, err := DecodeBool(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	if b {
+	if DecodeBool(zv) {
 		return "true"
 	}
 	return "false"

--- a/bytes.go
+++ b/bytes.go
@@ -16,8 +16,8 @@ func EncodeBytes(b []byte) zcode.Bytes {
 	return zcode.Bytes(b)
 }
 
-func DecodeBytes(zv zcode.Bytes) ([]byte, error) {
-	return []byte(zv), nil
+func DecodeBytes(zv zcode.Bytes) []byte {
+	return []byte(zv)
 }
 
 func (t *TypeOfBytes) ID() int {
@@ -28,8 +28,8 @@ func (t *TypeOfBytes) String() string {
 	return "bytes"
 }
 
-func (t *TypeOfBytes) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return t.Format(zv), nil
+func (t *TypeOfBytes) Marshal(zv zcode.Bytes) interface{} {
+	return t.Format(zv)
 }
 
 func (t *TypeOfBytes) Format(zv zcode.Bytes) string {

--- a/duration.go
+++ b/duration.go
@@ -19,9 +19,8 @@ func AppendDuration(bytes zcode.Bytes, d nano.Duration) zcode.Bytes {
 	return AppendInt(bytes, int64(d))
 }
 
-func DecodeDuration(zv zcode.Bytes) (nano.Duration, error) {
-	i, err := DecodeInt(zv)
-	return nano.Duration(i), err
+func DecodeDuration(zv zcode.Bytes) nano.Duration {
+	return nano.Duration(DecodeInt(zv))
 }
 
 func (t *TypeOfDuration) ID() int {
@@ -32,14 +31,10 @@ func (t *TypeOfDuration) String() string {
 	return "duration"
 }
 
-func (t *TypeOfDuration) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return t.Format(zv), nil
+func (t *TypeOfDuration) Marshal(zv zcode.Bytes) interface{} {
+	return t.Format(zv)
 }
 
 func (t *TypeOfDuration) Format(zv zcode.Bytes) string {
-	d, err := DecodeDuration(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return d.String()
+	return DecodeDuration(zv).String()
 }

--- a/enum.go
+++ b/enum.go
@@ -36,7 +36,7 @@ func (t *TypeEnum) Lookup(symbol string) int {
 	return -1
 }
 
-func (t *TypeEnum) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeEnum) Marshal(zv zcode.Bytes) interface{} {
 	return TypeUint64.Marshal(zv)
 }
 
@@ -54,12 +54,9 @@ func (t *TypeEnum) String() string {
 }
 
 func (t *TypeEnum) Format(zv zcode.Bytes) string {
-	id, err := DecodeUint(zv)
-	if id >= uint64(len(t.Symbols)) || err != nil {
-		if err == nil {
-			err = errors.New("enum index out of range")
-		}
-		return badZNG(err, t, zv)
+	id := DecodeUint(zv)
+	if id >= uint64(len(t.Symbols)) {
+		return badZNG(errors.New("enum index out of range"), t, zv)
 	}
 	return t.Symbols[id]
 }

--- a/error.go
+++ b/error.go
@@ -26,11 +26,11 @@ func EncodeError(err error) zcode.Bytes {
 	return zcode.Bytes(err.Error())
 }
 
-func DecodeError(zv zcode.Bytes) (error, error) {
+func DecodeError(zv zcode.Bytes) error {
 	if zv == nil {
-		return nil, nil
+		return nil
 	}
-	return errors.New(string(zv)), nil
+	return errors.New(string(zv))
 }
 
 type TypeError struct {
@@ -50,15 +50,8 @@ func (t *TypeError) String() string {
 	return fmt.Sprintf("error<%s>", t.Type)
 }
 
-func (t *TypeError) Marshal(zv zcode.Bytes) (interface{}, error) {
-	// start out with zero-length container so we get "[]" instead of nil
-	val, err := t.Type.Marshal(zv)
-	if err != nil {
-		return nil, err
-	}
-	m := make(map[string]interface{})
-	m["error"] = val
-	return m, nil
+func (t *TypeError) Marshal(zv zcode.Bytes) interface{} {
+	return map[string]interface{}{"error": t.Type.Marshal(zv)}
 }
 
 func (t *TypeError) Format(zv zcode.Bytes) string {

--- a/expr/agg/avg.go
+++ b/expr/agg/avg.go
@@ -52,10 +52,6 @@ func (a *Avg) ConsumeAsPartial(partial *zed.Value) {
 	if sumVal.Type != zed.TypeFloat64 {
 		panic(fmt.Errorf("avg: partial sum has bad type: %s", zson.MustFormatValue(sumVal)))
 	}
-	sum, err := zed.DecodeFloat64(sumVal.Bytes)
-	if err != nil {
-		panic(err)
-	}
 	countVal, err := rec.ValueByField(countName)
 	if err != nil {
 		panic(err)
@@ -63,12 +59,8 @@ func (a *Avg) ConsumeAsPartial(partial *zed.Value) {
 	if countVal.Type != zed.TypeUint64 {
 		panic(fmt.Errorf("avg: partial count has bad type: %s", zson.MustFormatValue(countVal)))
 	}
-	count, err := zed.DecodeUint(countVal.Bytes)
-	if err != nil {
-		panic(err)
-	}
-	a.sum += sum
-	a.count += count
+	a.sum += zed.DecodeFloat64(sumVal.Bytes)
+	a.count += zed.DecodeUint(countVal.Bytes)
 }
 
 func (a *Avg) ResultAsPartial(zctx *zed.Context) *zed.Value {

--- a/expr/agg/count.go
+++ b/expr/agg/count.go
@@ -20,11 +20,7 @@ func (c *Count) ConsumeAsPartial(partial *zed.Value) {
 	if partial.Type != zed.TypeUint64 {
 		panic("count: partial not uint64")
 	}
-	u, err := zed.DecodeUint(partial.Bytes)
-	if err != nil {
-		panic(err)
-	}
-	*c += Count(u)
+	*c += Count(zed.DecodeUint(partial.Bytes))
 }
 
 func (c Count) ResultAsPartial(*zed.Context) *zed.Value {

--- a/expr/boolean.go
+++ b/expr/boolean.go
@@ -45,10 +45,7 @@ func CompareBool(op string, pattern bool) (Boolean, error) {
 		if val.Type.ID() != zed.IDBool {
 			return false
 		}
-		b, err := zed.DecodeBool(val.Bytes)
-		if err != nil {
-			return false
-		}
+		b := zed.DecodeBool(val.Bytes)
 		return compare(b, pattern)
 	}, nil
 }
@@ -83,30 +80,18 @@ func CompareInt64(op string, pattern int64) (Boolean, error) {
 		zv := val.Bytes
 		switch val.Type.ID() {
 		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
-			v, err := zed.DecodeInt(zv)
-			if err == nil {
-				return CompareInt(v, pattern)
-			}
+			return CompareInt(zed.DecodeInt(zv), pattern)
 		case zed.IDUint8, zed.IDUint16, zed.IDUint32, zed.IDUint64:
-			v, err := zed.DecodeUint(zv)
-			if err == nil && v <= math.MaxInt64 {
+			v := zed.DecodeUint(zv)
+			if v <= math.MaxInt64 {
 				return CompareInt(int64(v), pattern)
 			}
 		case zed.IDFloat32, zed.IDFloat64:
-			v, err := zed.DecodeFloat(zv)
-			if err == nil {
-				return CompareFloat(v, float64(pattern))
-			}
+			return CompareFloat(zed.DecodeFloat(zv), float64(pattern))
 		case zed.IDTime:
-			ts, err := zed.DecodeTime(zv)
-			if err == nil {
-				return CompareInt(int64(ts), pattern*1e9)
-			}
+			return CompareInt(int64(zed.DecodeTime(zv)), pattern*1e9)
 		case zed.IDDuration:
-			v, err := zed.DecodeInt(zv)
-			if err == nil {
-				return CompareInt(int64(v), pattern*1e9)
-			}
+			return CompareInt(int64(zed.DecodeDuration(zv)), pattern*1e9)
 		}
 		return false
 	}, nil
@@ -123,30 +108,18 @@ func CompareTime(op string, pattern int64) (Boolean, error) {
 		zv := val.Bytes
 		switch val.Type.ID() {
 		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
-			v, err := zed.DecodeInt(zv)
-			if err == nil {
-				return CompareInt(v, pattern)
-			}
+			return CompareInt(zed.DecodeInt(zv), pattern)
 		case zed.IDUint8, zed.IDUint16, zed.IDUint32, zed.IDUint64:
-			v, err := zed.DecodeUint(zv)
-			if err == nil && v <= math.MaxInt64 {
+			v := zed.DecodeUint(zv)
+			if v <= math.MaxInt64 {
 				return CompareInt(int64(v), pattern)
 			}
 		case zed.IDFloat32, zed.IDFloat64:
-			v, err := zed.DecodeFloat(zv)
-			if err == nil {
-				return CompareFloat(v, float64(pattern))
-			}
+			return CompareFloat(zed.DecodeFloat(zv), float64(pattern))
 		case zed.IDTime:
-			ts, err := zed.DecodeTime(zv)
-			if err == nil {
-				return CompareInt(int64(ts), pattern)
-			}
+			return CompareInt(int64(zed.DecodeTime(zv)), pattern)
 		case zed.IDDuration:
-			v, err := zed.DecodeInt(zv)
-			if err == nil {
-				return CompareInt(int64(v), pattern)
-			}
+			return CompareInt(int64(zed.DecodeDuration(zv)), pattern)
 		}
 		return false
 	}, nil
@@ -175,11 +148,7 @@ func CompareIP(op string, pattern net.IP) (Boolean, error) {
 		if val.Type.ID() != zed.IDIP {
 			return false
 		}
-		ip, err := zed.DecodeIP(val.Bytes)
-		if err != nil {
-			return false
-		}
-		return compare(ip, pattern)
+		return compare(zed.DecodeIP(val.Bytes), pattern)
 	}, nil
 }
 
@@ -202,30 +171,15 @@ func CompareFloat64(op string, pattern float64) (Boolean, error) {
 		// use an integer constant instead of a float constant to
 		// compare with the integer-y field.
 		case zed.IDFloat32, zed.IDFloat64:
-			v, err := zed.DecodeFloat(zv)
-			if err == nil {
-				return compare(v, pattern)
-			}
+			return compare(zed.DecodeFloat(zv), pattern)
 		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
-			v, err := zed.DecodeInt(zv)
-			if err == nil {
-				return compare(float64(v), pattern)
-			}
+			return compare(float64(zed.DecodeInt(zv)), pattern)
 		case zed.IDUint8, zed.IDUint16, zed.IDUint32, zed.IDUint64:
-			v, err := zed.DecodeUint(zv)
-			if err == nil {
-				return compare(float64(v), pattern)
-			}
+			return compare(float64(zed.DecodeUint(zv)), pattern)
 		case zed.IDTime:
-			ts, err := zed.DecodeTime(zv)
-			if err == nil {
-				return compare(float64(ts)/1e9, pattern)
-			}
+			return compare(float64(zed.DecodeTime(zv))/1e9, pattern)
 		case zed.IDDuration:
-			v, err := zed.DecodeDuration(zv)
-			if err == nil {
-				return compare(float64(v)/1e9, pattern)
-			}
+			return compare(float64(zed.DecodeDuration(zv))/1e9, pattern)
 		}
 		return false
 	}, nil
@@ -367,15 +321,9 @@ func CompareSubnet(op string, pattern *net.IPNet) (Boolean, error) {
 	return func(val *zed.Value) bool {
 		switch val.Type.ID() {
 		case zed.IDIP:
-			ip, err := zed.DecodeIP(val.Bytes)
-			if err == nil {
-				return match(ip, pattern)
-			}
+			return match(zed.DecodeIP(val.Bytes), pattern)
 		case zed.IDNet:
-			subnet, err := zed.DecodeNet(val.Bytes)
-			if err == nil {
-				return compare(subnet, pattern)
-			}
+			return compare(zed.DecodeNet(val.Bytes), pattern)
 		}
 		return false
 	}, nil
@@ -413,45 +361,21 @@ func Comparison(op string, val *zed.Value) (Boolean, error) {
 	case *zed.TypeOfNull:
 		return CompareNull(op)
 	case *zed.TypeOfIP:
-		v, err := zed.DecodeIP(val.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		return CompareIP(op, v)
+		return CompareIP(op, zed.DecodeIP(val.Bytes))
 	case *zed.TypeOfNet:
-		v, err := zed.DecodeNet(val.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		return CompareSubnet(op, v)
+		return CompareSubnet(op, zed.DecodeNet(val.Bytes))
 	case *zed.TypeOfBool:
-		v, err := zed.DecodeBool(val.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		return CompareBool(op, v)
+		return CompareBool(op, zed.DecodeBool(val.Bytes))
 	case *zed.TypeOfFloat64:
-		v, err := zed.DecodeFloat64(val.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		return CompareFloat64(op, v)
+		return CompareFloat64(op, zed.DecodeFloat64(val.Bytes))
 	case *zed.TypeOfString:
 		return CompareString(op, val.Bytes)
 	case *zed.TypeOfBytes, *zed.TypeOfType:
 		return CompareBytes(op, val.Bytes)
 	case *zed.TypeOfInt64:
-		v, err := zed.DecodeInt(val.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		return CompareInt64(op, v)
+		return CompareInt64(op, zed.DecodeInt(val.Bytes))
 	case *zed.TypeOfTime, *zed.TypeOfDuration:
-		v, err := zed.DecodeInt(val.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		return CompareTime(op, v)
+		return CompareTime(op, zed.DecodeInt(val.Bytes))
 	default:
 		return nil, fmt.Errorf("literal comparison of type %q unsupported", val.Type)
 	}

--- a/expr/cast.go
+++ b/expr/cast.go
@@ -175,11 +175,7 @@ func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
 		return ectx.NewValue(zed.TypeDuration, zed.EncodeDuration(d))
 	}
 	if zed.IsFloat(id) {
-		f, err := zed.DecodeFloat(val.Bytes)
-		if err != nil {
-			panic(err)
-		}
-		d := nano.DurationFromFloat(f)
+		d := nano.DurationFromFloat(zed.DecodeFloat(val.Bytes))
 		return ectx.NewValue(zed.TypeDuration, zed.EncodeDuration(d))
 	}
 	v, ok := coerce.ToInt(*val)
@@ -213,11 +209,7 @@ func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
 			ts = nano.Ts(gotime.UnixNano())
 		}
 	case zed.IsFloat(id):
-		sec, err := zed.DecodeFloat(val.Bytes)
-		if err != nil {
-			panic(err)
-		}
-		ts = nano.Ts(sec * 1e9)
+		ts = nano.Ts(zed.DecodeFloat(val.Bytes) * 1e9)
 	case zed.IsInteger(id):
 		//XXX we call coerce here to avoid unsigned/signed decode
 		v, ok := coerce.ToInt(*val)
@@ -244,7 +236,7 @@ func (c *casterString) Eval(ectx Context, val *zed.Value) *zed.Value {
 		return ectx.NewValue(zed.TypeString, val.Bytes)
 	}
 	if enum, ok := val.Type.(*zed.TypeEnum); ok {
-		selector, _ := zed.DecodeUint(val.Bytes)
+		selector := zed.DecodeUint(val.Bytes)
 		symbol, err := enum.Symbol(int(selector))
 		if err != nil {
 			return ectx.CopyValue(*c.zctx.NewError(err))

--- a/expr/coerce/coerce.go
+++ b/expr/coerce/coerce.go
@@ -99,15 +99,13 @@ func (c *Pair) compare(lhs, rhs *zed.Value) (bool, error) {
 
 func intToFloat(id int, b zcode.Bytes) float64 {
 	if zed.IsSigned(id) {
-		v, _ := zed.DecodeInt(b)
-		return float64(v)
+		return float64(zed.DecodeInt(b))
 	}
-	v, _ := zed.DecodeUint(b)
-	return float64(v)
+	return float64(zed.DecodeUint(b))
 }
 
 func (c *Pair) promoteToSigned(in zcode.Bytes) (zcode.Bytes, bool) {
-	v, _ := zed.DecodeUint(in)
+	v := zed.DecodeUint(in)
 	if v > math.MaxInt64 {
 		return nil, false
 	}
@@ -115,7 +113,7 @@ func (c *Pair) promoteToSigned(in zcode.Bytes) (zcode.Bytes, bool) {
 }
 
 func (c *Pair) promoteToUnsigned(in zcode.Bytes) (zcode.Bytes, bool) {
-	v, _ := zed.DecodeInt(in)
+	v := zed.DecodeInt(in)
 	if v < 0 {
 		return nil, false
 	}
@@ -125,22 +123,14 @@ func (c *Pair) promoteToUnsigned(in zcode.Bytes) (zcode.Bytes, bool) {
 func (c *Pair) coerceNumbers(aid, bid int) (int, bool) {
 	if zed.IsFloat(aid) {
 		if aid == zed.IDFloat32 {
-			v, err := zed.DecodeFloat32(c.A)
-			if err != nil {
-				panic(err)
-			}
-			c.A = c.buf2.Float64(float64(v))
+			c.A = c.buf2.Float64(float64(zed.DecodeFloat32(c.A)))
 		}
 		c.B = c.Float64(intToFloat(bid, c.B))
 		return aid, true
 	}
 	if zed.IsFloat(bid) {
 		if bid == zed.IDFloat32 {
-			v, err := zed.DecodeFloat32(c.B)
-			if err != nil {
-				panic(err)
-			}
-			c.B = c.buf2.Float64(float64(v))
+			c.B = c.buf2.Float64(float64(zed.DecodeFloat32(c.B)))
 		}
 		c.A = c.Float64(intToFloat(aid, c.A))
 		return bid, true
@@ -184,21 +174,17 @@ func (c *Pair) coerceNumbers(aid, bid int) (int, bool) {
 func ToFloat(zv zed.Value) (float64, bool) {
 	id := zv.Type.ID()
 	if zed.IsFloat(id) {
-		f, _ := zed.DecodeFloat(zv.Bytes)
-		return f, true
+		return zed.DecodeFloat(zv.Bytes), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			v, _ := zed.DecodeInt(zv.Bytes)
-			return float64(v), true
+			return float64(zed.DecodeInt(zv.Bytes)), true
 		} else {
-			v, _ := zed.DecodeUint(zv.Bytes)
-			return float64(v), true
+			return float64(zed.DecodeUint(zv.Bytes)), true
 		}
 	}
 	if id == zed.IDDuration {
-		v, _ := zed.DecodeInt(zv.Bytes)
-		return 1e-9 * float64(v), true
+		return 1e-9 * float64(zed.DecodeInt(zv.Bytes)), true
 	}
 	if id == zed.IDString {
 		v, err := strconv.ParseFloat(string(zv.Bytes), 64)
@@ -210,24 +196,21 @@ func ToFloat(zv zed.Value) (float64, bool) {
 func ToUint(zv zed.Value) (uint64, bool) {
 	id := zv.Type.ID()
 	if zed.IsFloat(id) {
-		f, _ := zed.DecodeFloat(zv.Bytes)
-		return uint64(f), true
+		return uint64(zed.DecodeFloat(zv.Bytes)), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			v, _ := zed.DecodeInt(zv.Bytes)
+			v := zed.DecodeInt(zv.Bytes)
 			if v < 0 {
 				return 0, false
 			}
 			return uint64(v), true
 		} else {
-			v, _ := zed.DecodeUint(zv.Bytes)
-			return uint64(v), true
+			return uint64(zed.DecodeUint(zv.Bytes)), true
 		}
 	}
 	if id == zed.IDDuration {
-		v, _ := zed.DecodeInt(zv.Bytes)
-		return uint64(v / 1_000_000_000), true
+		return uint64(zed.DecodeInt(zv.Bytes) / 1_000_000_000), true
 	}
 	if id == zed.IDString {
 		v, err := strconv.ParseUint(string(zv.Bytes), 10, 64)
@@ -239,22 +222,18 @@ func ToUint(zv zed.Value) (uint64, bool) {
 func ToInt(zv zed.Value) (int64, bool) {
 	id := zv.Type.ID()
 	if zed.IsFloat(id) {
-		f, _ := zed.DecodeFloat(zv.Bytes)
-		return int64(f), true
+		return int64(zed.DecodeFloat(zv.Bytes)), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			v, _ := zed.DecodeInt(zv.Bytes)
 			// XXX check if negative? should -1:uint64 be maxint64 or an error?
-			return int64(v), true
+			return int64(zed.DecodeInt(zv.Bytes)), true
 		} else {
-			v, _ := zed.DecodeUint(zv.Bytes)
-			return int64(v), true
+			return int64(zed.DecodeUint(zv.Bytes)), true
 		}
 	}
 	if id == zed.IDDuration {
-		v, _ := zed.DecodeInt(zv.Bytes)
-		return int64(v / 1_000_000_000), true
+		return int64(zed.DecodeInt(zv.Bytes) / 1_000_000_000), true
 	}
 	if id == zed.IDString {
 		v, err := strconv.ParseInt(string(zv.Bytes), 10, 64)
@@ -275,15 +254,13 @@ func ToBool(zv zed.Value) (bool, bool) {
 func ToTime(zv zed.Value) (nano.Ts, bool) {
 	id := zv.Type.ID()
 	if id == zed.IDTime {
-		ts, _ := zed.DecodeTime(zv.Bytes)
-		return ts, true
+		return zed.DecodeTime(zv.Bytes), true
 	}
 	if zed.IsSigned(id) {
-		v, _ := zed.DecodeInt(zv.Bytes)
-		return nano.Ts(v) * 1_000_000_000, true
+		return nano.Ts(zed.DecodeInt(zv.Bytes)) * 1_000_000_000, true
 	}
 	if zed.IsInteger(id) {
-		v, _ := zed.DecodeUint(zv.Bytes)
+		v := zed.DecodeUint(zv.Bytes)
 		// check for overflow
 		if v > math.MaxInt64 {
 			return 0, false
@@ -291,8 +268,7 @@ func ToTime(zv zed.Value) (nano.Ts, bool) {
 		return nano.Ts(v), true
 	}
 	if zed.IsFloat(id) {
-		v, _ := zed.DecodeFloat(zv.Bytes)
-		return nano.Ts(v * 1e9), true
+		return nano.Ts(zed.DecodeFloat(zv.Bytes) * 1e9), true
 	}
 	return 0, false
 }
@@ -302,33 +278,22 @@ func ToTime(zv zed.Value) (nano.Ts, bool) {
 // written to out, and true is returned. If the value cannot be
 // coerced, then false is returned.
 func ToDuration(in zed.Value) (nano.Duration, bool) {
-	var out nano.Duration
-	var err error
 	switch in.Type.ID() {
 	case zed.IDDuration:
-		out, err = zed.DecodeDuration(in.Bytes)
+		return zed.DecodeDuration(in.Bytes), true
 	case zed.IDUint16, zed.IDUint32, zed.IDUint64:
-		var v uint64
-		v, err = zed.DecodeUint(in.Bytes)
+		v := zed.DecodeUint(in.Bytes)
 		// check for overflow
 		if v > math.MaxInt64 {
 			return 0, false
 		}
-		out = nano.Duration(v) * nano.Second
+		return nano.Duration(v) * nano.Second, true
 	case zed.IDInt16, zed.IDInt32, zed.IDInt64:
-		var v int64
-		v, err = zed.DecodeInt(in.Bytes)
+		v := zed.DecodeInt(in.Bytes)
 		//XXX check for overflow here
-		out = nano.Duration(v) * nano.Second
+		return nano.Duration(v) * nano.Second, true
 	case zed.IDFloat32, zed.IDFloat64:
-		var v float64
-		v, err = zed.DecodeFloat(in.Bytes)
-		out = nano.DurationFromFloat(v)
-	default:
-		return 0, false
+		return nano.DurationFromFloat(zed.DecodeFloat(in.Bytes)), true
 	}
-	if err != nil {
-		return 0, false
-	}
-	return out, true
+	return 0, false
 }

--- a/expr/function/bytes.go
+++ b/expr/function/bytes.go
@@ -21,8 +21,7 @@ func (f *FromBase64) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zv.Bytes == nil {
 		return zed.NullType
 	}
-	s, _ := zed.DecodeString(zv.Bytes)
-	b, err := base64.StdEncoding.DecodeString(s)
+	b, err := base64.StdEncoding.DecodeString(zed.DecodeString(zv.Bytes))
 	if err != nil {
 		panic(err)
 	}

--- a/expr/function/ip.go
+++ b/expr/function/ip.go
@@ -18,10 +18,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newErrorf(n.zctx, ctx, "network_of: not an IP")
 	}
 	// XXX GC
-	ip, err := zed.DecodeIP(args[0].Bytes)
-	if err != nil {
-		panic(err)
-	}
+	ip := zed.DecodeIP(args[0].Bytes)
 	var mask net.IPMask
 	if len(args) == 1 {
 		mask = ip.DefaultMask()
@@ -33,11 +30,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		id := args[1].Type.ID()
 		body := args[1].Bytes
 		if id == zed.IDNet {
-			var err error
-			cidrMask, err := zed.DecodeNet(body)
-			if err != nil {
-				panic(err)
-			}
+			cidrMask := zed.DecodeNet(body)
 			if !bytes.Equal(cidrMask.IP, cidrMask.Mask) {
 				return newErrorf(n.zctx, ctx, "network_of: network arg not a cidr mask")
 			}
@@ -45,17 +38,9 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		} else if zed.IsInteger(id) {
 			var nbits uint
 			if zed.IsSigned(id) {
-				v, err := zed.DecodeInt(body)
-				if err != nil {
-					panic(err)
-				}
-				nbits = uint(v)
+				nbits = uint(zed.DecodeInt(body))
 			} else {
-				v, err := zed.DecodeUint(body)
-				if err != nil {
-					panic(err)
-				}
-				nbits = uint(v)
+				nbits = uint(zed.DecodeUint(body))
 			}
 			if nbits > 64 {
 				return newErrorf(n.zctx, ctx, "network_of: cidr bit count out of range")

--- a/expr/function/math.go
+++ b/expr/function/math.go
@@ -18,11 +18,7 @@ func (a *Abs) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	v := args[0]
 	id := v.Type.ID()
 	if zed.IsFloat(id) {
-		f, err := zed.DecodeFloat64(v.Bytes)
-		if err != nil {
-			panic(err)
-		}
-		f = math.Abs(f)
+		f := math.Abs(zed.DecodeFloat64(v.Bytes))
 		return newFloat64(ctx, f)
 	}
 	if !zed.IsInteger(id) {
@@ -31,10 +27,7 @@ func (a *Abs) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !zed.IsSigned(id) {
 		return ctx.CopyValue(args[0])
 	}
-	x, err := zed.DecodeInt(v.Bytes)
-	if err != nil {
-		panic(err)
-	}
+	x := zed.DecodeInt(v.Bytes)
 	if x < 0 {
 		x = -x
 	}
@@ -51,11 +44,7 @@ func (c *Ceil) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	id := v.Type.ID()
 	switch {
 	case zed.IsFloat(id):
-		f, err := zed.DecodeFloat64(v.Bytes)
-		if err != nil {
-			panic(err)
-		}
-		f = math.Ceil(f)
+		f := math.Ceil(zed.DecodeFloat64(v.Bytes))
 		return newFloat64(ctx, f)
 	case zed.IsInteger(id):
 		return ctx.CopyValue(args[0])
@@ -74,8 +63,7 @@ func (f *Floor) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	id := v.Type.ID()
 	switch {
 	case zed.IsFloat(id):
-		v, _ := zed.DecodeFloat64(v.Bytes)
-		v = math.Floor(v)
+		v := math.Floor(zed.DecodeFloat64(v.Bytes))
 		return newFloat64(ctx, v)
 	case zed.IsInteger(id):
 		return ctx.CopyValue(args[0])
@@ -113,7 +101,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zed.IsFloat(id) {
 		//XXX this is wrong like math aggregators...
 		// need to be more robust and adjust type as new types encountered
-		result, _ := zed.DecodeFloat64(zv.Bytes)
+		result := zed.DecodeFloat64(zv.Bytes)
 		for _, val := range args[1:] {
 			v, ok := coerce.ToFloat(zv)
 			if !ok {
@@ -127,7 +115,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(zv))
 	}
 	if zed.IsSigned(id) {
-		result, _ := zed.DecodeInt(zv.Bytes)
+		result := zed.DecodeInt(zv.Bytes)
 		for _, val := range args[1:] {
 			//XXX this is really bad because we silently coerce
 			// floats to ints if we hit a float first
@@ -139,7 +127,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 		return newInt64(ctx, result)
 	}
-	result, _ := zed.DecodeUint(zv.Bytes)
+	result := zed.DecodeUint(zv.Bytes)
 	for _, val := range args[1:] {
 		v, ok := coerce.ToUint(val)
 		if !ok {
@@ -159,10 +147,7 @@ func (r *Round) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	zv := args[0]
 	id := zv.Type.ID()
 	if zed.IsFloat(id) {
-		f, err := zed.DecodeFloat64(zv.Bytes)
-		if err != nil {
-			panic(err)
-		}
+		f := zed.DecodeFloat64(zv.Bytes)
 		return newFloat64(ctx, math.Round(f))
 	}
 	if !zed.IsNumber(id) {

--- a/expr/function/parse.go
+++ b/expr/function/parse.go
@@ -21,10 +21,7 @@ func (p *ParseURI) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !in.IsString() || in.Bytes == nil {
 		return newErrorf(p.zctx, ctx, "parse_uri: non-empty string arg required")
 	}
-	s, err := zed.DecodeString(in.Bytes)
-	if err != nil {
-		panic(err)
-	}
+	s := zed.DecodeString(in.Bytes)
 	u, err := url.Parse(s)
 	if err != nil {
 		return newErrorf(p.zctx, ctx, "parse_uri: %s (%q)", err, s)
@@ -92,10 +89,7 @@ func (p *ParseZSON) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if in.Bytes == nil {
 		return zed.Null
 	}
-	s, err := zed.DecodeString(in.Bytes)
-	if err != nil {
-		panic(err)
-	}
+	s := zed.DecodeString(in.Bytes)
 	parser := zson.NewParser(strings.NewReader(s))
 	ast, err := parser.ParseValue()
 	if err != nil {

--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -26,18 +26,9 @@ func (r *Replace) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zvold.Bytes == nil || zvnew.Bytes == nil {
 		return newErrorf(r.zctx, ctx, "replace: an input arg is null")
 	}
-	s, err := zed.DecodeString(zvs.Bytes)
-	if err != nil {
-		panic(err)
-	}
-	old, err := zed.DecodeString(zvold.Bytes)
-	if err != nil {
-		panic(err)
-	}
-	new, err := zed.DecodeString(zvnew.Bytes)
-	if err != nil {
-		panic(err)
-	}
+	s := zed.DecodeString(zvs.Bytes)
+	old := zed.DecodeString(zvold.Bytes)
+	new := zed.DecodeString(zvnew.Bytes)
 	return newString(ctx, strings.ReplaceAll(s, old, new))
 }
 
@@ -54,11 +45,8 @@ func (r *RuneLen) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zv.Bytes == nil {
 		return newInt64(ctx, 0)
 	}
-	in, err := zed.DecodeString(zv.Bytes)
-	if err != nil {
-		panic(err)
-	}
-	return newInt64(ctx, int64(utf8.RuneCountInString(in)))
+	s := zed.DecodeString(zv.Bytes)
+	return newInt64(ctx, int64(utf8.RuneCountInString(s)))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#to_lower
@@ -74,10 +62,7 @@ func (t *ToLower) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zv.IsNull() {
 		return zed.NullString
 	}
-	s, err := zed.DecodeString(zv.Bytes)
-	if err != nil {
-		panic(err)
-	}
+	s := zed.DecodeString(zv.Bytes)
 	return newString(ctx, strings.ToLower(s))
 }
 
@@ -94,10 +79,7 @@ func (t *ToUpper) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zv.IsNull() {
 		return zed.NullString
 	}
-	s, err := zed.DecodeString(zv.Bytes)
-	if err != nil {
-		panic(err)
-	}
+	s := zed.DecodeString(zv.Bytes)
 	return newString(ctx, strings.ToUpper(s))
 }
 
@@ -114,10 +96,7 @@ func (t *Trim) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zv.IsNull() {
 		return zed.NullString
 	}
-	s, err := zed.DecodeString(zv.Bytes)
-	if err != nil {
-		panic(err)
-	}
+	s := zed.DecodeString(zv.Bytes)
 	return newString(ctx, strings.TrimSpace(s))
 }
 
@@ -142,14 +121,8 @@ func (s *Split) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zs.IsNull() || zsep.IsNull() {
 		return ctx.NewValue(s.typ, nil)
 	}
-	str, err := zed.DecodeString(zs.Bytes)
-	if err != nil {
-		panic(err)
-	}
-	sep, err := zed.DecodeString(zsep.Bytes)
-	if err != nil {
-		panic(err)
-	}
+	str := zed.DecodeString(zs.Bytes)
+	sep := zed.DecodeString(zsep.Bytes)
 	splits := strings.Split(str, sep)
 	var b zcode.Bytes
 	for _, substr := range splits {
@@ -179,24 +152,16 @@ func (j *Join) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		if !zsep.IsString() {
 			return newErrorf(j.zctx, ctx, "join: separator must be string")
 		}
-		var err error
-		separator, err = zed.DecodeString(zsep.Bytes)
-		if err != nil {
-			panic(err)
-		}
+		separator = zed.DecodeString(zsep.Bytes)
 	}
 	b := j.builder
 	b.Reset()
 	it := zsplits.Bytes.Iter()
 	var sep string
 	for !it.Done() {
-		bytes, _ := it.Next()
-		s, err := zed.DecodeString(bytes)
-		if err != nil {
-			panic(err)
-		}
 		b.WriteString(sep)
-		b.WriteString(s)
+		bytes, _ := it.Next()
+		b.WriteString(zed.DecodeString(bytes))
 		sep = separator
 	}
 	return newString(ctx, b.String())

--- a/expr/function/time.go
+++ b/expr/function/time.go
@@ -27,11 +27,7 @@ func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	}
 	var bin nano.Duration
 	if binArg.Type == zed.TypeDuration {
-		var err error
-		bin, err = zed.DecodeDuration(binArg.Bytes)
-		if err != nil {
-			panic(err)
-		}
+		bin = zed.DecodeDuration(binArg.Bytes)
 	} else {
 		d, ok := coerce.ToInt(binArg)
 		if !ok {
@@ -40,10 +36,7 @@ func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		bin = nano.Duration(d) * nano.Second
 	}
 	if zed.TypeUnder(tsArg.Type) == zed.TypeDuration {
-		dur, err := zed.DecodeDuration(tsArg.Bytes)
-		if err != nil {
-			panic(err)
-		}
+		dur := zed.DecodeDuration(tsArg.Bytes)
 		return newDuration(ctx, dur.Trunc(bin))
 	}
 	ts, ok := coerce.ToTime(tsArg)

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -249,14 +249,7 @@ func LookupCompare(typ zed.Type) comparefn {
 	switch typ.ID() {
 	case zed.IDBool:
 		return func(a, b zcode.Bytes) int {
-			va, err := zed.DecodeBool(a)
-			if err != nil {
-				return -1
-			}
-			vb, err := zed.DecodeBool(b)
-			if err != nil {
-				return 1
-			}
+			va, vb := zed.DecodeBool(a), zed.DecodeBool(b)
 			if va == vb {
 				return 0
 			}
@@ -273,14 +266,7 @@ func LookupCompare(typ zed.Type) comparefn {
 
 	case zed.IDInt16, zed.IDInt32, zed.IDInt64:
 		return func(a, b zcode.Bytes) int {
-			va, err := zed.DecodeInt(a)
-			if err != nil {
-				return -1
-			}
-			vb, err := zed.DecodeInt(b)
-			if err != nil {
-				return 1
-			}
+			va, vb := zed.DecodeInt(a), zed.DecodeInt(b)
 			if va < vb {
 				return -1
 			} else if va > vb {
@@ -291,14 +277,7 @@ func LookupCompare(typ zed.Type) comparefn {
 
 	case zed.IDUint16, zed.IDUint32, zed.IDUint64:
 		return func(a, b zcode.Bytes) int {
-			va, err := zed.DecodeUint(a)
-			if err != nil {
-				return -1
-			}
-			vb, err := zed.DecodeUint(b)
-			if err != nil {
-				return 1
-			}
+			va, vb := zed.DecodeUint(a), zed.DecodeUint(b)
 			if va < vb {
 				return -1
 			} else if va > vb {
@@ -309,14 +288,7 @@ func LookupCompare(typ zed.Type) comparefn {
 
 	case zed.IDFloat32, zed.IDFloat64:
 		return func(a, b zcode.Bytes) int {
-			va, err := zed.DecodeFloat(a)
-			if err != nil {
-				return -1
-			}
-			vb, err := zed.DecodeFloat(b)
-			if err != nil {
-				return 1
-			}
+			va, vb := zed.DecodeFloat(a), zed.DecodeFloat(b)
 			if va < vb {
 				return -1
 			} else if va > vb {
@@ -327,14 +299,7 @@ func LookupCompare(typ zed.Type) comparefn {
 
 	case zed.IDTime:
 		return func(a, b zcode.Bytes) int {
-			va, err := zed.DecodeTime(a)
-			if err != nil {
-				return -1
-			}
-			vb, err := zed.DecodeTime(b)
-			if err != nil {
-				return 1
-			}
+			va, vb := zed.DecodeTime(a), zed.DecodeTime(b)
 			if va < vb {
 				return -1
 			} else if va > vb {
@@ -345,14 +310,7 @@ func LookupCompare(typ zed.Type) comparefn {
 
 	case zed.IDDuration:
 		return func(a, b zcode.Bytes) int {
-			va, err := zed.DecodeDuration(a)
-			if err != nil {
-				return -1
-			}
-			vb, err := zed.DecodeDuration(b)
-			if err != nil {
-				return 1
-			}
+			va, vb := zed.DecodeDuration(a), zed.DecodeDuration(b)
 			if va < vb {
 				return -1
 			} else if va > vb {
@@ -363,14 +321,7 @@ func LookupCompare(typ zed.Type) comparefn {
 
 	case zed.IDIP:
 		return func(a, b zcode.Bytes) int {
-			va, err := zed.DecodeIP(a)
-			if err != nil {
-				return -1
-			}
-			vb, err := zed.DecodeIP(b)
-			if err != nil {
-				return 1
-			}
+			va, vb := zed.DecodeIP(a), zed.DecodeIP(b)
 			return bytes.Compare(va.To16(), vb.To16())
 		}
 

--- a/float.go
+++ b/float.go
@@ -2,7 +2,6 @@ package zed
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -10,16 +9,19 @@ import (
 	"github.com/brimdata/zed/zcode"
 )
 
-func DecodeFloat(zb zcode.Bytes) (float64, error) {
+func DecodeFloat(zb zcode.Bytes) float64 {
+	if zb == nil {
+		return 0
+	}
 	switch len(zb) {
 	case 4:
 		bits := binary.LittleEndian.Uint32(zb)
-		return float64(math.Float32frombits(bits)), nil
+		return float64(math.Float32frombits(bits))
 	case 8:
 		bits := binary.LittleEndian.Uint64(zb)
-		return math.Float64frombits(bits), nil
+		return math.Float64frombits(bits)
 	}
-	return 0, errors.New("float encoding is neither 4 nor 8 bytes")
+	panic("float encoding is neither 4 nor 8 bytes")
 }
 
 type TypeOfFloat32 struct{}
@@ -38,12 +40,11 @@ func EncodeFloat32(d float32) zcode.Bytes {
 	return AppendFloat32(nil, d)
 }
 
-func DecodeFloat32(zb zcode.Bytes) (float32, error) {
-	if len(zb) != 4 {
-		return 0, errors.New("byte encoding of float32 not 4 bytes")
+func DecodeFloat32(zb zcode.Bytes) float32 {
+	if zb == nil {
+		return 0
 	}
-	bits := binary.LittleEndian.Uint32(zb)
-	return math.Float32frombits(bits), nil
+	return math.Float32frombits(binary.LittleEndian.Uint32(zb))
 }
 
 func (t *TypeOfFloat32) ID() int {
@@ -54,15 +55,12 @@ func (t *TypeOfFloat32) String() string {
 	return "float32"
 }
 
-func (t *TypeOfFloat32) Marshal(zb zcode.Bytes) (interface{}, error) {
+func (t *TypeOfFloat32) Marshal(zb zcode.Bytes) interface{} {
 	return DecodeFloat32(zb)
 }
 
 func (t *TypeOfFloat32) Format(zb zcode.Bytes) string {
-	f, err := DecodeFloat32(zb)
-	if err != nil {
-		return badZNG(err, t, zb)
-	}
+	f := DecodeFloat32(zb)
 	if f == float32(int64(f)) {
 		return fmt.Sprintf("%d.", int(f))
 	}
@@ -85,12 +83,11 @@ func EncodeFloat64(d float64) zcode.Bytes {
 	return AppendFloat64(nil, d)
 }
 
-func DecodeFloat64(zv zcode.Bytes) (float64, error) {
-	if len(zv) != 8 {
-		return 0, errors.New("byte encoding of double not 8 bytes")
+func DecodeFloat64(zv zcode.Bytes) float64 {
+	if zv == nil {
+		return 0
 	}
-	bits := binary.LittleEndian.Uint64(zv)
-	return math.Float64frombits(bits), nil
+	return math.Float64frombits(binary.LittleEndian.Uint64(zv))
 }
 
 func (t *TypeOfFloat64) ID() int {
@@ -101,15 +98,12 @@ func (t *TypeOfFloat64) String() string {
 	return "float64"
 }
 
-func (t *TypeOfFloat64) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfFloat64) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeFloat64(zv)
 }
 
 func (t *TypeOfFloat64) Format(zv zcode.Bytes) string {
-	d, err := DecodeFloat64(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
+	d := DecodeFloat64(zv)
 	if d == float64(int64(d)) {
 		return fmt.Sprintf("%d.", int64(d))
 	}

--- a/int.go
+++ b/int.go
@@ -30,18 +30,12 @@ func AppendUint(bytes zcode.Bytes, i uint64) zcode.Bytes {
 	return zcode.AppendCountedUvarint(bytes, i)
 }
 
-func DecodeInt(zv zcode.Bytes) (int64, error) {
-	if zv == nil {
-		return 0, nil
-	}
-	return zcode.DecodeCountedVarint(zv), nil
+func DecodeInt(zv zcode.Bytes) int64 {
+	return zcode.DecodeCountedVarint(zv)
 }
 
-func DecodeUint(zv zcode.Bytes) (uint64, error) {
-	if zv == nil {
-		return 0, nil
-	}
-	return zcode.DecodeCountedUvarint(zv), nil
+func DecodeUint(zv zcode.Bytes) uint64 {
+	return zcode.DecodeCountedUvarint(zv)
 }
 
 type TypeOfInt8 struct{}
@@ -54,16 +48,12 @@ func (t *TypeOfInt8) String() string {
 	return "int8"
 }
 
-func (t *TypeOfInt8) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfInt8) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeInt(zv)
 }
 
 func (t *TypeOfInt8) Format(zv zcode.Bytes) string {
-	b, err := DecodeInt(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return strconv.FormatInt(int64(b), 10)
+	return strconv.FormatInt(DecodeInt(zv), 10)
 }
 
 type TypeOfUint8 struct{}
@@ -76,16 +66,12 @@ func (t *TypeOfUint8) String() string {
 	return "uint8"
 }
 
-func (t *TypeOfUint8) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfUint8) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeUint(zv)
 }
 
 func (t *TypeOfUint8) Format(zv zcode.Bytes) string {
-	b, err := DecodeUint(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return strconv.FormatUint(uint64(b), 10)
+	return strconv.FormatUint(DecodeUint(zv), 10)
 }
 
 type TypeOfInt16 struct{}
@@ -98,16 +84,12 @@ func (t *TypeOfInt16) String() string {
 	return "int16"
 }
 
-func (t *TypeOfInt16) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfInt16) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeInt(zv)
 }
 
 func (t *TypeOfInt16) Format(zv zcode.Bytes) string {
-	b, err := DecodeInt(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return strconv.FormatInt(int64(b), 10)
+	return strconv.FormatInt(DecodeInt(zv), 10)
 }
 
 type TypeOfUint16 struct{}
@@ -120,16 +102,12 @@ func (t *TypeOfUint16) String() string {
 	return "uint16"
 }
 
-func (t *TypeOfUint16) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfUint16) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeUint(zv)
 }
 
 func (t *TypeOfUint16) Format(zv zcode.Bytes) string {
-	b, err := DecodeUint(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return strconv.FormatUint(uint64(b), 10)
+	return strconv.FormatUint(DecodeUint(zv), 10)
 }
 
 type TypeOfInt32 struct{}
@@ -142,16 +120,12 @@ func (t *TypeOfInt32) String() string {
 	return "int32"
 }
 
-func (t *TypeOfInt32) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfInt32) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeInt(zv)
 }
 
 func (t *TypeOfInt32) Format(zv zcode.Bytes) string {
-	b, err := DecodeInt(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return strconv.FormatInt(int64(b), 10)
+	return strconv.FormatInt(DecodeInt(zv), 10)
 }
 
 type TypeOfUint32 struct{}
@@ -164,16 +138,12 @@ func (t *TypeOfUint32) String() string {
 	return "uint32"
 }
 
-func (t *TypeOfUint32) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfUint32) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeUint(zv)
 }
 
 func (t *TypeOfUint32) Format(zv zcode.Bytes) string {
-	b, err := DecodeUint(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return strconv.FormatUint(uint64(b), 10)
+	return strconv.FormatUint(DecodeUint(zv), 10)
 }
 
 type TypeOfInt64 struct{}
@@ -186,16 +156,12 @@ func (t *TypeOfInt64) String() string {
 	return "int64"
 }
 
-func (t *TypeOfInt64) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfInt64) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeInt(zv)
 }
 
 func (t *TypeOfInt64) Format(zv zcode.Bytes) string {
-	b, err := DecodeInt(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return strconv.FormatInt(int64(b), 10)
+	return strconv.FormatInt(DecodeInt(zv), 10)
 }
 
 type TypeOfUint64 struct{}
@@ -208,14 +174,10 @@ func (t *TypeOfUint64) String() string {
 	return "uint64"
 }
 
-func (t *TypeOfUint64) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeOfUint64) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeUint(zv)
 }
 
 func (t *TypeOfUint64) Format(zv zcode.Bytes) string {
-	b, err := DecodeUint(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return strconv.FormatUint(uint64(b), 10)
+	return strconv.FormatUint(DecodeUint(zv), 10)
 }

--- a/ip.go
+++ b/ip.go
@@ -1,7 +1,6 @@
 package zed
 
 import (
-	"errors"
 	"net"
 
 	"github.com/brimdata/zed/zcode"
@@ -25,15 +24,15 @@ func EncodeIP(a net.IP) zcode.Bytes {
 	return AppendIP(nil, a)
 }
 
-func DecodeIP(zv zcode.Bytes) (net.IP, error) {
+func DecodeIP(zv zcode.Bytes) net.IP {
 	if zv == nil {
-		return nil, nil
+		return nil
 	}
 	switch len(zv) {
 	case 4, 16:
-		return net.IP(zv), nil
+		return net.IP(zv)
 	}
-	return nil, errors.New("failure trying to decode IP address that is not 4 or 16 bytes long")
+	panic("failure trying to decode IP address that is not 4 or 16 bytes long")
 }
 
 func (t *TypeOfIP) ID() int {
@@ -44,18 +43,10 @@ func (t *TypeOfIP) String() string {
 	return "ip"
 }
 
-func (t *TypeOfIP) Marshal(zv zcode.Bytes) (interface{}, error) {
-	ip, err := DecodeIP(zv)
-	if err != nil {
-		return nil, err
-	}
-	return ip.String(), nil
+func (t *TypeOfIP) Marshal(zv zcode.Bytes) interface{} {
+	return DecodeIP(zv).String()
 }
 
-func (t *TypeOfIP) Format(zv zcode.Bytes) string {
-	ip, err := DecodeIP(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return ip.String()
+func (t *TypeOfIP) Format(zb zcode.Bytes) string {
+	return DecodeIP(zb).String()
 }

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -401,8 +401,8 @@ func (b *Branch) Stats(ctx context.Context, snap commits.View) (info BranchStats
 	if poolSpan != nil {
 		min := poolSpan.First()
 		if min.Type == zed.TypeTime {
-			firstTs, _ := zed.DecodeTime(min.Bytes)
-			lastTs, _ := zed.DecodeTime(poolSpan.Last().Bytes)
+			firstTs := zed.DecodeTime(min.Bytes)
+			lastTs := zed.DecodeTime(poolSpan.Last().Bytes)
 			if lastTs < firstTs {
 				firstTs, lastTs = lastTs, firstTs
 			}

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -233,8 +233,8 @@ func (p *Pool) Stats(ctx context.Context, snap commits.View) (info PoolStats, er
 	if poolSpan != nil {
 		min := poolSpan.First()
 		if min.Type == zed.TypeTime {
-			firstTs, _ := zed.DecodeTime(min.Bytes)
-			lastTs, _ := zed.DecodeTime(poolSpan.Last().Bytes)
+			firstTs := zed.DecodeTime(min.Bytes)
+			lastTs := zed.DecodeTime(poolSpan.Last().Bytes)
 			if lastTs < firstTs {
 				firstTs, lastTs = lastTs, firstTs
 			}

--- a/lake/seekindex/lookup.go
+++ b/lake/seekindex/lookup.go
@@ -42,10 +42,7 @@ func lookup(r zio.Reader, path field.Path, from, to *zed.Value, cmp expr.Compare
 		if err != nil {
 			return Range{}, err
 		}
-		rg.Start, err = zed.DecodeInt(off.Bytes)
-		if err != nil {
-			return Range{}, err
-		}
+		rg.Start = zed.DecodeInt(off.Bytes)
 		if cmp(&key, from) == 0 {
 			break
 		}
@@ -60,10 +57,7 @@ func lookup(r zio.Reader, path field.Path, from, to *zed.Value, cmp expr.Compare
 			if err != nil {
 				return Range{}, err
 			}
-			rg.End, err = zed.DecodeInt(off.Bytes)
-			if err != nil {
-				return Range{}, err
-			}
+			rg.End = zed.DecodeInt(off.Bytes)
 			break
 		}
 		rec, err = r.Read()

--- a/map.go
+++ b/map.go
@@ -43,7 +43,7 @@ func (t *TypeMap) Decode(zv zcode.Bytes) (Value, Value, error) {
 	return Value{t.KeyType, key}, Value{t.ValType, val}, nil
 }
 
-func (t *TypeMap) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeMap) Marshal(zv zcode.Bytes) interface{} {
 	// start out with zero-length container so we get "[]" instead of nil
 	vals := []*Value{}
 	it := zv.Iter()
@@ -53,7 +53,7 @@ func (t *TypeMap) Marshal(zv zcode.Bytes) (interface{}, error) {
 		val, _ = it.Next()
 		vals = append(vals, &Value{t.ValType, val})
 	}
-	return vals, nil
+	return vals
 }
 
 type keyval struct {

--- a/net.go
+++ b/net.go
@@ -1,7 +1,6 @@
 package zed
 
 import (
-	"errors"
 	"net"
 
 	"github.com/brimdata/zed/zcode"
@@ -29,27 +28,23 @@ func EncodeNet(subnet *net.IPNet) zcode.Bytes {
 	return AppendNet(nil, subnet)
 }
 
-func DecodeNet(zv zcode.Bytes) (*net.IPNet, error) {
+func DecodeNet(zv zcode.Bytes) *net.IPNet {
 	if zv == nil {
-		return nil, nil
+		return nil
 	}
 	switch len(zv) {
 	case 8:
-		ip := net.IP(zv[:4])
-		mask := net.IPMask(zv[4:])
 		return &net.IPNet{
-			IP:   ip,
-			Mask: mask,
-		}, nil
+			IP:   net.IP(zv[:4]),
+			Mask: net.IPMask(zv[4:]),
+		}
 	case 32:
-		ip := net.IP(zv[:16])
-		mask := net.IPMask(zv[16:])
 		return &net.IPNet{
-			IP:   ip,
-			Mask: mask,
-		}, nil
+			IP:   net.IP(zv[:16]),
+			Mask: net.IPMask(zv[16:]),
+		}
 	}
-	return nil, errors.New("failure trying to decode IP subnet that is not 8 or 32 bytes long")
+	panic("failure trying to decode IP subnet that is not 8 or 32 bytes long")
 }
 
 func (t *TypeOfNet) ID() int {
@@ -60,19 +55,10 @@ func (t *TypeOfNet) String() string {
 	return "net"
 }
 
-func (t *TypeOfNet) Marshal(zv zcode.Bytes) (interface{}, error) {
-	s, err := DecodeNet(zv)
-	if err != nil {
-		return nil, err
-	}
-	return (*s).String(), nil
+func (t *TypeOfNet) Marshal(zb zcode.Bytes) interface{} {
+	return DecodeNet(zb).String()
 }
 
-func (t *TypeOfNet) Format(zv zcode.Bytes) string {
-	s, err := DecodeNet(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	ipnet := net.IPNet(*s)
-	return ipnet.String()
+func (t *TypeOfNet) Format(zb zcode.Bytes) string {
+	return DecodeNet(zb).String()
 }

--- a/null.go
+++ b/null.go
@@ -14,10 +14,10 @@ func (t *TypeOfNull) String() string {
 	return "null"
 }
 
-func (t *TypeOfNull) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return nil, nil
+func (t *TypeOfNull) Marshal(zcode.Bytes) interface{} {
+	return nil
 }
 
-func (t *TypeOfNull) Format(zv zcode.Bytes) string {
+func (t *TypeOfNull) Format(zcode.Bytes) string {
 	return "null"
 }

--- a/proc/shape/shaper.go
+++ b/proc/shape/shaper.go
@@ -70,7 +70,7 @@ func (i *integer) check(zv zed.Value) {
 		i.unsigned = false
 		return
 	}
-	f, _ := zed.DecodeFloat64(zv.Bytes)
+	f := zed.DecodeFloat64(zv.Bytes)
 	//XXX We could track signed vs unsigned and overflow,
 	// but for now, we leave it as float64 unless we can
 	// guarantee int64.
@@ -283,7 +283,7 @@ func recode(from, to []zed.Column, bytes zcode.Bytes) (zcode.Bytes, error) {
 			if fromCol.Type != zed.TypeFloat64 {
 				return nil, errors.New("shape: can't recode from non float64")
 			}
-			f, _ := zed.DecodeFloat64(b)
+			f := zed.DecodeFloat64(b)
 			if toType == zed.TypeInt64 {
 				b = zed.EncodeInt(int64(f))
 			} else if toType == zed.TypeUint64 {

--- a/record.go
+++ b/record.go
@@ -46,14 +46,14 @@ func (t *TypeRecord) Decode(zv zcode.Bytes) ([]Value, error) {
 	return vals, nil
 }
 
-func (t *TypeRecord) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeRecord) Marshal(zv zcode.Bytes) interface{} {
 	m := make(map[string]*Value)
 	it := zv.Iter()
 	for _, col := range t.Columns {
 		zv, _ := it.Next()
 		m[col.Name] = &Value{col.Type, zv}
 	}
-	return m, nil
+	return m
 }
 
 func (t *TypeRecord) ColumnOfField(field string) (int, bool) {

--- a/set.go
+++ b/set.go
@@ -26,7 +26,7 @@ func (t *TypeSet) String() string {
 	return fmt.Sprintf("|[%s]|", t.Type)
 }
 
-func (t *TypeSet) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeSet) Marshal(zv zcode.Bytes) interface{} {
 	// start out with zero-length container so we get "[]" instead of nil
 	vals := []*Value{}
 	it := zv.Iter()
@@ -34,7 +34,7 @@ func (t *TypeSet) Marshal(zv zcode.Bytes) (interface{}, error) {
 		val, _ := it.Next()
 		vals = append(vals, &Value{t.Type, val})
 	}
-	return vals, nil
+	return vals
 }
 
 func (t *TypeSet) Format(zv zcode.Bytes) string {

--- a/string.go
+++ b/string.go
@@ -14,8 +14,8 @@ func EncodeString(s string) zcode.Bytes {
 	return zcode.Bytes(s)
 }
 
-func DecodeString(zv zcode.Bytes) (string, error) {
-	return string(zv), nil
+func DecodeString(zv zcode.Bytes) string {
+	return string(zv)
 }
 
 func (t *TypeOfString) ID() int {
@@ -26,8 +26,8 @@ func (t *TypeOfString) String() string {
 	return "string"
 }
 
-func (t *TypeOfString) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return string(zv), nil
+func (t *TypeOfString) Marshal(zv zcode.Bytes) interface{} {
+	return string(zv)
 }
 
 func (t *TypeOfString) Format(zv zcode.Bytes) string {

--- a/time.go
+++ b/time.go
@@ -23,11 +23,8 @@ func AppendTime(bytes zcode.Bytes, t nano.Ts) zcode.Bytes {
 	return AppendInt(bytes, int64(t))
 }
 
-func DecodeTime(zv zcode.Bytes) (nano.Ts, error) {
-	if zv == nil {
-		return 0, nil
-	}
-	return nano.Ts(zcode.DecodeCountedVarint(zv)), nil
+func DecodeTime(zv zcode.Bytes) nano.Ts {
+	return nano.Ts(zcode.DecodeCountedVarint(zv))
 }
 
 func (t *TypeOfTime) ID() int {
@@ -38,19 +35,10 @@ func (t *TypeOfTime) String() string {
 	return "time"
 }
 
-func (t *TypeOfTime) Marshal(zv zcode.Bytes) (interface{}, error) {
-	ts, err := DecodeTime(zv)
-	if err != nil {
-		return nil, err
-	}
-	return ts.Time().Format(time.RFC3339Nano), nil
+func (t *TypeOfTime) Marshal(zv zcode.Bytes) interface{} {
+	return DecodeTime(zv).Time().Format(time.RFC3339Nano)
 }
 
 func (t *TypeOfTime) Format(zv zcode.Bytes) string {
-	ts, err := DecodeTime(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	b := ts.Time().Format(time.RFC3339Nano)
-	return string(b)
+	return DecodeTime(zv).Time().Format(time.RFC3339Nano)
 }

--- a/type.go
+++ b/type.go
@@ -26,7 +26,7 @@ var (
 // Types can be used to infer type compatibility and create new values
 // of the underlying type.
 type Type interface {
-	Marshal(zcode.Bytes) (interface{}, error)
+	Marshal(zcode.Bytes) interface{}
 	// ID returns a unique (per Context) identifier that
 	// represents this type.  For an aliased type, this identifier
 	// represents the actual underlying type and not the alias itself.

--- a/typetype.go
+++ b/typetype.go
@@ -18,8 +18,8 @@ func (t *TypeOfType) String() string {
 	return "type"
 }
 
-func (t *TypeOfType) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return t.Format(zv), nil
+func (t *TypeOfType) Marshal(zv zcode.Bytes) interface{} {
+	return t.Format(zv)
 }
 
 func (t *TypeOfType) Format(zv zcode.Bytes) string {

--- a/union.go
+++ b/union.go
@@ -36,10 +36,7 @@ func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	if container {
 		return nil, -1, nil, ErrBadValue
 	}
-	selector, err := DecodeInt(v)
-	if err != nil {
-		return nil, -1, nil, err
-	}
+	selector := DecodeInt(v)
 	inner, err := t.Type(int(selector))
 	if err != nil {
 		return nil, -1, nil, err
@@ -48,15 +45,15 @@ func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	if !it.Done() {
 		return nil, -1, nil, ErrBadValue
 	}
-	return inner, int64(selector), v, nil
+	return inner, selector, v, nil
 }
 
-func (t *TypeUnion) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeUnion) Marshal(zv zcode.Bytes) interface{} {
 	inner, _, zv, err := t.SplitZNG(zv)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
-	return Value{inner, zv}, nil
+	return Value{inner, zv}
 }
 
 func (t *TypeUnion) String() string {

--- a/value.go
+++ b/value.go
@@ -55,11 +55,7 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 	if v.Bytes == nil {
 		return json.Marshal(nil)
 	}
-	object, err := v.Type.Marshal(v.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(object)
+	return json.Marshal(v.Type.Marshal(v.Bytes))
 }
 
 func badZNG(err error, t Type, zv zcode.Bytes) string {

--- a/walk.go
+++ b/walk.go
@@ -109,10 +109,7 @@ func walkUnion(typ *TypeUnion, body zcode.Bytes, visit Visitor) error {
 	if container {
 		return ErrBadValue
 	}
-	selector, err := DecodeInt(v)
-	if err != nil {
-		return err
-	}
+	selector := DecodeInt(v)
 	inner, err := typ.Type(int(selector))
 	if err != nil {
 		return err

--- a/zio/parquetio/data.go
+++ b/zio/parquetio/data.go
@@ -12,46 +12,30 @@ func newData(typ zed.Type, zb zcode.Bytes) (interface{}, error) {
 		return nil, nil
 	}
 	switch typ := zed.TypeUnder(typ).(type) {
-	case *zed.TypeOfUint8:
-		v, err := zed.DecodeUint(zb)
-		return uint32(v), err
-	case *zed.TypeOfUint16:
-		v, err := zed.DecodeUint(zb)
-		return uint32(v), err
-	case *zed.TypeOfUint32:
-		v, err := zed.DecodeUint(zb)
-		return uint32(v), err
+	case *zed.TypeOfUint8, *zed.TypeOfUint16, *zed.TypeOfUint32:
+		return uint32(zed.DecodeUint(zb)), nil
 	case *zed.TypeOfUint64:
-		return zed.DecodeUint(zb)
-	case *zed.TypeOfInt8:
-		v, err := zed.DecodeInt(zb)
-		return int32(v), err
-	case *zed.TypeOfInt16:
-		v, err := zed.DecodeInt(zb)
-		return int32(v), err
-	case *zed.TypeOfInt32:
-		v, err := zed.DecodeInt(zb)
-		return int32(v), err
+		return zed.DecodeUint(zb), nil
+	case *zed.TypeOfInt8, *zed.TypeOfInt16, *zed.TypeOfInt32:
+		return int32(zed.DecodeInt(zb)), nil
 	case *zed.TypeOfInt64, *zed.TypeOfDuration, *zed.TypeOfTime:
-		return zed.DecodeInt(zb)
+		return zed.DecodeInt(zb), nil
 	// XXX add TypeFloat16
 	case *zed.TypeOfFloat32:
-		return zed.DecodeFloat32(zb)
+		return zed.DecodeFloat32(zb), nil
 	case *zed.TypeOfFloat64:
-		return zed.DecodeFloat64(zb)
+		return zed.DecodeFloat64(zb), nil
 	// XXX add TypeDecimal
 	case *zed.TypeOfBool:
-		return zed.DecodeBool(zb)
+		return zed.DecodeBool(zb), nil
 	case *zed.TypeOfBytes, *zed.TypeOfString:
-		return zed.DecodeBytes(zb)
+		return zed.DecodeBytes(zb), nil
 	case *zed.TypeOfIP:
-		v, err := zed.DecodeIP(zb)
-		return []byte(v.String()), err
+		return []byte(zed.DecodeIP(zb).String()), nil
 	case *zed.TypeOfNet:
-		v, err := zed.DecodeNet(zb)
-		return []byte(v.String()), err
+		return []byte(zed.DecodeNet(zb).String()), nil
 	case *zed.TypeOfType:
-		return zed.DecodeBytes(zb)
+		return zed.DecodeBytes(zb), nil
 	case *zed.TypeOfNull:
 		return nil, ErrNullType
 	case *zed.TypeRecord:

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -57,11 +57,7 @@ func (w *Writer) Write(r *zed.Value) error {
 		value := r.ValueByColumn(k)
 		if col.Type == zed.TypeTime {
 			if !value.IsNull() {
-				ts, err := zed.DecodeTime(value.Bytes)
-				if err != nil {
-					return err
-				}
-				v = ts.Time().UTC().Format(time.RFC3339Nano)
+				v = zed.DecodeTime(value.Bytes).Time().Format(time.RFC3339Nano)
 			}
 		} else {
 			v = zeekio.FormatValue(value)

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -40,11 +40,7 @@ func (w *Writer) Write(rec *zed.Value) error {
 			if value.IsNull() {
 				s = "-"
 			} else {
-				ts, err := zed.DecodeTime(value.Bytes)
-				if err != nil {
-					return err
-				}
-				s = ts.Time().UTC().Format(time.RFC3339Nano)
+				s = zed.DecodeTime(value.Bytes).Time().Format(time.RFC3339Nano)
 			}
 		} else {
 			s = zeekio.FormatValue(value)

--- a/zio/zeekio/parser_test.go
+++ b/zio/zeekio/parser_test.go
@@ -115,8 +115,7 @@ func TestLegacyZeekValid(t *testing.T) {
 func assertInt64(t *testing.T, i int64, val zed.Value, what string) {
 	ok := val.Type == zed.TypeInt64
 	assert.Truef(t, ok, "%s is type int", what)
-	v, _ := zed.DecodeInt(val.Bytes)
-	assert.Equalf(t, i, v, "%s has value %d", what, i)
+	assert.Equalf(t, i, zed.DecodeInt(val.Bytes), "%s has value %d", what, i)
 }
 
 func TestNestedRecords(t *testing.T) {

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -120,10 +120,7 @@ func ZeekStrings(r *zed.Value) ([]string, error) {
 		if val, _ := it.Next(); val == nil {
 			field = "-"
 		} else if col.Type == zed.TypeTime {
-			ts, err := zed.DecodeTime(val)
-			if err != nil {
-				return nil, err
-			}
+			ts := zed.DecodeTime(val)
 			precision := 6
 			if isHighPrecision(ts) {
 				precision = 9

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -681,9 +681,8 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 			v.Set(reflect.Zero(v.Type()))
 			return nil
 		}
-		x, err := zed.DecodeTime(zv.Bytes)
-		v.Set(reflect.ValueOf(x))
-		return err
+		v.Set(reflect.ValueOf(zed.DecodeTime(zv.Bytes)))
+		return nil
 	}
 	if _, ok := v.Interface().(zed.Value); ok {
 		// For zed.Values we simply set the reflect value to the
@@ -755,9 +754,8 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 			v.Set(reflect.Zero(v.Type()))
 			return nil
 		}
-		x, err := zed.DecodeString(zv.Bytes)
-		v.SetString(x)
-		return err
+		v.SetString(zed.DecodeString(zv.Bytes))
+		return nil
 	case reflect.Bool:
 		if zed.TypeUnder(zv.Type) != zed.TypeBool {
 			return incompatTypeError(zv.Type, v)
@@ -766,9 +764,8 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 			v.Set(reflect.Zero(v.Type()))
 			return nil
 		}
-		x, err := zed.DecodeBool(zv.Bytes)
-		v.SetBool(x)
-		return err
+		v.SetBool(zed.DecodeBool(zv.Bytes))
+		return nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		switch zed.TypeUnder(zv.Type) {
 		case zed.TypeInt8, zed.TypeInt16, zed.TypeInt32, zed.TypeInt64:
@@ -779,9 +776,8 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 			v.Set(reflect.Zero(v.Type()))
 			return nil
 		}
-		x, err := zed.DecodeInt(zv.Bytes)
-		v.SetInt(x)
-		return err
+		v.SetInt(zed.DecodeInt(zv.Bytes))
+		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		switch zed.TypeUnder(zv.Type) {
 		case zed.TypeUint8, zed.TypeUint16, zed.TypeUint32, zed.TypeUint64:
@@ -792,9 +788,8 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 			v.Set(reflect.Zero(v.Type()))
 			return nil
 		}
-		x, err := zed.DecodeUint(zv.Bytes)
-		v.SetUint(x)
-		return err
+		v.SetUint(zed.DecodeUint(zv.Bytes))
+		return nil
 	case reflect.Float32:
 		if zed.TypeUnder(zv.Type) != zed.TypeFloat32 {
 			return incompatTypeError(zv.Type, v)
@@ -803,9 +798,8 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 			v.Set(reflect.Zero(v.Type()))
 			return nil
 		}
-		x, err := zed.DecodeFloat32(zv.Bytes)
-		v.SetFloat(float64(x))
-		return err
+		v.SetFloat(float64(zed.DecodeFloat32(zv.Bytes)))
+		return nil
 	case reflect.Float64:
 		if zed.TypeUnder(zv.Type) != zed.TypeFloat64 {
 			return incompatTypeError(zv.Type, v)
@@ -814,9 +808,8 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 			v.Set(reflect.Zero(v.Type()))
 			return nil
 		}
-		x, err := zed.DecodeFloat64(zv.Bytes)
-		v.SetFloat(x)
-		return err
+		v.SetFloat(zed.DecodeFloat64(zv.Bytes))
+		return nil
 	default:
 		return fmt.Errorf("unsupported type: %v", v.Kind())
 	}
@@ -834,9 +827,8 @@ func (u *UnmarshalZNGContext) decodeIP(zv zed.Value, v reflect.Value) error {
 		v.Set(reflect.Zero(v.Type()))
 		return nil
 	}
-	x, err := zed.DecodeIP(zv.Bytes)
-	v.Set(reflect.ValueOf(x))
-	return err
+	v.Set(reflect.ValueOf(zed.DecodeIP(zv.Bytes)))
+	return nil
 }
 
 func (u *UnmarshalZNGContext) decodeMap(zv zed.Value, mapVal reflect.Value) error {

--- a/zst/column/int.go
+++ b/zst/column/int.go
@@ -23,6 +23,5 @@ func (p *Int) Read() (int32, error) {
 	if err != nil {
 		return 0, err
 	}
-	v, err := zed.DecodeInt(zv)
-	return int32(v), err
+	return int32(zed.DecodeInt(zv)), err
 }

--- a/zst/column/segment.go
+++ b/zst/column/segment.go
@@ -27,17 +27,13 @@ func UnmarshalSegment(zv zcode.Bytes, s *Segment) error {
 	if isContainer {
 		return ErrCorruptSegment
 	}
-	v, err := zed.DecodeInt(zv)
-	if err != nil {
-		return err
-	}
-	s.Offset = v
+	s.Offset = zed.DecodeInt(zv)
 	zv, isContainer = it.Next()
 	if isContainer {
 		return ErrCorruptSegment
 	}
-	s.Length, err = zed.DecodeInt(zv)
-	return err
+	s.Length = zed.DecodeInt(zv)
+	return nil
 }
 
 func checkSegType(col zed.Column, which string, typ zed.Type) bool {

--- a/zst/trailer.go
+++ b/zst/trailer.go
@@ -166,11 +166,7 @@ func decodeSections(rec *zed.Value) ([]int64, error) {
 		if zv.Type != zed.TypeInt64 {
 			return nil, errors.New("section element is not an int64")
 		}
-		size, err := zed.DecodeInt(zv.Bytes)
-		if err != nil {
-			return nil, errors.New("int64 section element could not be decoded")
-		}
-		sizes = append(sizes, size)
+		sizes = append(sizes, zed.DecodeInt(zv.Bytes))
 	}
 	return sizes, nil
 }


### PR DESCRIPTION
The functions that decode Zed primitive values return an error if
decoding fails, but these errors are generally unrecoverable.  Panic
instead.