### PR TITLE
fix bug that confused ZNG error and JSON error in query end point

### DIFF
--- a/api/queryio/client.go
+++ b/api/queryio/client.go
@@ -32,11 +32,11 @@ func (q *Query) Read() (*zed.Value, error) {
 		}
 		value, err := zson.ParseValue(zed.NewContext(), string(ctrl.Bytes))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("client query: unable to parse Zed control message: %w (%s)", err, string(ctrl.Bytes))
 		}
 		var v interface{}
 		if err := unmarshaler.Unmarshal(value, &v); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("client query: unable to unmarshal Zed control message: %w (%s)", err, string(ctrl.Bytes))
 		}
 		return nil, controlToError(v)
 	}

--- a/api/queryio/client.go
+++ b/api/queryio/client.go
@@ -32,11 +32,11 @@ func (q *Query) Read() (*zed.Value, error) {
 		}
 		value, err := zson.ParseValue(zed.NewContext(), string(ctrl.Bytes))
 		if err != nil {
-			return nil, fmt.Errorf("client query: unable to parse Zed control message: %w (%s)", err, string(ctrl.Bytes))
+			return nil, fmt.Errorf("unable to parse Zed control message: %w (%s)", err, string(ctrl.Bytes))
 		}
 		var v interface{}
 		if err := unmarshaler.Unmarshal(value, &v); err != nil {
-			return nil, fmt.Errorf("client query: unable to unmarshal Zed control message: %w (%s)", err, string(ctrl.Bytes))
+			return nil, fmt.Errorf("unable to unmarshal Zed control message: %w (%s)", err, string(ctrl.Bytes))
 		}
 		return nil, controlToError(v)
 	}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -60,7 +60,7 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 	}
 	// Once we defer writer.Close() are going to write ZNG to the HTTP
 	// response body and for errors after this point, we must call
-	// writer.WriterError() isntead of w.Error().
+	// writer.WriterError() instead of w.Error().
 	defer writer.Close()
 	timer := time.NewTicker(queryStatsInterval)
 	defer timer.Stop()


### PR DESCRIPTION
This commit fixes a bug that is tripped up by the ZNG 2022 format
changes where the query handler could return a ZNG-encoded error
instead of a JSON error but the client expected JSON.  Also, it was
hard to track down because of the vague error message, so the
error messages are improved here too.