### PR TITLE
rename expr.KeyCompareFn to index.keyCompareFn

### DIFF
--- a/expr/sort.go
+++ b/expr/sort.go
@@ -10,7 +10,6 @@ import (
 )
 
 type CompareFn func(a *zed.Value, b *zed.Value) int
-type KeyCompareFn func(Context, *zed.Value) int
 
 // Internal function that compares two values of compatible types.
 type comparefn func(a, b zcode.Bytes) int

--- a/index/findreader.go
+++ b/index/findreader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/expr"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
 )
@@ -12,7 +11,7 @@ import (
 // FinderReader is zio.Reader version of Finder that streams back all records
 // in a microindex that match the provided key Record.
 type FinderReader struct {
-	compare expr.KeyCompareFn
+	compare keyCompareFn
 	finder  *Finder
 	inputs  []string
 	reader  zio.Reader


### PR DESCRIPTION
This type is used only in package index.