### PR TITLE
semantic compiler: no scopes for lvals

### DIFF
--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -410,11 +410,11 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 	case *ast.Rename:
 		var assignments []dag.Assignment
 		for _, fa := range p.Args {
-			dst, err := semField(scope, fa.LHS)
+			dst, err := semField(scope, fa.LHS, false)
 			if err != nil {
 				return nil, err
 			}
-			src, err := semField(scope, fa.RHS)
+			src, err := semField(scope, fa.RHS, false)
 			if err != nil {
 				return nil, err
 			}
@@ -503,7 +503,7 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 			As:   as,
 		}, nil
 	case *ast.Merge:
-		e, err := semField(scope, p.Field)
+		e, err := semField(scope, p.Field, false)
 		if err != nil {
 			return nil, err
 		}

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -238,7 +238,7 @@ func convertSQLAlias(scope *Scope, e ast.Expr) (*dag.Cut, string, error) {
 	if e == nil {
 		return nil, "", nil
 	}
-	fld, err := semField(scope, e)
+	fld, err := semField(scope, e, false)
 	if err != nil {
 		return nil, "", fmt.Errorf("illegal alias: %w", err)
 	}
@@ -550,7 +550,7 @@ func deriveAs(scope *Scope, a ast.Assignment) (field.Path, error) {
 }
 
 func sqlField(scope *Scope, e ast.Expr) (field.Path, error) {
-	name, err := semField(scope, e)
+	name, err := semField(scope, e, false)
 	if err != nil {
 		return nil, err
 	}

--- a/proc/traverse/ztests/scope-groupby-key.yaml
+++ b/proc/traverse/ztests/scope-groupby-key.yaml
@@ -11,4 +11,3 @@ output: |
   {s:"a",sum:3}
   {s:"b",sum:9}
   {s:"b",sum:13}
-

--- a/proc/traverse/ztests/scope-groupby-key.yaml
+++ b/proc/traverse/ztests/scope-groupby-key.yaml
@@ -1,0 +1,14 @@
+zed: let s=s over x => (sum(this) by s)
+
+input: |
+  {s:"a",x:[1,2]}
+  {s:"a",x:[3]}
+  {s:"b",x:[4,5]}
+  {s:"b",x:[6,7]}
+
+output: |
+  {s:"a",sum:3}
+  {s:"a",sum:3}
+  {s:"b",sum:9}
+  {s:"b",sum:13}
+


### PR DESCRIPTION
Do not have the semantic compiler replace lvals with scope variables.

Closes #3941