### PR TITLE
update zst coding idioms

### DIFF
--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/brimdata/zed/zst/column"
 )
 
-var ErrBadTypeNumber = errors.New("ZST: bad type number in root reassembly map")
+var ErrBadTypeNumber = errors.New("bad type number in ZST root reassembly map")
 
 // Assembler reads a columnar ZST object to generate a stream of zed.Values.
 // It also has methods to read metadata for test and debugging.
@@ -47,8 +47,8 @@ func NewAssembler(a *Assembly, seeker *storage.Seeker) (*Assembler, error) {
 	}
 	return &Assembler{
 		root:    root,
-		types:   a.types,
 		readers: readers,
+		types:   a.types,
 	}, nil
 }
 
@@ -65,8 +65,7 @@ func (a *Assembler) Read() (*zed.Value, error) {
 	if reader == nil {
 		return nil, ErrBadTypeNumber
 	}
-	err = reader.Read(&a.builder)
-	if err != nil {
+	if err = reader.Read(&a.builder); err != nil {
 		return nil, err
 	}
 	body, err := a.builder.Bytes().Body()

--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -7,10 +7,23 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zst/column"
 )
 
-var ErrBadSchemaID = errors.New("bad schema id in root reassembly column")
+var ErrBadTypeNumber = errors.New("ZST: bad type number in root reassembly map")
+
+// Assembler reads a columnar ZST object to generate a stream of zed.Values.
+// It also has methods to read metadata for test and debugging.
+type Assembler struct {
+	root    *column.IntReader
+	readers []column.Reader
+	types   []zed.Type
+	builder zcode.Builder
+	err     error
+}
+
+var _ zio.Reader = (*Assembler)(nil)
 
 type Assembly struct {
 	root  zed.Value
@@ -19,34 +32,24 @@ type Assembly struct {
 }
 
 func NewAssembler(a *Assembly, seeker *storage.Seeker) (*Assembler, error) {
-	assembler := &Assembler{
-		root:  &column.Int{},
-		types: a.types,
-	}
-	if err := assembler.root.UnmarshalZNG(zed.TypeInt64, a.root, seeker); err != nil {
+	root, err := column.NewIntReader(a.root, seeker)
+	if err != nil {
 		return nil, err
 	}
-	assembler.columns = make([]column.Any, len(a.types))
+	var readers []column.Reader
 	for k := range a.types {
 		val := a.maps[k]
-		col, err := column.Unmarshal(a.types[k], *val, seeker)
+		reader, err := column.NewReader(a.types[k], *val, seeker)
 		if err != nil {
 			return nil, err
 		}
-		assembler.columns[k] = col
+		readers = append(readers, reader)
 	}
-	return assembler, nil
-}
-
-// Assembler implements the zio.Reader and io.Closer.  It reads a columnar
-// zst object to generate a stream of zed.Records.  It also has methods
-// to read metainformation for test and debugging.
-type Assembler struct {
-	root    *column.Int
-	columns []column.Any
-	types   []zed.Type
-	builder zcode.Builder
-	err     error
+	return &Assembler{
+		root:    root,
+		types:   a.types,
+		readers: readers,
+	}, nil
 }
 
 func (a *Assembler) Read() (*zed.Value, error) {
@@ -55,14 +58,14 @@ func (a *Assembler) Read() (*zed.Value, error) {
 	if err == io.EOF {
 		return nil, nil
 	}
-	if typeNo < 0 || int(typeNo) >= len(a.columns) {
-		return nil, ErrBadSchemaID
+	if typeNo < 0 || int(typeNo) >= len(a.readers) {
+		return nil, ErrBadTypeNumber
 	}
-	col := a.columns[typeNo]
-	if col == nil {
-		return nil, ErrBadSchemaID
+	reader := a.readers[typeNo]
+	if reader == nil {
+		return nil, ErrBadTypeNumber
 	}
-	err = col.Read(&a.builder)
+	err = reader.Read(&a.builder)
 	if err != nil {
 		return nil, err
 	}

--- a/zst/column/column.go
+++ b/zst/column/column.go
@@ -14,12 +14,12 @@
 // byte threshold or until Flush is called.
 //
 // After all of the Zed data is written, a reassembly map is formed for
-// the any column writer by calling its EncodeMap method, which builds the
-// value in place using zcode.Builder and returns the type
-// of that record column.
+// each column writer by calling its EncodeMap method, which builds the
+// value in place using zcode.Builder and returns the Zed type of
+// the reassembly map value.
 //
-// Data is read from a ZST file by scanning the reassembly records then building
-// column Readers for each Zed type by calling NewReader, which
+// Data is read from a ZST file by scanning the reassembly maps to build
+// column Readers for each Zed type by calling NewReader with the map, which
 // recusirvely builds an assembly structure.  An io.ReaderAt is passed to NewReader
 // so each column reader can access the underlying storage object and read its
 // column data effciently in largish column chunks.

--- a/zst/column/column.go
+++ b/zst/column/column.go
@@ -1,34 +1,34 @@
 // Package column implements the organization of columns on storage for a
-// zst columnar storage object.
+// ZST columnar storage object.
 //
-// A zst object is created by allocating a RecordWriter for a top-level zng row type
-// (i.e., "schema") via NewRecordWriter.  The object to be written to is wrapped
+// A ZST object is created by allocating a Writer for any top-level Zed type
+// ia NewWriter.  The object to be written to is wrapped
 // in a Spiller with a column threshold.  Output is streamed to the underlying spiller
 // in a single pass.  (In the future, we may implement multiple passes to optimize
-// the storage layout of column data or spread a given zst object across multiple
+// the storage layout of column data or spread a given ZST object across multiple
+// files.
 //
-// NewRecordWriter recursively decends the record type, allocating a column Writer
-// for each node in the type tree.  The top-level record body is written via a call
-// to Write and all of the columns are called with their respetive values represented
-// as a zcode.Bytes.  The columns buffer data in memorry until they reach their
+// NewWriter recursively decends into the Zed type, allocating a Writers
+// for each node in the type tree.  The top-level body is written via a call
+// to Write.  The columns buffer data in memory until they reach their
 // byte threshold or until Flush is called.
 //
-// After all of the zng data is written, a reassembly record may be formed for
-// the RecordColumn by calling its MarshalZNG method, which builds the record
-// value in place using zcode.Builder and returns the zed.TypeRecord (i.e., schema)
+// After all of the Zed data is written, a reassembly map is formed for
+// the any column writer by calling its EncodeMap method, which builds the
+// value in place using zcode.Builder and returns the type
 // of that record column.
 //
-// Data is read from a zst file by scanning the reassembly records then unmarshaling
-// a zed.Record body into an empty Record by calling Record.UnmarshalZNG, which
-// recusirvely builds an assembly structure.  An io.ReaderAt is passed to unmarshal
+// Data is read from a ZST file by scanning the reassembly records then building
+// column Readers for each Zed type by calling NewReader, which
+// recusirvely builds an assembly structure.  An io.ReaderAt is passed to NewReader
 // so each column reader can access the underlying storage object and read its
 // column data effciently in largish column chunks.
 //
-// Once an assembly is built, the recontructed zng row data can be read from the
+// Once an assembly is built, the recontructed Zed row data can be read from the
 // assembly by calling the Read method on the top-level Record and passing in
 // a zcode.Builder to reconstruct the record body in place.  The assembly does not
 // need any type information as the structure of values is entirely self describing
-// in the zng data format.
+// in the Zed data format.
 package column
 
 import (
@@ -49,9 +49,9 @@ type Writer interface {
 	Write(zcode.Bytes) error
 	// Push all in-memory column data to the storage layer.
 	Flush(bool) error
-	// MarshalZNG is called after all data is flushed to build the reassembly
+	// EncodeMap is called after all data is flushed to build the reassembly
 	// record for this column.
-	MarshalZNG(*zed.Context, *zcode.Builder) (zed.Type, error)
+	EncodeMap(*zed.Context, *zcode.Builder) (zed.Type, error)
 }
 
 func NewWriter(typ zed.Type, spiller *Spiller) Writer {
@@ -73,38 +73,29 @@ func NewWriter(typ zed.Type, spiller *Spiller) Writer {
 	}
 }
 
-type Any interface {
-	UnmarshalZNG(zed.Type, zed.Value, io.ReaderAt) error
+type Reader interface {
 	Read(*zcode.Builder) error
 }
 
-func Unmarshal(typ zed.Type, in zed.Value, r io.ReaderAt) (Any, error) {
+func NewReader(typ zed.Type, in zed.Value, r io.ReaderAt) (Reader, error) {
 	switch typ := typ.(type) {
 	case *zed.TypeAlias:
-		return Unmarshal(typ.Type, in, r)
+		return NewReader(typ.Type, in, r)
 	case *zed.TypeRecord:
-		record := &Record{}
-		err := record.UnmarshalZNG(typ, in, r)
-		return record, err
+		return NewRecordReader(typ, in, r)
 	case *zed.TypeArray:
-		a := &Array{}
-		err := a.UnmarshalZNG(typ.Type, in, r)
-		return a, err
+		return NewArrayReader(typ.Type, in, r)
 	case *zed.TypeSet:
-		a := &Array{}
-		err := a.UnmarshalZNG(typ.Type, in, r)
-		return a, err
+		return NewArrayReader(typ.Type, in, r)
 	case *zed.TypeUnion:
-		u := &Union{}
-		err := u.UnmarshalZNG(typ, in, r)
-		return u, err
+		return NewUnionReader(typ, in, r)
 	case *zed.TypeMap:
 		return nil, errors.New("type 'map' is currently unsupported by the ZST implementation")
 	case *zed.TypeEnum:
 		return nil, errors.New("type 'enum' is currently unsupported by the ZST implementation")
+	case *zed.TypeError:
+		return nil, errors.New("type 'error' is currently unsupported by the ZST implementation")
 	default:
-		p := &Primitive{}
-		err := p.UnmarshalZNG(typ, in, r)
-		return p, err
+		return NewPrimitiveReader(in, r)
 	}
 }

--- a/zst/column/column.go
+++ b/zst/column/column.go
@@ -2,13 +2,13 @@
 // ZST columnar storage object.
 //
 // A ZST object is created by allocating a Writer for any top-level Zed type
-// ia NewWriter.  The object to be written to is wrapped
+// via NewWriter.  The object to be written is wrapped
 // in a Spiller with a column threshold.  Output is streamed to the underlying spiller
 // in a single pass.  (In the future, we may implement multiple passes to optimize
 // the storage layout of column data or spread a given ZST object across multiple
 // files.
 //
-// NewWriter recursively decends into the Zed type, allocating a Writers
+// NewWriter recursively decends into the Zed type, allocating a Writer
 // for each node in the type tree.  The top-level body is written via a call
 // to Write.  The columns buffer data in memory until they reach their
 // byte threshold or until Flush is called.

--- a/zst/column/int.go
+++ b/zst/column/int.go
@@ -1,6 +1,10 @@
 package column
 
-import "github.com/brimdata/zed"
+import (
+	"io"
+
+	"github.com/brimdata/zed"
+)
 
 type IntWriter struct {
 	PrimitiveWriter
@@ -14,14 +18,22 @@ func (p *IntWriter) Write(v int32) error {
 	return p.PrimitiveWriter.Write(zed.EncodeInt(int64(v)))
 }
 
-type Int struct {
-	Primitive
+type IntReader struct {
+	PrimitiveReader
 }
 
-func (p *Int) Read() (int32, error) {
+func NewIntReader(val zed.Value, r io.ReaderAt) (*IntReader, error) {
+	reader, err := NewPrimitiveReader(val, r)
+	if err != nil {
+		return nil, err
+	}
+	return &IntReader{*reader}, nil
+}
+
+func (p *IntReader) Read() (int64, error) {
 	zv, err := p.read()
 	if err != nil {
 		return 0, err
 	}
-	return int32(zed.DecodeInt(zv)), err
+	return zed.DecodeInt(zv), err
 }

--- a/zst/column/presence.go
+++ b/zst/column/presence.go
@@ -36,27 +36,30 @@ func (p *PresenceWriter) Finish() {
 	p.Write(p.run)
 }
 
-type Presence struct {
-	Int
+type PresenceReader struct {
+	IntReader
 	null bool
 	run  int
 }
 
-func NewPresence() *Presence {
+func NewPresence(i IntReader) *PresenceReader {
 	// We start out with null true so it is immediately flipped to
 	// false on the first call to Read.
-	return &Presence{null: true}
+	return &PresenceReader{
+		IntReader: i,
+		null:      true,
+	}
 }
 
-func (p *Presence) IsEmpty() bool {
+func (p *PresenceReader) IsEmpty() bool {
 	return len(p.segmap) == 0
 }
 
-func (p *Presence) Read() (bool, error) {
+func (p *PresenceReader) Read() (bool, error) {
 	run := p.run
 	for run == 0 {
 		p.null = !p.null
-		v, err := p.Int.Read()
+		v, err := p.IntReader.Read()
 		if err != nil {
 			return false, err
 		}

--- a/zst/column/segment.go
+++ b/zst/column/segment.go
@@ -23,9 +23,8 @@ var ErrCorruptSegment = errors.New("segmap value corrupt")
 
 func NewSegment(zv zcode.Bytes) Segment {
 	it := zv.Iter()
-	offset := zed.DecodeInt(it.Next())
 	return Segment{
-		Offset: offset,
+		Offset: zed.DecodeInt(it.Next()),
 		Length: zed.DecodeInt(it.Next()),
 	}
 }
@@ -47,8 +46,7 @@ func NewSegmap(in zed.Value) ([]Segment, error) {
 		return nil, errors.New("ZST object segmap element not a record[offset:int64,length:int32]")
 	}
 	var s []Segment
-	it := in.Bytes.Iter()
-	for !it.Done() {
+	for it := in.Bytes.Iter(); !it.Done(); {
 		s = append(s, NewSegment(it.Next()))
 	}
 	return s, nil

--- a/zst/column/segment.go
+++ b/zst/column/segment.go
@@ -21,37 +21,35 @@ func (s Segment) NewSectionReader(r io.ReaderAt) io.Reader {
 
 var ErrCorruptSegment = errors.New("segmap value corrupt")
 
-func UnmarshalSegment(zv zcode.Bytes, s *Segment) error {
+func NewSegment(zv zcode.Bytes) Segment {
 	it := zv.Iter()
-	s.Offset = zed.DecodeInt(it.Next())
-	s.Length = zed.DecodeInt(it.Next())
-	return nil
+	offset := zed.DecodeInt(it.Next())
+	return Segment{
+		Offset: offset,
+		Length: zed.DecodeInt(it.Next()),
+	}
 }
 
 func checkSegType(col zed.Column, which string, typ zed.Type) bool {
 	return col.Name == which && col.Type == typ
 }
 
-func UnmarshalSegmap(in zed.Value, s *[]Segment) error {
+func NewSegmap(in zed.Value) ([]Segment, error) {
 	typ, ok := in.Type.(*zed.TypeArray)
 	if !ok {
-		return errors.New("ZST object segmap not an array")
+		return nil, errors.New("ZST object segmap not an array")
 	}
 	segType, ok := typ.Type.(*zed.TypeRecord)
 	if !ok {
-		return errors.New("ZST object segmap element not a record")
+		return nil, errors.New("ZST object segmap element not a record")
 	}
 	if len(segType.Columns) != 2 || !checkSegType(segType.Columns[0], "offset", zed.TypeInt64) || !checkSegType(segType.Columns[1], "length", zed.TypeInt32) {
-		return errors.New("ZST object segmap element not a record[offset:int64,length:int32]")
+		return nil, errors.New("ZST object segmap element not a record[offset:int64,length:int32]")
 	}
-	*s = []Segment{}
+	var s []Segment
 	it := in.Bytes.Iter()
 	for !it.Done() {
-		var segment Segment
-		if err := UnmarshalSegment(it.Next(), &segment); err != nil {
-			return err
-		}
-		*s = append(*s, segment)
+		s = append(s, NewSegment(it.Next()))
 	}
-	return nil
+	return s, nil
 }

--- a/zst/object.go
+++ b/zst/object.go
@@ -1,16 +1,12 @@
-// Package zst implements reading and writing zst storage objects
-// to and from zng row format.  The zst storage format consists of
-// a section of column data stored in zng values followed by a section
-// containing a zng record stream comprised of N zng "reassembly records"
-// (one for each zed.TypeRecord or "schema") stored in the zst object, plus
-// an N+1st zng record describing the list of schemas IDs of the original
-// zng rows that were encoded into the zst object.
+// Package zst implements reading and writing ZST storage objects
+// to and from any Zed format.  The ZST storage format is described
+// at https://github.com/brimdata/zed/blob/main/docs/data-model/zst.md.
 //
-// A zst storage object must be seekable (e.g., a local file or s3 object),
-// so, unlike zng, streaming of zst objects is not supported.
+// A ZST storage object must be seekable (e.g., a local file or s3 object),
+// so, unlike ZNG, streaming of ZST objects is not supported.
 //
 // The zst/column package handles reading and writing row data to columns,
-// while the zst package comprises the API used to read and write zst objects.
+// while the zst package comprises the API used to read and write ZST objects.
 //
 // An Object provides the interface to the underlying storage object.
 // To generate rows or cuts (and in the future more sophisticated traversals

--- a/zst/object.go
+++ b/zst/object.go
@@ -1,8 +1,8 @@
-// Package zst implements reading and writing ZST storage objects
+// Package zst implements the reading and writing of ZST storage objects
 // to and from any Zed format.  The ZST storage format is described
 // at https://github.com/brimdata/zed/blob/main/docs/data-model/zst.md.
 //
-// A ZST storage object must be seekable (e.g., a local file or s3 object),
+// A ZST storage object must be seekable (e.g., a local file or S3 object),
 // so, unlike ZNG, streaming of ZST objects is not supported.
 //
 // The zst/column package handles reading and writing row data to columns,

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -177,7 +177,7 @@ func (w *Writer) finalize() error {
 	}
 	// Next, we write the root reassembly map.
 	var b zcode.Builder
-	typ, err := w.root.MarshalZNG(w.zctx, &b)
+	typ, err := w.root.EncodeMap(w.zctx, &b)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func (w *Writer) finalize() error {
 	// for that type.
 	for _, col := range w.columns {
 		b.Reset()
-		typ, err := col.MarshalZNG(w.zctx, &b)
+		typ, err := col.EncodeMap(w.zctx, &b)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit updates the the zst and column packages to use
customary Go programming and naming patterns.  Mistakes were
made and readability is now improved.