### PR TITLE
fix textio for non-record values

### DIFF
--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -27,7 +27,15 @@ func (w *Writer) Close() error {
 	return w.writer.Close()
 }
 
-func (w *Writer) Write(rec *zed.Value) error {
+func (w *Writer) Write(val *zed.Value) error {
+	if _, ok := zed.TypeUnder(val.Type).(*zed.TypeRecord); ok {
+		return w.writeRecord(val)
+	}
+	_, err := fmt.Fprintf(w.writer, "%s\n", zeekio.FormatValue(*val))
+	return err
+}
+
+func (w *Writer) writeRecord(rec *zed.Value) error {
 	rec, err := w.flattener.Flatten(rec)
 	if err != nil {
 		return err

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -31,7 +31,7 @@ func (w *Writer) Write(val *zed.Value) error {
 	if _, ok := zed.TypeUnder(val.Type).(*zed.TypeRecord); ok {
 		return w.writeRecord(val)
 	}
-	_, err := fmt.Fprintf(w.writer, "%s\n", zeekio.FormatValue(*val))
+	_, err := fmt.Fprintln(w.writer, zeekio.FormatValue(*val))
 	return err
 }
 
@@ -56,6 +56,6 @@ func (w *Writer) writeRecord(rec *zed.Value) error {
 		out = append(out, s)
 	}
 	s := strings.Join(out, "\t")
-	_, err = fmt.Fprintf(w.writer, "%s\n", s)
+	_, err = fmt.Fprintln(w.writer, s)
 	return err
 }

--- a/zio/textio/ztests/vals.yaml
+++ b/zio/textio/ztests/vals.yaml
@@ -1,0 +1,23 @@
+zed: '*'
+
+input: |
+  1
+  2
+  "hello"
+  [3,4]
+  {a:1}
+  true
+  false
+  null
+
+output-flags: -f text
+
+output: |
+  1
+  2
+  hello
+  3,4
+  1
+  T
+  F
+  -

--- a/zio/textio/ztests/vals.yaml
+++ b/zio/textio/ztests/vals.yaml
@@ -6,6 +6,7 @@ input: |
   "hello"
   [3,4]
   {a:1}
+  {a:1,b:2}
   true
   false
   null
@@ -18,6 +19,7 @@ output: |
   hello
   3,4
   1
+  1	2
   T
   F
   -


### PR DESCRIPTION
This commit fixes the textio record to handle non-record value by
printing them using the zeek TSV value format.