### PR TITLE
move all formatting out of package zed

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -1,11 +1,5 @@
 package zed
 
-import (
-	"fmt"
-
-	"github.com/brimdata/zed/zcode"
-)
-
 type TypeAlias struct {
 	id   int
 	Name string
@@ -28,12 +22,8 @@ func (t *TypeAlias) AliasID() int {
 	return t.id
 }
 
-func (t *TypeAlias) String() string {
-	return fmt.Sprintf("%s=(%s)", t.Name, t.Type)
-}
-
-func (t *TypeAlias) Format(zv zcode.Bytes) string {
-	return t.Type.Format(zv)
+func (t *TypeAlias) Kind() string {
+	return t.Type.Kind()
 }
 
 func TypeUnder(typ Type) Type {

--- a/alias.go
+++ b/alias.go
@@ -22,7 +22,7 @@ func (t *TypeAlias) AliasID() int {
 	return t.id
 }
 
-func (t *TypeAlias) Kind() string {
+func (t *TypeAlias) Kind() Kind {
 	return t.Type.Kind()
 }
 

--- a/array.go
+++ b/array.go
@@ -13,6 +13,6 @@ func (t *TypeArray) ID() int {
 	return t.id
 }
 
-func (t *TypeArray) Kind() string {
-	return "array"
+func (t *TypeArray) Kind() Kind {
+	return ArrayKind
 }

--- a/array.go
+++ b/array.go
@@ -1,12 +1,5 @@
 package zed
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/brimdata/zed/zcode"
-)
-
 type TypeArray struct {
 	id   int
 	Type Type
@@ -20,24 +13,6 @@ func (t *TypeArray) ID() int {
 	return t.id
 }
 
-func (t *TypeArray) String() string {
-	return fmt.Sprintf("[%s]", t.Type)
-}
-
-func (t *TypeArray) Format(zv zcode.Bytes) string {
-	var b strings.Builder
-	sep := ""
-	b.WriteByte('[')
-	it := zv.Iter()
-	for !it.Done() {
-		b.WriteString(sep)
-		if val := it.Next(); val == nil {
-			b.WriteString("null")
-		} else {
-			b.WriteString(t.Type.Format(val))
-		}
-		sep = ","
-	}
-	b.WriteByte(']')
-	return b.String()
+func (t *TypeArray) Kind() string {
+	return "array"
 }

--- a/bool.go
+++ b/bool.go
@@ -44,6 +44,6 @@ func (t *TypeOfBool) ID() int {
 	return IDBool
 }
 
-func (t *TypeOfBool) Kind() string {
-	return "primitive"
+func (t *TypeOfBool) Kind() Kind {
+	return PrimitiveKind
 }

--- a/bool.go
+++ b/bool.go
@@ -44,13 +44,6 @@ func (t *TypeOfBool) ID() int {
 	return IDBool
 }
 
-func (t *TypeOfBool) String() string {
-	return "bool"
-}
-
-func (t *TypeOfBool) Format(zv zcode.Bytes) string {
-	if DecodeBool(zv) {
-		return "true"
-	}
-	return "false"
+func (t *TypeOfBool) Kind() string {
+	return "primitive"
 }

--- a/bytes.go
+++ b/bytes.go
@@ -24,8 +24,8 @@ func (t *TypeOfBytes) ID() int {
 	return IDBytes
 }
 
-func (t *TypeOfBytes) Kind() string {
-	return "primitive"
+func (t *TypeOfBytes) Kind() Kind {
+	return PrimitiveKind
 }
 
 func (t *TypeOfBytes) Format(zv zcode.Bytes) string {

--- a/bytes.go
+++ b/bytes.go
@@ -24,8 +24,8 @@ func (t *TypeOfBytes) ID() int {
 	return IDBytes
 }
 
-func (t *TypeOfBytes) String() string {
-	return "bytes"
+func (t *TypeOfBytes) Kind() string {
+	return "primitive"
 }
 
 func (t *TypeOfBytes) Format(zv zcode.Bytes) string {

--- a/context.go
+++ b/context.go
@@ -474,9 +474,6 @@ func DecodeName(tv zcode.Bytes) (string, zcode.Bytes) {
 }
 
 func DecodeLength(tv zcode.Bytes) (int, zcode.Bytes) {
-	if len(tv) < 0 {
-		return 0, nil
-	}
 	namelen, n := binary.Uvarint(tv)
 	if n <= 0 {
 		return 0, nil

--- a/duration.go
+++ b/duration.go
@@ -27,6 +27,6 @@ func (t *TypeOfDuration) ID() int {
 	return IDDuration
 }
 
-func (t *TypeOfDuration) Kind() string {
-	return "primitive"
+func (t *TypeOfDuration) Kind() Kind {
+	return PrimitiveKind
 }

--- a/duration.go
+++ b/duration.go
@@ -27,10 +27,6 @@ func (t *TypeOfDuration) ID() int {
 	return IDDuration
 }
 
-func (t *TypeOfDuration) String() string {
-	return "duration"
-}
-
-func (t *TypeOfDuration) Format(zv zcode.Bytes) string {
-	return DecodeDuration(zv).String()
+func (t *TypeOfDuration) Kind() string {
+	return "primitive"
 }

--- a/enum.go
+++ b/enum.go
@@ -1,12 +1,5 @@
 package zed
 
-import (
-	"errors"
-	"strings"
-
-	"github.com/brimdata/zed/zcode"
-)
-
 type TypeEnum struct {
 	id      int
 	Symbols []string
@@ -36,23 +29,6 @@ func (t *TypeEnum) Lookup(symbol string) int {
 	return -1
 }
 
-func (t *TypeEnum) String() string {
-	var b strings.Builder
-	b.WriteByte('<')
-	for k, s := range t.Symbols {
-		if k > 0 {
-			b.WriteByte(',')
-		}
-		b.WriteString(QuotedName(s))
-	}
-	b.WriteByte('>')
-	return b.String()
-}
-
-func (t *TypeEnum) Format(zv zcode.Bytes) string {
-	id := DecodeUint(zv)
-	if id >= uint64(len(t.Symbols)) {
-		return badZNG(errors.New("enum index out of range"), t, zv)
-	}
-	return t.Symbols[id]
+func (t *TypeEnum) Kind() string {
+	return "enum"
 }

--- a/enum.go
+++ b/enum.go
@@ -29,6 +29,6 @@ func (t *TypeEnum) Lookup(symbol string) int {
 	return -1
 }
 
-func (t *TypeEnum) Kind() string {
-	return "enum"
+func (t *TypeEnum) Kind() Kind {
+	return EnumKind
 }

--- a/error.go
+++ b/error.go
@@ -45,8 +45,8 @@ func (t *TypeError) ID() int {
 	return t.id
 }
 
-func (t *TypeError) Kind() string {
-	return "error"
+func (t *TypeError) Kind() Kind {
+	return ErrorKind
 }
 
 func (t *TypeError) IsMissing(zv zcode.Bytes) bool {

--- a/error.go
+++ b/error.go
@@ -3,7 +3,6 @@ package zed
 import (
 	"bytes"
 	"errors"
-	"fmt"
 
 	"github.com/brimdata/zed/zcode"
 )
@@ -46,12 +45,8 @@ func (t *TypeError) ID() int {
 	return t.id
 }
 
-func (t *TypeError) String() string {
-	return fmt.Sprintf("error<%s>", t.Type)
-}
-
-func (t *TypeError) Format(zv zcode.Bytes) string {
-	return fmt.Sprintf("error(%s)", t.Type.Format(zv))
+func (t *TypeError) Kind() string {
+	return "error"
 }
 
 func (t *TypeError) IsMissing(zv zcode.Bytes) bool {

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -477,7 +477,7 @@ func (a *Add) Eval(ectx Context, this *zed.Value) *zed.Value {
 		// XXX GC
 		return ectx.NewValue(typ, zed.EncodeString(v1+v2))
 	}
-	return ectx.CopyValue(*a.zctx.NewErrorf("type %s incompatible with '+' operator", typ))
+	return ectx.CopyValue(*a.zctx.NewErrorf("type %s incompatible with '+' operator", zson.FormatType(typ)))
 }
 
 func (s *Subtract) Eval(ectx Context, this *zed.Value) *zed.Value {
@@ -500,7 +500,7 @@ func (s *Subtract) Eval(ectx Context, this *zed.Value) *zed.Value {
 		v1, v2 := s.operands.uints()
 		return ectx.NewValue(typ, zed.EncodeUint(v1-v2))
 	}
-	return ectx.CopyValue(*s.zctx.NewErrorf("type %s incompatible with '-' operator", typ))
+	return ectx.CopyValue(*s.zctx.NewErrorf("type %s incompatible with '-' operator", zson.FormatType(typ)))
 }
 
 func (m *Multiply) Eval(ectx Context, this *zed.Value) *zed.Value {
@@ -523,7 +523,7 @@ func (m *Multiply) Eval(ectx Context, this *zed.Value) *zed.Value {
 		v1, v2 := m.operands.uints()
 		return ectx.NewValue(typ, zed.EncodeUint(v1*v2))
 	}
-	return ectx.CopyValue(*m.zctx.NewErrorf("type %s incompatible with '*' operator", typ))
+	return ectx.CopyValue(*m.zctx.NewErrorf("type %s incompatible with '*' operator", zson.FormatType(typ)))
 }
 
 func (d *Divide) Eval(ectx Context, this *zed.Value) *zed.Value {
@@ -555,7 +555,7 @@ func (d *Divide) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		return ectx.NewValue(typ, zed.EncodeUint(v1/v2))
 	}
-	return ectx.CopyValue(*d.zctx.NewErrorf("type %s incompatible with '/' operator", typ))
+	return ectx.CopyValue(*d.zctx.NewErrorf("type %s incompatible with '/' operator", zson.FormatType(typ)))
 }
 
 func (m *Modulo) Eval(ectx Context, this *zed.Value) *zed.Value {
@@ -568,7 +568,7 @@ func (m *Modulo) Eval(ectx Context, this *zed.Value) *zed.Value {
 	}
 	typ := zed.LookupPrimitiveByID(id)
 	if zed.IsFloat(id) || !zed.IsNumber(id) {
-		return ectx.CopyValue(*m.zctx.NewErrorf("type %s incompatible with '%%' operator", typ))
+		return ectx.CopyValue(*m.zctx.NewErrorf("type %s incompatible with '%%' operator", zson.FormatType(typ)))
 	}
 	if zed.IsSigned(id) {
 		x, y := m.operands.ints()

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -7,6 +7,7 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/expr/coerce"
 	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zson"
 )
 
 type CompareFn func(a *zed.Value, b *zed.Value) int
@@ -101,7 +102,7 @@ func compareValues(a, b *zed.Value, comparefns map[zed.Type]comparefn, pair *coe
 			// representation of the type.
 			// XXX This is heavyweight and should probably just compare
 			// the zcode.Bytes.  See issue #2354.
-			return bytes.Compare([]byte(a.Type.String()), []byte(b.Type.String()))
+			return bytes.Compare([]byte(zson.String(a.Type)), []byte(zson.String(b.Type)))
 		}
 		abytes, bbytes = pair.A, pair.B
 	}

--- a/float.go
+++ b/float.go
@@ -49,8 +49,8 @@ func (t *TypeOfFloat32) ID() int {
 	return IDFloat32
 }
 
-func (t *TypeOfFloat32) Kind() string {
-	return "primitive"
+func (t *TypeOfFloat32) Kind() Kind {
+	return PrimitiveKind
 }
 
 func (t *TypeOfFloat32) Marshal(zb zcode.Bytes) interface{} {
@@ -84,8 +84,8 @@ func (t *TypeOfFloat64) ID() int {
 	return IDFloat64
 }
 
-func (t *TypeOfFloat64) Kind() string {
-	return "primitive"
+func (t *TypeOfFloat64) Kind() Kind {
+	return PrimitiveKind
 }
 
 func (t *TypeOfFloat64) Marshal(zv zcode.Bytes) interface{} {

--- a/float.go
+++ b/float.go
@@ -2,9 +2,7 @@ package zed
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math"
-	"strconv"
 
 	"github.com/brimdata/zed/zcode"
 )
@@ -51,20 +49,12 @@ func (t *TypeOfFloat32) ID() int {
 	return IDFloat32
 }
 
-func (t *TypeOfFloat32) String() string {
-	return "float32"
+func (t *TypeOfFloat32) Kind() string {
+	return "primitive"
 }
 
 func (t *TypeOfFloat32) Marshal(zb zcode.Bytes) interface{} {
 	return DecodeFloat32(zb)
-}
-
-func (t *TypeOfFloat32) Format(zb zcode.Bytes) string {
-	f := DecodeFloat32(zb)
-	if f == float32(int64(f)) {
-		return fmt.Sprintf("%d.", int(f))
-	}
-	return strconv.FormatFloat(float64(f), 'g', -1, 32)
 }
 
 type TypeOfFloat64 struct{}
@@ -94,18 +84,10 @@ func (t *TypeOfFloat64) ID() int {
 	return IDFloat64
 }
 
-func (t *TypeOfFloat64) String() string {
-	return "float64"
+func (t *TypeOfFloat64) Kind() string {
+	return "primitive"
 }
 
 func (t *TypeOfFloat64) Marshal(zv zcode.Bytes) interface{} {
 	return DecodeFloat64(zv)
-}
-
-func (t *TypeOfFloat64) Format(zv zcode.Bytes) string {
-	d := DecodeFloat64(zv)
-	if d == float64(int64(d)) {
-		return fmt.Sprintf("%d.", int64(d))
-	}
-	return strconv.FormatFloat(d, 'g', -1, 64)
 }

--- a/int.go
+++ b/int.go
@@ -42,8 +42,8 @@ func (t *TypeOfInt8) ID() int {
 	return IDInt8
 }
 
-func (t *TypeOfInt8) Kind() string {
-	return "primitive"
+func (t *TypeOfInt8) Kind() Kind {
+	return PrimitiveKind
 }
 
 type TypeOfUint8 struct{}
@@ -52,8 +52,8 @@ func (t *TypeOfUint8) ID() int {
 	return IDUint8
 }
 
-func (t *TypeOfUint8) Kind() string {
-	return "primitive"
+func (t *TypeOfUint8) Kind() Kind {
+	return PrimitiveKind
 }
 
 type TypeOfInt16 struct{}
@@ -62,8 +62,8 @@ func (t *TypeOfInt16) ID() int {
 	return IDInt16
 }
 
-func (t *TypeOfInt16) Kind() string {
-	return "primitive"
+func (t *TypeOfInt16) Kind() Kind {
+	return PrimitiveKind
 }
 
 type TypeOfUint16 struct{}
@@ -72,8 +72,8 @@ func (t *TypeOfUint16) ID() int {
 	return IDUint16
 }
 
-func (t *TypeOfUint16) Kind() string {
-	return "primitive"
+func (t *TypeOfUint16) Kind() Kind {
+	return PrimitiveKind
 }
 
 type TypeOfInt32 struct{}
@@ -82,8 +82,8 @@ func (t *TypeOfInt32) ID() int {
 	return IDInt32
 }
 
-func (t *TypeOfInt32) Kind() string {
-	return "primitive"
+func (t *TypeOfInt32) Kind() Kind {
+	return PrimitiveKind
 }
 
 type TypeOfUint32 struct{}
@@ -92,8 +92,8 @@ func (t *TypeOfUint32) ID() int {
 	return IDUint32
 }
 
-func (t *TypeOfUint32) Kind() string {
-	return "primitive"
+func (t *TypeOfUint32) Kind() Kind {
+	return PrimitiveKind
 }
 
 type TypeOfInt64 struct{}
@@ -102,8 +102,8 @@ func (t *TypeOfInt64) ID() int {
 	return IDInt64
 }
 
-func (t *TypeOfInt64) Kind() string {
-	return "primitive"
+func (t *TypeOfInt64) Kind() Kind {
+	return PrimitiveKind
 }
 
 type TypeOfUint64 struct{}
@@ -112,6 +112,6 @@ func (t *TypeOfUint64) ID() int {
 	return IDUint64
 }
 
-func (t *TypeOfUint64) Kind() string {
-	return "primitive"
+func (t *TypeOfUint64) Kind() Kind {
+	return PrimitiveKind
 }

--- a/int.go
+++ b/int.go
@@ -1,8 +1,6 @@
 package zed
 
 import (
-	"strconv"
-
 	"github.com/brimdata/zed/zcode"
 )
 
@@ -44,12 +42,8 @@ func (t *TypeOfInt8) ID() int {
 	return IDInt8
 }
 
-func (t *TypeOfInt8) String() string {
-	return "int8"
-}
-
-func (t *TypeOfInt8) Format(zv zcode.Bytes) string {
-	return strconv.FormatInt(DecodeInt(zv), 10)
+func (t *TypeOfInt8) Kind() string {
+	return "primitive"
 }
 
 type TypeOfUint8 struct{}
@@ -58,12 +52,8 @@ func (t *TypeOfUint8) ID() int {
 	return IDUint8
 }
 
-func (t *TypeOfUint8) String() string {
-	return "uint8"
-}
-
-func (t *TypeOfUint8) Format(zv zcode.Bytes) string {
-	return strconv.FormatUint(DecodeUint(zv), 10)
+func (t *TypeOfUint8) Kind() string {
+	return "primitive"
 }
 
 type TypeOfInt16 struct{}
@@ -72,12 +62,8 @@ func (t *TypeOfInt16) ID() int {
 	return IDInt16
 }
 
-func (t *TypeOfInt16) String() string {
-	return "int16"
-}
-
-func (t *TypeOfInt16) Format(zv zcode.Bytes) string {
-	return strconv.FormatInt(DecodeInt(zv), 10)
+func (t *TypeOfInt16) Kind() string {
+	return "primitive"
 }
 
 type TypeOfUint16 struct{}
@@ -86,12 +72,8 @@ func (t *TypeOfUint16) ID() int {
 	return IDUint16
 }
 
-func (t *TypeOfUint16) String() string {
-	return "uint16"
-}
-
-func (t *TypeOfUint16) Format(zv zcode.Bytes) string {
-	return strconv.FormatUint(DecodeUint(zv), 10)
+func (t *TypeOfUint16) Kind() string {
+	return "primitive"
 }
 
 type TypeOfInt32 struct{}
@@ -100,12 +82,8 @@ func (t *TypeOfInt32) ID() int {
 	return IDInt32
 }
 
-func (t *TypeOfInt32) String() string {
-	return "int32"
-}
-
-func (t *TypeOfInt32) Format(zv zcode.Bytes) string {
-	return strconv.FormatInt(DecodeInt(zv), 10)
+func (t *TypeOfInt32) Kind() string {
+	return "primitive"
 }
 
 type TypeOfUint32 struct{}
@@ -114,12 +92,8 @@ func (t *TypeOfUint32) ID() int {
 	return IDUint32
 }
 
-func (t *TypeOfUint32) String() string {
-	return "uint32"
-}
-
-func (t *TypeOfUint32) Format(zv zcode.Bytes) string {
-	return strconv.FormatUint(DecodeUint(zv), 10)
+func (t *TypeOfUint32) Kind() string {
+	return "primitive"
 }
 
 type TypeOfInt64 struct{}
@@ -128,12 +102,8 @@ func (t *TypeOfInt64) ID() int {
 	return IDInt64
 }
 
-func (t *TypeOfInt64) String() string {
-	return "int64"
-}
-
-func (t *TypeOfInt64) Format(zv zcode.Bytes) string {
-	return strconv.FormatInt(DecodeInt(zv), 10)
+func (t *TypeOfInt64) Kind() string {
+	return "primitive"
 }
 
 type TypeOfUint64 struct{}
@@ -142,10 +112,6 @@ func (t *TypeOfUint64) ID() int {
 	return IDUint64
 }
 
-func (t *TypeOfUint64) String() string {
-	return "uint64"
-}
-
-func (t *TypeOfUint64) Format(zv zcode.Bytes) string {
-	return strconv.FormatUint(DecodeUint(zv), 10)
+func (t *TypeOfUint64) Kind() string {
+	return "primitive"
 }

--- a/ip.go
+++ b/ip.go
@@ -38,6 +38,6 @@ func (t *TypeOfIP) ID() int {
 	return IDIP
 }
 
-func (t *TypeOfIP) Kind() string {
-	return "primitve"
+func (t *TypeOfIP) Kind() Kind {
+	return PrimitiveKind
 }

--- a/ip.go
+++ b/ip.go
@@ -38,10 +38,6 @@ func (t *TypeOfIP) ID() int {
 	return IDIP
 }
 
-func (t *TypeOfIP) String() string {
-	return "ip"
-}
-
-func (t *TypeOfIP) Format(zb zcode.Bytes) string {
-	return DecodeIP(zb).String()
+func (t *TypeOfIP) Kind() string {
+	return "primitve"
 }

--- a/map.go
+++ b/map.go
@@ -2,9 +2,7 @@ package zed
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/brimdata/zed/zcode"
 )
@@ -23,8 +21,8 @@ func (t *TypeMap) ID() int {
 	return t.id
 }
 
-func (t *TypeMap) String() string {
-	return fmt.Sprintf("|{%s:%s|}", t.KeyType, t.ValType)
+func (t *TypeMap) Kind() string {
+	return "map"
 }
 
 func (t *TypeMap) Decode(zv zcode.Bytes) (Value, Value, error) {
@@ -68,23 +66,4 @@ func NormalizeMap(zv zcode.Bytes) zcode.Bytes {
 		}
 	}
 	return norm
-}
-
-func (t *TypeMap) Format(zv zcode.Bytes) string {
-	var b strings.Builder
-	it := zv.Iter()
-	b.WriteString("|{")
-	sep := ""
-	for !it.Done() {
-		b.WriteString(sep)
-		b.WriteByte('{')
-		b.WriteString(t.KeyType.Format(it.Next()))
-		b.WriteByte(',')
-		b.WriteString(t.ValType.Format(it.Next()))
-		b.WriteByte('}')
-		b.WriteString(sep)
-		sep = ","
-	}
-	b.WriteString("}|")
-	return b.String()
 }

--- a/map.go
+++ b/map.go
@@ -21,8 +21,8 @@ func (t *TypeMap) ID() int {
 	return t.id
 }
 
-func (t *TypeMap) Kind() string {
-	return "map"
+func (t *TypeMap) Kind() Kind {
+	return MapKind
 }
 
 func (t *TypeMap) Decode(zv zcode.Bytes) (Value, Value, error) {

--- a/net.go
+++ b/net.go
@@ -51,6 +51,6 @@ func (t *TypeOfNet) ID() int {
 	return IDNet
 }
 
-func (t *TypeOfNet) Kind() string {
-	return "primitive"
+func (t *TypeOfNet) Kind() Kind {
+	return PrimitiveKind
 }

--- a/net.go
+++ b/net.go
@@ -51,10 +51,6 @@ func (t *TypeOfNet) ID() int {
 	return IDNet
 }
 
-func (t *TypeOfNet) String() string {
-	return "net"
-}
-
-func (t *TypeOfNet) Format(zb zcode.Bytes) string {
-	return DecodeNet(zb).String()
+func (t *TypeOfNet) Kind() string {
+	return "primitive"
 }

--- a/null.go
+++ b/null.go
@@ -6,6 +6,6 @@ func (t *TypeOfNull) ID() int {
 	return IDNull
 }
 
-func (t *TypeOfNull) Kind() string {
-	return "primitive"
+func (t *TypeOfNull) Kind() Kind {
+	return PrimitiveKind
 }

--- a/null.go
+++ b/null.go
@@ -1,19 +1,11 @@
 package zed
 
-import (
-	"github.com/brimdata/zed/zcode"
-)
-
 type TypeOfNull struct{}
 
 func (t *TypeOfNull) ID() int {
 	return IDNull
 }
 
-func (t *TypeOfNull) String() string {
-	return "null"
-}
-
-func (t *TypeOfNull) Format(zcode.Bytes) string {
-	return "null"
+func (t *TypeOfNull) Kind() string {
+	return "primitive"
 }

--- a/record.go
+++ b/record.go
@@ -79,6 +79,6 @@ func (t *TypeRecord) createLUT() {
 	}
 }
 
-func (t *TypeRecord) Kind() string {
-	return "record"
+func (t *TypeRecord) Kind() Kind {
+	return RecordKind
 }

--- a/record.go
+++ b/record.go
@@ -2,7 +2,6 @@ package zed
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/brimdata/zed/zcode"
 )
@@ -80,37 +79,6 @@ func (t *TypeRecord) createLUT() {
 	}
 }
 
-func (t *TypeRecord) String() string {
-	var b strings.Builder
-	b.WriteString("{")
-	sep := ""
-	for _, c := range t.Columns {
-		b.WriteString(sep)
-		b.WriteString(QuotedName(c.Name))
-		b.WriteByte(':')
-		b.WriteString(c.Type.String())
-		sep = ","
-	}
-	b.WriteString("}")
-	return b.String()
-}
-
-func (t *TypeRecord) Format(zv zcode.Bytes) string {
-	var b strings.Builder
-	b.WriteString("{")
-	sep := ""
-	it := zv.Iter()
-	for _, c := range t.Columns {
-		b.WriteString(sep)
-		b.WriteString(QuotedName(c.Name))
-		b.WriteByte(':')
-		if val := it.Next(); val == nil {
-			b.WriteString("null")
-		} else {
-			b.WriteString(c.Type.Format(val))
-		}
-		sep = ","
-	}
-	b.WriteString("}")
-	return b.String()
+func (t *TypeRecord) Kind() string {
+	return "record"
 }

--- a/recordval_test.go
+++ b/recordval_test.go
@@ -5,72 +5,10 @@ import (
 	"testing"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zio/zsonio"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestRecordTypeCheck(t *testing.T) {
-	r := zed.NewValue(
-		zed.NewTypeRecord(0, []zed.Column{
-			zed.NewColumn("f", zed.NewTypeSet(0, zed.TypeString)),
-		}),
-		nil)
-	t.Run("set/error/duplicate-element", func(t *testing.T) {
-		var b zcode.Builder
-		b.BeginContainer()
-		b.Append([]byte("dup"))
-		b.Append([]byte("dup"))
-		// Don't normalize.
-		b.EndContainer()
-		r.Bytes = b.Bytes()
-		assert.EqualError(t, r.TypeCheck(), "<set element> (|[string]|): duplicate element")
-	})
-	t.Run("set/error/unsorted-elements", func(t *testing.T) {
-		var b zcode.Builder
-		b.BeginContainer()
-		b.Append([]byte("a"))
-		b.Append([]byte("z"))
-		b.Append([]byte("b"))
-		// Don't normalize.
-		b.EndContainer()
-		r.Bytes = b.Bytes()
-		assert.EqualError(t, r.TypeCheck(), "<set element> (|[string]|): elements not sorted")
-	})
-	t.Run("set/primitive-elements", func(t *testing.T) {
-		var b zcode.Builder
-		b.BeginContainer()
-		b.Append([]byte("dup"))
-		b.Append([]byte("dup"))
-		b.Append([]byte("z"))
-		b.Append([]byte("a"))
-		b.TransformContainer(zed.NormalizeSet)
-		b.EndContainer()
-		r.Bytes = b.Bytes()
-		assert.NoError(t, r.TypeCheck())
-	})
-	t.Run("set/complex-elements", func(t *testing.T) {
-		var b zcode.Builder
-		b.BeginContainer()
-		for _, s := range []string{"dup", "dup", "z", "a"} {
-			b.BeginContainer()
-			b.Append([]byte(s))
-			b.EndContainer()
-		}
-		b.TransformContainer(zed.NormalizeSet)
-		b.EndContainer()
-		r := zed.NewValue(
-			zed.NewTypeRecord(0, []zed.Column{
-				zed.NewColumn("f", zed.NewTypeSet(0, zed.NewTypeRecord(0, []zed.Column{
-					zed.NewColumn("g", zed.TypeString),
-				}))),
-			}),
-			b.Bytes())
-		assert.NoError(t, r.TypeCheck())
-	})
-
-}
 
 func TestRecordAccessAlias(t *testing.T) {
 	const input = `{foo:"hello" (=zfile),bar:true (=zbool)} (=0)`

--- a/set.go
+++ b/set.go
@@ -2,9 +2,7 @@ package zed
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/brimdata/zed/zcode"
 )
@@ -22,26 +20,8 @@ func (t *TypeSet) ID() int {
 	return t.id
 }
 
-func (t *TypeSet) String() string {
-	return fmt.Sprintf("|[%s]|", t.Type)
-}
-
-func (t *TypeSet) Format(zv zcode.Bytes) string {
-	var b strings.Builder
-	b.WriteString("|[")
-	sep := ""
-	it := zv.Iter()
-	for !it.Done() {
-		b.WriteString(sep)
-		if val := it.Next(); val == nil {
-			b.WriteString("null")
-		} else {
-			b.WriteString(t.Type.Format(val))
-		}
-		sep = ","
-	}
-	b.WriteString("]|")
-	return b.String()
+func (t *TypeSet) Kind() string {
+	return "set"
 }
 
 // NormalizeSet interprets zv as a set body and returns an equivalent set body

--- a/set.go
+++ b/set.go
@@ -20,8 +20,8 @@ func (t *TypeSet) ID() int {
 	return t.id
 }
 
-func (t *TypeSet) Kind() string {
-	return "set"
+func (t *TypeSet) Kind() Kind {
+	return SetKind
 }
 
 // NormalizeSet interprets zv as a set body and returns an equivalent set body

--- a/string.go
+++ b/string.go
@@ -22,10 +22,6 @@ func (t *TypeOfString) ID() int {
 	return IDString
 }
 
-func (t *TypeOfString) String() string {
-	return "string"
-}
-
-func (t *TypeOfString) Format(zv zcode.Bytes) string {
-	return QuotedString(zv, false)
+func (t *TypeOfString) Kind() string {
+	return "primitive"
 }

--- a/string.go
+++ b/string.go
@@ -22,6 +22,6 @@ func (t *TypeOfString) ID() int {
 	return IDString
 }
 
-func (t *TypeOfString) Kind() string {
-	return "primitive"
+func (t *TypeOfString) Kind() Kind {
+	return PrimitiveKind
 }

--- a/time.go
+++ b/time.go
@@ -29,6 +29,6 @@ func (t *TypeOfTime) ID() int {
 	return IDTime
 }
 
-func (t *TypeOfTime) Kind() string {
-	return "primitive"
+func (t *TypeOfTime) Kind() Kind {
+	return PrimitiveKind
 }

--- a/time.go
+++ b/time.go
@@ -1,8 +1,6 @@
 package zed
 
 import (
-	"time"
-
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zcode"
 )
@@ -31,10 +29,6 @@ func (t *TypeOfTime) ID() int {
 	return IDTime
 }
 
-func (t *TypeOfTime) String() string {
-	return "time"
-}
-
-func (t *TypeOfTime) Format(zv zcode.Bytes) string {
-	return DecodeTime(zv).Time().Format(time.RFC3339Nano)
+func (t *TypeOfTime) Kind() string {
+	return "primitive"
 }

--- a/type.go
+++ b/type.go
@@ -32,7 +32,43 @@ type Type interface {
 	// example should prefer to use this instead of using the go
 	// .(type) operator on a Type instance.
 	ID() int
-	Kind() string
+	Kind() Kind
+}
+
+type Kind int
+
+const (
+	PrimitiveKind Kind = iota
+	RecordKind
+	ArrayKind
+	SetKind
+	MapKind
+	UnionKind
+	EnumKind
+	ErrorKind
+)
+
+func (k Kind) String() string {
+	switch k {
+	case PrimitiveKind:
+		return "primitive"
+	case RecordKind:
+		return "record"
+	case ArrayKind:
+		return "array"
+	case SetKind:
+		return "set"
+	case MapKind:
+		return "map"
+	case UnionKind:
+		return "union"
+	case EnumKind:
+		return "enum"
+	case ErrorKind:
+		return "error"
+	default:
+		return fmt.Sprintf("<unknown kind: %d>", k)
+	}
 }
 
 var (

--- a/type.go
+++ b/type.go
@@ -11,8 +11,7 @@ package zed
 
 import (
 	"errors"
-
-	"github.com/brimdata/zed/zcode"
+	"fmt"
 )
 
 var (
@@ -33,8 +32,7 @@ type Type interface {
 	// example should prefer to use this instead of using the go
 	// .(type) operator on a Type instance.
 	ID() int
-	String() string
-	Format(zv zcode.Bytes) string
+	Kind() string
 }
 
 var (
@@ -178,11 +176,52 @@ func LookupPrimitive(name string) Type {
 	return nil
 }
 
-func LookupPrimitiveByID(id int) Type {
-	if id == 17 {
-		// XXX this will be soon removed with Zed formats update
-		panic("bstring type is deprecated")
+func PrimitiveName(typ Type) string {
+	switch typ.(type) {
+	case *TypeOfUint8:
+		return "uint8"
+	case *TypeOfUint16:
+		return "uint16"
+	case *TypeOfUint32:
+		return "uint32"
+	case *TypeOfUint64:
+		return "uint64"
+	case *TypeOfInt8:
+		return "int8"
+	case *TypeOfInt16:
+		return "int16"
+	case *TypeOfInt32:
+		return "int32"
+	case *TypeOfInt64:
+		return "int64"
+	case *TypeOfDuration:
+		return "duration"
+	case *TypeOfTime:
+		return "time"
+	case *TypeOfFloat32:
+		return "float32"
+	case *TypeOfFloat64:
+		return "float64"
+	case *TypeOfBool:
+		return "bool"
+	case *TypeOfBytes:
+		return "bytes"
+	case *TypeOfString:
+		return "string"
+	case *TypeOfIP:
+		return "ip"
+	case *TypeOfNet:
+		return "net"
+	case *TypeOfType:
+		return "type"
+	case *TypeOfNull:
+		return "null"
+	default:
+		return fmt.Sprintf("unknown primitive type: %T", typ)
 	}
+}
+
+func LookupPrimitiveByID(id int) Type {
 	switch id {
 	case IDBool:
 		return TypeBool

--- a/typetype.go
+++ b/typetype.go
@@ -1,10 +1,6 @@
 package zed
 
 import (
-	"encoding/binary"
-	"fmt"
-	"strings"
-
 	"github.com/brimdata/zed/zcode"
 )
 
@@ -14,12 +10,8 @@ func (t *TypeOfType) ID() int {
 	return IDType
 }
 
-func (t *TypeOfType) String() string {
-	return "type"
-}
-
-func (t *TypeOfType) Format(zv zcode.Bytes) string {
-	return fmt.Sprintf("<%s>", FormatTypeValue(zv))
+func (t *TypeOfType) Kind() string {
+	return "primitive"
 }
 
 func NewTypeValue(t Type) *Value {
@@ -91,153 +83,4 @@ func appendTypeValue(b zcode.Bytes, t Type, typedefs *map[string]Type) zcode.Byt
 		// Primitive type
 		return append(b, byte(t.ID()))
 	}
-}
-
-func FormatTypeValue(tv zcode.Bytes) string {
-	var b strings.Builder
-	formatTypeValue(tv, &b)
-	return b.String()
-}
-
-func truncErr(b *strings.Builder) {
-	b.WriteString("<ERR truncated type value>")
-}
-
-func formatTypeValue(tv zcode.Bytes, b *strings.Builder) zcode.Bytes {
-	if len(tv) == 0 {
-		truncErr(b)
-		return nil
-	}
-	id := tv[0]
-	tv = tv[1:]
-	switch id {
-	case TypeValueNameDef:
-		name, tv := decodeNameAndCheck(tv, b)
-		if tv == nil {
-			return nil
-		}
-		b.WriteString(name)
-		b.WriteString("=<")
-		tv = formatTypeValue(tv, b)
-		b.WriteByte('>')
-		return tv
-	case TypeValueNameRef:
-		name, tv := decodeNameAndCheck(tv, b)
-		if tv == nil {
-			return nil
-		}
-		b.WriteString(name)
-		return tv
-	case TypeValueRecord:
-		b.WriteByte('{')
-		var n int
-		n, tv = decodeInt(tv)
-		if tv == nil {
-			truncErr(b)
-			return nil
-		}
-		for k := 0; k < n; k++ {
-			if k > 0 {
-				b.WriteByte(',')
-			}
-			var name string
-			name, tv = decodeNameAndCheck(tv, b)
-			b.WriteString(QuotedName(name))
-			b.WriteString(":")
-			tv = formatTypeValue(tv, b)
-			if tv == nil {
-				return nil
-			}
-		}
-		b.WriteByte('}')
-	case TypeValueArray:
-		b.WriteByte('[')
-		tv = formatTypeValue(tv, b)
-		b.WriteByte(']')
-	case TypeValueSet:
-		b.WriteString("|[")
-		tv = formatTypeValue(tv, b)
-		b.WriteString("]|")
-	case TypeValueMap:
-		b.WriteString("|{")
-		tv = formatTypeValue(tv, b)
-		b.WriteByte(':')
-		tv = formatTypeValue(tv, b)
-		b.WriteString("}|")
-	case TypeValueUnion:
-		b.WriteByte('(')
-		var n int
-		n, tv = decodeInt(tv)
-		if tv == nil {
-			truncErr(b)
-			return nil
-		}
-		for k := 0; k < n; k++ {
-			if k > 0 {
-				b.WriteByte(',')
-			}
-			tv = formatTypeValue(tv, b)
-		}
-		b.WriteByte(')')
-	case TypeValueEnum:
-		b.WriteByte('<')
-		var n int
-		n, tv = decodeInt(tv)
-		if tv == nil {
-			truncErr(b)
-			return nil
-		}
-		for k := 0; k < n; k++ {
-			if k > 0 {
-				b.WriteByte(',')
-			}
-			var symbol string
-			symbol, tv = decodeNameAndCheck(tv, b)
-			if tv == nil {
-				return nil
-			}
-			b.WriteString(QuotedName(symbol))
-		}
-		b.WriteByte('>')
-	case TypeValueError:
-		b.WriteString("error<")
-		tv = formatTypeValue(tv, b)
-		b.WriteByte('>')
-	default:
-		if id < 0 || id > TypeValueMax {
-			b.WriteString(fmt.Sprintf("<ERR bad type ID %d in type value>", id))
-			return nil
-		}
-		typ := LookupPrimitiveByID(int(id))
-		b.WriteString(typ.String())
-	}
-	return tv
-}
-
-func decodeNameAndCheck(tv zcode.Bytes, b *strings.Builder) (string, zcode.Bytes) {
-	var name string
-	name, tv = decodeName(tv)
-	if tv == nil {
-		truncErr(b)
-	}
-	return name, tv
-}
-
-func decodeName(tv zcode.Bytes) (string, zcode.Bytes) {
-	namelen, tv := decodeInt(tv)
-	if tv == nil || int(namelen) > len(tv) {
-		return "", nil
-	}
-	return string(tv[:namelen]), tv[namelen:]
-}
-
-func decodeInt(tv zcode.Bytes) (int, zcode.Bytes) {
-	if len(tv) < 0 {
-		return 0, nil
-	}
-	namelen, n := binary.Uvarint(tv)
-	if n <= 0 {
-		return 0, nil
-	}
-	return int(namelen), tv[n:]
 }

--- a/typetype.go
+++ b/typetype.go
@@ -10,8 +10,8 @@ func (t *TypeOfType) ID() int {
 	return IDType
 }
 
-func (t *TypeOfType) Kind() string {
-	return "primitive"
+func (t *TypeOfType) Kind() Kind {
+	return PrimitiveKind
 }
 
 func NewTypeValue(t Type) *Value {

--- a/union.go
+++ b/union.go
@@ -37,8 +37,8 @@ func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	return inner, selector, it.Next(), nil
 }
 
-func (t *TypeUnion) Kind() string {
-	return "union"
+func (t *TypeUnion) Kind() Kind {
+	return UnionKind
 }
 
 // BuildUnion appends to b a union described by selector and val.

--- a/union.go
+++ b/union.go
@@ -1,9 +1,6 @@
 package zed
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/brimdata/zed/zcode"
 )
 
@@ -40,20 +37,8 @@ func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	return inner, selector, it.Next(), nil
 }
 
-func (t *TypeUnion) String() string {
-	var ss []string
-	for _, typ := range t.Types {
-		ss = append(ss, typ.String())
-	}
-	return fmt.Sprintf("(%s)", strings.Join(ss, ","))
-}
-
-func (t *TypeUnion) Format(zv zcode.Bytes) string {
-	typ, _, iv, err := t.SplitZNG(zv)
-	if err != nil {
-		return badZNG(err, t, zv)
-	}
-	return fmt.Sprintf("%s (%s) %s", typ.Format(iv), typ, t)
+func (t *TypeUnion) Kind() string {
+	return "union"
 }
 
 // BuildUnion appends to b a union described by selector and val.

--- a/zcode/bytes.go
+++ b/zcode/bytes.go
@@ -20,10 +20,7 @@ import (
 	"io"
 )
 
-var (
-	ErrNotContainer = errors.New("not a container")
-	ErrNotSingleton = errors.New("not a single container")
-)
+var ErrNotSingleton = errors.New("value body has more than one encoded value")
 
 // Bytes is the serialized representation of a sequence of ZNG values.
 type Bytes []byte

--- a/zio/zeekio/types.go
+++ b/zio/zeekio/types.go
@@ -44,7 +44,7 @@ func zngTypeToZeek(typ zed.Type) (string, error) {
 		}
 		return zngTypeToZeek(typ.Type)
 	case *zed.TypeOfBool, *zed.TypeOfString, *zed.TypeOfTime:
-		return typ.String(), nil
+		return zed.PrimitiveName(typ), nil
 	default:
 		return "", fmt.Errorf("type %s: %w", typ, ErrIncompatibleZeekType)
 	}

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -69,11 +69,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err != nil {
 		return nil, e(err)
 	}
-	zv := zed.NewValue(typ, bytes)
-	if err := zv.TypeCheck(); err != nil {
-		return nil, err
-	}
-	return zv, nil
+	return zed.NewValue(typ, bytes), nil
 }
 
 func (r *Reader) decodeTypes(types []astzed.Type) error {

--- a/zio/zjsonio/stream.go
+++ b/zio/zjsonio/stream.go
@@ -56,7 +56,7 @@ func (s *Stream) typeID(typ zed.Type) (string, astzed.Type) {
 		return id, nil
 	}
 	if zed.TypeID(typ) < zed.IDTypeComplex {
-		id := typ.String()
+		id := zed.PrimitiveName(typ)
 		s.encoder[typ] = id
 		return id, nil
 	}

--- a/zio/zjsonio/types.go
+++ b/zio/zjsonio/types.go
@@ -57,7 +57,7 @@ func (e encoder) encodeType(zctx *zed.Context, typ zed.Type) astzed.Type {
 	default:
 		return &astzed.TypePrimitive{
 			Kind: "primitive",
-			Name: typ.String(),
+			Name: zed.PrimitiveName(typ),
 		}
 	}
 }

--- a/zio/zjsonio/values.go
+++ b/zio/zjsonio/values.go
@@ -64,7 +64,7 @@ func encodePrimitive(zctx *zed.Context, typ zed.Type, v zcode.Bytes) (interface{
 			return nil, err
 		}
 		if zed.TypeID(typ) < zed.IDTypeComplex {
-			return typ.String(), nil
+			return zed.PrimitiveName(typ), nil
 		}
 		if alias, ok := typ.(*zed.TypeAlias); ok {
 			return alias.Name, nil
@@ -74,7 +74,7 @@ func encodePrimitive(zctx *zed.Context, typ zed.Type, v zcode.Bytes) (interface{
 	if typ.ID() == zed.IDString {
 		return string(v), nil
 	}
-	return typ.Format(v), nil
+	return zson.FormatPrimitive(typ, v), nil
 }
 
 func encodeValue(zctx *zed.Context, typ zed.Type, val zcode.Bytes) (interface{}, error) {
@@ -144,7 +144,7 @@ func decodeRecord(b *zcode.Builder, typ *zed.TypeRecord, v interface{}) error {
 	b.BeginContainer()
 	for k, val := range values {
 		if k >= len(cols) {
-			return &zed.RecordTypeError{Name: "<record>", Type: typ.String(), Err: zed.ErrExtraField}
+			return zed.ErrExtraField
 		}
 		// each column either a string value or an array of string values
 		if val == nil {

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -318,9 +318,7 @@ func decodeVal(r reader, m *zed.Mapper, validate bool, valRef *zed.Value) error 
 	valRef.Type = typ
 	valRef.Bytes = b
 	if validate {
-		// This can panic but the scanner will always be wrapped in
-		// cathcers inside of the runtime.
-		if err := valRef.TypeCheck(); err != nil {
+		if err := Validate(valRef); err != nil {
 			return err
 		}
 	}

--- a/zio/zngio/validate.go
+++ b/zio/zngio/validate.go
@@ -1,0 +1,67 @@
+package zngio
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zqe"
+)
+
+// Validate checks that the Bytes field is structurally consistent
+// with this value's Type.  It does not check that the actual leaf
+// values when parsed are type compatible with the leaf types.
+func Validate(val *zed.Value) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = zqe.RecoverError(r)
+		}
+	}()
+	return val.Walk(func(typ zed.Type, body zcode.Bytes) error {
+		if typset, ok := typ.(*zed.TypeSet); ok {
+			if err := checkSet(typset, body); err != nil {
+				return err
+			}
+			return zed.SkipContainer
+		}
+		if typ, ok := typ.(*zed.TypeEnum); ok {
+			if err := checkEnum(typ, body); err != nil {
+				return err
+			}
+			return zed.SkipContainer
+		}
+		return nil
+	})
+}
+
+func checkSet(typ *zed.TypeSet, body zcode.Bytes) error {
+	if body == nil {
+		return nil
+	}
+	it := body.Iter()
+	var prev zcode.Bytes
+	for !it.Done() {
+		tagAndBody := it.NextTagAndBody()
+		if prev != nil {
+			switch bytes.Compare(prev, tagAndBody) {
+			case 0:
+				return errors.New("invalid ZNG: duplicate set element")
+			case 1:
+				return errors.New("invalid ZNG: set elements not sorted")
+			}
+		}
+		prev = tagAndBody
+	}
+	return nil
+}
+
+func checkEnum(typ *zed.TypeEnum, body zcode.Bytes) error {
+	if body == nil {
+		return nil
+	}
+	if selector := zed.DecodeUint(body); int(selector) >= len(typ.Symbols) {
+		return errors.New("enum selector out of range")
+	}
+	return nil
+}

--- a/zio/zngio/validate.go
+++ b/zio/zngio/validate.go
@@ -9,8 +9,8 @@ import (
 	"github.com/brimdata/zed/zqe"
 )
 
-// Validate checks that the Bytes field is structurally consistent
-// with this value's Type.  It does not check that the actual leaf
+// Validate checks that val.Bytes is structurally consistent
+// with val.Type.  It does not check that the actual leaf
 // values when parsed are type compatible with the leaf types.
 func Validate(val *zed.Value) (err error) {
 	defer func() {

--- a/zio/zngio/validate_test.go
+++ b/zio/zngio/validate_test.go
@@ -66,5 +66,4 @@ func TestValidate(t *testing.T) {
 			b.Bytes())
 		assert.NoError(t, Validate(r))
 	})
-
 }

--- a/zio/zngio/validate_test.go
+++ b/zio/zngio/validate_test.go
@@ -1,0 +1,70 @@
+package zngio
+
+import (
+	"testing"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	r := zed.NewValue(
+		zed.NewTypeRecord(0, []zed.Column{
+			zed.NewColumn("f", zed.NewTypeSet(0, zed.TypeString)),
+		}),
+		nil)
+	t.Run("set/error/duplicate-element", func(t *testing.T) {
+		var b zcode.Builder
+		b.BeginContainer()
+		b.Append([]byte("dup"))
+		b.Append([]byte("dup"))
+		// Don't normalize.
+		b.EndContainer()
+		r.Bytes = b.Bytes()
+		assert.EqualError(t, Validate(r), "invalid ZNG: duplicate set element")
+	})
+	t.Run("set/error/unsorted-elements", func(t *testing.T) {
+		var b zcode.Builder
+		b.BeginContainer()
+		b.Append([]byte("a"))
+		b.Append([]byte("z"))
+		b.Append([]byte("b"))
+		// Don't normalize.
+		b.EndContainer()
+		r.Bytes = b.Bytes()
+		assert.EqualError(t, Validate(r), "invalid ZNG: set elements not sorted")
+	})
+	t.Run("set/primitive-elements", func(t *testing.T) {
+		var b zcode.Builder
+		b.BeginContainer()
+		b.Append([]byte("dup"))
+		b.Append([]byte("dup"))
+		b.Append([]byte("z"))
+		b.Append([]byte("a"))
+		b.TransformContainer(zed.NormalizeSet)
+		b.EndContainer()
+		r.Bytes = b.Bytes()
+		assert.NoError(t, Validate(r))
+	})
+	t.Run("set/complex-elements", func(t *testing.T) {
+		var b zcode.Builder
+		b.BeginContainer()
+		for _, s := range []string{"dup", "dup", "z", "a"} {
+			b.BeginContainer()
+			b.Append([]byte(s))
+			b.EndContainer()
+		}
+		b.TransformContainer(zed.NormalizeSet)
+		b.EndContainer()
+		r := zed.NewValue(
+			zed.NewTypeRecord(0, []zed.Column{
+				zed.NewColumn("f", zed.NewTypeSet(0, zed.NewTypeRecord(0, []zed.Column{
+					zed.NewColumn("g", zed.TypeString),
+				}))),
+			}),
+			b.Bytes())
+		assert.NoError(t, Validate(r))
+	})
+
+}

--- a/zio/zsonio/reader_test.go
+++ b/zio/zsonio/reader_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/zio/zsonio"
+	"github.com/brimdata/zed/zson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +35,7 @@ func TestReadOneLineNoEOF(t *testing.T) {
 	case res := <-done:
 		require.NoError(t, res.err)
 		rec := res.zv
-		assert.Equal(t, expected, rec.Type.Format(rec.Bytes))
+		assert.Equal(t, expected, zson.String(rec))
 	}
 }
 

--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -504,7 +504,7 @@ func (a Analyzer) convertEnum(zctx *zed.Context, val *astzed.Enum, cast zed.Type
 			}, nil
 		}
 	}
-	return nil, fmt.Errorf("identifier %q not a member of enum type %q", val.Name, enum)
+	return nil, fmt.Errorf("symbol %q not a member of type %q", val.Name, FormatType(enum))
 }
 
 func (a Analyzer) convertMap(zctx *zed.Context, m *astzed.Map, cast zed.Type) (Value, error) {

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -385,23 +385,23 @@ func TestInterfaceZNGMarshal(t *testing.T) {
 	m.Decorate(zson.StylePackage)
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
-	assert.Equal(t, "zson_test.ThingTwo=({c:string})", zv.Type.String())
+	assert.Equal(t, "zson_test.ThingTwo=<{c:string}>", zson.String(zv.Type))
 
 	m.Decorate(zson.StyleSimple)
 	rolls := Rolls{1, 2, 3}
 	zv, err = m.Marshal(rolls)
 	require.NoError(t, err)
-	assert.Equal(t, "Rolls=([int64])", zv.Type.String())
+	assert.Equal(t, "Rolls=<[int64]>", zson.String(zv.Type))
 
 	m.Decorate(zson.StyleFull)
 	zv, err = m.Marshal(rolls)
 	require.NoError(t, err)
-	assert.Equal(t, "github.com/brimdata/zed/zson_test.Rolls=([int64])", zv.Type.String())
+	assert.Equal(t, "github.com/brimdata/zed/zson_test.Rolls=<[int64]>", zson.String(zv.Type))
 
 	plain := []int32{1, 2, 3}
 	zv, err = m.Marshal(plain)
 	require.NoError(t, err)
-	assert.Equal(t, "[int32]", zv.Type.String())
+	assert.Equal(t, "[int32]", zson.String(zv.Type))
 }
 
 func TestInterfaceUnmarshal(t *testing.T) {
@@ -410,7 +410,7 @@ func TestInterfaceUnmarshal(t *testing.T) {
 	m.Decorate(zson.StylePackage)
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
-	assert.Equal(t, "zson_test.ZNGThing=({a:string,B:int64})", zv.Type.String())
+	assert.Equal(t, "zson_test.ZNGThing=<{a:string,B:int64}>", zson.String(zv.Type))
 
 	u := zson.NewZNGUnmarshaler()
 	u.Bind(ZNGThing{}, ThingTwo{})
@@ -443,7 +443,7 @@ func TestBindings(t *testing.T) {
 	})
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
-	assert.Equal(t, "SpecialThingOne=({a:string,B:int64})", zv.Type.String())
+	assert.Equal(t, "SpecialThingOne=<{a:string,B:int64}>", zson.String(zv.Type))
 
 	u := zson.NewZNGUnmarshaler()
 	u.NamedBindings([]zson.Binding{
@@ -460,7 +460,7 @@ func TestBindings(t *testing.T) {
 func TestEmptyInterface(t *testing.T) {
 	zv, err := zson.MarshalZNG(int8(123))
 	require.NoError(t, err)
-	assert.Equal(t, "int8", zv.Type.String())
+	assert.Equal(t, "int8", zson.String(zv.Type))
 
 	var v interface{}
 	err = zson.UnmarshalZNG(zv, &v)
@@ -484,7 +484,7 @@ func TestNamedNormal(t *testing.T) {
 
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
-	assert.Equal(t, "CustomInt8=(int8)", zv.Type.String())
+	assert.Equal(t, "CustomInt8=<int8>", zson.String(zv.Type))
 
 	var actual CustomInt8
 	u := zson.NewZNGUnmarshaler()
@@ -517,7 +517,7 @@ func TestEmbeddedInterface(t *testing.T) {
 	m.Decorate(zson.StyleSimple)
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
-	assert.Equal(t, "EmbeddedA=({A:ZNGThing=({a:string,B:int64})})", zv.Type.String())
+	assert.Equal(t, "EmbeddedA=<{A:ZNGThing=<{a:string,B:int64}>}>", zson.String(zv.Type))
 
 	u := zson.NewZNGUnmarshaler()
 	u.Bind(ZNGThing{}, ThingTwo{})

--- a/zson/typeval_test.go
+++ b/zson/typeval_test.go
@@ -1,4 +1,4 @@
-package zed_test
+package zson_test
 
 import (
 	"testing"
@@ -14,7 +14,7 @@ func TestTypeValue(t *testing.T) {
 	typ, err := zson.ParseType(zed.NewContext(), s)
 	require.NoError(t, err)
 	tv := zctx.LookupTypeValue(typ)
-	require.Exactly(t, s, zed.FormatTypeValue(tv.Bytes))
+	require.Exactly(t, s, zson.FormatTypeValue(tv.Bytes))
 }
 
 func TestTypeValueCrossContext(t *testing.T) {
@@ -22,5 +22,5 @@ func TestTypeValueCrossContext(t *testing.T) {
 	typ, err := zson.ParseType(zed.NewContext(), s)
 	require.NoError(t, err)
 	tv := zed.NewContext().LookupTypeValue(typ)
-	require.Exactly(t, s, zed.FormatTypeValue(tv.Bytes))
+	require.Exactly(t, s, zson.FormatTypeValue(tv.Bytes))
 }

--- a/ztests/enum-err.yaml
+++ b/ztests/enum-err.yaml
@@ -1,12 +1,12 @@
 script: |
-  ! zq -z -
+  ! zq -i zson -
 
 inputs:
   - name: stdin
     data: |
-      {e:%bang (enum<foo,bar,baz>)} (=1)
+      {e:%bang (enum<foo,bar,baz>)}
 
 outputs:
   - name: stderr
-    regexp: |
-      zson: identifier "bang" not a member of enum type "<foo,bar,baz>"
+    data: |
+      stdio:stdin: symbol "bang" not a member of type "enum<foo,bar,baz>"


### PR DESCRIPTION
This commit moves the last bits of formatting out of package zed.
This was an ancient vestige of the original code before we had
all the serialization formats figured out.  At this point, you
should use a specific serialization format to get text formatting
of Zed data.

We also moved the ZNG validation logic out of zed and into zngio.

The zng.Type interface now consists of just ID() and Kind()
methods.  The Kind() method is new and return a string indicating
"primitive", "record", "set", etc.  This will be useful in
data shaping and introspection and we should add a kind()
function to Zed subsequent to this commit.

Finally, these changes exposed a number of bugs that have been fixed.