### PR TITLE
simplify ZST reassembly maps

### DIFF
--- a/cmd/zed/dev/zst/read/command.go
+++ b/cmd/zed/dev/zst/read/command.go
@@ -1,4 +1,4 @@
-package inspect
+package read
 
 import (
 	"errors"

--- a/docs/data-model/zst.md
+++ b/docs/data-model/zst.md
@@ -192,11 +192,11 @@ values in the ZST file have the same super ID,
 the super column will compress trivially.
 
 The reassembly map appears as the next value in the reassembly section
-is of type `<segmap>`.
+and is of type `<segmap>`.
 
 #### The Reassembly Records
 
-Following the root reassembly map are N reassembly maps one for each unique super type.
+Following the root reassembly map are N reassembly maps, one for each unique super type.
 
 Each reassembly record is a record of type `<any_column>`, as defined below,
 where each reassembly record appears in the same sequence as the original N schemas.
@@ -411,7 +411,8 @@ zed dev dig section -Z 1 hello.zst
 ```
 which provides the Zed output (comments added with explanations):
 ```
-// First, the all types are declared with null values (just one here).
+// First, all of the types of the encoded value sequence are declared
+// with null values (just one here).
 
 null ({a:string,b:string})
 

--- a/docs/data-model/zst.md
+++ b/docs/data-model/zst.md
@@ -191,16 +191,12 @@ will compress very significantly, e.g., in the special case that all the
 values in the ZST file have the same super ID,
 the super column will compress trivially.
 
-The type of the reassembly record for the super column stream has the
-type signature:
-```
-{root:<segmap>}
-```
+The reassembly map appears as the next value in the reassembly section
+is of type `<segmap>`.
 
 #### The Reassembly Records
 
-The remaining N records in the reassembly stream define the reassembly
-maps for each super type.
+Following the root reassembly map are N reassembly maps one for each unique super type.
 
 Each reassembly record is a record of type `<any_column>`, as defined below,
 where each reassembly record appears in the same sequence as the original N schemas.
@@ -330,8 +326,8 @@ the memory footprint roughly exceeds this threshold,
 and an array of sizes in bytes of the sections of the ZST file.
 
 This type of this record has the format
-```
-{magic:string,version:int32,skew_thresh:int32,segment_thresh:int32,sections:[int64]}
+````
+{magic:string,type:string,version:int64,sections:[int64],meta:{skew_thresh:int64,segment_thresh:int64}
 ```
 The trailer can be efficiently found by scanning backward from the end of the
 ZST file to the find a valid ZNG stream containing a single record value
@@ -408,32 +404,29 @@ gracie
 0
 ===
 ```
-
 To see the detailed ZST structure described as ZSON, you can use the `zst`
 command like this:
 ```
-zst inspect -Z -trailer hello.zst
+zed dev dig section -Z 1 hello.zst
 ```
 which provides the Zed output (comments added with explanations):
 ```
-// First, the schemas are defined (just one here).
-{
-    a: null (string),               
-    b: null (string)
-}
+// First, the all types are declared with null values (just one here).
 
-// Then, the root reassembly record.
-{
-    root: [                         
-        {
-            offset: 29,
-            length: 2 (int32)
-        }
-    ]
-}
+null ({a:string,b:string})
 
-// Next comes the column assembly records.
+// Then comes the root reassembly map.
+
+[
+    {
+        offset: 29,
+        length: 2 (int32)
+    }
+]
+
+// Finally comes the column assembly records.
 // (Again, only one schema in this example, so only one such record.)
+
 {
     a: {
         column: [
@@ -455,18 +448,28 @@ which provides the Zed output (comments added with explanations):
     }
 }
 
-// Finally, the trailer as a new ZNG stream.
+```
+The ZST trailer can be viewed with this command:
+```
+zed dev dig trailer -Z hello.zst
+```
+giving
+```
 {
-    magic: "zst",
-    version: 1 (int32),
-    skew_thresh: 26214400 (int32),
-    segment_thresh: 5242880 (int32),
+    magic: "ZNG Trailer",
+    type: "zst",
+    version: 2,
     sections: [
         31,
-        94
-    ]
-}
+        95
+    ],
+    meta: {
+        skew_thresh: 26214400,
+        segment_thresh: 5242880
+    } (=zst.FileMeta)
+} (=zngio.Trailer)
 ```
+
 > Note finally, if there were 10MB of ZNG row data here, the reassembly section
 > would be basically the same size, with perhaps a few segmaps.  This emphasizes
 > just how small this data structure is compared to the data section.

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -145,6 +145,7 @@ func (m *MarshalZNGContext) Marshal(v interface{}) (zed.Value, error) {
 	return zed.Value{typ, it.Next()}, nil
 }
 
+//XXX get rid of this?
 func (m *MarshalZNGContext) MarshalRecord(v interface{}) (*zed.Value, error) {
 	m.Builder.Reset()
 	typ, err := m.encodeValue(reflect.ValueOf(v))

--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -13,9 +13,9 @@ import (
 var ErrBadSchemaID = errors.New("bad schema id in root reassembly column")
 
 type Assembly struct {
-	root    zed.Value
-	types   []zed.Type
-	columns []*zed.Value
+	root  zed.Value
+	types []zed.Type
+	maps  []*zed.Value
 }
 
 func NewAssembler(a *Assembly, seeker *storage.Seeker) (*Assembler, error) {
@@ -28,7 +28,7 @@ func NewAssembler(a *Assembly, seeker *storage.Seeker) (*Assembler, error) {
 	}
 	assembler.columns = make([]column.Any, len(a.types))
 	for k := range a.types {
-		val := a.columns[k]
+		val := a.maps[k]
 		col, err := column.Unmarshal(a.types[k], *val, seeker)
 		if err != nil {
 			return nil, err

--- a/zst/column/array.go
+++ b/zst/column/array.go
@@ -67,7 +67,7 @@ type Array struct {
 func (a *Array) UnmarshalZNG(inner zed.Type, in zed.Value, r io.ReaderAt) error {
 	typ, ok := in.Type.(*zed.TypeRecord)
 	if !ok {
-		return errors.New("zst object array_column not a record")
+		return errors.New("ZST object array_column not a record")
 	}
 	rec := zed.NewValue(typ, in.Bytes)
 	zv, err := rec.Access("values")

--- a/zst/column/column.go
+++ b/zst/column/column.go
@@ -92,14 +92,16 @@ func Unmarshal(typ zed.Type, in zed.Value, r io.ReaderAt) (Any, error) {
 		return a, err
 	case *zed.TypeSet:
 		a := &Array{}
-		err := a.UnmarshalZNG(typ, in, r)
+		err := a.UnmarshalZNG(typ.Type, in, r)
 		return a, err
 	case *zed.TypeUnion:
 		u := &Union{}
 		err := u.UnmarshalZNG(typ, in, r)
 		return u, err
-	case *zed.TypeMap, *zed.TypeEnum:
-		return nil, errors.New("unsupported")
+	case *zed.TypeMap:
+		return nil, errors.New("types 'map' is currently unsupported by the ZST implementation")
+	case *zed.TypeEnum:
+		return nil, errors.New("types 'enum' is currently unsupported by the ZST implementation")
 	default:
 		p := &Primitive{}
 		err := p.UnmarshalZNG(typ, in, r)

--- a/zst/column/column.go
+++ b/zst/column/column.go
@@ -99,9 +99,9 @@ func Unmarshal(typ zed.Type, in zed.Value, r io.ReaderAt) (Any, error) {
 		err := u.UnmarshalZNG(typ, in, r)
 		return u, err
 	case *zed.TypeMap:
-		return nil, errors.New("types 'map' is currently unsupported by the ZST implementation")
+		return nil, errors.New("type 'map' is currently unsupported by the ZST implementation")
 	case *zed.TypeEnum:
-		return nil, errors.New("types 'enum' is currently unsupported by the ZST implementation")
+		return nil, errors.New("type 'enum' is currently unsupported by the ZST implementation")
 	default:
 		p := &Primitive{}
 		err := p.UnmarshalZNG(typ, in, r)

--- a/zst/column/field.go
+++ b/zst/column/field.go
@@ -90,7 +90,7 @@ type Field struct {
 func (f *Field) UnmarshalZNG(typ zed.Type, in zed.Value, r io.ReaderAt) error {
 	rtype, ok := in.Type.(*zed.TypeRecord)
 	if !ok {
-		return errors.New("zst object array_column not a record")
+		return errors.New("ZST object array_column not a record")
 	}
 	rec := zed.NewValue(rtype, in.Bytes)
 	zv, err := rec.Access("column")

--- a/zst/column/primitive.go
+++ b/zst/column/primitive.go
@@ -98,7 +98,7 @@ func (p *Primitive) next() error {
 		return err
 	}
 	if n < int(segment.Length) {
-		return errors.New("truncated read of zst column")
+		return errors.New("truncated read of ZST column")
 	}
 	p.iter = zcode.Iter(b)
 	return nil

--- a/zst/column/record.go
+++ b/zst/column/record.go
@@ -70,7 +70,7 @@ type Record []*Field
 func (r *Record) UnmarshalZNG(utyp zed.Type, in zed.Value, reader io.ReaderAt) error {
 	typ, ok := zed.TypeUnder(utyp).(*zed.TypeRecord)
 	if !ok {
-		return errors.New("cannot unmarshal non-record into record")
+		return errors.New("corrupt zst object: record_column is not a record")
 	}
 	rtype, ok := in.Type.(*zed.TypeRecord)
 	if !ok {

--- a/zst/column/record.go
+++ b/zst/column/record.go
@@ -70,11 +70,11 @@ type Record []*Field
 func (r *Record) UnmarshalZNG(utyp zed.Type, in zed.Value, reader io.ReaderAt) error {
 	typ, ok := zed.TypeUnder(utyp).(*zed.TypeRecord)
 	if !ok {
-		return errors.New("corrupt zst object: record_column is not a record")
+		return errors.New("corrupt ZST object: record_column is not a record")
 	}
 	rtype, ok := in.Type.(*zed.TypeRecord)
 	if !ok {
-		return errors.New("corrupt zst object: record_column is not a record")
+		return errors.New("corrupt ZST object: record_column is not a record")
 	}
 	k := 0
 	for it := in.Bytes.Iter(); !it.Done(); k++ {

--- a/zst/column/segment.go
+++ b/zst/column/segment.go
@@ -35,14 +35,14 @@ func checkSegType(col zed.Column, which string, typ zed.Type) bool {
 func UnmarshalSegmap(in zed.Value, s *[]Segment) error {
 	typ, ok := in.Type.(*zed.TypeArray)
 	if !ok {
-		return errors.New("zst object segmap not an array")
+		return errors.New("ZST object segmap not an array")
 	}
 	segType, ok := typ.Type.(*zed.TypeRecord)
 	if !ok {
-		return errors.New("zst object segmap element not a record")
+		return errors.New("ZST object segmap element not a record")
 	}
 	if len(segType.Columns) != 2 || !checkSegType(segType.Columns[0], "offset", zed.TypeInt64) || !checkSegType(segType.Columns[1], "length", zed.TypeInt32) {
-		return errors.New("zst object segmap element not a record[offset:int64,length:int32]")
+		return errors.New("ZST object segmap element not a record[offset:int64,length:int32]")
 	}
 	*s = []Segment{}
 	it := in.Bytes.Iter()

--- a/zst/column/union.go
+++ b/zst/column/union.go
@@ -86,7 +86,7 @@ func (u *Union) UnmarshalZNG(utyp zed.Type, in zed.Value, r io.ReaderAt) error {
 	}
 	rtype, ok := in.Type.(*zed.TypeRecord)
 	if !ok {
-		return errors.New("zst object union_column not a record")
+		return errors.New("ZST object union_column not a record")
 	}
 	rec := zed.NewValue(rtype, in.Bytes)
 	for k := 0; k < len(typ.Types); k++ {
@@ -114,7 +114,7 @@ func (u *Union) Read(b *zcode.Builder) error {
 		return err
 	}
 	if selector < 0 || int(selector) >= len(u.values) {
-		return errors.New("bad selector in zst union reader")
+		return errors.New("bad selector in ZST union reader")
 	}
 	b.BeginContainer()
 	b.Append(zed.EncodeInt(int64(selector)))

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -51,7 +51,7 @@ type CutAssembler struct {
 
 func NewCutAssembler(zctx *zed.Context, fields []string, object *Object) (*CutAssembler, error) {
 	a := object.assembly
-	n := len(a.columns)
+	n := len(a.maps)
 	ca := &CutAssembler{
 		zctx:     zctx,
 		root:     &column.Int{},
@@ -68,10 +68,14 @@ func NewCutAssembler(zctx *zed.Context, fields []string, object *Object) (*CutAs
 	for k, typ := range a.types {
 		recType := zed.TypeRecordOf(typ)
 		if typ == nil {
-			return nil, fmt.Errorf("zst cut requires all top-level values to be records: encountered type %s", zson.FormatType(typ))
+			// We could be smarter here and just ignore values that
+			// aren't records but all this will be subsumed when we
+			// work on predicate pushdown, so no sense spending time
+			// on this right now.
+			return nil, fmt.Errorf("zst cut requires all top-level records to be records: encountered type %s", zson.FormatType(typ))
 		}
 		topcol := &column.Record{}
-		if err := topcol.UnmarshalZNG(recType, *a.columns[k], object.seeker); err != nil {
+		if err := topcol.UnmarshalZNG(recType, *a.maps[k], object.seeker); err != nil {
 			return nil, err
 		}
 		var err error

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -72,7 +72,7 @@ func NewCutAssembler(zctx *zed.Context, fields []string, object *Object) (*CutAs
 			// aren't records but all this will be subsumed when we
 			// work on predicate pushdown, so no sense spending time
 			// on this right now.
-			return nil, fmt.Errorf("zst cut requires all top-level records to be records: encountered type %s", zson.FormatType(typ))
+			return nil, fmt.Errorf("ZST cut requires all top-level records to be records: encountered type %s", zson.FormatType(typ))
 		}
 		topcol := &column.Record{}
 		if err := topcol.UnmarshalZNG(recType, *a.maps[k], object.seeker); err != nil {

--- a/zst/object.go
+++ b/zst/object.go
@@ -120,27 +120,22 @@ func (o *Object) IsEmpty() bool {
 func (o *Object) readAssembly() (*Assembly, error) {
 	reader := o.NewReassemblyReader()
 	assembly := &Assembly{}
-	var rec *zed.Value
+	var val *zed.Value
 	for {
 		var err error
-		rec, err = reader.Read()
+		val, err = reader.Read()
 		if err != nil {
 			return nil, err
 		}
-		if rec == nil {
-			return nil, errors.New("no reassembly records found in zst file")
+		if val == nil {
+			return nil, errors.New("zst: corrupt trailer: root ressembly map not found")
 		}
-		zv := rec.ValueByColumn(0)
-		if zv.Bytes != nil {
+		if !val.IsNull() {
 			break
 		}
-		assembly.types = append(assembly.types, rec.Type)
+		assembly.types = append(assembly.types, val.Type)
 	}
-	root, err := rec.Access("root")
-	if err != nil {
-		return nil, err
-	}
-	assembly.root = *root.Copy()
+	assembly.root = *val.Copy()
 	expectedType, err := zson.ParseType(o.zctx, column.SegmapTypeString)
 	if err != nil {
 		return nil, err
@@ -148,22 +143,23 @@ func (o *Object) readAssembly() (*Assembly, error) {
 	if assembly.root.Type != expectedType {
 		return nil, fmt.Errorf("zst root reassembly value has wrong type: %s; should be %s", assembly.root.Type, expectedType)
 	}
-
 	for range assembly.types {
-		rec, err := reader.Read()
+		val, err := reader.Read()
 		if err != nil {
 			return nil, err
 		}
-		assembly.columns = append(assembly.columns, rec.Copy())
+		if val == nil {
+			return nil, errors.New("zst: corrupt reassembly section: number of reassembly maps not equal to number of types")
+		}
+		assembly.maps = append(assembly.maps, val.Copy())
 	}
-	rec, _ = reader.Read()
-	if rec != nil {
-		return nil, errors.New("extra records in reassembly section")
+	val, _ = reader.Read()
+	if val != nil {
+		return nil, errors.New("zst: corrupt reassembly section: numer of reassembly maps exceeds number of types")
 	}
 	return assembly, nil
 }
 
-//XXX this should be a common method on Trailer and shared with microindexes
 func (o *Object) section(level int) (int64, int64) {
 	off := int64(0)
 	for k := 0; k < level; k++ {

--- a/zst/object.go
+++ b/zst/object.go
@@ -153,8 +153,7 @@ func (o *Object) readAssembly() (*Assembly, error) {
 		}
 		assembly.maps = append(assembly.maps, val.Copy())
 	}
-	val, _ = reader.Read()
-	if val != nil {
+	if val, _ = reader.Read(); val != nil {
 		return nil, errors.New("zst: corrupt reassembly section: numer of reassembly maps exceeds number of types")
 	}
 	return assembly, nil

--- a/zst/trailer.go
+++ b/zst/trailer.go
@@ -24,10 +24,10 @@ func readTrailer(r io.ReaderAt, n int64) (*FileMeta, []int64, error) {
 		return nil, nil, err
 	}
 	if trailer.Type != FileType {
-		return nil, nil, fmt.Errorf("not a zst file: trailer type is %q", trailer.Type)
+		return nil, nil, fmt.Errorf("not a ZST file: trailer type is %q", trailer.Type)
 	}
 	if trailer.Version != Version {
-		return nil, nil, fmt.Errorf("zst version %d found while expecting version %d", trailer.Version, Version)
+		return nil, nil, fmt.Errorf("ZST version %d found while expecting version %d", trailer.Version, Version)
 	}
 	var meta FileMeta
 	if err := zson.UnmarshalZNG(trailer.Meta, &meta); err != nil {

--- a/zst/trailer.go
+++ b/zst/trailer.go
@@ -14,8 +14,8 @@ const (
 )
 
 type FileMeta struct {
-	SkewThresh    int
-	SegmentThresh int
+	SkewThresh    int `zed:"skew_thresh"`
+	SegmentThresh int `zed:"segment_thresh"`
 }
 
 func readTrailer(r io.ReaderAt, n int64) (*FileMeta, []int64, error) {

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -94,10 +94,10 @@ func NewWriterFromPath(ctx context.Context, engine storage.Engine, path string, 
 
 func checkThresh(which string, max, thresh int) error {
 	if thresh == 0 {
-		return fmt.Errorf("zst %s threshold cannot be zero", which)
+		return fmt.Errorf("ZST %s threshold cannot be zero", which)
 	}
 	if thresh > max {
-		return fmt.Errorf("zst %s threshold too large (%d)", which, thresh)
+		return fmt.Errorf("ZST %s threshold too large (%d)", which, thresh)
 	}
 	return nil
 }
@@ -183,7 +183,7 @@ func (w *Writer) finalize() error {
 	}
 	bytes, err := b.Bytes().Body()
 	if err != nil {
-		return errors.New("zst: corrupt root reassembly")
+		return errors.New("ZST: corrupt root reassembly")
 	}
 	root := zed.NewValue(typ, bytes)
 	if err := zw.Write(root); err != nil {
@@ -213,7 +213,7 @@ func (w *Writer) finalize() error {
 	// Finally, we build and write the section trailer based on the size
 	// of the data and size of the reassembly maps.
 	sections := []int64{dataSize, mapsSize}
-	val, err := zngio.MarshalTrailer("zst", Version, sections, &FileMeta{w.skewThresh, w.segThresh})
+	val, err := zngio.MarshalTrailer(FileType, Version, sections, &FileMeta{w.skewThresh, w.segThresh})
 	if err != nil {
 		return err
 	}

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -2,6 +2,7 @@ package zst
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -165,30 +166,31 @@ func (w *Writer) finalize() error {
 	// to the underlying spiller, so we start writing zng at this point.
 	zw := zngio.NewWriter(w.writer, zngio.WriterOpts{})
 	dataSize := w.spiller.Position()
-	// First, we write out empty values for each column corresponding to
-	// a type serialized into the ZST file in the order of its type number.
+	// First, we write out null values for each column corresponding to
+	// a type serialized into the ZST file in the order of its type number
+	// in the root map.
 	for _, typ := range w.types {
 		val := zed.NewValue(typ, nil)
 		if err := zw.Write(val); err != nil {
 			return err
 		}
 	}
-	// Next, write the root reassembly record.
+	// Next, we write the root reassembly map.
 	var b zcode.Builder
 	typ, err := w.root.MarshalZNG(w.zctx, &b)
 	if err != nil {
 		return err
 	}
-	rootType, err := w.zctx.LookupTypeRecord([]zed.Column{{"root", typ}})
+	bytes, err := b.Bytes().Body()
 	if err != nil {
+		return errors.New("zst: corrupt root reassembly")
+	}
+	root := zed.NewValue(typ, bytes)
+	if err := zw.Write(root); err != nil {
 		return err
 	}
-	rec := zed.NewValue(rootType, b.Bytes())
-	if err := zw.Write(rec); err != nil {
-		return err
-	}
-	// Now, write out the reassembly record for each top-level type.
-	// Each record here is highly nested and encodes all of the segmaps
+	// Now, write out a reassembly map for each top-level type.
+	// Each map here is highly nested and encodes all of the segmaps
 	// for every column stream needed to reconstruct all of the values
 	// for that type.
 	for _, col := range w.columns {
@@ -197,33 +199,26 @@ func (w *Writer) finalize() error {
 		if err != nil {
 			return err
 		}
-		body, err := b.Bytes().Body()
+		bytes, err := b.Bytes().Body()
 		if err != nil {
 			return err
 		}
-		val := zed.NewValue(typ, body)
+		val := zed.NewValue(typ, bytes)
 		if err := zw.Write(val); err != nil {
 			return err
 		}
 	}
 	zw.EndStream()
-	columnSize := zw.Position()
-	sizes := []int64{dataSize, columnSize}
-	return writeTrailer(zw, w.zctx, w.skewThresh, w.segThresh, sizes)
-}
-
-func (w *Writer) writeEmptyTrailer() error {
-	zw := zngio.NewWriter(w.writer, zngio.WriterOpts{})
-	return writeTrailer(zw, w.zctx, w.skewThresh, w.segThresh, nil)
-}
-
-func writeTrailer(w *zngio.Writer, zctx *zed.Context, skewThresh, segThresh int, sections []int64) error {
-	val, err := zngio.MarshalTrailer("zst", Version, sections, &FileMeta{skewThresh, segThresh})
+	mapsSize := zw.Position()
+	// Finally, we build and write the section trailer based on the size
+	// of the data and size of the reassembly maps.
+	sections := []int64{dataSize, mapsSize}
+	val, err := zngio.MarshalTrailer("zst", Version, sections, &FileMeta{w.skewThresh, w.segThresh})
 	if err != nil {
 		return err
 	}
-	if err := w.Write(&val); err != nil {
+	if err := zw.Write(&val); err != nil {
 		return err
 	}
-	return w.EndStream()
+	return zw.EndStream()
 }

--- a/zst/ztests/vals.yaml
+++ b/zst/ztests/vals.yaml
@@ -12,6 +12,13 @@ inputs:
       {a:1}
       true
       false
+      1((int64,string))
+      "foo"((int64,string))
+      <int64>
+      |[1,2,3]|
+      null(int64)
+      null(string)
+      null(type)
 
 outputs:
   - name: stdout


### PR DESCRIPTION
Now that ZST handles any typ of top-level value, this commit simplifies
the reassembly section that defines the reassembly maps.
This is a baby step toward a larger PR that will simplify the
column maps and clean up how the column maps are built.

We updated the ZST format doc to reflect the changes and the
new dig tooling and adding nulls to the tests as the rebase onto
zng-2022 fixed the bug with nulls in zst.  There is still a bug
with null container types but this will get fixed with an
ancipated refactor of the column maps.

We also fixed a bug with the handling of sets where set type instead
of the element type was passed to the column constructor.