### PR TITLE
add scoping of "this" to Zed language

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -269,6 +269,7 @@ type (
 	Over struct {
 		Kind  string      `json:"kind" unpack:""`
 		Exprs []Expr      `json:"exprs"`
+		As    string      `json:"as"`
 		Scope *Sequential `json:"scope"`
 	}
 	Let struct {

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -726,29 +726,35 @@ function peg$parse(input, options) {
       peg$c253 = function(field) {
       	  return {"kind":"Merge", "field":field}
           },
-      peg$c254 = "over",
-      peg$c255 = peg$literalExpectation("over", true),
-      peg$c256 = function(exprs) {
-            return {"kind":"Over", "exprs":exprs, "scope":null}
+      peg$c254 = function(over) {
+            return {"kind":"Let", "locals":null, "over":over}
           },
-      peg$c257 = function(exprs, scope) {
-            return {"kind":"Over", "exprs":exprs, "scope":scope}
+      peg$c255 = "over",
+      peg$c256 = peg$literalExpectation("over", true),
+      peg$c257 = function(exprs) {
+            return {"kind":"Over", "exprs":exprs, "scope":null, "as":""}
           },
-      peg$c258 = "let",
-      peg$c259 = peg$literalExpectation("let", true),
-      peg$c260 = function(locals, over) {
+      peg$c258 = function(exprs, as, scope) {
+            return {"kind":"Over", "exprs":exprs, "scope":scope, "as":as}
+          },
+      peg$c259 = "as",
+      peg$c260 = peg$literalExpectation("as", false),
+      peg$c261 = function() { return "" },
+      peg$c262 = "let",
+      peg$c263 = peg$literalExpectation("let", true),
+      peg$c264 = function(locals, over) {
             return {"kind":"Let", "locals":locals, "over":over}
           },
-      peg$c261 = function(seq) { return seq },
-      peg$c262 = function(first, a) { return a },
-      peg$c263 = "yield",
-      peg$c264 = peg$literalExpectation("yield", true),
-      peg$c265 = function(exprs) {
+      peg$c265 = function(seq) { return seq },
+      peg$c266 = function(first, a) { return a },
+      peg$c267 = "yield",
+      peg$c268 = peg$literalExpectation("yield", true),
+      peg$c269 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c266 = function(typ) { return typ},
-      peg$c267 = function(lhs) { return lhs },
-      peg$c269 = function(first, rest) {
+      peg$c270 = function(typ) { return typ},
+      peg$c271 = function(lhs) { return lhs },
+      peg$c273 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -757,53 +763,53 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c270 = function(first, rest) {
+      peg$c274 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c271 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c272 = "?",
-      peg$c273 = peg$literalExpectation("?", false),
-      peg$c274 = function(condition, thenClause, elseClause) {
+      peg$c275 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c276 = "?",
+      peg$c277 = peg$literalExpectation("?", false),
+      peg$c278 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c275 = function(first, op, expr) { return [op, expr] },
-      peg$c276 = function(first, rest) {
+      peg$c279 = function(first, op, expr) { return [op, expr] },
+      peg$c280 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c277 = function(first, comp, expr) { return [comp, expr] },
-      peg$c278 = function() { return "="},
-      peg$c279 = "+",
-      peg$c280 = peg$literalExpectation("+", false),
-      peg$c281 = "-",
-      peg$c282 = peg$literalExpectation("-", false),
-      peg$c283 = "/",
-      peg$c284 = peg$literalExpectation("/", false),
-      peg$c285 = "%",
-      peg$c286 = peg$literalExpectation("%", false),
-      peg$c287 = function(e) {
+      peg$c281 = function(first, comp, expr) { return [comp, expr] },
+      peg$c282 = function() { return "="},
+      peg$c283 = "+",
+      peg$c284 = peg$literalExpectation("+", false),
+      peg$c285 = "-",
+      peg$c286 = peg$literalExpectation("-", false),
+      peg$c287 = "/",
+      peg$c288 = peg$literalExpectation("/", false),
+      peg$c289 = "%",
+      peg$c290 = peg$literalExpectation("%", false),
+      peg$c291 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c288 = "not",
-      peg$c289 = peg$literalExpectation("not", false),
-      peg$c290 = "search",
-      peg$c291 = peg$literalExpectation("search", false),
-      peg$c292 = "select",
-      peg$c293 = peg$literalExpectation("select", false),
-      peg$c294 = function(typ, expr) {
+      peg$c292 = "not",
+      peg$c293 = peg$literalExpectation("not", false),
+      peg$c294 = "search",
+      peg$c295 = peg$literalExpectation("search", false),
+      peg$c296 = "select",
+      peg$c297 = peg$literalExpectation("select", false),
+      peg$c298 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c295 = function(fn, args, where) {
+      peg$c299 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c296 = function(first, e) { return e },
-      peg$c297 = function(e) { return e },
-      peg$c298 = function() {
+      peg$c300 = function(first, e) { return e },
+      peg$c301 = function(e) { return e },
+      peg$c302 = function() {
             return {"kind":"ID","name":"this"}
           },
-      peg$c299 = "this",
-      peg$c300 = peg$literalExpectation("this", false),
-      peg$c301 = function() { return {"kind":"ID","name":"this"} },
-      peg$c302 = function(field) {
+      peg$c303 = "this",
+      peg$c304 = peg$literalExpectation("this", false),
+      peg$c305 = function() { return {"kind":"ID","name":"this"} },
+      peg$c306 = function(field) {
             return {"kind": "BinaryExpr", "op":".",
                            
             "lhs":{"kind":"ID","name":"this"},
@@ -812,9 +818,9 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c303 = "]",
-      peg$c304 = peg$literalExpectation("]", false),
-      peg$c305 = function(expr) {
+      peg$c307 = "]",
+      peg$c308 = peg$literalExpectation("]", false),
+      peg$c309 = function(expr) {
             return {"kind": "BinaryExpr", "op":"[",
                            
             "lhs":{"kind":"ID","name":"this"},
@@ -823,55 +829,55 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c306 = function(from, to) {
+      peg$c310 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c307 = function(to) {
+      peg$c311 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c308 = function(from) {
+      peg$c312 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c309 = function(expr) { return ["[", expr] },
-      peg$c310 = function(id) { return [".", id] },
-      peg$c311 = "}",
-      peg$c312 = peg$literalExpectation("}", false),
-      peg$c313 = function(fields) {
+      peg$c313 = function(expr) { return ["[", expr] },
+      peg$c314 = function(id) { return [".", id] },
+      peg$c315 = "}",
+      peg$c316 = peg$literalExpectation("}", false),
+      peg$c317 = function(fields) {
             return {"kind":"RecordExpr", "fields":fields }
           },
-      peg$c314 = function(name, value) {
+      peg$c318 = function(name, value) {
             return {"name": name, "value": value}
           },
-      peg$c315 = function(exprs) {
+      peg$c319 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c316 = "|[",
-      peg$c317 = peg$literalExpectation("|[", false),
-      peg$c318 = "]|",
-      peg$c319 = peg$literalExpectation("]|", false),
-      peg$c320 = function(exprs) {
+      peg$c320 = "|[",
+      peg$c321 = peg$literalExpectation("|[", false),
+      peg$c322 = "]|",
+      peg$c323 = peg$literalExpectation("]|", false),
+      peg$c324 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c321 = "|{",
-      peg$c322 = peg$literalExpectation("|{", false),
-      peg$c323 = "}|",
-      peg$c324 = peg$literalExpectation("}|", false),
-      peg$c325 = function(exprs) {
+      peg$c325 = "|{",
+      peg$c326 = peg$literalExpectation("|{", false),
+      peg$c327 = "}|",
+      peg$c328 = peg$literalExpectation("}|", false),
+      peg$c329 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c326 = function(key, value) {
+      peg$c330 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c327 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c331 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -893,13 +899,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c328 = function(assignments) { return assignments },
-      peg$c329 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c330 = function(table, alias) {
+      peg$c332 = function(assignments) { return assignments },
+      peg$c333 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c334 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c331 = function(first, join) { return join },
-      peg$c332 = function(style, table, alias, leftKey, rightKey) {
+      peg$c335 = function(first, join) { return join },
+      peg$c336 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -917,284 +923,283 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c333 = function(style) { return style },
-      peg$c334 = function(keys, order) {
+      peg$c337 = function(style) { return style },
+      peg$c338 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c335 = function(dir) { return dir },
-      peg$c336 = function(count) { return count },
-      peg$c337 = peg$literalExpectation("select", true),
-      peg$c338 = function() { return "select" },
-      peg$c339 = "as",
-      peg$c340 = peg$literalExpectation("as", true),
-      peg$c341 = function() { return "as" },
-      peg$c342 = function() { return "from" },
-      peg$c343 = function() { return "join" },
-      peg$c344 = peg$literalExpectation("where", true),
-      peg$c345 = function() { return "where" },
-      peg$c346 = "group",
-      peg$c347 = peg$literalExpectation("group", true),
-      peg$c348 = function() { return "group" },
-      peg$c349 = "having",
-      peg$c350 = peg$literalExpectation("having", true),
-      peg$c351 = function() { return "having" },
-      peg$c352 = function() { return "order" },
-      peg$c353 = "on",
-      peg$c354 = peg$literalExpectation("on", true),
-      peg$c355 = function() { return "on" },
-      peg$c356 = "limit",
-      peg$c357 = peg$literalExpectation("limit", true),
-      peg$c358 = function() { return "limit" },
-      peg$c359 = function(v) {
+      peg$c339 = function(dir) { return dir },
+      peg$c340 = function(count) { return count },
+      peg$c341 = peg$literalExpectation("select", true),
+      peg$c342 = function() { return "select" },
+      peg$c343 = peg$literalExpectation("as", true),
+      peg$c344 = function() { return "as" },
+      peg$c345 = function() { return "from" },
+      peg$c346 = function() { return "join" },
+      peg$c347 = peg$literalExpectation("where", true),
+      peg$c348 = function() { return "where" },
+      peg$c349 = "group",
+      peg$c350 = peg$literalExpectation("group", true),
+      peg$c351 = function() { return "group" },
+      peg$c352 = "having",
+      peg$c353 = peg$literalExpectation("having", true),
+      peg$c354 = function() { return "having" },
+      peg$c355 = function() { return "order" },
+      peg$c356 = "on",
+      peg$c357 = peg$literalExpectation("on", true),
+      peg$c358 = function() { return "on" },
+      peg$c359 = "limit",
+      peg$c360 = peg$literalExpectation("limit", true),
+      peg$c361 = function() { return "limit" },
+      peg$c362 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c360 = function(v) {
+      peg$c363 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c361 = function(v) {
+      peg$c364 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c362 = function(v) {
+      peg$c365 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c363 = "true",
-      peg$c364 = peg$literalExpectation("true", false),
-      peg$c365 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c366 = "false",
-      peg$c367 = peg$literalExpectation("false", false),
-      peg$c368 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c369 = "null",
-      peg$c370 = peg$literalExpectation("null", false),
-      peg$c371 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c372 = "0x",
-      peg$c373 = peg$literalExpectation("0x", false),
-      peg$c374 = function() {
+      peg$c366 = "true",
+      peg$c367 = peg$literalExpectation("true", false),
+      peg$c368 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c369 = "false",
+      peg$c370 = peg$literalExpectation("false", false),
+      peg$c371 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c372 = "null",
+      peg$c373 = peg$literalExpectation("null", false),
+      peg$c374 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c375 = "0x",
+      peg$c376 = peg$literalExpectation("0x", false),
+      peg$c377 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c375 = function(typ) {
+      peg$c378 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c376 = function(name) { return name },
-      peg$c377 = function(name, typ) {
+      peg$c379 = function(name) { return name },
+      peg$c380 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c378 = function(name) {
+      peg$c381 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c379 = function(u) { return u },
-      peg$c380 = function(types) {
+      peg$c382 = function(u) { return u },
+      peg$c383 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c381 = function(typ) { return typ },
-      peg$c382 = function(fields) {
+      peg$c384 = function(typ) { return typ },
+      peg$c385 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c383 = function(typ) {
+      peg$c386 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c384 = function(typ) {
+      peg$c387 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c385 = function(keyType, valType) {
+      peg$c388 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c386 = function(v) {
+      peg$c389 = function(v) {
             if (!v) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c387 = "\"",
-      peg$c388 = peg$literalExpectation("\"", false),
-      peg$c389 = "'",
-      peg$c390 = peg$literalExpectation("'", false),
-      peg$c391 = function(v) {
+      peg$c390 = "\"",
+      peg$c391 = peg$literalExpectation("\"", false),
+      peg$c392 = "'",
+      peg$c393 = peg$literalExpectation("'", false),
+      peg$c394 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c392 = "\\",
-      peg$c393 = peg$literalExpectation("\\", false),
-      peg$c394 = "${",
-      peg$c395 = peg$literalExpectation("${", false),
-      peg$c396 = "uint8",
-      peg$c397 = peg$literalExpectation("uint8", false),
-      peg$c398 = "uint16",
-      peg$c399 = peg$literalExpectation("uint16", false),
-      peg$c400 = "uint32",
-      peg$c401 = peg$literalExpectation("uint32", false),
-      peg$c402 = "uint64",
-      peg$c403 = peg$literalExpectation("uint64", false),
-      peg$c404 = "int8",
-      peg$c405 = peg$literalExpectation("int8", false),
-      peg$c406 = "int16",
-      peg$c407 = peg$literalExpectation("int16", false),
-      peg$c408 = "int32",
-      peg$c409 = peg$literalExpectation("int32", false),
-      peg$c410 = "int64",
-      peg$c411 = peg$literalExpectation("int64", false),
-      peg$c412 = "float32",
-      peg$c413 = peg$literalExpectation("float32", false),
-      peg$c414 = "float64",
-      peg$c415 = peg$literalExpectation("float64", false),
-      peg$c416 = "bool",
-      peg$c417 = peg$literalExpectation("bool", false),
-      peg$c418 = "string",
-      peg$c419 = peg$literalExpectation("string", false),
-      peg$c420 = "duration",
-      peg$c421 = peg$literalExpectation("duration", false),
-      peg$c422 = "time",
-      peg$c423 = peg$literalExpectation("time", false),
-      peg$c424 = "bytes",
-      peg$c425 = peg$literalExpectation("bytes", false),
-      peg$c426 = "ip",
-      peg$c427 = peg$literalExpectation("ip", false),
-      peg$c428 = "net",
-      peg$c429 = peg$literalExpectation("net", false),
-      peg$c430 = "error",
-      peg$c431 = peg$literalExpectation("error", false),
-      peg$c432 = function() {
+      peg$c395 = "\\",
+      peg$c396 = peg$literalExpectation("\\", false),
+      peg$c397 = "${",
+      peg$c398 = peg$literalExpectation("${", false),
+      peg$c399 = "uint8",
+      peg$c400 = peg$literalExpectation("uint8", false),
+      peg$c401 = "uint16",
+      peg$c402 = peg$literalExpectation("uint16", false),
+      peg$c403 = "uint32",
+      peg$c404 = peg$literalExpectation("uint32", false),
+      peg$c405 = "uint64",
+      peg$c406 = peg$literalExpectation("uint64", false),
+      peg$c407 = "int8",
+      peg$c408 = peg$literalExpectation("int8", false),
+      peg$c409 = "int16",
+      peg$c410 = peg$literalExpectation("int16", false),
+      peg$c411 = "int32",
+      peg$c412 = peg$literalExpectation("int32", false),
+      peg$c413 = "int64",
+      peg$c414 = peg$literalExpectation("int64", false),
+      peg$c415 = "float32",
+      peg$c416 = peg$literalExpectation("float32", false),
+      peg$c417 = "float64",
+      peg$c418 = peg$literalExpectation("float64", false),
+      peg$c419 = "bool",
+      peg$c420 = peg$literalExpectation("bool", false),
+      peg$c421 = "string",
+      peg$c422 = peg$literalExpectation("string", false),
+      peg$c423 = "duration",
+      peg$c424 = peg$literalExpectation("duration", false),
+      peg$c425 = "time",
+      peg$c426 = peg$literalExpectation("time", false),
+      peg$c427 = "bytes",
+      peg$c428 = peg$literalExpectation("bytes", false),
+      peg$c429 = "ip",
+      peg$c430 = peg$literalExpectation("ip", false),
+      peg$c431 = "net",
+      peg$c432 = peg$literalExpectation("net", false),
+      peg$c433 = "error",
+      peg$c434 = peg$literalExpectation("error", false),
+      peg$c435 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c433 = function(name, typ) {
+      peg$c436 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c434 = "and",
-      peg$c435 = peg$literalExpectation("and", true),
-      peg$c436 = function() { return "and" },
-      peg$c437 = "or",
-      peg$c438 = peg$literalExpectation("or", true),
-      peg$c439 = function() { return "or" },
-      peg$c442 = peg$literalExpectation("not", true),
-      peg$c443 = function() { return "not" },
-      peg$c444 = "by",
-      peg$c445 = peg$literalExpectation("by", true),
-      peg$c446 = function() { return "by" },
-      peg$c447 = /^[A-Za-z_$]/,
-      peg$c448 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c449 = /^[0-9]/,
-      peg$c450 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c451 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c452 = "$",
-      peg$c453 = peg$literalExpectation("$", false),
-      peg$c454 = "T",
-      peg$c455 = peg$literalExpectation("T", false),
-      peg$c456 = function() {
+      peg$c437 = "and",
+      peg$c438 = peg$literalExpectation("and", true),
+      peg$c439 = function() { return "and" },
+      peg$c440 = "or",
+      peg$c441 = peg$literalExpectation("or", true),
+      peg$c442 = function() { return "or" },
+      peg$c445 = peg$literalExpectation("not", true),
+      peg$c446 = function() { return "not" },
+      peg$c447 = "by",
+      peg$c448 = peg$literalExpectation("by", true),
+      peg$c449 = function() { return "by" },
+      peg$c450 = /^[A-Za-z_$]/,
+      peg$c451 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c452 = /^[0-9]/,
+      peg$c453 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c454 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c455 = "$",
+      peg$c456 = peg$literalExpectation("$", false),
+      peg$c457 = "T",
+      peg$c458 = peg$literalExpectation("T", false),
+      peg$c459 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c457 = "Z",
-      peg$c458 = peg$literalExpectation("Z", false),
-      peg$c459 = function() {
+      peg$c460 = "Z",
+      peg$c461 = peg$literalExpectation("Z", false),
+      peg$c462 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c460 = "ns",
-      peg$c461 = peg$literalExpectation("ns", true),
-      peg$c462 = "us",
-      peg$c463 = peg$literalExpectation("us", true),
-      peg$c464 = "ms",
-      peg$c465 = peg$literalExpectation("ms", true),
-      peg$c466 = "s",
-      peg$c467 = peg$literalExpectation("s", true),
-      peg$c468 = "m",
-      peg$c469 = peg$literalExpectation("m", true),
-      peg$c470 = "h",
-      peg$c471 = peg$literalExpectation("h", true),
-      peg$c472 = "d",
-      peg$c473 = peg$literalExpectation("d", true),
-      peg$c474 = "w",
-      peg$c475 = peg$literalExpectation("w", true),
-      peg$c476 = "y",
-      peg$c477 = peg$literalExpectation("y", true),
-      peg$c478 = function(a, b) {
+      peg$c463 = "ns",
+      peg$c464 = peg$literalExpectation("ns", true),
+      peg$c465 = "us",
+      peg$c466 = peg$literalExpectation("us", true),
+      peg$c467 = "ms",
+      peg$c468 = peg$literalExpectation("ms", true),
+      peg$c469 = "s",
+      peg$c470 = peg$literalExpectation("s", true),
+      peg$c471 = "m",
+      peg$c472 = peg$literalExpectation("m", true),
+      peg$c473 = "h",
+      peg$c474 = peg$literalExpectation("h", true),
+      peg$c475 = "d",
+      peg$c476 = peg$literalExpectation("d", true),
+      peg$c477 = "w",
+      peg$c478 = peg$literalExpectation("w", true),
+      peg$c479 = "y",
+      peg$c480 = peg$literalExpectation("y", true),
+      peg$c481 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c479 = "::",
-      peg$c480 = peg$literalExpectation("::", false),
-      peg$c481 = function(a, b, d, e) {
+      peg$c482 = "::",
+      peg$c483 = peg$literalExpectation("::", false),
+      peg$c484 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c482 = function(a, b) {
+      peg$c485 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c483 = function(a, b) {
+      peg$c486 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c484 = function() {
+      peg$c487 = function() {
             return "::"
           },
-      peg$c485 = function(v) { return ":" + v },
-      peg$c486 = function(v) { return v + ":" },
-      peg$c487 = function(a, m) {
+      peg$c488 = function(v) { return ":" + v },
+      peg$c489 = function(v) { return v + ":" },
+      peg$c490 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c488 = function(a, m) {
+      peg$c491 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c489 = function(s) { return parseInt(s) },
-      peg$c490 = function() {
+      peg$c492 = function(s) { return parseInt(s) },
+      peg$c493 = function() {
             return text()
           },
-      peg$c491 = "e",
-      peg$c492 = peg$literalExpectation("e", true),
-      peg$c493 = /^[+\-]/,
-      peg$c494 = peg$classExpectation(["+", "-"], false, false),
-      peg$c495 = /^[0-9a-fA-F]/,
-      peg$c496 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c497 = function(v) { return joinChars(v) },
-      peg$c498 = peg$anyExpectation(),
-      peg$c499 = function(head, tail) { return head + joinChars(tail) },
-      peg$c500 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c501 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c502 = function(head, tail) {
+      peg$c494 = "e",
+      peg$c495 = peg$literalExpectation("e", true),
+      peg$c496 = /^[+\-]/,
+      peg$c497 = peg$classExpectation(["+", "-"], false, false),
+      peg$c498 = /^[0-9a-fA-F]/,
+      peg$c499 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c500 = function(v) { return joinChars(v) },
+      peg$c501 = peg$anyExpectation(),
+      peg$c502 = function(head, tail) { return head + joinChars(tail) },
+      peg$c503 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c504 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c505 = function(head, tail) {
             return reglob$1.Reglob(head + joinChars(tail))
           },
-      peg$c503 = function() { return "*"},
-      peg$c504 = function() { return "=" },
-      peg$c505 = function() { return "\\*" },
-      peg$c506 = "b",
-      peg$c507 = peg$literalExpectation("b", false),
-      peg$c508 = function() { return "\b" },
-      peg$c509 = "f",
-      peg$c510 = peg$literalExpectation("f", false),
-      peg$c511 = function() { return "\f" },
-      peg$c512 = "n",
-      peg$c513 = peg$literalExpectation("n", false),
-      peg$c514 = function() { return "\n" },
-      peg$c515 = "r",
-      peg$c516 = peg$literalExpectation("r", false),
-      peg$c517 = function() { return "\r" },
-      peg$c518 = "t",
-      peg$c519 = peg$literalExpectation("t", false),
-      peg$c520 = function() { return "\t" },
-      peg$c521 = "v",
-      peg$c522 = peg$literalExpectation("v", false),
-      peg$c523 = function() { return "\v" },
-      peg$c524 = function() { return "*" },
-      peg$c525 = "u",
-      peg$c526 = peg$literalExpectation("u", false),
-      peg$c527 = function(chars) {
+      peg$c506 = function() { return "*"},
+      peg$c507 = function() { return "=" },
+      peg$c508 = function() { return "\\*" },
+      peg$c509 = "b",
+      peg$c510 = peg$literalExpectation("b", false),
+      peg$c511 = function() { return "\b" },
+      peg$c512 = "f",
+      peg$c513 = peg$literalExpectation("f", false),
+      peg$c514 = function() { return "\f" },
+      peg$c515 = "n",
+      peg$c516 = peg$literalExpectation("n", false),
+      peg$c517 = function() { return "\n" },
+      peg$c518 = "r",
+      peg$c519 = peg$literalExpectation("r", false),
+      peg$c520 = function() { return "\r" },
+      peg$c521 = "t",
+      peg$c522 = peg$literalExpectation("t", false),
+      peg$c523 = function() { return "\t" },
+      peg$c524 = "v",
+      peg$c525 = peg$literalExpectation("v", false),
+      peg$c526 = function() { return "\v" },
+      peg$c527 = function() { return "*" },
+      peg$c528 = "u",
+      peg$c529 = peg$literalExpectation("u", false),
+      peg$c530 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c528 = /^[^\/\\]/,
-      peg$c529 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c530 = /^[\0-\x1F\\]/,
-      peg$c531 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c532 = peg$otherExpectation("whitespace"),
-      peg$c533 = "\t",
-      peg$c534 = peg$literalExpectation("\t", false),
-      peg$c535 = "\x0B",
-      peg$c536 = peg$literalExpectation("\x0B", false),
-      peg$c537 = "\f",
-      peg$c538 = peg$literalExpectation("\f", false),
-      peg$c539 = " ",
-      peg$c540 = peg$literalExpectation(" ", false),
-      peg$c541 = "\xA0",
-      peg$c542 = peg$literalExpectation("\xA0", false),
-      peg$c543 = "\uFEFF",
-      peg$c544 = peg$literalExpectation("\uFEFF", false),
-      peg$c545 = /^[\n\r\u2028\u2029]/,
-      peg$c546 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c547 = peg$otherExpectation("comment"),
-      peg$c552 = "//",
-      peg$c553 = peg$literalExpectation("//", false),
+      peg$c531 = /^[^\/\\]/,
+      peg$c532 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c533 = /^[\0-\x1F\\]/,
+      peg$c534 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c535 = peg$otherExpectation("whitespace"),
+      peg$c536 = "\t",
+      peg$c537 = peg$literalExpectation("\t", false),
+      peg$c538 = "\x0B",
+      peg$c539 = peg$literalExpectation("\x0B", false),
+      peg$c540 = "\f",
+      peg$c541 = peg$literalExpectation("\f", false),
+      peg$c542 = " ",
+      peg$c543 = peg$literalExpectation(" ", false),
+      peg$c544 = "\xA0",
+      peg$c545 = peg$literalExpectation("\xA0", false),
+      peg$c546 = "\uFEFF",
+      peg$c547 = peg$literalExpectation("\uFEFF", false),
+      peg$c548 = /^[\n\r\u2028\u2029]/,
+      peg$c549 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c550 = peg$otherExpectation("comment"),
+      peg$c555 = "//",
+      peg$c556 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -6010,15 +6015,21 @@ function peg$parse(input, options) {
   function peg$parseOverProc() {
     var s0, s1, s2, s3;
 
-    s0 = peg$parseScopedOver();
+    s0 = peg$currPos;
+    s1 = peg$parseScopedOver();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c254(s1);
+    }
+    s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c254) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c255) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c255); }
+        if (peg$silentFails === 0) { peg$fail(peg$c256); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6026,7 +6037,7 @@ function peg$parse(input, options) {
           s3 = peg$parseExprs();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c256(s3);
+            s1 = peg$c257(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6046,28 +6057,34 @@ function peg$parse(input, options) {
   }
 
   function peg$parseScopedOver() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c254) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c255) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          s4 = peg$parseAs();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseScope();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c257(s3, s5);
-              s0 = s1;
+              s6 = peg$parseScope();
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c258(s3, s4, s6);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -6092,16 +6109,66 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseAs() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c259) {
+        s2 = peg$c259;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c260); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseIdentifierName();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c214(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$c99;
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c261();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
   function peg$parseLetProc() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c258) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c262) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c259); }
+      if (peg$silentFails === 0) { peg$fail(peg$c263); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6113,7 +6180,7 @@ function peg$parse(input, options) {
             s5 = peg$parseScopedOver();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c260(s3, s5);
+              s1 = peg$c264(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6176,7 +6243,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c261(s5);
+                  s1 = peg$c265(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6233,7 +6300,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLetAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c262(s1, s7);
+              s4 = peg$c266(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6269,7 +6336,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLetAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c262(s1, s7);
+                s4 = peg$c266(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6355,12 +6422,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c263) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c267) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6368,7 +6435,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c265(s3);
+          s1 = peg$c269(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6399,7 +6466,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c266(s4);
+            s1 = peg$c270(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6434,7 +6501,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c267(s4);
+            s1 = peg$c271(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6534,7 +6601,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c269(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6571,7 +6638,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c262(s1, s7);
+              s4 = peg$c266(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6607,7 +6674,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c262(s1, s7);
+                s4 = peg$c266(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6628,7 +6695,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6663,7 +6730,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c271(s1, s5);
+              s1 = peg$c275(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6706,11 +6773,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c272;
+          s3 = peg$c276;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6732,7 +6799,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c274(s1, s5, s9);
+                      s1 = peg$c278(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6794,7 +6861,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6824,7 +6891,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6845,7 +6912,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6876,7 +6943,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6906,7 +6973,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6927,7 +6994,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6960,7 +7027,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c277(s1, s5, s7);
+                s4 = peg$c281(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6990,7 +7057,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRelativeExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s3;
-                  s4 = peg$c277(s1, s5, s7);
+                  s4 = peg$c281(s1, s5, s7);
                   s3 = s4;
                 } else {
                   peg$currPos = s3;
@@ -7011,7 +7078,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c276(s1, s2);
+          s1 = peg$c280(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7039,7 +7106,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c278();
+      s1 = peg$c282();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7119,7 +7186,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7149,7 +7216,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7170,7 +7237,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7248,7 +7315,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7278,7 +7345,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7299,7 +7366,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7318,19 +7385,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c279;
+      s1 = peg$c283;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c281;
+        s1 = peg$c285;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7359,7 +7426,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7389,7 +7456,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7410,7 +7477,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7437,19 +7504,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c283;
+        s1 = peg$c287;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c285;
+          s1 = peg$c289;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c290); }
         }
       }
     }
@@ -7479,7 +7546,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c287(s3);
+          s1 = peg$c291(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7597,28 +7664,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c288) {
-      s0 = peg$c288;
+    if (input.substr(peg$currPos, 3) === peg$c292) {
+      s0 = peg$c292;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c289); }
+      if (peg$silentFails === 0) { peg$fail(peg$c293); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c290) {
-        s0 = peg$c290;
+      if (input.substr(peg$currPos, 6) === peg$c294) {
+        s0 = peg$c294;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c291); }
+        if (peg$silentFails === 0) { peg$fail(peg$c295); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c292) {
-          s0 = peg$c292;
+        if (input.substr(peg$currPos, 6) === peg$c296) {
+          s0 = peg$c296;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c293); }
+          if (peg$silentFails === 0) { peg$fail(peg$c297); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c11) {
@@ -7639,12 +7706,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c290) {
-      s1 = peg$c290;
+    if (input.substr(peg$currPos, 6) === peg$c294) {
+      s1 = peg$c294;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7725,7 +7792,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c294(s1, s5);
+                  s1 = peg$c298(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7806,7 +7873,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c295(s2, s6, s9);
+                      s1 = peg$c299(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7888,7 +7955,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c296(s1, s7);
+              s4 = peg$c300(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7924,7 +7991,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c296(s1, s7);
+                s4 = peg$c300(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7977,7 +8044,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExprPattern();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c297(s2);
+        s1 = peg$c301(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8070,7 +8137,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298();
+            s1 = peg$c302();
           }
           s0 = s1;
         }
@@ -8084,16 +8151,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c299) {
-      s1 = peg$c299;
+    if (input.substr(peg$currPos, 4) === peg$c303) {
+      s1 = peg$c303;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
+      if (peg$silentFails === 0) { peg$fail(peg$c304); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c301();
+      s1 = peg$c305();
     }
     s0 = s1;
 
@@ -8115,7 +8182,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c302(s2);
+        s1 = peg$c306(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8146,15 +8213,15 @@ function peg$parse(input, options) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c303;
+              s4 = peg$c307;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c304); }
+              if (peg$silentFails === 0) { peg$fail(peg$c308); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305(s3);
+              s1 = peg$c309(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8206,15 +8273,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c303;
+                  s7 = peg$c307;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c308); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c306(s2, s6);
+                  s1 = peg$c310(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8269,15 +8336,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c303;
+                  s6 = peg$c307;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c308); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c307(s5);
+                  s1 = peg$c311(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8328,15 +8395,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c303;
+                    s6 = peg$c307;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c308); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c308(s2);
+                    s1 = peg$c312(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8375,15 +8442,15 @@ function peg$parse(input, options) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c303;
+                s3 = peg$c307;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                if (peg$silentFails === 0) { peg$fail(peg$c308); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c309(s2);
+                s1 = peg$c313(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8427,7 +8494,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c310(s3);
+                  s1 = peg$c314(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8536,15 +8603,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c315;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313(s3);
+              s1 = peg$c317(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8584,7 +8651,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8669,7 +8736,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314(s1, s5);
+              s1 = peg$c318(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8714,15 +8781,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c303;
+              s5 = peg$c307;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c304); }
+              if (peg$silentFails === 0) { peg$fail(peg$c308); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s3);
+              s1 = peg$c319(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8752,12 +8819,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c316) {
-      s1 = peg$c316;
+    if (input.substr(peg$currPos, 2) === peg$c320) {
+      s1 = peg$c320;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c321); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8766,16 +8833,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c318) {
-              s5 = peg$c318;
+            if (input.substr(peg$currPos, 2) === peg$c322) {
+              s5 = peg$c322;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c319); }
+              if (peg$silentFails === 0) { peg$fail(peg$c323); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s3);
+              s1 = peg$c324(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8805,12 +8872,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c321) {
-      s1 = peg$c321;
+    if (input.substr(peg$currPos, 2) === peg$c325) {
+      s1 = peg$c325;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c326); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8819,16 +8886,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c323) {
-              s5 = peg$c323;
+            if (input.substr(peg$currPos, 2) === peg$c327) {
+              s5 = peg$c327;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c324); }
+              if (peg$silentFails === 0) { peg$fail(peg$c328); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c325(s3);
+              s1 = peg$c329(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8868,7 +8935,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8910,7 +8977,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c297(s4);
+            s1 = peg$c301(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8953,7 +9020,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c326(s1, s5);
+              s1 = peg$c330(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9018,7 +9085,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c327(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c331(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9096,7 +9163,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c328(s3);
+            s1 = peg$c332(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9130,7 +9197,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c329(s1, s5);
+              s1 = peg$c333(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9277,7 +9344,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s4, s5);
+              s1 = peg$c334(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9432,7 +9499,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c331(s1, s4);
+        s4 = peg$c335(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9441,7 +9508,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c331(s1, s4);
+          s4 = peg$c335(s1, s4);
         }
         s3 = s4;
       }
@@ -9503,7 +9570,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c332(s1, s5, s6, s10, s14);
+                                s1 = peg$c336(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9583,7 +9650,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s2);
+        s1 = peg$c337(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9742,7 +9809,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c334(s6, s7);
+                  s1 = peg$c338(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9788,7 +9855,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c335(s2);
+        s1 = peg$c339(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9824,7 +9891,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c336(s4);
+            s1 = peg$c340(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9859,16 +9926,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c292) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c296) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c337); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c338();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -9879,16 +9946,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c259) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -9908,7 +9975,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c345();
     }
     s0 = s1;
 
@@ -9928,7 +9995,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c343();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -9944,26 +10011,6 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c345();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseGROUP() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
@@ -9975,13 +10022,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseHAVING() {
+  function peg$parseGROUP() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c349) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c350); }
@@ -9989,6 +10036,26 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
       s1 = peg$c351();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseHAVING() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c352) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c354();
     }
     s0 = s1;
 
@@ -10008,7 +10075,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c352();
+      s1 = peg$c355();
     }
     s0 = s1;
 
@@ -10019,16 +10086,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c353) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c356) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c355();
+      s1 = peg$c358();
     }
     s0 = s1;
 
@@ -10039,16 +10106,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c356) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c359) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c358();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10266,7 +10333,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359(s1);
+        s1 = peg$c362(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10281,7 +10348,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359(s1);
+        s1 = peg$c362(s1);
       }
       s0 = s1;
     }
@@ -10307,7 +10374,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c360(s1);
+        s1 = peg$c363(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10322,7 +10389,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c360(s1);
+        s1 = peg$c363(s1);
       }
       s0 = s1;
     }
@@ -10337,7 +10404,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c361(s1);
+      s1 = peg$c364(s1);
     }
     s0 = s1;
 
@@ -10351,7 +10418,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362(s1);
+      s1 = peg$c365(s1);
     }
     s0 = s1;
 
@@ -10362,30 +10429,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c363) {
-      s1 = peg$c363;
+    if (input.substr(peg$currPos, 4) === peg$c366) {
+      s1 = peg$c366;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c365();
+      s1 = peg$c368();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c366) {
-        s1 = peg$c366;
+      if (input.substr(peg$currPos, 5) === peg$c369) {
+        s1 = peg$c369;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c367); }
+        if (peg$silentFails === 0) { peg$fail(peg$c370); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c368();
+        s1 = peg$c371();
       }
       s0 = s1;
     }
@@ -10397,16 +10464,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c369) {
-      s1 = peg$c369;
+    if (input.substr(peg$currPos, 4) === peg$c372) {
+      s1 = peg$c372;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c371();
+      s1 = peg$c374();
     }
     s0 = s1;
 
@@ -10417,12 +10484,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c372) {
-      s1 = peg$c372;
+    if (input.substr(peg$currPos, 2) === peg$c375) {
+      s1 = peg$c375;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c376); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10433,7 +10500,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c374();
+        s1 = peg$c377();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10470,7 +10537,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c375(s2);
+          s1 = peg$c378(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10531,7 +10598,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c379(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10580,7 +10647,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c377(s1, s7);
+                        s1 = peg$c380(s1, s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10623,7 +10690,7 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c378(s1);
+          s1 = peg$c381(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10649,7 +10716,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c379(s3);
+                  s1 = peg$c382(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10681,7 +10748,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c380(s1);
+      s1 = peg$c383(s1);
     }
     s0 = s1;
 
@@ -10706,7 +10773,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10739,7 +10806,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c381(s4);
+            s1 = peg$c384(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10780,15 +10847,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c315;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c382(s3);
+              s1 = peg$c385(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10827,15 +10894,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c303;
+                s5 = peg$c307;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                if (peg$silentFails === 0) { peg$fail(peg$c308); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c383(s3);
+                s1 = peg$c386(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10859,12 +10926,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c316) {
-          s1 = peg$c316;
+        if (input.substr(peg$currPos, 2) === peg$c320) {
+          s1 = peg$c320;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c317); }
+          if (peg$silentFails === 0) { peg$fail(peg$c321); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10873,16 +10940,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c318) {
-                  s5 = peg$c318;
+                if (input.substr(peg$currPos, 2) === peg$c322) {
+                  s5 = peg$c322;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c323); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c384(s3);
+                  s1 = peg$c387(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10906,12 +10973,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c321) {
-            s1 = peg$c321;
+          if (input.substr(peg$currPos, 2) === peg$c325) {
+            s1 = peg$c325;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c322); }
+            if (peg$silentFails === 0) { peg$fail(peg$c326); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10934,16 +11001,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c323) {
-                            s9 = peg$c323;
+                          if (input.substr(peg$currPos, 2) === peg$c327) {
+                            s9 = peg$c327;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c328); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c385(s3, s7);
+                            s1 = peg$c388(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10995,7 +11062,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c386(s1);
+      s1 = peg$c389(s1);
     }
     s0 = s1;
 
@@ -11007,11 +11074,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c387;
+      s1 = peg$c390;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11022,11 +11089,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c387;
+          s3 = peg$c390;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c388); }
+          if (peg$silentFails === 0) { peg$fail(peg$c391); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11047,11 +11114,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c389;
+        s1 = peg$c392;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+        if (peg$silentFails === 0) { peg$fail(peg$c393); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11062,11 +11129,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c389;
+            s3 = peg$c392;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c390); }
+            if (peg$silentFails === 0) { peg$fail(peg$c393); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11107,7 +11174,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391(s1);
+        s1 = peg$c394(s1);
       }
       s0 = s1;
     }
@@ -11120,19 +11187,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c392;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c394) {
-        s2 = peg$c394;
+      if (input.substr(peg$currPos, 2) === peg$c397) {
+        s2 = peg$c397;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c395); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11150,12 +11217,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c394) {
-        s2 = peg$c394;
+      if (input.substr(peg$currPos, 2) === peg$c397) {
+        s2 = peg$c397;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c395); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11201,7 +11268,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391(s1);
+        s1 = peg$c394(s1);
       }
       s0 = s1;
     }
@@ -11214,19 +11281,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c392;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c394) {
-        s2 = peg$c394;
+      if (input.substr(peg$currPos, 2) === peg$c397) {
+        s2 = peg$c397;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c395); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11244,12 +11311,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c394) {
-        s2 = peg$c394;
+      if (input.substr(peg$currPos, 2) === peg$c397) {
+        s2 = peg$c397;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c395); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11281,12 +11348,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c394) {
-      s1 = peg$c394;
+    if (input.substr(peg$currPos, 2) === peg$c397) {
+      s1 = peg$c397;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11296,15 +11363,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c315;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c297(s3);
+              s1 = peg$c301(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11334,140 +11401,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c396) {
-      s1 = peg$c396;
+    if (input.substr(peg$currPos, 5) === peg$c399) {
+      s1 = peg$c399;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c397); }
+      if (peg$silentFails === 0) { peg$fail(peg$c400); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c398) {
-        s1 = peg$c398;
+      if (input.substr(peg$currPos, 6) === peg$c401) {
+        s1 = peg$c401;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c399); }
+        if (peg$silentFails === 0) { peg$fail(peg$c402); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c400) {
-          s1 = peg$c400;
+        if (input.substr(peg$currPos, 6) === peg$c403) {
+          s1 = peg$c403;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c402) {
-            s1 = peg$c402;
+          if (input.substr(peg$currPos, 6) === peg$c405) {
+            s1 = peg$c405;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c406); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c404) {
-              s1 = peg$c404;
+            if (input.substr(peg$currPos, 4) === peg$c407) {
+              s1 = peg$c407;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c405); }
+              if (peg$silentFails === 0) { peg$fail(peg$c408); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c406) {
-                s1 = peg$c406;
+              if (input.substr(peg$currPos, 5) === peg$c409) {
+                s1 = peg$c409;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c407); }
+                if (peg$silentFails === 0) { peg$fail(peg$c410); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c408) {
-                  s1 = peg$c408;
+                if (input.substr(peg$currPos, 5) === peg$c411) {
+                  s1 = peg$c411;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c409); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c412); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c410) {
-                    s1 = peg$c410;
+                  if (input.substr(peg$currPos, 5) === peg$c413) {
+                    s1 = peg$c413;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c411); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c414); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c412) {
-                      s1 = peg$c412;
+                    if (input.substr(peg$currPos, 7) === peg$c415) {
+                      s1 = peg$c415;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c413); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c416); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c414) {
-                        s1 = peg$c414;
+                      if (input.substr(peg$currPos, 7) === peg$c417) {
+                        s1 = peg$c417;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c415); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c418); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c416) {
-                          s1 = peg$c416;
+                        if (input.substr(peg$currPos, 4) === peg$c419) {
+                          s1 = peg$c419;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c417); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c420); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c418) {
-                            s1 = peg$c418;
+                          if (input.substr(peg$currPos, 6) === peg$c421) {
+                            s1 = peg$c421;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c419); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c422); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c420) {
-                              s1 = peg$c420;
+                            if (input.substr(peg$currPos, 8) === peg$c423) {
+                              s1 = peg$c423;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c424); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c422) {
-                                s1 = peg$c422;
+                              if (input.substr(peg$currPos, 4) === peg$c425) {
+                                s1 = peg$c425;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c426); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c424) {
-                                  s1 = peg$c424;
+                                if (input.substr(peg$currPos, 5) === peg$c427) {
+                                  s1 = peg$c427;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c428); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c426) {
-                                    s1 = peg$c426;
+                                  if (input.substr(peg$currPos, 2) === peg$c429) {
+                                    s1 = peg$c429;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c427); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c430); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c428) {
-                                      s1 = peg$c428;
+                                    if (input.substr(peg$currPos, 3) === peg$c431) {
+                                      s1 = peg$c431;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c432); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c11) {
@@ -11478,20 +11545,20 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c12); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 5) === peg$c430) {
-                                          s1 = peg$c430;
+                                        if (input.substr(peg$currPos, 5) === peg$c433) {
+                                          s1 = peg$c433;
                                           peg$currPos += 5;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c434); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4) === peg$c369) {
-                                            s1 = peg$c369;
+                                          if (input.substr(peg$currPos, 4) === peg$c372) {
+                                            s1 = peg$c372;
                                             peg$currPos += 4;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c370); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c373); }
                                           }
                                         }
                                       }
@@ -11514,7 +11581,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c432();
+      s1 = peg$c435();
     }
     s0 = s1;
 
@@ -11535,7 +11602,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11568,7 +11635,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c381(s4);
+            s1 = peg$c384(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11611,7 +11678,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c433(s1, s5);
+              s1 = peg$c436(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11652,47 +11719,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c434) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c437) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c435); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c436();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseOrToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c437) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c438); }
@@ -11724,16 +11753,16 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseNotToken() {
+  function peg$parseOrToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c288) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c440) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+      if (peg$silentFails === 0) { peg$fail(peg$c441); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11748,7 +11777,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c443();
+        s1 = peg$c442();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11762,13 +11791,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseByToken() {
+  function peg$parseNotToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c444) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c292) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c445); }
@@ -11800,15 +11829,53 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseByToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c447) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c448); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c449();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c447.test(input.charAt(peg$currPos))) {
+    if (peg$c450.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c448); }
+      if (peg$silentFails === 0) { peg$fail(peg$c451); }
     }
 
     return s0;
@@ -11819,12 +11886,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
     }
 
@@ -11838,7 +11905,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c451(s1);
+      s1 = peg$c454(s1);
     }
     s0 = s1;
 
@@ -11910,11 +11977,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c452;
+        s1 = peg$c455;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c453); }
+        if (peg$silentFails === 0) { peg$fail(peg$c456); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11924,11 +11991,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c392;
+          s1 = peg$c395;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+          if (peg$silentFails === 0) { peg$fail(peg$c396); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12030,17 +12097,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c454;
+        s2 = peg$c457;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c455); }
+        if (peg$silentFails === 0) { peg$fail(peg$c458); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c456();
+          s1 = peg$c459();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12065,21 +12132,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c281;
+        s2 = peg$c285;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c281;
+            s4 = peg$c285;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c282); }
+            if (peg$silentFails === 0) { peg$fail(peg$c286); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12114,36 +12181,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c449.test(input.charAt(peg$currPos))) {
+    if (peg$c452.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+      if (peg$silentFails === 0) { peg$fail(peg$c453); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c449.test(input.charAt(peg$currPos))) {
+        if (peg$c452.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c450); }
+          if (peg$silentFails === 0) { peg$fail(peg$c453); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c449.test(input.charAt(peg$currPos))) {
+          if (peg$c452.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c450); }
+            if (peg$silentFails === 0) { peg$fail(peg$c453); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12172,20 +12239,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c449.test(input.charAt(peg$currPos))) {
+    if (peg$c452.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+      if (peg$silentFails === 0) { peg$fail(peg$c453); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12260,22 +12327,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c449.test(input.charAt(peg$currPos))) {
+                if (peg$c452.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c453); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c449.test(input.charAt(peg$currPos))) {
+                    if (peg$c452.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c453); }
                     }
                   }
                 } else {
@@ -12330,28 +12397,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c457;
+      s0 = peg$c460;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c458); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c279;
+        s1 = peg$c283;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c284); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c281;
+          s1 = peg$c285;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c282); }
+          if (peg$silentFails === 0) { peg$fail(peg$c286); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12377,22 +12444,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c449.test(input.charAt(peg$currPos))) {
+                if (peg$c452.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c453); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c449.test(input.charAt(peg$currPos))) {
+                    if (peg$c452.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c453); }
                     }
                   }
                 } else {
@@ -12445,11 +12512,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c285;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12495,7 +12562,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c459();
+        s1 = peg$c462();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12557,76 +12624,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c460) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c463) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c462) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c465) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c464) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c467) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c465); }
+          if (peg$silentFails === 0) { peg$fail(peg$c468); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c466) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c469) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c470); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c468) {
+            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c471) {
               s0 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c469); }
+              if (peg$silentFails === 0) { peg$fail(peg$c472); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c470) {
+              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c473) {
                 s0 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                if (peg$silentFails === 0) { peg$fail(peg$c474); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c472) {
+                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c475) {
                   s0 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c473); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c476); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c474) {
+                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c477) {
                     s0 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c475); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c478); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c476) {
+                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c479) {
                       s0 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c477); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c480); }
                     }
                   }
                 }
@@ -12811,7 +12878,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c478(s1, s2);
+        s1 = peg$c481(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12832,12 +12899,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c479) {
-            s3 = peg$c479;
+          if (input.substr(peg$currPos, 2) === peg$c482) {
+            s3 = peg$c482;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c480); }
+            if (peg$silentFails === 0) { peg$fail(peg$c483); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12850,7 +12917,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c481(s1, s2, s4, s5);
+                s1 = peg$c484(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12874,12 +12941,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c479) {
-          s1 = peg$c479;
+        if (input.substr(peg$currPos, 2) === peg$c482) {
+          s1 = peg$c482;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c480); }
+          if (peg$silentFails === 0) { peg$fail(peg$c483); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12892,7 +12959,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c482(s2, s3);
+              s1 = peg$c485(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12917,16 +12984,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c479) {
-                s3 = peg$c479;
+              if (input.substr(peg$currPos, 2) === peg$c482) {
+                s3 = peg$c482;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c480); }
+                if (peg$silentFails === 0) { peg$fail(peg$c483); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c483(s1, s2);
+                s1 = peg$c486(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12942,16 +13009,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c479) {
-              s1 = peg$c479;
+            if (input.substr(peg$currPos, 2) === peg$c482) {
+              s1 = peg$c482;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c480); }
+              if (peg$silentFails === 0) { peg$fail(peg$c483); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c484();
+              s1 = peg$c487();
             }
             s0 = s1;
           }
@@ -12988,7 +13055,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c485(s2);
+        s1 = peg$c488(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13017,7 +13084,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c486(s1);
+        s1 = peg$c489(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13038,17 +13105,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c283;
+        s2 = peg$c287;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c487(s1, s3);
+          s1 = peg$c490(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13073,17 +13140,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c283;
+        s2 = peg$c287;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c488(s1, s3);
+          s1 = peg$c491(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13108,7 +13175,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c489(s1);
+      s1 = peg$c492(s1);
     }
     s0 = s1;
 
@@ -13131,22 +13198,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c449.test(input.charAt(peg$currPos))) {
+    if (peg$c452.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+      if (peg$silentFails === 0) { peg$fail(peg$c453); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c449.test(input.charAt(peg$currPos))) {
+        if (peg$c452.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c450); }
+          if (peg$silentFails === 0) { peg$fail(peg$c453); }
         }
       }
     } else {
@@ -13166,11 +13233,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c285;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13195,33 +13262,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c285;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c449.test(input.charAt(peg$currPos))) {
+          if (peg$c452.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c450); }
+            if (peg$silentFails === 0) { peg$fail(peg$c453); }
           }
         }
       } else {
@@ -13237,22 +13304,22 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c449.test(input.charAt(peg$currPos))) {
+          if (peg$c452.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c450); }
+            if (peg$silentFails === 0) { peg$fail(peg$c453); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c449.test(input.charAt(peg$currPos))) {
+              if (peg$c452.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                if (peg$silentFails === 0) { peg$fail(peg$c453); }
               }
             }
           } else {
@@ -13265,7 +13332,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c490();
+              s1 = peg$c493();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13290,11 +13357,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c281;
+        s1 = peg$c285;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13309,22 +13376,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c449.test(input.charAt(peg$currPos))) {
+          if (peg$c452.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c450); }
+            if (peg$silentFails === 0) { peg$fail(peg$c453); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c449.test(input.charAt(peg$currPos))) {
+              if (peg$c452.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                if (peg$silentFails === 0) { peg$fail(peg$c453); }
               }
             }
           } else {
@@ -13337,7 +13404,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c490();
+              s1 = peg$c493();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13364,20 +13431,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c491) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c494) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c492); }
+      if (peg$silentFails === 0) { peg$fail(peg$c495); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c493.test(input.charAt(peg$currPos))) {
+      if (peg$c496.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c494); }
+        if (peg$silentFails === 0) { peg$fail(peg$c497); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13429,12 +13496,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c495.test(input.charAt(peg$currPos))) {
+    if (peg$c498.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c496); }
+      if (peg$silentFails === 0) { peg$fail(peg$c499); }
     }
 
     return s0;
@@ -13445,11 +13512,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c387;
+      s1 = peg$c390;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13460,15 +13527,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c387;
+          s3 = peg$c390;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c388); }
+          if (peg$silentFails === 0) { peg$fail(peg$c391); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c497(s2);
+          s1 = peg$c500(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13485,11 +13552,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c389;
+        s1 = peg$c392;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+        if (peg$silentFails === 0) { peg$fail(peg$c393); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13500,15 +13567,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c389;
+            s3 = peg$c392;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c390); }
+            if (peg$silentFails === 0) { peg$fail(peg$c393); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c497(s2);
+            s1 = peg$c500(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13534,11 +13601,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c387;
+      s2 = peg$c390;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13556,7 +13623,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c498); }
+        if (peg$silentFails === 0) { peg$fail(peg$c501); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13573,11 +13640,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c392;
+        s1 = peg$c395;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c396); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13612,7 +13679,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c499(s1, s2);
+        s1 = peg$c502(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13641,12 +13708,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c500.test(input.charAt(peg$currPos))) {
+    if (peg$c503.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c501); }
+      if (peg$silentFails === 0) { peg$fail(peg$c504); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13662,12 +13729,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
     }
 
@@ -13679,11 +13746,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c392;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13742,7 +13809,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c502(s3, s4);
+            s1 = peg$c505(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13853,7 +13920,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c503();
+          s1 = peg$c506();
         }
         s0 = s1;
       }
@@ -13867,12 +13934,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
     }
 
@@ -13884,11 +13951,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c392;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -13924,7 +13991,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c504();
+      s1 = peg$c507();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -13938,16 +14005,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c505();
+        s1 = peg$c508();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c493.test(input.charAt(peg$currPos))) {
+        if (peg$c496.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c494); }
+          if (peg$silentFails === 0) { peg$fail(peg$c497); }
         }
       }
     }
@@ -13962,11 +14029,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c389;
+      s2 = peg$c392;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13984,7 +14051,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c498); }
+        if (peg$silentFails === 0) { peg$fail(peg$c501); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14001,11 +14068,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c392;
+        s1 = peg$c395;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c396); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14041,20 +14108,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c389;
+      s0 = peg$c392;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c387;
+        s1 = peg$c390;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c388); }
+        if (peg$silentFails === 0) { peg$fail(peg$c391); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14063,94 +14130,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c392;
+          s0 = peg$c395;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+          if (peg$silentFails === 0) { peg$fail(peg$c396); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c506;
+            s1 = peg$c509;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c507); }
+            if (peg$silentFails === 0) { peg$fail(peg$c510); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c508();
+            s1 = peg$c511();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c509;
+              s1 = peg$c512;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c510); }
+              if (peg$silentFails === 0) { peg$fail(peg$c513); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c511();
+              s1 = peg$c514();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c512;
+                s1 = peg$c515;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c513); }
+                if (peg$silentFails === 0) { peg$fail(peg$c516); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c514();
+                s1 = peg$c517();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c515;
+                  s1 = peg$c518;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c516); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c519); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c517();
+                  s1 = peg$c520();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c518;
+                    s1 = peg$c521;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c519); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c522); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c520();
+                    s1 = peg$c523();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c521;
+                      s1 = peg$c524;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c525); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c523();
+                      s1 = peg$c526();
                     }
                     s0 = s1;
                   }
@@ -14178,7 +14245,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c504();
+      s1 = peg$c507();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14192,16 +14259,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c524();
+        s1 = peg$c527();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c493.test(input.charAt(peg$currPos))) {
+        if (peg$c496.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c494); }
+          if (peg$silentFails === 0) { peg$fail(peg$c497); }
         }
       }
     }
@@ -14214,11 +14281,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c525;
+      s1 = peg$c528;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c526); }
+      if (peg$silentFails === 0) { peg$fail(peg$c529); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14250,7 +14317,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c527(s2);
+        s1 = peg$c530(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14263,11 +14330,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c525;
+        s1 = peg$c528;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c526); }
+        if (peg$silentFails === 0) { peg$fail(peg$c529); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14334,15 +14401,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c311;
+              s4 = peg$c315;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c527(s3);
+              s1 = peg$c530(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14370,21 +14437,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c283;
+      s1 = peg$c287;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c283;
+          s3 = peg$c287;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c284); }
+          if (peg$silentFails === 0) { peg$fail(peg$c288); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14426,21 +14493,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c528.test(input.charAt(peg$currPos))) {
+    if (peg$c531.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c529); }
+      if (peg$silentFails === 0) { peg$fail(peg$c532); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c392;
+        s3 = peg$c395;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c396); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14448,7 +14515,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c498); }
+          if (peg$silentFails === 0) { peg$fail(peg$c501); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14465,21 +14532,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c528.test(input.charAt(peg$currPos))) {
+        if (peg$c531.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c529); }
+          if (peg$silentFails === 0) { peg$fail(peg$c532); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c392;
+            s3 = peg$c395;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c393); }
+            if (peg$silentFails === 0) { peg$fail(peg$c396); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14487,7 +14554,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c498); }
+              if (peg$silentFails === 0) { peg$fail(peg$c501); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14517,12 +14584,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c530.test(input.charAt(peg$currPos))) {
+    if (peg$c533.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c531); }
+      if (peg$silentFails === 0) { peg$fail(peg$c534); }
     }
 
     return s0;
@@ -14580,7 +14647,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c498); }
+      if (peg$silentFails === 0) { peg$fail(peg$c501); }
     }
 
     return s0;
@@ -14591,51 +14658,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c533;
+      s0 = peg$c536;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c534); }
+      if (peg$silentFails === 0) { peg$fail(peg$c537); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c535;
+        s0 = peg$c538;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c536); }
+        if (peg$silentFails === 0) { peg$fail(peg$c539); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c537;
+          s0 = peg$c540;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c538); }
+          if (peg$silentFails === 0) { peg$fail(peg$c541); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c539;
+            s0 = peg$c542;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c540); }
+            if (peg$silentFails === 0) { peg$fail(peg$c543); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c541;
+              s0 = peg$c544;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c542); }
+              if (peg$silentFails === 0) { peg$fail(peg$c545); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c543;
+                s0 = peg$c546;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c544); }
+                if (peg$silentFails === 0) { peg$fail(peg$c547); }
               }
             }
           }
@@ -14644,7 +14711,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c532); }
+      if (peg$silentFails === 0) { peg$fail(peg$c535); }
     }
 
     return s0;
@@ -14653,12 +14720,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c545.test(input.charAt(peg$currPos))) {
+    if (peg$c548.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c546); }
+      if (peg$silentFails === 0) { peg$fail(peg$c549); }
     }
 
     return s0;
@@ -14671,7 +14738,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
 
     return s0;
@@ -14681,12 +14748,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c552) {
-      s1 = peg$c552;
+    if (input.substr(peg$currPos, 2) === peg$c555) {
+      s1 = peg$c555;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c553); }
+      if (peg$silentFails === 0) { peg$fail(peg$c556); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14777,7 +14844,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c498); }
+      if (peg$silentFails === 0) { peg$fail(peg$c501); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -4048,30 +4048,38 @@ var g = &grammar{
 			expr: &choiceExpr{
 				pos: position{line: 527, col: 5, offset: 15432},
 				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 527, col: 5, offset: 15432},
-						name: "ScopedOver",
+					&actionExpr{
+						pos: position{line: 527, col: 5, offset: 15432},
+						run: (*parser).callonOverProc2,
+						expr: &labeledExpr{
+							pos:   position{line: 527, col: 5, offset: 15432},
+							label: "over",
+							expr: &ruleRefExpr{
+								pos:  position{line: 527, col: 10, offset: 15437},
+								name: "ScopedOver",
+							},
+						},
 					},
 					&actionExpr{
-						pos: position{line: 528, col: 5, offset: 15447},
-						run: (*parser).callonOverProc3,
+						pos: position{line: 530, col: 5, offset: 15542},
+						run: (*parser).callonOverProc5,
 						expr: &seqExpr{
-							pos: position{line: 528, col: 5, offset: 15447},
+							pos: position{line: 530, col: 5, offset: 15542},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 528, col: 5, offset: 15447},
+									pos:        position{line: 530, col: 5, offset: 15542},
 									val:        "over",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 528, col: 13, offset: 15455},
+									pos:  position{line: 530, col: 13, offset: 15550},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 528, col: 15, offset: 15457},
+									pos:   position{line: 530, col: 15, offset: 15552},
 									label: "exprs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 528, col: 21, offset: 15463},
+										pos:  position{line: 530, col: 21, offset: 15558},
 										name: "Exprs",
 									},
 								},
@@ -4083,39 +4091,47 @@ var g = &grammar{
 		},
 		{
 			name: "ScopedOver",
-			pos:  position{line: 532, col: 1, offset: 15562},
+			pos:  position{line: 534, col: 1, offset: 15666},
 			expr: &actionExpr{
-				pos: position{line: 533, col: 5, offset: 15577},
+				pos: position{line: 535, col: 5, offset: 15681},
 				run: (*parser).callonScopedOver1,
 				expr: &seqExpr{
-					pos: position{line: 533, col: 5, offset: 15577},
+					pos: position{line: 535, col: 5, offset: 15681},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 533, col: 5, offset: 15577},
+							pos:        position{line: 535, col: 5, offset: 15681},
 							val:        "over",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 533, col: 13, offset: 15585},
+							pos:  position{line: 535, col: 13, offset: 15689},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 533, col: 15, offset: 15587},
+							pos:   position{line: 535, col: 15, offset: 15691},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 533, col: 21, offset: 15593},
+								pos:  position{line: 535, col: 21, offset: 15697},
 								name: "Exprs",
 							},
 						},
+						&labeledExpr{
+							pos:   position{line: 535, col: 27, offset: 15703},
+							label: "as",
+							expr: &ruleRefExpr{
+								pos:  position{line: 535, col: 30, offset: 15706},
+								name: "As",
+							},
+						},
 						&ruleRefExpr{
-							pos:  position{line: 533, col: 27, offset: 15599},
+							pos:  position{line: 535, col: 33, offset: 15709},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 533, col: 30, offset: 15602},
+							pos:   position{line: 535, col: 36, offset: 15712},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 533, col: 36, offset: 15608},
+								pos:  position{line: 535, col: 42, offset: 15718},
 								name: "Scope",
 							},
 						},
@@ -4124,40 +4140,88 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "As",
+			pos:  position{line: 539, col: 1, offset: 15828},
+			expr: &choiceExpr{
+				pos: position{line: 540, col: 5, offset: 15835},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 540, col: 5, offset: 15835},
+						run: (*parser).callonAs2,
+						expr: &seqExpr{
+							pos: position{line: 540, col: 5, offset: 15835},
+							exprs: []interface{}{
+								&ruleRefExpr{
+									pos:  position{line: 540, col: 5, offset: 15835},
+									name: "_",
+								},
+								&litMatcher{
+									pos:        position{line: 540, col: 7, offset: 15837},
+									val:        "as",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 540, col: 12, offset: 15842},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 540, col: 14, offset: 15844},
+									label: "id",
+									expr: &ruleRefExpr{
+										pos:  position{line: 540, col: 17, offset: 15847},
+										name: "IdentifierName",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 541, col: 5, offset: 15885},
+						run: (*parser).callonAs9,
+						expr: &litMatcher{
+							pos:        position{line: 541, col: 5, offset: 15885},
+							val:        "",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "LetProc",
-			pos:  position{line: 537, col: 1, offset: 15709},
+			pos:  position{line: 544, col: 1, offset: 15909},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 5, offset: 15721},
+				pos: position{line: 545, col: 5, offset: 15921},
 				run: (*parser).callonLetProc1,
 				expr: &seqExpr{
-					pos: position{line: 538, col: 5, offset: 15721},
+					pos: position{line: 545, col: 5, offset: 15921},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 538, col: 5, offset: 15721},
+							pos:        position{line: 545, col: 5, offset: 15921},
 							val:        "let",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 538, col: 12, offset: 15728},
+							pos:  position{line: 545, col: 12, offset: 15928},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 538, col: 14, offset: 15730},
+							pos:   position{line: 545, col: 14, offset: 15930},
 							label: "locals",
 							expr: &ruleRefExpr{
-								pos:  position{line: 538, col: 21, offset: 15737},
+								pos:  position{line: 545, col: 21, offset: 15937},
 								name: "LetAssignments",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 538, col: 36, offset: 15752},
+							pos:  position{line: 545, col: 36, offset: 15952},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 538, col: 39, offset: 15755},
+							pos:   position{line: 545, col: 39, offset: 15955},
 							label: "over",
 							expr: &ruleRefExpr{
-								pos:  position{line: 538, col: 44, offset: 15760},
+								pos:  position{line: 545, col: 44, offset: 15960},
 								name: "ScopedOver",
 							},
 						},
@@ -4167,45 +4231,45 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 542, col: 1, offset: 15865},
+			pos:  position{line: 549, col: 1, offset: 16066},
 			expr: &actionExpr{
-				pos: position{line: 542, col: 9, offset: 15873},
+				pos: position{line: 549, col: 9, offset: 16074},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 542, col: 9, offset: 15873},
+					pos: position{line: 549, col: 9, offset: 16074},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 542, col: 9, offset: 15873},
+							pos:        position{line: 549, col: 9, offset: 16074},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 542, col: 14, offset: 15878},
+							pos:  position{line: 549, col: 14, offset: 16079},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 542, col: 17, offset: 15881},
+							pos:        position{line: 549, col: 17, offset: 16082},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 542, col: 21, offset: 15885},
+							pos:  position{line: 549, col: 21, offset: 16086},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 542, col: 24, offset: 15888},
+							pos:   position{line: 549, col: 24, offset: 16089},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 542, col: 28, offset: 15892},
+								pos:  position{line: 549, col: 28, offset: 16093},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 542, col: 39, offset: 15903},
+							pos:  position{line: 549, col: 39, offset: 16104},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 542, col: 42, offset: 15906},
+							pos:        position{line: 549, col: 42, offset: 16107},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4215,50 +4279,50 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignments",
-			pos:  position{line: 544, col: 1, offset: 15931},
+			pos:  position{line: 551, col: 1, offset: 16132},
 			expr: &actionExpr{
-				pos: position{line: 545, col: 5, offset: 15950},
+				pos: position{line: 552, col: 5, offset: 16151},
 				run: (*parser).callonLetAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 545, col: 5, offset: 15950},
+					pos: position{line: 552, col: 5, offset: 16151},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 545, col: 5, offset: 15950},
+							pos:   position{line: 552, col: 5, offset: 16151},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 11, offset: 15956},
+								pos:  position{line: 552, col: 11, offset: 16157},
 								name: "LetAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 25, offset: 15970},
+							pos:   position{line: 552, col: 25, offset: 16171},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 545, col: 30, offset: 15975},
+								pos: position{line: 552, col: 30, offset: 16176},
 								expr: &actionExpr{
-									pos: position{line: 545, col: 31, offset: 15976},
+									pos: position{line: 552, col: 31, offset: 16177},
 									run: (*parser).callonLetAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 545, col: 31, offset: 15976},
+										pos: position{line: 552, col: 31, offset: 16177},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 545, col: 31, offset: 15976},
+												pos:  position{line: 552, col: 31, offset: 16177},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 545, col: 34, offset: 15979},
+												pos:        position{line: 552, col: 34, offset: 16180},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 545, col: 38, offset: 15983},
+												pos:  position{line: 552, col: 38, offset: 16184},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 545, col: 41, offset: 15986},
+												pos:   position{line: 552, col: 41, offset: 16187},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 545, col: 43, offset: 15988},
+													pos:  position{line: 552, col: 43, offset: 16189},
 													name: "LetAssignment",
 												},
 											},
@@ -4273,39 +4337,39 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignment",
-			pos:  position{line: 549, col: 1, offset: 16106},
+			pos:  position{line: 556, col: 1, offset: 16307},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 17, offset: 16122},
+				pos: position{line: 556, col: 17, offset: 16323},
 				run: (*parser).callonLetAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 549, col: 17, offset: 16122},
+					pos: position{line: 556, col: 17, offset: 16323},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 549, col: 17, offset: 16122},
+							pos:   position{line: 556, col: 17, offset: 16323},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 20, offset: 16125},
+								pos:  position{line: 556, col: 20, offset: 16326},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 35, offset: 16140},
+							pos:  position{line: 556, col: 35, offset: 16341},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 549, col: 38, offset: 16143},
+							pos:        position{line: 556, col: 38, offset: 16344},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 42, offset: 16147},
+							pos:  position{line: 556, col: 42, offset: 16348},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 549, col: 45, offset: 16150},
+							pos:   position{line: 556, col: 45, offset: 16351},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 50, offset: 16155},
+								pos:  position{line: 556, col: 50, offset: 16356},
 								name: "Expr",
 							},
 						},
@@ -4315,27 +4379,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldProc",
-			pos:  position{line: 553, col: 1, offset: 16234},
+			pos:  position{line: 560, col: 1, offset: 16435},
 			expr: &actionExpr{
-				pos: position{line: 554, col: 5, offset: 16248},
+				pos: position{line: 561, col: 5, offset: 16449},
 				run: (*parser).callonYieldProc1,
 				expr: &seqExpr{
-					pos: position{line: 554, col: 5, offset: 16248},
+					pos: position{line: 561, col: 5, offset: 16449},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 554, col: 5, offset: 16248},
+							pos:        position{line: 561, col: 5, offset: 16449},
 							val:        "yield",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 554, col: 14, offset: 16257},
+							pos:  position{line: 561, col: 14, offset: 16458},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 554, col: 16, offset: 16259},
+							pos:   position{line: 561, col: 16, offset: 16460},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 554, col: 22, offset: 16265},
+								pos:  position{line: 561, col: 22, offset: 16466},
 								name: "Exprs",
 							},
 						},
@@ -4345,30 +4409,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 558, col: 1, offset: 16349},
+			pos:  position{line: 565, col: 1, offset: 16550},
 			expr: &actionExpr{
-				pos: position{line: 559, col: 5, offset: 16361},
+				pos: position{line: 566, col: 5, offset: 16562},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 559, col: 5, offset: 16361},
+					pos: position{line: 566, col: 5, offset: 16562},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 559, col: 5, offset: 16361},
+							pos:  position{line: 566, col: 5, offset: 16562},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 559, col: 7, offset: 16363},
+							pos:  position{line: 566, col: 7, offset: 16564},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 559, col: 10, offset: 16366},
+							pos:  position{line: 566, col: 10, offset: 16567},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 559, col: 12, offset: 16368},
+							pos:   position{line: 566, col: 12, offset: 16569},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 559, col: 16, offset: 16372},
+								pos:  position{line: 566, col: 16, offset: 16573},
 								name: "Type",
 							},
 						},
@@ -4378,30 +4442,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 561, col: 1, offset: 16397},
+			pos:  position{line: 568, col: 1, offset: 16598},
 			expr: &actionExpr{
-				pos: position{line: 562, col: 5, offset: 16407},
+				pos: position{line: 569, col: 5, offset: 16608},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 562, col: 5, offset: 16407},
+					pos: position{line: 569, col: 5, offset: 16608},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 5, offset: 16407},
+							pos:  position{line: 569, col: 5, offset: 16608},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 7, offset: 16409},
+							pos:  position{line: 569, col: 7, offset: 16610},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 10, offset: 16412},
+							pos:  position{line: 569, col: 10, offset: 16613},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 562, col: 12, offset: 16414},
+							pos:   position{line: 569, col: 12, offset: 16615},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 16, offset: 16418},
+								pos:  position{line: 569, col: 16, offset: 16619},
 								name: "Lval",
 							},
 						},
@@ -4411,58 +4475,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 566, col: 1, offset: 16469},
+			pos:  position{line: 573, col: 1, offset: 16670},
 			expr: &ruleRefExpr{
-				pos:  position{line: 566, col: 8, offset: 16476},
+				pos:  position{line: 573, col: 8, offset: 16677},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 568, col: 1, offset: 16487},
+			pos:  position{line: 575, col: 1, offset: 16688},
 			expr: &actionExpr{
-				pos: position{line: 569, col: 5, offset: 16497},
+				pos: position{line: 576, col: 5, offset: 16698},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 569, col: 5, offset: 16497},
+					pos: position{line: 576, col: 5, offset: 16698},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 569, col: 5, offset: 16497},
+							pos:   position{line: 576, col: 5, offset: 16698},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 569, col: 11, offset: 16503},
+								pos:  position{line: 576, col: 11, offset: 16704},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 569, col: 16, offset: 16508},
+							pos:   position{line: 576, col: 16, offset: 16709},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 569, col: 21, offset: 16513},
+								pos: position{line: 576, col: 21, offset: 16714},
 								expr: &actionExpr{
-									pos: position{line: 569, col: 22, offset: 16514},
+									pos: position{line: 576, col: 22, offset: 16715},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 569, col: 22, offset: 16514},
+										pos: position{line: 576, col: 22, offset: 16715},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 569, col: 22, offset: 16514},
+												pos:  position{line: 576, col: 22, offset: 16715},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 569, col: 25, offset: 16517},
+												pos:        position{line: 576, col: 25, offset: 16718},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 569, col: 29, offset: 16521},
+												pos:  position{line: 576, col: 29, offset: 16722},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 569, col: 32, offset: 16524},
+												pos:   position{line: 576, col: 32, offset: 16725},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 569, col: 37, offset: 16529},
+													pos:  position{line: 576, col: 37, offset: 16730},
 													name: "Lval",
 												},
 											},
@@ -4477,52 +4541,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 573, col: 1, offset: 16641},
+			pos:  position{line: 580, col: 1, offset: 16842},
 			expr: &ruleRefExpr{
-				pos:  position{line: 573, col: 13, offset: 16653},
+				pos:  position{line: 580, col: 13, offset: 16854},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 575, col: 1, offset: 16659},
+			pos:  position{line: 582, col: 1, offset: 16860},
 			expr: &actionExpr{
-				pos: position{line: 576, col: 5, offset: 16674},
+				pos: position{line: 583, col: 5, offset: 16875},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 576, col: 5, offset: 16674},
+					pos: position{line: 583, col: 5, offset: 16875},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 576, col: 5, offset: 16674},
+							pos:   position{line: 583, col: 5, offset: 16875},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 576, col: 11, offset: 16680},
+								pos:  position{line: 583, col: 11, offset: 16881},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 576, col: 21, offset: 16690},
+							pos:   position{line: 583, col: 21, offset: 16891},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 576, col: 26, offset: 16695},
+								pos: position{line: 583, col: 26, offset: 16896},
 								expr: &seqExpr{
-									pos: position{line: 576, col: 27, offset: 16696},
+									pos: position{line: 583, col: 27, offset: 16897},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 576, col: 27, offset: 16696},
+											pos:  position{line: 583, col: 27, offset: 16897},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 576, col: 30, offset: 16699},
+											pos:        position{line: 583, col: 30, offset: 16900},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 576, col: 34, offset: 16703},
+											pos:  position{line: 583, col: 34, offset: 16904},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 576, col: 37, offset: 16706},
+											pos:  position{line: 583, col: 37, offset: 16907},
 											name: "FieldExpr",
 										},
 									},
@@ -4535,50 +4599,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 586, col: 1, offset: 16905},
+			pos:  position{line: 593, col: 1, offset: 17106},
 			expr: &actionExpr{
-				pos: position{line: 587, col: 5, offset: 16921},
+				pos: position{line: 594, col: 5, offset: 17122},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 587, col: 5, offset: 16921},
+					pos: position{line: 594, col: 5, offset: 17122},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 587, col: 5, offset: 16921},
+							pos:   position{line: 594, col: 5, offset: 17122},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 587, col: 11, offset: 16927},
+								pos:  position{line: 594, col: 11, offset: 17128},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 587, col: 22, offset: 16938},
+							pos:   position{line: 594, col: 22, offset: 17139},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 587, col: 27, offset: 16943},
+								pos: position{line: 594, col: 27, offset: 17144},
 								expr: &actionExpr{
-									pos: position{line: 587, col: 28, offset: 16944},
+									pos: position{line: 594, col: 28, offset: 17145},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 587, col: 28, offset: 16944},
+										pos: position{line: 594, col: 28, offset: 17145},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 587, col: 28, offset: 16944},
+												pos:  position{line: 594, col: 28, offset: 17145},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 587, col: 31, offset: 16947},
+												pos:        position{line: 594, col: 31, offset: 17148},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 587, col: 35, offset: 16951},
+												pos:  position{line: 594, col: 35, offset: 17152},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 587, col: 38, offset: 16954},
+												pos:   position{line: 594, col: 38, offset: 17155},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 587, col: 40, offset: 16956},
+													pos:  position{line: 594, col: 40, offset: 17157},
 													name: "Assignment",
 												},
 											},
@@ -4593,39 +4657,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 591, col: 1, offset: 17067},
+			pos:  position{line: 598, col: 1, offset: 17268},
 			expr: &actionExpr{
-				pos: position{line: 592, col: 5, offset: 17082},
+				pos: position{line: 599, col: 5, offset: 17283},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 592, col: 5, offset: 17082},
+					pos: position{line: 599, col: 5, offset: 17283},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 592, col: 5, offset: 17082},
+							pos:   position{line: 599, col: 5, offset: 17283},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 592, col: 9, offset: 17086},
+								pos:  position{line: 599, col: 9, offset: 17287},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 14, offset: 17091},
+							pos:  position{line: 599, col: 14, offset: 17292},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 592, col: 17, offset: 17094},
+							pos:        position{line: 599, col: 17, offset: 17295},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 22, offset: 17099},
+							pos:  position{line: 599, col: 22, offset: 17300},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 592, col: 25, offset: 17102},
+							pos:   position{line: 599, col: 25, offset: 17303},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 592, col: 29, offset: 17106},
+								pos:  position{line: 599, col: 29, offset: 17307},
 								name: "Expr",
 							},
 						},
@@ -4635,71 +4699,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 594, col: 1, offset: 17197},
+			pos:  position{line: 601, col: 1, offset: 17398},
 			expr: &ruleRefExpr{
-				pos:  position{line: 594, col: 8, offset: 17204},
+				pos:  position{line: 601, col: 8, offset: 17405},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 596, col: 1, offset: 17221},
+			pos:  position{line: 603, col: 1, offset: 17422},
 			expr: &choiceExpr{
-				pos: position{line: 597, col: 5, offset: 17241},
+				pos: position{line: 604, col: 5, offset: 17442},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 597, col: 5, offset: 17241},
+						pos: position{line: 604, col: 5, offset: 17442},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 597, col: 5, offset: 17241},
+							pos: position{line: 604, col: 5, offset: 17442},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 597, col: 5, offset: 17241},
+									pos:   position{line: 604, col: 5, offset: 17442},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 597, col: 15, offset: 17251},
+										pos:  position{line: 604, col: 15, offset: 17452},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 29, offset: 17265},
+									pos:  position{line: 604, col: 29, offset: 17466},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 597, col: 32, offset: 17268},
+									pos:        position{line: 604, col: 32, offset: 17469},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 36, offset: 17272},
+									pos:  position{line: 604, col: 36, offset: 17473},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 597, col: 39, offset: 17275},
+									pos:   position{line: 604, col: 39, offset: 17476},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 597, col: 50, offset: 17286},
+										pos:  position{line: 604, col: 50, offset: 17487},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 55, offset: 17291},
+									pos:  position{line: 604, col: 55, offset: 17492},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 597, col: 58, offset: 17294},
+									pos:        position{line: 604, col: 58, offset: 17495},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 62, offset: 17298},
+									pos:  position{line: 604, col: 62, offset: 17499},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 597, col: 65, offset: 17301},
+									pos:   position{line: 604, col: 65, offset: 17502},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 597, col: 76, offset: 17312},
+										pos:  position{line: 604, col: 76, offset: 17513},
 										name: "Expr",
 									},
 								},
@@ -4707,7 +4771,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 600, col: 5, offset: 17452},
+						pos:  position{line: 607, col: 5, offset: 17653},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4715,53 +4779,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 602, col: 1, offset: 17467},
+			pos:  position{line: 609, col: 1, offset: 17668},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 5, offset: 17485},
+				pos: position{line: 610, col: 5, offset: 17686},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 603, col: 5, offset: 17485},
+					pos: position{line: 610, col: 5, offset: 17686},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 603, col: 5, offset: 17485},
+							pos:   position{line: 610, col: 5, offset: 17686},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 603, col: 11, offset: 17491},
+								pos:  position{line: 610, col: 11, offset: 17692},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 604, col: 5, offset: 17510},
+							pos:   position{line: 611, col: 5, offset: 17711},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 604, col: 10, offset: 17515},
+								pos: position{line: 611, col: 10, offset: 17716},
 								expr: &actionExpr{
-									pos: position{line: 604, col: 11, offset: 17516},
+									pos: position{line: 611, col: 11, offset: 17717},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 604, col: 11, offset: 17516},
+										pos: position{line: 611, col: 11, offset: 17717},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 604, col: 11, offset: 17516},
+												pos:  position{line: 611, col: 11, offset: 17717},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 604, col: 14, offset: 17519},
+												pos:   position{line: 611, col: 14, offset: 17720},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 604, col: 17, offset: 17522},
+													pos:  position{line: 611, col: 17, offset: 17723},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 604, col: 25, offset: 17530},
+												pos:  position{line: 611, col: 25, offset: 17731},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 604, col: 28, offset: 17533},
+												pos:   position{line: 611, col: 28, offset: 17734},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 604, col: 33, offset: 17538},
+													pos:  position{line: 611, col: 33, offset: 17739},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4776,53 +4840,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 608, col: 1, offset: 17656},
+			pos:  position{line: 615, col: 1, offset: 17857},
 			expr: &actionExpr{
-				pos: position{line: 609, col: 5, offset: 17675},
+				pos: position{line: 616, col: 5, offset: 17876},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 609, col: 5, offset: 17675},
+					pos: position{line: 616, col: 5, offset: 17876},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 609, col: 5, offset: 17675},
+							pos:   position{line: 616, col: 5, offset: 17876},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 11, offset: 17681},
+								pos:  position{line: 616, col: 11, offset: 17882},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 5, offset: 17705},
+							pos:   position{line: 617, col: 5, offset: 17906},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 610, col: 10, offset: 17710},
+								pos: position{line: 617, col: 10, offset: 17911},
 								expr: &actionExpr{
-									pos: position{line: 610, col: 11, offset: 17711},
+									pos: position{line: 617, col: 11, offset: 17912},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 610, col: 11, offset: 17711},
+										pos: position{line: 617, col: 11, offset: 17912},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 610, col: 11, offset: 17711},
+												pos:  position{line: 617, col: 11, offset: 17912},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 610, col: 14, offset: 17714},
+												pos:   position{line: 617, col: 14, offset: 17915},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 610, col: 17, offset: 17717},
+													pos:  position{line: 617, col: 17, offset: 17918},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 610, col: 26, offset: 17726},
+												pos:  position{line: 617, col: 26, offset: 17927},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 610, col: 29, offset: 17729},
+												pos:   position{line: 617, col: 29, offset: 17930},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 610, col: 34, offset: 17734},
+													pos:  position{line: 617, col: 34, offset: 17935},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -4837,60 +4901,60 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 614, col: 1, offset: 17857},
+			pos:  position{line: 621, col: 1, offset: 18058},
 			expr: &choiceExpr{
-				pos: position{line: 615, col: 5, offset: 17881},
+				pos: position{line: 622, col: 5, offset: 18082},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 615, col: 5, offset: 17881},
+						pos:  position{line: 622, col: 5, offset: 18082},
 						name: "PatternMatch",
 					},
 					&actionExpr{
-						pos: position{line: 616, col: 5, offset: 17898},
+						pos: position{line: 623, col: 5, offset: 18099},
 						run: (*parser).callonEqualityCompareExpr3,
 						expr: &seqExpr{
-							pos: position{line: 616, col: 5, offset: 17898},
+							pos: position{line: 623, col: 5, offset: 18099},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 616, col: 5, offset: 17898},
+									pos:   position{line: 623, col: 5, offset: 18099},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 616, col: 11, offset: 17904},
+										pos:  position{line: 623, col: 11, offset: 18105},
 										name: "RelativeExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 617, col: 5, offset: 17921},
+									pos:   position{line: 624, col: 5, offset: 18122},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 617, col: 10, offset: 17926},
+										pos: position{line: 624, col: 10, offset: 18127},
 										expr: &actionExpr{
-											pos: position{line: 617, col: 11, offset: 17927},
+											pos: position{line: 624, col: 11, offset: 18128},
 											run: (*parser).callonEqualityCompareExpr9,
 											expr: &seqExpr{
-												pos: position{line: 617, col: 11, offset: 17927},
+												pos: position{line: 624, col: 11, offset: 18128},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 617, col: 11, offset: 17927},
+														pos:  position{line: 624, col: 11, offset: 18128},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 617, col: 14, offset: 17930},
+														pos:   position{line: 624, col: 14, offset: 18131},
 														label: "comp",
 														expr: &ruleRefExpr{
-															pos:  position{line: 617, col: 19, offset: 17935},
+															pos:  position{line: 624, col: 19, offset: 18136},
 															name: "EqualityComparator",
 														},
 													},
 													&ruleRefExpr{
-														pos:  position{line: 617, col: 38, offset: 17954},
+														pos:  position{line: 624, col: 38, offset: 18155},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 617, col: 41, offset: 17957},
+														pos:   position{line: 624, col: 41, offset: 18158},
 														label: "expr",
 														expr: &ruleRefExpr{
-															pos:  position{line: 617, col: 46, offset: 17962},
+															pos:  position{line: 624, col: 46, offset: 18163},
 															name: "RelativeExpr",
 														},
 													},
@@ -4907,24 +4971,24 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 621, col: 1, offset: 18080},
+			pos:  position{line: 628, col: 1, offset: 18281},
 			expr: &choiceExpr{
-				pos: position{line: 622, col: 5, offset: 18101},
+				pos: position{line: 629, col: 5, offset: 18302},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 622, col: 5, offset: 18101},
+						pos: position{line: 629, col: 5, offset: 18302},
 						run: (*parser).callonEqualityOperator2,
 						expr: &litMatcher{
-							pos:        position{line: 622, col: 5, offset: 18101},
+							pos:        position{line: 629, col: 5, offset: 18302},
 							val:        "==",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 623, col: 5, offset: 18130},
+						pos: position{line: 630, col: 5, offset: 18331},
 						run: (*parser).callonEqualityOperator4,
 						expr: &litMatcher{
-							pos:        position{line: 623, col: 5, offset: 18130},
+							pos:        position{line: 630, col: 5, offset: 18331},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -4934,29 +4998,29 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 625, col: 1, offset: 18167},
+			pos:  position{line: 632, col: 1, offset: 18368},
 			expr: &choiceExpr{
-				pos: position{line: 626, col: 5, offset: 18190},
+				pos: position{line: 633, col: 5, offset: 18391},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 626, col: 5, offset: 18190},
+						pos:  position{line: 633, col: 5, offset: 18391},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 627, col: 5, offset: 18211},
+						pos: position{line: 634, col: 5, offset: 18412},
 						run: (*parser).callonEqualityComparator3,
 						expr: &seqExpr{
-							pos: position{line: 627, col: 5, offset: 18211},
+							pos: position{line: 634, col: 5, offset: 18412},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 627, col: 5, offset: 18211},
+									pos:        position{line: 634, col: 5, offset: 18412},
 									val:        "in",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 627, col: 10, offset: 18216},
+									pos: position{line: 634, col: 10, offset: 18417},
 									expr: &ruleRefExpr{
-										pos:  position{line: 627, col: 11, offset: 18217},
+										pos:  position{line: 634, col: 11, offset: 18418},
 										name: "IdentifierRest",
 									},
 								},
@@ -4968,53 +5032,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 629, col: 1, offset: 18264},
+			pos:  position{line: 636, col: 1, offset: 18465},
 			expr: &actionExpr{
-				pos: position{line: 630, col: 5, offset: 18281},
+				pos: position{line: 637, col: 5, offset: 18482},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 630, col: 5, offset: 18281},
+					pos: position{line: 637, col: 5, offset: 18482},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 630, col: 5, offset: 18281},
+							pos:   position{line: 637, col: 5, offset: 18482},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 11, offset: 18287},
+								pos:  position{line: 637, col: 11, offset: 18488},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 631, col: 5, offset: 18304},
+							pos:   position{line: 638, col: 5, offset: 18505},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 631, col: 10, offset: 18309},
+								pos: position{line: 638, col: 10, offset: 18510},
 								expr: &actionExpr{
-									pos: position{line: 631, col: 11, offset: 18310},
+									pos: position{line: 638, col: 11, offset: 18511},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 631, col: 11, offset: 18310},
+										pos: position{line: 638, col: 11, offset: 18511},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 631, col: 11, offset: 18310},
+												pos:  position{line: 638, col: 11, offset: 18511},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 631, col: 14, offset: 18313},
+												pos:   position{line: 638, col: 14, offset: 18514},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 631, col: 17, offset: 18316},
+													pos:  position{line: 638, col: 17, offset: 18517},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 631, col: 34, offset: 18333},
+												pos:  position{line: 638, col: 34, offset: 18534},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 631, col: 37, offset: 18336},
+												pos:   position{line: 638, col: 37, offset: 18537},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 631, col: 42, offset: 18341},
+													pos:  position{line: 638, col: 42, offset: 18542},
 													name: "AdditiveExpr",
 												},
 											},
@@ -5029,30 +5093,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 635, col: 1, offset: 18457},
+			pos:  position{line: 642, col: 1, offset: 18658},
 			expr: &actionExpr{
-				pos: position{line: 635, col: 20, offset: 18476},
+				pos: position{line: 642, col: 20, offset: 18677},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 635, col: 21, offset: 18477},
+					pos: position{line: 642, col: 21, offset: 18678},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 635, col: 21, offset: 18477},
+							pos:        position{line: 642, col: 21, offset: 18678},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 635, col: 28, offset: 18484},
+							pos:        position{line: 642, col: 28, offset: 18685},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 635, col: 34, offset: 18490},
+							pos:        position{line: 642, col: 34, offset: 18691},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 635, col: 41, offset: 18497},
+							pos:        position{line: 642, col: 41, offset: 18698},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -5062,53 +5126,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 637, col: 1, offset: 18534},
+			pos:  position{line: 644, col: 1, offset: 18735},
 			expr: &actionExpr{
-				pos: position{line: 638, col: 5, offset: 18551},
+				pos: position{line: 645, col: 5, offset: 18752},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 638, col: 5, offset: 18551},
+					pos: position{line: 645, col: 5, offset: 18752},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 638, col: 5, offset: 18551},
+							pos:   position{line: 645, col: 5, offset: 18752},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 11, offset: 18557},
+								pos:  position{line: 645, col: 11, offset: 18758},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 639, col: 5, offset: 18580},
+							pos:   position{line: 646, col: 5, offset: 18781},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 639, col: 10, offset: 18585},
+								pos: position{line: 646, col: 10, offset: 18786},
 								expr: &actionExpr{
-									pos: position{line: 639, col: 11, offset: 18586},
+									pos: position{line: 646, col: 11, offset: 18787},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 639, col: 11, offset: 18586},
+										pos: position{line: 646, col: 11, offset: 18787},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 639, col: 11, offset: 18586},
+												pos:  position{line: 646, col: 11, offset: 18787},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 639, col: 14, offset: 18589},
+												pos:   position{line: 646, col: 14, offset: 18790},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 639, col: 17, offset: 18592},
+													pos:  position{line: 646, col: 17, offset: 18793},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 639, col: 34, offset: 18609},
+												pos:  position{line: 646, col: 34, offset: 18810},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 639, col: 37, offset: 18612},
+												pos:   position{line: 646, col: 37, offset: 18813},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 639, col: 42, offset: 18617},
+													pos:  position{line: 646, col: 42, offset: 18818},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5123,20 +5187,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 643, col: 1, offset: 18739},
+			pos:  position{line: 650, col: 1, offset: 18940},
 			expr: &actionExpr{
-				pos: position{line: 643, col: 20, offset: 18758},
+				pos: position{line: 650, col: 20, offset: 18959},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 643, col: 21, offset: 18759},
+					pos: position{line: 650, col: 21, offset: 18960},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 643, col: 21, offset: 18759},
+							pos:        position{line: 650, col: 21, offset: 18960},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 643, col: 27, offset: 18765},
+							pos:        position{line: 650, col: 27, offset: 18966},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5146,53 +5210,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 645, col: 1, offset: 18802},
+			pos:  position{line: 652, col: 1, offset: 19003},
 			expr: &actionExpr{
-				pos: position{line: 646, col: 5, offset: 18825},
+				pos: position{line: 653, col: 5, offset: 19026},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 646, col: 5, offset: 18825},
+					pos: position{line: 653, col: 5, offset: 19026},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 646, col: 5, offset: 18825},
+							pos:   position{line: 653, col: 5, offset: 19026},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 646, col: 11, offset: 18831},
+								pos:  position{line: 653, col: 11, offset: 19032},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 647, col: 5, offset: 18843},
+							pos:   position{line: 654, col: 5, offset: 19044},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 647, col: 10, offset: 18848},
+								pos: position{line: 654, col: 10, offset: 19049},
 								expr: &actionExpr{
-									pos: position{line: 647, col: 11, offset: 18849},
+									pos: position{line: 654, col: 11, offset: 19050},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 647, col: 11, offset: 18849},
+										pos: position{line: 654, col: 11, offset: 19050},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 647, col: 11, offset: 18849},
+												pos:  position{line: 654, col: 11, offset: 19050},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 647, col: 14, offset: 18852},
+												pos:   position{line: 654, col: 14, offset: 19053},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 647, col: 17, offset: 18855},
+													pos:  position{line: 654, col: 17, offset: 19056},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 647, col: 40, offset: 18878},
+												pos:  position{line: 654, col: 40, offset: 19079},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 647, col: 43, offset: 18881},
+												pos:   position{line: 654, col: 43, offset: 19082},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 647, col: 48, offset: 18886},
+													pos:  position{line: 654, col: 48, offset: 19087},
 													name: "NotExpr",
 												},
 											},
@@ -5207,25 +5271,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 651, col: 1, offset: 18997},
+			pos:  position{line: 658, col: 1, offset: 19198},
 			expr: &actionExpr{
-				pos: position{line: 651, col: 26, offset: 19022},
+				pos: position{line: 658, col: 26, offset: 19223},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 651, col: 27, offset: 19023},
+					pos: position{line: 658, col: 27, offset: 19224},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 651, col: 27, offset: 19023},
+							pos:        position{line: 658, col: 27, offset: 19224},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 651, col: 33, offset: 19029},
+							pos:        position{line: 658, col: 33, offset: 19230},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 651, col: 39, offset: 19035},
+							pos:        position{line: 658, col: 39, offset: 19236},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5235,30 +5299,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 653, col: 1, offset: 19072},
+			pos:  position{line: 660, col: 1, offset: 19273},
 			expr: &choiceExpr{
-				pos: position{line: 654, col: 5, offset: 19084},
+				pos: position{line: 661, col: 5, offset: 19285},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 654, col: 5, offset: 19084},
+						pos: position{line: 661, col: 5, offset: 19285},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 654, col: 5, offset: 19084},
+							pos: position{line: 661, col: 5, offset: 19285},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 654, col: 5, offset: 19084},
+									pos:        position{line: 661, col: 5, offset: 19285},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 654, col: 9, offset: 19088},
+									pos:  position{line: 661, col: 9, offset: 19289},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 654, col: 12, offset: 19091},
+									pos:   position{line: 661, col: 12, offset: 19292},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 654, col: 14, offset: 19093},
+										pos:  position{line: 661, col: 14, offset: 19294},
 										name: "NotExpr",
 									},
 								},
@@ -5266,7 +5330,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 657, col: 5, offset: 19202},
+						pos:  position{line: 664, col: 5, offset: 19403},
 						name: "FuncExpr",
 					},
 				},
@@ -5274,35 +5338,35 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 659, col: 1, offset: 19212},
+			pos:  position{line: 666, col: 1, offset: 19413},
 			expr: &choiceExpr{
-				pos: position{line: 660, col: 5, offset: 19225},
+				pos: position{line: 667, col: 5, offset: 19426},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 660, col: 5, offset: 19225},
+						pos:  position{line: 667, col: 5, offset: 19426},
 						name: "MatchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 661, col: 5, offset: 19239},
+						pos: position{line: 668, col: 5, offset: 19440},
 						run: (*parser).callonFuncExpr3,
 						expr: &seqExpr{
-							pos: position{line: 661, col: 5, offset: 19239},
+							pos: position{line: 668, col: 5, offset: 19440},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 661, col: 5, offset: 19239},
+									pos:   position{line: 668, col: 5, offset: 19440},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 661, col: 11, offset: 19245},
+										pos:  position{line: 668, col: 11, offset: 19446},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 661, col: 16, offset: 19250},
+									pos:   position{line: 668, col: 16, offset: 19451},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 661, col: 21, offset: 19255},
+										pos: position{line: 668, col: 21, offset: 19456},
 										expr: &ruleRefExpr{
-											pos:  position{line: 661, col: 22, offset: 19256},
+											pos:  position{line: 668, col: 22, offset: 19457},
 											name: "Deref",
 										},
 									},
@@ -5311,26 +5375,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 19327},
+						pos: position{line: 671, col: 5, offset: 19528},
 						run: (*parser).callonFuncExpr10,
 						expr: &seqExpr{
-							pos: position{line: 664, col: 5, offset: 19327},
+							pos: position{line: 671, col: 5, offset: 19528},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 664, col: 5, offset: 19327},
+									pos:   position{line: 671, col: 5, offset: 19528},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 664, col: 11, offset: 19333},
+										pos:  position{line: 671, col: 11, offset: 19534},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 664, col: 20, offset: 19342},
+									pos:   position{line: 671, col: 20, offset: 19543},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 664, col: 25, offset: 19347},
+										pos: position{line: 671, col: 25, offset: 19548},
 										expr: &ruleRefExpr{
-											pos:  position{line: 664, col: 26, offset: 19348},
+											pos:  position{line: 671, col: 26, offset: 19549},
 											name: "Deref",
 										},
 									},
@@ -5339,11 +5403,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 19419},
+						pos:  position{line: 674, col: 5, offset: 19620},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 668, col: 5, offset: 19433},
+						pos:  position{line: 675, col: 5, offset: 19634},
 						name: "Primary",
 					},
 				},
@@ -5351,20 +5415,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 670, col: 1, offset: 19442},
+			pos:  position{line: 677, col: 1, offset: 19643},
 			expr: &seqExpr{
-				pos: position{line: 670, col: 13, offset: 19454},
+				pos: position{line: 677, col: 13, offset: 19655},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 670, col: 13, offset: 19454},
+						pos:  position{line: 677, col: 13, offset: 19655},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 670, col: 22, offset: 19463},
+						pos:  position{line: 677, col: 22, offset: 19664},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 670, col: 25, offset: 19466},
+						pos:        position{line: 677, col: 25, offset: 19667},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5373,27 +5437,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 672, col: 1, offset: 19471},
+			pos:  position{line: 679, col: 1, offset: 19672},
 			expr: &choiceExpr{
-				pos: position{line: 673, col: 5, offset: 19484},
+				pos: position{line: 680, col: 5, offset: 19685},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 673, col: 5, offset: 19484},
+						pos:        position{line: 680, col: 5, offset: 19685},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 674, col: 5, offset: 19494},
+						pos:        position{line: 681, col: 5, offset: 19695},
 						val:        "search",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 675, col: 5, offset: 19507},
+						pos:        position{line: 682, col: 5, offset: 19708},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 676, col: 5, offset: 19520},
+						pos:        position{line: 683, col: 5, offset: 19721},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -5402,37 +5466,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 678, col: 1, offset: 19528},
+			pos:  position{line: 685, col: 1, offset: 19729},
 			expr: &actionExpr{
-				pos: position{line: 679, col: 5, offset: 19542},
+				pos: position{line: 686, col: 5, offset: 19743},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 679, col: 5, offset: 19542},
+					pos: position{line: 686, col: 5, offset: 19743},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 679, col: 5, offset: 19542},
+							pos:        position{line: 686, col: 5, offset: 19743},
 							val:        "search",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 679, col: 14, offset: 19551},
+							pos:  position{line: 686, col: 14, offset: 19752},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 679, col: 17, offset: 19554},
+							pos:        position{line: 686, col: 17, offset: 19755},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 679, col: 21, offset: 19558},
+							pos:   position{line: 686, col: 21, offset: 19759},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 26, offset: 19563},
+								pos:  position{line: 686, col: 26, offset: 19764},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 679, col: 40, offset: 19577},
+							pos:        position{line: 686, col: 40, offset: 19778},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5442,48 +5506,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 681, col: 1, offset: 19603},
+			pos:  position{line: 688, col: 1, offset: 19804},
 			expr: &actionExpr{
-				pos: position{line: 682, col: 5, offset: 19612},
+				pos: position{line: 689, col: 5, offset: 19813},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 682, col: 5, offset: 19612},
+					pos: position{line: 689, col: 5, offset: 19813},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 682, col: 5, offset: 19612},
+							pos:   position{line: 689, col: 5, offset: 19813},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 682, col: 9, offset: 19616},
+								pos:  position{line: 689, col: 9, offset: 19817},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 682, col: 18, offset: 19625},
+							pos:  position{line: 689, col: 18, offset: 19826},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 682, col: 21, offset: 19628},
+							pos:        position{line: 689, col: 21, offset: 19829},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 682, col: 25, offset: 19632},
+							pos:  position{line: 689, col: 25, offset: 19833},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 682, col: 28, offset: 19635},
+							pos:   position{line: 689, col: 28, offset: 19836},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 682, col: 33, offset: 19640},
+								pos:  position{line: 689, col: 33, offset: 19841},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 682, col: 38, offset: 19645},
+							pos:  position{line: 689, col: 38, offset: 19846},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 682, col: 41, offset: 19648},
+							pos:        position{line: 689, col: 41, offset: 19849},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5493,65 +5557,65 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 686, col: 1, offset: 19745},
+			pos:  position{line: 693, col: 1, offset: 19946},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 5, offset: 19758},
+				pos: position{line: 694, col: 5, offset: 19959},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 687, col: 5, offset: 19758},
+					pos: position{line: 694, col: 5, offset: 19959},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 687, col: 5, offset: 19758},
+							pos: position{line: 694, col: 5, offset: 19959},
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 6, offset: 19759},
+								pos:  position{line: 694, col: 6, offset: 19960},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 687, col: 16, offset: 19769},
+							pos:   position{line: 694, col: 16, offset: 19970},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 19, offset: 19772},
+								pos:  position{line: 694, col: 19, offset: 19973},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 687, col: 34, offset: 19787},
+							pos:  position{line: 694, col: 34, offset: 19988},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 687, col: 37, offset: 19790},
+							pos:        position{line: 694, col: 37, offset: 19991},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 687, col: 41, offset: 19794},
+							pos:  position{line: 694, col: 41, offset: 19995},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 687, col: 44, offset: 19797},
+							pos:   position{line: 694, col: 44, offset: 19998},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 49, offset: 19802},
+								pos:  position{line: 694, col: 49, offset: 20003},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 687, col: 63, offset: 19816},
+							pos:  position{line: 694, col: 63, offset: 20017},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 687, col: 66, offset: 19819},
+							pos:        position{line: 694, col: 66, offset: 20020},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 687, col: 70, offset: 19823},
+							pos:   position{line: 694, col: 70, offset: 20024},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 687, col: 76, offset: 19829},
+								pos: position{line: 694, col: 76, offset: 20030},
 								expr: &ruleRefExpr{
-									pos:  position{line: 687, col: 76, offset: 19829},
+									pos:  position{line: 694, col: 76, offset: 20030},
 									name: "WhereClause",
 								},
 							},
@@ -5562,19 +5626,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 691, col: 1, offset: 19950},
+			pos:  position{line: 698, col: 1, offset: 20151},
 			expr: &choiceExpr{
-				pos: position{line: 692, col: 5, offset: 19968},
+				pos: position{line: 699, col: 5, offset: 20169},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 692, col: 5, offset: 19968},
+						pos:  position{line: 699, col: 5, offset: 20169},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 693, col: 5, offset: 19978},
+						pos: position{line: 700, col: 5, offset: 20179},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 693, col: 5, offset: 19978},
+							pos:  position{line: 700, col: 5, offset: 20179},
 							name: "__",
 						},
 					},
@@ -5583,50 +5647,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 695, col: 1, offset: 20014},
+			pos:  position{line: 702, col: 1, offset: 20215},
 			expr: &actionExpr{
-				pos: position{line: 696, col: 5, offset: 20024},
+				pos: position{line: 703, col: 5, offset: 20225},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 696, col: 5, offset: 20024},
+					pos: position{line: 703, col: 5, offset: 20225},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 696, col: 5, offset: 20024},
+							pos:   position{line: 703, col: 5, offset: 20225},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 696, col: 11, offset: 20030},
+								pos:  position{line: 703, col: 11, offset: 20231},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 696, col: 16, offset: 20035},
+							pos:   position{line: 703, col: 16, offset: 20236},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 696, col: 21, offset: 20040},
+								pos: position{line: 703, col: 21, offset: 20241},
 								expr: &actionExpr{
-									pos: position{line: 696, col: 22, offset: 20041},
+									pos: position{line: 703, col: 22, offset: 20242},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 696, col: 22, offset: 20041},
+										pos: position{line: 703, col: 22, offset: 20242},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 696, col: 22, offset: 20041},
+												pos:  position{line: 703, col: 22, offset: 20242},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 696, col: 25, offset: 20044},
+												pos:        position{line: 703, col: 25, offset: 20245},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 696, col: 29, offset: 20048},
+												pos:  position{line: 703, col: 29, offset: 20249},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 696, col: 32, offset: 20051},
+												pos:   position{line: 703, col: 32, offset: 20252},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 696, col: 34, offset: 20053},
+													pos:  position{line: 703, col: 34, offset: 20254},
 													name: "Expr",
 												},
 											},
@@ -5641,25 +5705,25 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 700, col: 1, offset: 20162},
+			pos:  position{line: 707, col: 1, offset: 20363},
 			expr: &actionExpr{
-				pos: position{line: 700, col: 13, offset: 20174},
+				pos: position{line: 707, col: 13, offset: 20375},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 700, col: 13, offset: 20174},
+					pos: position{line: 707, col: 13, offset: 20375},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 700, col: 13, offset: 20174},
+							pos: position{line: 707, col: 13, offset: 20375},
 							expr: &ruleRefExpr{
-								pos:  position{line: 700, col: 14, offset: 20175},
+								pos:  position{line: 707, col: 14, offset: 20376},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 700, col: 18, offset: 20179},
+							pos:   position{line: 707, col: 18, offset: 20380},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 700, col: 20, offset: 20181},
+								pos:  position{line: 707, col: 20, offset: 20382},
 								name: "DerefExprPattern",
 							},
 						},
@@ -5669,31 +5733,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExprPattern",
-			pos:  position{line: 702, col: 1, offset: 20217},
+			pos:  position{line: 709, col: 1, offset: 20418},
 			expr: &choiceExpr{
-				pos: position{line: 703, col: 5, offset: 20238},
+				pos: position{line: 710, col: 5, offset: 20439},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 703, col: 5, offset: 20238},
+						pos: position{line: 710, col: 5, offset: 20439},
 						run: (*parser).callonDerefExprPattern2,
 						expr: &seqExpr{
-							pos: position{line: 703, col: 5, offset: 20238},
+							pos: position{line: 710, col: 5, offset: 20439},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 703, col: 5, offset: 20238},
+									pos:   position{line: 710, col: 5, offset: 20439},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 703, col: 11, offset: 20244},
+										pos:  position{line: 710, col: 11, offset: 20445},
 										name: "DotID",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 703, col: 17, offset: 20250},
+									pos:   position{line: 710, col: 17, offset: 20451},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 703, col: 22, offset: 20255},
+										pos: position{line: 710, col: 22, offset: 20456},
 										expr: &ruleRefExpr{
-											pos:  position{line: 703, col: 23, offset: 20256},
+											pos:  position{line: 710, col: 23, offset: 20457},
 											name: "Deref",
 										},
 									},
@@ -5702,26 +5766,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20327},
+						pos: position{line: 713, col: 5, offset: 20528},
 						run: (*parser).callonDerefExprPattern9,
 						expr: &seqExpr{
-							pos: position{line: 706, col: 5, offset: 20327},
+							pos: position{line: 713, col: 5, offset: 20528},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 706, col: 5, offset: 20327},
+									pos:   position{line: 713, col: 5, offset: 20528},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 706, col: 11, offset: 20333},
+										pos:  position{line: 713, col: 11, offset: 20534},
 										name: "This",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 706, col: 16, offset: 20338},
+									pos:   position{line: 713, col: 16, offset: 20539},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 706, col: 21, offset: 20343},
+										pos: position{line: 713, col: 21, offset: 20544},
 										expr: &ruleRefExpr{
-											pos:  position{line: 706, col: 22, offset: 20344},
+											pos:  position{line: 713, col: 22, offset: 20545},
 											name: "Deref",
 										},
 									},
@@ -5730,26 +5794,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 709, col: 5, offset: 20415},
+						pos: position{line: 716, col: 5, offset: 20616},
 						run: (*parser).callonDerefExprPattern16,
 						expr: &seqExpr{
-							pos: position{line: 709, col: 5, offset: 20415},
+							pos: position{line: 716, col: 5, offset: 20616},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 709, col: 5, offset: 20415},
+									pos:   position{line: 716, col: 5, offset: 20616},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 709, col: 11, offset: 20421},
+										pos:  position{line: 716, col: 11, offset: 20622},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 709, col: 22, offset: 20432},
+									pos:   position{line: 716, col: 22, offset: 20633},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 709, col: 27, offset: 20437},
+										pos: position{line: 716, col: 27, offset: 20638},
 										expr: &ruleRefExpr{
-											pos:  position{line: 709, col: 28, offset: 20438},
+											pos:  position{line: 716, col: 28, offset: 20639},
 											name: "Deref",
 										},
 									},
@@ -5758,10 +5822,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 20509},
+						pos: position{line: 719, col: 5, offset: 20710},
 						run: (*parser).callonDerefExprPattern23,
 						expr: &litMatcher{
-							pos:        position{line: 712, col: 5, offset: 20509},
+							pos:        position{line: 719, col: 5, offset: 20710},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -5771,12 +5835,12 @@ var g = &grammar{
 		},
 		{
 			name: "This",
-			pos:  position{line: 716, col: 1, offset: 20590},
+			pos:  position{line: 723, col: 1, offset: 20791},
 			expr: &actionExpr{
-				pos: position{line: 716, col: 8, offset: 20597},
+				pos: position{line: 723, col: 8, offset: 20798},
 				run: (*parser).callonThis1,
 				expr: &litMatcher{
-					pos:        position{line: 716, col: 8, offset: 20597},
+					pos:        position{line: 723, col: 8, offset: 20798},
 					val:        "this",
 					ignoreCase: false,
 				},
@@ -5784,26 +5848,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotID",
-			pos:  position{line: 718, col: 1, offset: 20671},
+			pos:  position{line: 725, col: 1, offset: 20872},
 			expr: &choiceExpr{
-				pos: position{line: 719, col: 5, offset: 20681},
+				pos: position{line: 726, col: 5, offset: 20882},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 20681},
+						pos: position{line: 726, col: 5, offset: 20882},
 						run: (*parser).callonDotID2,
 						expr: &seqExpr{
-							pos: position{line: 719, col: 5, offset: 20681},
+							pos: position{line: 726, col: 5, offset: 20882},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 719, col: 5, offset: 20681},
+									pos:        position{line: 726, col: 5, offset: 20882},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 719, col: 9, offset: 20685},
+									pos:   position{line: 726, col: 9, offset: 20886},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 719, col: 15, offset: 20691},
+										pos:  position{line: 726, col: 15, offset: 20892},
 										name: "Identifier",
 									},
 								},
@@ -5811,31 +5875,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 728, col: 5, offset: 20919},
+						pos: position{line: 735, col: 5, offset: 21120},
 						run: (*parser).callonDotID7,
 						expr: &seqExpr{
-							pos: position{line: 728, col: 5, offset: 20919},
+							pos: position{line: 735, col: 5, offset: 21120},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 728, col: 5, offset: 20919},
+									pos:        position{line: 735, col: 5, offset: 21120},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 728, col: 9, offset: 20923},
+									pos:        position{line: 735, col: 9, offset: 21124},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 13, offset: 20927},
+									pos:   position{line: 735, col: 13, offset: 21128},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 728, col: 18, offset: 20932},
+										pos:  position{line: 735, col: 18, offset: 21133},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 728, col: 23, offset: 20937},
+									pos:        position{line: 735, col: 23, offset: 21138},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5847,52 +5911,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 738, col: 1, offset: 21154},
+			pos:  position{line: 745, col: 1, offset: 21355},
 			expr: &choiceExpr{
-				pos: position{line: 739, col: 5, offset: 21164},
+				pos: position{line: 746, col: 5, offset: 21365},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 739, col: 5, offset: 21164},
+						pos: position{line: 746, col: 5, offset: 21365},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 739, col: 5, offset: 21164},
+							pos: position{line: 746, col: 5, offset: 21365},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 739, col: 5, offset: 21164},
+									pos:        position{line: 746, col: 5, offset: 21365},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 739, col: 9, offset: 21168},
+									pos:   position{line: 746, col: 9, offset: 21369},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 14, offset: 21173},
+										pos:  position{line: 746, col: 14, offset: 21374},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 739, col: 27, offset: 21186},
+									pos:  position{line: 746, col: 27, offset: 21387},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 739, col: 30, offset: 21189},
+									pos:        position{line: 746, col: 30, offset: 21390},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 739, col: 34, offset: 21193},
+									pos:  position{line: 746, col: 34, offset: 21394},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 739, col: 37, offset: 21196},
+									pos:   position{line: 746, col: 37, offset: 21397},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 40, offset: 21199},
+										pos:  position{line: 746, col: 40, offset: 21400},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 739, col: 53, offset: 21212},
+									pos:        position{line: 746, col: 53, offset: 21413},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5900,39 +5964,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 745, col: 5, offset: 21383},
+						pos: position{line: 752, col: 5, offset: 21584},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 745, col: 5, offset: 21383},
+							pos: position{line: 752, col: 5, offset: 21584},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 745, col: 5, offset: 21383},
+									pos:        position{line: 752, col: 5, offset: 21584},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 745, col: 9, offset: 21387},
+									pos:  position{line: 752, col: 9, offset: 21588},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 745, col: 12, offset: 21390},
+									pos:        position{line: 752, col: 12, offset: 21591},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 745, col: 16, offset: 21394},
+									pos:  position{line: 752, col: 16, offset: 21595},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 745, col: 19, offset: 21397},
+									pos:   position{line: 752, col: 19, offset: 21598},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 745, col: 22, offset: 21400},
+										pos:  position{line: 752, col: 22, offset: 21601},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 745, col: 35, offset: 21413},
+									pos:        position{line: 752, col: 35, offset: 21614},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5940,39 +6004,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 751, col: 5, offset: 21584},
+						pos: position{line: 758, col: 5, offset: 21785},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 751, col: 5, offset: 21584},
+							pos: position{line: 758, col: 5, offset: 21785},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 751, col: 5, offset: 21584},
+									pos:        position{line: 758, col: 5, offset: 21785},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 751, col: 9, offset: 21588},
+									pos:   position{line: 758, col: 9, offset: 21789},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 751, col: 14, offset: 21593},
+										pos:  position{line: 758, col: 14, offset: 21794},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 751, col: 27, offset: 21606},
+									pos:  position{line: 758, col: 27, offset: 21807},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 751, col: 30, offset: 21609},
+									pos:        position{line: 758, col: 30, offset: 21810},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 751, col: 34, offset: 21613},
+									pos:  position{line: 758, col: 34, offset: 21814},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 751, col: 37, offset: 21616},
+									pos:        position{line: 758, col: 37, offset: 21817},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5980,26 +6044,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 757, col: 5, offset: 21789},
+						pos: position{line: 764, col: 5, offset: 21990},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 757, col: 5, offset: 21789},
+							pos: position{line: 764, col: 5, offset: 21990},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 757, col: 5, offset: 21789},
+									pos:        position{line: 764, col: 5, offset: 21990},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 757, col: 9, offset: 21793},
+									pos:   position{line: 764, col: 9, offset: 21994},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 757, col: 14, offset: 21798},
+										pos:  position{line: 764, col: 14, offset: 21999},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 757, col: 19, offset: 21803},
+									pos:        position{line: 764, col: 19, offset: 22004},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6007,29 +6071,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 758, col: 5, offset: 21852},
+						pos: position{line: 765, col: 5, offset: 22053},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 758, col: 5, offset: 21852},
+							pos: position{line: 765, col: 5, offset: 22053},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 758, col: 5, offset: 21852},
+									pos:        position{line: 765, col: 5, offset: 22053},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 758, col: 9, offset: 21856},
+									pos: position{line: 765, col: 9, offset: 22057},
 									expr: &litMatcher{
-										pos:        position{line: 758, col: 11, offset: 21858},
+										pos:        position{line: 765, col: 11, offset: 22059},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 758, col: 16, offset: 21863},
+									pos:   position{line: 765, col: 16, offset: 22064},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 758, col: 19, offset: 21866},
+										pos:  position{line: 765, col: 19, offset: 22067},
 										name: "Identifier",
 									},
 								},
@@ -6041,59 +6105,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 760, col: 1, offset: 21917},
+			pos:  position{line: 767, col: 1, offset: 22118},
 			expr: &choiceExpr{
-				pos: position{line: 761, col: 5, offset: 21929},
+				pos: position{line: 768, col: 5, offset: 22130},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 761, col: 5, offset: 21929},
+						pos:  position{line: 768, col: 5, offset: 22130},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 762, col: 5, offset: 21940},
+						pos:  position{line: 769, col: 5, offset: 22141},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 763, col: 5, offset: 21950},
+						pos:  position{line: 770, col: 5, offset: 22151},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 764, col: 5, offset: 21958},
+						pos:  position{line: 771, col: 5, offset: 22159},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 765, col: 5, offset: 21966},
+						pos:  position{line: 772, col: 5, offset: 22167},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 766, col: 5, offset: 21978},
+						pos: position{line: 773, col: 5, offset: 22179},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 766, col: 5, offset: 21978},
+							pos: position{line: 773, col: 5, offset: 22179},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 766, col: 5, offset: 21978},
+									pos:        position{line: 773, col: 5, offset: 22179},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 766, col: 9, offset: 21982},
+									pos:  position{line: 773, col: 9, offset: 22183},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 766, col: 12, offset: 21985},
+									pos:   position{line: 773, col: 12, offset: 22186},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 766, col: 17, offset: 21990},
+										pos:  position{line: 773, col: 17, offset: 22191},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 766, col: 22, offset: 21995},
+									pos:  position{line: 773, col: 22, offset: 22196},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 766, col: 25, offset: 21998},
+									pos:        position{line: 773, col: 25, offset: 22199},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6105,36 +6169,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 768, col: 1, offset: 22024},
+			pos:  position{line: 775, col: 1, offset: 22225},
 			expr: &actionExpr{
-				pos: position{line: 769, col: 5, offset: 22035},
+				pos: position{line: 776, col: 5, offset: 22236},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 769, col: 5, offset: 22035},
+					pos: position{line: 776, col: 5, offset: 22236},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 769, col: 5, offset: 22035},
+							pos:        position{line: 776, col: 5, offset: 22236},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 769, col: 9, offset: 22039},
+							pos:  position{line: 776, col: 9, offset: 22240},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 769, col: 12, offset: 22042},
+							pos:   position{line: 776, col: 12, offset: 22243},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 769, col: 19, offset: 22049},
+								pos:  position{line: 776, col: 19, offset: 22250},
 								name: "Fields",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 769, col: 26, offset: 22056},
+							pos:  position{line: 776, col: 26, offset: 22257},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 769, col: 29, offset: 22059},
+							pos:        position{line: 776, col: 29, offset: 22260},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6144,31 +6208,31 @@ var g = &grammar{
 		},
 		{
 			name: "Fields",
-			pos:  position{line: 773, col: 1, offset: 22152},
+			pos:  position{line: 780, col: 1, offset: 22353},
 			expr: &choiceExpr{
-				pos: position{line: 774, col: 5, offset: 22163},
+				pos: position{line: 781, col: 5, offset: 22364},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 774, col: 5, offset: 22163},
+						pos: position{line: 781, col: 5, offset: 22364},
 						run: (*parser).callonFields2,
 						expr: &seqExpr{
-							pos: position{line: 774, col: 5, offset: 22163},
+							pos: position{line: 781, col: 5, offset: 22364},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 774, col: 5, offset: 22163},
+									pos:   position{line: 781, col: 5, offset: 22364},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 774, col: 11, offset: 22169},
+										pos:  position{line: 781, col: 11, offset: 22370},
 										name: "Field",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 774, col: 17, offset: 22175},
+									pos:   position{line: 781, col: 17, offset: 22376},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 774, col: 22, offset: 22180},
+										pos: position{line: 781, col: 22, offset: 22381},
 										expr: &ruleRefExpr{
-											pos:  position{line: 774, col: 22, offset: 22180},
+											pos:  position{line: 781, col: 22, offset: 22381},
 											name: "FieldTail",
 										},
 									},
@@ -6177,10 +6241,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 777, col: 5, offset: 22274},
+						pos: position{line: 784, col: 5, offset: 22475},
 						run: (*parser).callonFields9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 777, col: 5, offset: 22274},
+							pos:  position{line: 784, col: 5, offset: 22475},
 							name: "__",
 						},
 					},
@@ -6189,31 +6253,31 @@ var g = &grammar{
 		},
 		{
 			name: "FieldTail",
-			pos:  position{line: 779, col: 1, offset: 22310},
+			pos:  position{line: 786, col: 1, offset: 22511},
 			expr: &actionExpr{
-				pos: position{line: 779, col: 13, offset: 22322},
+				pos: position{line: 786, col: 13, offset: 22523},
 				run: (*parser).callonFieldTail1,
 				expr: &seqExpr{
-					pos: position{line: 779, col: 13, offset: 22322},
+					pos: position{line: 786, col: 13, offset: 22523},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 13, offset: 22322},
+							pos:  position{line: 786, col: 13, offset: 22523},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 779, col: 16, offset: 22325},
+							pos:        position{line: 786, col: 16, offset: 22526},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 20, offset: 22329},
+							pos:  position{line: 786, col: 20, offset: 22530},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 779, col: 23, offset: 22332},
+							pos:   position{line: 786, col: 23, offset: 22533},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 779, col: 25, offset: 22334},
+								pos:  position{line: 786, col: 25, offset: 22535},
 								name: "Field",
 							},
 						},
@@ -6223,39 +6287,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 781, col: 1, offset: 22359},
+			pos:  position{line: 788, col: 1, offset: 22560},
 			expr: &actionExpr{
-				pos: position{line: 782, col: 5, offset: 22369},
+				pos: position{line: 789, col: 5, offset: 22570},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 782, col: 5, offset: 22369},
+					pos: position{line: 789, col: 5, offset: 22570},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 782, col: 5, offset: 22369},
+							pos:   position{line: 789, col: 5, offset: 22570},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 782, col: 10, offset: 22374},
+								pos:  position{line: 789, col: 10, offset: 22575},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 782, col: 20, offset: 22384},
+							pos:  position{line: 789, col: 20, offset: 22585},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 782, col: 23, offset: 22387},
+							pos:        position{line: 789, col: 23, offset: 22588},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 782, col: 27, offset: 22391},
+							pos:  position{line: 789, col: 27, offset: 22592},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 782, col: 30, offset: 22394},
+							pos:   position{line: 789, col: 30, offset: 22595},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 782, col: 36, offset: 22400},
+								pos:  position{line: 789, col: 36, offset: 22601},
 								name: "Expr",
 							},
 						},
@@ -6265,36 +6329,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 786, col: 1, offset: 22485},
+			pos:  position{line: 793, col: 1, offset: 22686},
 			expr: &actionExpr{
-				pos: position{line: 787, col: 5, offset: 22495},
+				pos: position{line: 794, col: 5, offset: 22696},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 787, col: 5, offset: 22495},
+					pos: position{line: 794, col: 5, offset: 22696},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 787, col: 5, offset: 22495},
+							pos:        position{line: 794, col: 5, offset: 22696},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 787, col: 9, offset: 22499},
+							pos:  position{line: 794, col: 9, offset: 22700},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 787, col: 12, offset: 22502},
+							pos:   position{line: 794, col: 12, offset: 22703},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 787, col: 18, offset: 22508},
+								pos:  position{line: 794, col: 18, offset: 22709},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 787, col: 32, offset: 22522},
+							pos:  position{line: 794, col: 32, offset: 22723},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 787, col: 35, offset: 22525},
+							pos:        position{line: 794, col: 35, offset: 22726},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6304,36 +6368,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 791, col: 1, offset: 22615},
+			pos:  position{line: 798, col: 1, offset: 22816},
 			expr: &actionExpr{
-				pos: position{line: 792, col: 5, offset: 22623},
+				pos: position{line: 799, col: 5, offset: 22824},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 792, col: 5, offset: 22623},
+					pos: position{line: 799, col: 5, offset: 22824},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 792, col: 5, offset: 22623},
+							pos:        position{line: 799, col: 5, offset: 22824},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 10, offset: 22628},
+							pos:  position{line: 799, col: 10, offset: 22829},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 792, col: 13, offset: 22631},
+							pos:   position{line: 799, col: 13, offset: 22832},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 792, col: 19, offset: 22637},
+								pos:  position{line: 799, col: 19, offset: 22838},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 33, offset: 22651},
+							pos:  position{line: 799, col: 33, offset: 22852},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 792, col: 36, offset: 22654},
+							pos:        position{line: 799, col: 36, offset: 22855},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6343,36 +6407,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 796, col: 1, offset: 22743},
+			pos:  position{line: 803, col: 1, offset: 22944},
 			expr: &actionExpr{
-				pos: position{line: 797, col: 5, offset: 22751},
+				pos: position{line: 804, col: 5, offset: 22952},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 797, col: 5, offset: 22751},
+					pos: position{line: 804, col: 5, offset: 22952},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 797, col: 5, offset: 22751},
+							pos:        position{line: 804, col: 5, offset: 22952},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 797, col: 10, offset: 22756},
+							pos:  position{line: 804, col: 10, offset: 22957},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 797, col: 13, offset: 22759},
+							pos:   position{line: 804, col: 13, offset: 22960},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 797, col: 19, offset: 22765},
+								pos:  position{line: 804, col: 19, offset: 22966},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 797, col: 27, offset: 22773},
+							pos:  position{line: 804, col: 27, offset: 22974},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 797, col: 30, offset: 22776},
+							pos:        position{line: 804, col: 30, offset: 22977},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6382,31 +6446,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 801, col: 1, offset: 22867},
+			pos:  position{line: 808, col: 1, offset: 23068},
 			expr: &choiceExpr{
-				pos: position{line: 802, col: 5, offset: 22879},
+				pos: position{line: 809, col: 5, offset: 23080},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 802, col: 5, offset: 22879},
+						pos: position{line: 809, col: 5, offset: 23080},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 802, col: 5, offset: 22879},
+							pos: position{line: 809, col: 5, offset: 23080},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 802, col: 5, offset: 22879},
+									pos:   position{line: 809, col: 5, offset: 23080},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 802, col: 11, offset: 22885},
+										pos:  position{line: 809, col: 11, offset: 23086},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 802, col: 17, offset: 22891},
+									pos:   position{line: 809, col: 17, offset: 23092},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 802, col: 22, offset: 22896},
+										pos: position{line: 809, col: 22, offset: 23097},
 										expr: &ruleRefExpr{
-											pos:  position{line: 802, col: 22, offset: 22896},
+											pos:  position{line: 809, col: 22, offset: 23097},
 											name: "EntryTail",
 										},
 									},
@@ -6415,10 +6479,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 805, col: 5, offset: 22990},
+						pos: position{line: 812, col: 5, offset: 23191},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 805, col: 5, offset: 22990},
+							pos:  position{line: 812, col: 5, offset: 23191},
 							name: "__",
 						},
 					},
@@ -6427,31 +6491,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 808, col: 1, offset: 23027},
+			pos:  position{line: 815, col: 1, offset: 23228},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 13, offset: 23039},
+				pos: position{line: 815, col: 13, offset: 23240},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 13, offset: 23039},
+					pos: position{line: 815, col: 13, offset: 23240},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 13, offset: 23039},
+							pos:  position{line: 815, col: 13, offset: 23240},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 808, col: 16, offset: 23042},
+							pos:        position{line: 815, col: 16, offset: 23243},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 20, offset: 23046},
+							pos:  position{line: 815, col: 20, offset: 23247},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 23, offset: 23049},
+							pos:   position{line: 815, col: 23, offset: 23250},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 25, offset: 23051},
+								pos:  position{line: 815, col: 25, offset: 23252},
 								name: "Entry",
 							},
 						},
@@ -6461,39 +6525,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 810, col: 1, offset: 23076},
+			pos:  position{line: 817, col: 1, offset: 23277},
 			expr: &actionExpr{
-				pos: position{line: 811, col: 5, offset: 23086},
+				pos: position{line: 818, col: 5, offset: 23287},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 811, col: 5, offset: 23086},
+					pos: position{line: 818, col: 5, offset: 23287},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 811, col: 5, offset: 23086},
+							pos:   position{line: 818, col: 5, offset: 23287},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 811, col: 9, offset: 23090},
+								pos:  position{line: 818, col: 9, offset: 23291},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 811, col: 14, offset: 23095},
+							pos:  position{line: 818, col: 14, offset: 23296},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 811, col: 17, offset: 23098},
+							pos:        position{line: 818, col: 17, offset: 23299},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 811, col: 21, offset: 23102},
+							pos:  position{line: 818, col: 21, offset: 23303},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 811, col: 24, offset: 23105},
+							pos:   position{line: 818, col: 24, offset: 23306},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 811, col: 30, offset: 23111},
+								pos:  position{line: 818, col: 30, offset: 23312},
 								name: "Expr",
 							},
 						},
@@ -6503,92 +6567,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLProc",
-			pos:  position{line: 817, col: 1, offset: 23218},
+			pos:  position{line: 824, col: 1, offset: 23419},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 5, offset: 23230},
+				pos: position{line: 825, col: 5, offset: 23431},
 				run: (*parser).callonSQLProc1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 5, offset: 23230},
+					pos: position{line: 825, col: 5, offset: 23431},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 818, col: 5, offset: 23230},
+							pos:   position{line: 825, col: 5, offset: 23431},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 15, offset: 23240},
+								pos:  position{line: 825, col: 15, offset: 23441},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 819, col: 5, offset: 23254},
+							pos:   position{line: 826, col: 5, offset: 23455},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 819, col: 10, offset: 23259},
+								pos: position{line: 826, col: 10, offset: 23460},
 								expr: &ruleRefExpr{
-									pos:  position{line: 819, col: 10, offset: 23259},
+									pos:  position{line: 826, col: 10, offset: 23460},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 820, col: 5, offset: 23272},
+							pos:   position{line: 827, col: 5, offset: 23473},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 820, col: 11, offset: 23278},
+								pos: position{line: 827, col: 11, offset: 23479},
 								expr: &ruleRefExpr{
-									pos:  position{line: 820, col: 11, offset: 23278},
+									pos:  position{line: 827, col: 11, offset: 23479},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 5, offset: 23292},
+							pos:   position{line: 828, col: 5, offset: 23493},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 821, col: 11, offset: 23298},
+								pos: position{line: 828, col: 11, offset: 23499},
 								expr: &ruleRefExpr{
-									pos:  position{line: 821, col: 11, offset: 23298},
+									pos:  position{line: 828, col: 11, offset: 23499},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 5, offset: 23312},
+							pos:   position{line: 829, col: 5, offset: 23513},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 822, col: 13, offset: 23320},
+								pos: position{line: 829, col: 13, offset: 23521},
 								expr: &ruleRefExpr{
-									pos:  position{line: 822, col: 13, offset: 23320},
+									pos:  position{line: 829, col: 13, offset: 23521},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 823, col: 5, offset: 23336},
+							pos:   position{line: 830, col: 5, offset: 23537},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 823, col: 12, offset: 23343},
+								pos: position{line: 830, col: 12, offset: 23544},
 								expr: &ruleRefExpr{
-									pos:  position{line: 823, col: 12, offset: 23343},
+									pos:  position{line: 830, col: 12, offset: 23544},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 824, col: 5, offset: 23358},
+							pos:   position{line: 831, col: 5, offset: 23559},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 824, col: 13, offset: 23366},
+								pos: position{line: 831, col: 13, offset: 23567},
 								expr: &ruleRefExpr{
-									pos:  position{line: 824, col: 13, offset: 23366},
+									pos:  position{line: 831, col: 13, offset: 23567},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 825, col: 5, offset: 23382},
+							pos:   position{line: 832, col: 5, offset: 23583},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 825, col: 11, offset: 23388},
+								pos:  position{line: 832, col: 11, offset: 23589},
 								name: "SQLLimit",
 							},
 						},
@@ -6598,26 +6662,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 849, col: 1, offset: 23755},
+			pos:  position{line: 856, col: 1, offset: 23956},
 			expr: &choiceExpr{
-				pos: position{line: 850, col: 5, offset: 23769},
+				pos: position{line: 857, col: 5, offset: 23970},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 850, col: 5, offset: 23769},
+						pos: position{line: 857, col: 5, offset: 23970},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 850, col: 5, offset: 23769},
+							pos: position{line: 857, col: 5, offset: 23970},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 850, col: 5, offset: 23769},
+									pos:  position{line: 857, col: 5, offset: 23970},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 850, col: 12, offset: 23776},
+									pos:  position{line: 857, col: 12, offset: 23977},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 850, col: 14, offset: 23778},
+									pos:        position{line: 857, col: 14, offset: 23979},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6625,24 +6689,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 851, col: 5, offset: 23806},
+						pos: position{line: 858, col: 5, offset: 24007},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 851, col: 5, offset: 23806},
+							pos: position{line: 858, col: 5, offset: 24007},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 851, col: 5, offset: 23806},
+									pos:  position{line: 858, col: 5, offset: 24007},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 851, col: 12, offset: 23813},
+									pos:  position{line: 858, col: 12, offset: 24014},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 851, col: 14, offset: 23815},
+									pos:   position{line: 858, col: 14, offset: 24016},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 851, col: 26, offset: 23827},
+										pos:  position{line: 858, col: 26, offset: 24028},
 										name: "SQLAssignments",
 									},
 								},
@@ -6654,41 +6718,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 853, col: 1, offset: 23871},
+			pos:  position{line: 860, col: 1, offset: 24072},
 			expr: &choiceExpr{
-				pos: position{line: 854, col: 5, offset: 23889},
+				pos: position{line: 861, col: 5, offset: 24090},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 854, col: 5, offset: 23889},
+						pos: position{line: 861, col: 5, offset: 24090},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 854, col: 5, offset: 23889},
+							pos: position{line: 861, col: 5, offset: 24090},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 854, col: 5, offset: 23889},
+									pos:   position{line: 861, col: 5, offset: 24090},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 854, col: 9, offset: 23893},
+										pos:  position{line: 861, col: 9, offset: 24094},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 854, col: 14, offset: 23898},
+									pos:  position{line: 861, col: 14, offset: 24099},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 854, col: 16, offset: 23900},
+									pos:  position{line: 861, col: 16, offset: 24101},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 854, col: 19, offset: 23903},
+									pos:  position{line: 861, col: 19, offset: 24104},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 854, col: 21, offset: 23905},
+									pos:   position{line: 861, col: 21, offset: 24106},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 854, col: 25, offset: 23909},
+										pos:  position{line: 861, col: 25, offset: 24110},
 										name: "Lval",
 									},
 								},
@@ -6696,13 +6760,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 855, col: 5, offset: 24003},
+						pos: position{line: 862, col: 5, offset: 24204},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 855, col: 5, offset: 24003},
+							pos:   position{line: 862, col: 5, offset: 24204},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 10, offset: 24008},
+								pos:  position{line: 862, col: 10, offset: 24209},
 								name: "Expr",
 							},
 						},
@@ -6712,50 +6776,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 857, col: 1, offset: 24100},
+			pos:  position{line: 864, col: 1, offset: 24301},
 			expr: &actionExpr{
-				pos: position{line: 858, col: 5, offset: 24119},
+				pos: position{line: 865, col: 5, offset: 24320},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 858, col: 5, offset: 24119},
+					pos: position{line: 865, col: 5, offset: 24320},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 858, col: 5, offset: 24119},
+							pos:   position{line: 865, col: 5, offset: 24320},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 858, col: 11, offset: 24125},
+								pos:  position{line: 865, col: 11, offset: 24326},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 858, col: 25, offset: 24139},
+							pos:   position{line: 865, col: 25, offset: 24340},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 858, col: 30, offset: 24144},
+								pos: position{line: 865, col: 30, offset: 24345},
 								expr: &actionExpr{
-									pos: position{line: 858, col: 31, offset: 24145},
+									pos: position{line: 865, col: 31, offset: 24346},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 858, col: 31, offset: 24145},
+										pos: position{line: 865, col: 31, offset: 24346},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 858, col: 31, offset: 24145},
+												pos:  position{line: 865, col: 31, offset: 24346},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 858, col: 34, offset: 24148},
+												pos:        position{line: 865, col: 34, offset: 24349},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 858, col: 38, offset: 24152},
+												pos:  position{line: 865, col: 38, offset: 24353},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 858, col: 41, offset: 24155},
+												pos:   position{line: 865, col: 41, offset: 24356},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 858, col: 46, offset: 24160},
+													pos:  position{line: 865, col: 46, offset: 24361},
 													name: "SQLAssignment",
 												},
 											},
@@ -6770,43 +6834,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 862, col: 1, offset: 24281},
+			pos:  position{line: 869, col: 1, offset: 24482},
 			expr: &choiceExpr{
-				pos: position{line: 863, col: 5, offset: 24293},
+				pos: position{line: 870, col: 5, offset: 24494},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 863, col: 5, offset: 24293},
+						pos: position{line: 870, col: 5, offset: 24494},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 863, col: 5, offset: 24293},
+							pos: position{line: 870, col: 5, offset: 24494},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 5, offset: 24293},
+									pos:  position{line: 870, col: 5, offset: 24494},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 7, offset: 24295},
+									pos:  position{line: 870, col: 7, offset: 24496},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 12, offset: 24300},
+									pos:  position{line: 870, col: 12, offset: 24501},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 863, col: 14, offset: 24302},
+									pos:   position{line: 870, col: 14, offset: 24503},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 863, col: 20, offset: 24308},
+										pos:  position{line: 870, col: 20, offset: 24509},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 863, col: 29, offset: 24317},
+									pos:   position{line: 870, col: 29, offset: 24518},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 863, col: 35, offset: 24323},
+										pos: position{line: 870, col: 35, offset: 24524},
 										expr: &ruleRefExpr{
-											pos:  position{line: 863, col: 35, offset: 24323},
+											pos:  position{line: 870, col: 35, offset: 24524},
 											name: "SQLAlias",
 										},
 									},
@@ -6815,25 +6879,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 866, col: 5, offset: 24418},
+						pos: position{line: 873, col: 5, offset: 24619},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 866, col: 5, offset: 24418},
+							pos: position{line: 873, col: 5, offset: 24619},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 5, offset: 24418},
+									pos:  position{line: 873, col: 5, offset: 24619},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 7, offset: 24420},
+									pos:  position{line: 873, col: 7, offset: 24621},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 12, offset: 24425},
+									pos:  position{line: 873, col: 12, offset: 24626},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 866, col: 14, offset: 24427},
+									pos:        position{line: 873, col: 14, offset: 24628},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6845,33 +6909,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 868, col: 1, offset: 24452},
+			pos:  position{line: 875, col: 1, offset: 24653},
 			expr: &choiceExpr{
-				pos: position{line: 869, col: 5, offset: 24465},
+				pos: position{line: 876, col: 5, offset: 24666},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 869, col: 5, offset: 24465},
+						pos: position{line: 876, col: 5, offset: 24666},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 869, col: 5, offset: 24465},
+							pos: position{line: 876, col: 5, offset: 24666},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 869, col: 5, offset: 24465},
+									pos:  position{line: 876, col: 5, offset: 24666},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 869, col: 7, offset: 24467},
+									pos:  position{line: 876, col: 7, offset: 24668},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 869, col: 10, offset: 24470},
+									pos:  position{line: 876, col: 10, offset: 24671},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 869, col: 12, offset: 24472},
+									pos:   position{line: 876, col: 12, offset: 24673},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 869, col: 15, offset: 24475},
+										pos:  position{line: 876, col: 15, offset: 24676},
 										name: "Lval",
 									},
 								},
@@ -6879,36 +6943,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 870, col: 5, offset: 24503},
+						pos: position{line: 877, col: 5, offset: 24704},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 870, col: 5, offset: 24503},
+							pos: position{line: 877, col: 5, offset: 24704},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 870, col: 5, offset: 24503},
+									pos:  position{line: 877, col: 5, offset: 24704},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 870, col: 7, offset: 24505},
+									pos: position{line: 877, col: 7, offset: 24706},
 									expr: &seqExpr{
-										pos: position{line: 870, col: 9, offset: 24507},
+										pos: position{line: 877, col: 9, offset: 24708},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 870, col: 9, offset: 24507},
+												pos:  position{line: 877, col: 9, offset: 24708},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 870, col: 27, offset: 24525},
+												pos:  position{line: 877, col: 27, offset: 24726},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 870, col: 30, offset: 24528},
+									pos:   position{line: 877, col: 30, offset: 24729},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 870, col: 33, offset: 24531},
+										pos:  position{line: 877, col: 33, offset: 24732},
 										name: "Lval",
 									},
 								},
@@ -6920,42 +6984,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 872, col: 1, offset: 24556},
+			pos:  position{line: 879, col: 1, offset: 24757},
 			expr: &ruleRefExpr{
-				pos:  position{line: 873, col: 5, offset: 24569},
+				pos:  position{line: 880, col: 5, offset: 24770},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 875, col: 1, offset: 24575},
+			pos:  position{line: 882, col: 1, offset: 24776},
 			expr: &actionExpr{
-				pos: position{line: 876, col: 5, offset: 24588},
+				pos: position{line: 883, col: 5, offset: 24789},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 876, col: 5, offset: 24588},
+					pos: position{line: 883, col: 5, offset: 24789},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 876, col: 5, offset: 24588},
+							pos:   position{line: 883, col: 5, offset: 24789},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 876, col: 11, offset: 24594},
+								pos:  position{line: 883, col: 11, offset: 24795},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 19, offset: 24602},
+							pos:   position{line: 883, col: 19, offset: 24803},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 876, col: 24, offset: 24607},
+								pos: position{line: 883, col: 24, offset: 24808},
 								expr: &actionExpr{
-									pos: position{line: 876, col: 25, offset: 24608},
+									pos: position{line: 883, col: 25, offset: 24809},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 876, col: 25, offset: 24608},
+										pos:   position{line: 883, col: 25, offset: 24809},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 876, col: 30, offset: 24613},
+											pos:  position{line: 883, col: 30, offset: 24814},
 											name: "SQLJoin",
 										},
 									},
@@ -6968,90 +7032,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 880, col: 1, offset: 24728},
+			pos:  position{line: 887, col: 1, offset: 24929},
 			expr: &actionExpr{
-				pos: position{line: 881, col: 5, offset: 24740},
+				pos: position{line: 888, col: 5, offset: 24941},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 881, col: 5, offset: 24740},
+					pos: position{line: 888, col: 5, offset: 24941},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 881, col: 5, offset: 24740},
+							pos:   position{line: 888, col: 5, offset: 24941},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 881, col: 11, offset: 24746},
+								pos:  position{line: 888, col: 11, offset: 24947},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 881, col: 24, offset: 24759},
+							pos:  position{line: 888, col: 24, offset: 24960},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 881, col: 26, offset: 24761},
+							pos:  position{line: 888, col: 26, offset: 24962},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 881, col: 31, offset: 24766},
+							pos:  position{line: 888, col: 31, offset: 24967},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 881, col: 33, offset: 24768},
+							pos:   position{line: 888, col: 33, offset: 24969},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 881, col: 39, offset: 24774},
+								pos:  position{line: 888, col: 39, offset: 24975},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 881, col: 48, offset: 24783},
+							pos:   position{line: 888, col: 48, offset: 24984},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 881, col: 54, offset: 24789},
+								pos: position{line: 888, col: 54, offset: 24990},
 								expr: &ruleRefExpr{
-									pos:  position{line: 881, col: 54, offset: 24789},
+									pos:  position{line: 888, col: 54, offset: 24990},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 881, col: 64, offset: 24799},
+							pos:  position{line: 888, col: 64, offset: 25000},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 881, col: 66, offset: 24801},
+							pos:  position{line: 888, col: 66, offset: 25002},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 881, col: 69, offset: 24804},
+							pos:  position{line: 888, col: 69, offset: 25005},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 881, col: 71, offset: 24806},
+							pos:   position{line: 888, col: 71, offset: 25007},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 881, col: 79, offset: 24814},
+								pos:  position{line: 888, col: 79, offset: 25015},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 881, col: 87, offset: 24822},
+							pos:  position{line: 888, col: 87, offset: 25023},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 881, col: 90, offset: 24825},
+							pos:        position{line: 888, col: 90, offset: 25026},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 881, col: 94, offset: 24829},
+							pos:  position{line: 888, col: 94, offset: 25030},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 881, col: 97, offset: 24832},
+							pos:   position{line: 888, col: 97, offset: 25033},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 881, col: 106, offset: 24841},
+								pos:  position{line: 888, col: 106, offset: 25042},
 								name: "JoinKey",
 							},
 						},
@@ -7061,40 +7125,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 900, col: 1, offset: 25076},
+			pos:  position{line: 907, col: 1, offset: 25277},
 			expr: &choiceExpr{
-				pos: position{line: 901, col: 5, offset: 25093},
+				pos: position{line: 908, col: 5, offset: 25294},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 901, col: 5, offset: 25093},
+						pos: position{line: 908, col: 5, offset: 25294},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 901, col: 5, offset: 25093},
+							pos: position{line: 908, col: 5, offset: 25294},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 901, col: 5, offset: 25093},
+									pos:  position{line: 908, col: 5, offset: 25294},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 901, col: 7, offset: 25095},
+									pos:   position{line: 908, col: 7, offset: 25296},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 901, col: 14, offset: 25102},
+										pos: position{line: 908, col: 14, offset: 25303},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 14, offset: 25102},
+												pos:  position{line: 908, col: 14, offset: 25303},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 21, offset: 25109},
+												pos:  position{line: 908, col: 21, offset: 25310},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 29, offset: 25117},
+												pos:  position{line: 908, col: 29, offset: 25318},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 36, offset: 25124},
+												pos:  position{line: 908, col: 36, offset: 25325},
 												name: "RIGHT",
 											},
 										},
@@ -7104,10 +7168,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 902, col: 5, offset: 25157},
+						pos: position{line: 909, col: 5, offset: 25358},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 902, col: 5, offset: 25157},
+							pos:        position{line: 909, col: 5, offset: 25358},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7117,30 +7181,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 904, col: 1, offset: 25185},
+			pos:  position{line: 911, col: 1, offset: 25386},
 			expr: &actionExpr{
-				pos: position{line: 905, col: 5, offset: 25198},
+				pos: position{line: 912, col: 5, offset: 25399},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 905, col: 5, offset: 25198},
+					pos: position{line: 912, col: 5, offset: 25399},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 5, offset: 25198},
+							pos:  position{line: 912, col: 5, offset: 25399},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 7, offset: 25200},
+							pos:  position{line: 912, col: 7, offset: 25401},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 13, offset: 25206},
+							pos:  position{line: 912, col: 13, offset: 25407},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 905, col: 15, offset: 25208},
+							pos:   position{line: 912, col: 15, offset: 25409},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 905, col: 20, offset: 25213},
+								pos:  position{line: 912, col: 20, offset: 25414},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7150,38 +7214,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 907, col: 1, offset: 25249},
+			pos:  position{line: 914, col: 1, offset: 25450},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 5, offset: 25264},
+				pos: position{line: 915, col: 5, offset: 25465},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 908, col: 5, offset: 25264},
+					pos: position{line: 915, col: 5, offset: 25465},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 5, offset: 25264},
+							pos:  position{line: 915, col: 5, offset: 25465},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 7, offset: 25266},
+							pos:  position{line: 915, col: 7, offset: 25467},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 13, offset: 25272},
+							pos:  position{line: 915, col: 13, offset: 25473},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 15, offset: 25274},
+							pos:  position{line: 915, col: 15, offset: 25475},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 18, offset: 25277},
+							pos:  position{line: 915, col: 18, offset: 25478},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 908, col: 20, offset: 25279},
+							pos:   position{line: 915, col: 20, offset: 25480},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 908, col: 28, offset: 25287},
+								pos:  position{line: 915, col: 28, offset: 25488},
 								name: "FieldExprs",
 							},
 						},
@@ -7191,30 +7255,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 910, col: 1, offset: 25323},
+			pos:  position{line: 917, col: 1, offset: 25524},
 			expr: &actionExpr{
-				pos: position{line: 911, col: 5, offset: 25337},
+				pos: position{line: 918, col: 5, offset: 25538},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 911, col: 5, offset: 25337},
+					pos: position{line: 918, col: 5, offset: 25538},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 5, offset: 25337},
+							pos:  position{line: 918, col: 5, offset: 25538},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 7, offset: 25339},
+							pos:  position{line: 918, col: 7, offset: 25540},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 14, offset: 25346},
+							pos:  position{line: 918, col: 14, offset: 25547},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 911, col: 16, offset: 25348},
+							pos:   position{line: 918, col: 16, offset: 25549},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 911, col: 21, offset: 25353},
+								pos:  position{line: 918, col: 21, offset: 25554},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7224,46 +7288,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 913, col: 1, offset: 25389},
+			pos:  position{line: 920, col: 1, offset: 25590},
 			expr: &actionExpr{
-				pos: position{line: 914, col: 5, offset: 25404},
+				pos: position{line: 921, col: 5, offset: 25605},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 914, col: 5, offset: 25404},
+					pos: position{line: 921, col: 5, offset: 25605},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 914, col: 5, offset: 25404},
+							pos:  position{line: 921, col: 5, offset: 25605},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 914, col: 7, offset: 25406},
+							pos:  position{line: 921, col: 7, offset: 25607},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 914, col: 13, offset: 25412},
+							pos:  position{line: 921, col: 13, offset: 25613},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 914, col: 15, offset: 25414},
+							pos:  position{line: 921, col: 15, offset: 25615},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 914, col: 18, offset: 25417},
+							pos:  position{line: 921, col: 18, offset: 25618},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 914, col: 20, offset: 25419},
+							pos:   position{line: 921, col: 20, offset: 25620},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 914, col: 25, offset: 25424},
+								pos:  position{line: 921, col: 25, offset: 25625},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 914, col: 31, offset: 25430},
+							pos:   position{line: 921, col: 31, offset: 25631},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 914, col: 37, offset: 25436},
+								pos:  position{line: 921, col: 37, offset: 25637},
 								name: "SQLOrder",
 							},
 						},
@@ -7273,32 +7337,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 918, col: 1, offset: 25546},
+			pos:  position{line: 925, col: 1, offset: 25747},
 			expr: &choiceExpr{
-				pos: position{line: 919, col: 5, offset: 25559},
+				pos: position{line: 926, col: 5, offset: 25760},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 919, col: 5, offset: 25559},
+						pos: position{line: 926, col: 5, offset: 25760},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 919, col: 5, offset: 25559},
+							pos: position{line: 926, col: 5, offset: 25760},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 919, col: 5, offset: 25559},
+									pos:  position{line: 926, col: 5, offset: 25760},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 919, col: 7, offset: 25561},
+									pos:   position{line: 926, col: 7, offset: 25762},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 919, col: 12, offset: 25566},
+										pos: position{line: 926, col: 12, offset: 25767},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 919, col: 12, offset: 25566},
+												pos:  position{line: 926, col: 12, offset: 25767},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 919, col: 18, offset: 25572},
+												pos:  position{line: 926, col: 18, offset: 25773},
 												name: "DESC",
 											},
 										},
@@ -7308,10 +7372,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 920, col: 5, offset: 25602},
+						pos: position{line: 927, col: 5, offset: 25803},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 920, col: 5, offset: 25602},
+							pos:        position{line: 927, col: 5, offset: 25803},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7321,33 +7385,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 922, col: 1, offset: 25628},
+			pos:  position{line: 929, col: 1, offset: 25829},
 			expr: &choiceExpr{
-				pos: position{line: 923, col: 5, offset: 25641},
+				pos: position{line: 930, col: 5, offset: 25842},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 923, col: 5, offset: 25641},
+						pos: position{line: 930, col: 5, offset: 25842},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 923, col: 5, offset: 25641},
+							pos: position{line: 930, col: 5, offset: 25842},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 5, offset: 25641},
+									pos:  position{line: 930, col: 5, offset: 25842},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 7, offset: 25643},
+									pos:  position{line: 930, col: 7, offset: 25844},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 13, offset: 25649},
+									pos:  position{line: 930, col: 13, offset: 25850},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 923, col: 15, offset: 25651},
+									pos:   position{line: 930, col: 15, offset: 25852},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 923, col: 21, offset: 25657},
+										pos:  position{line: 930, col: 21, offset: 25858},
 										name: "UInt",
 									},
 								},
@@ -7355,10 +7419,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 924, col: 5, offset: 25688},
+						pos: position{line: 931, col: 5, offset: 25889},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 924, col: 5, offset: 25688},
+							pos:        position{line: 931, col: 5, offset: 25889},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7368,12 +7432,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 926, col: 1, offset: 25710},
+			pos:  position{line: 933, col: 1, offset: 25911},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 10, offset: 25719},
+				pos: position{line: 933, col: 10, offset: 25920},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 926, col: 10, offset: 25719},
+					pos:        position{line: 933, col: 10, offset: 25920},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7381,12 +7445,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 927, col: 1, offset: 25754},
+			pos:  position{line: 934, col: 1, offset: 25955},
 			expr: &actionExpr{
-				pos: position{line: 927, col: 6, offset: 25759},
+				pos: position{line: 934, col: 6, offset: 25960},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 927, col: 6, offset: 25759},
+					pos:        position{line: 934, col: 6, offset: 25960},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7394,12 +7458,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 928, col: 1, offset: 25786},
+			pos:  position{line: 935, col: 1, offset: 25987},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 8, offset: 25793},
+				pos: position{line: 935, col: 8, offset: 25994},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 928, col: 8, offset: 25793},
+					pos:        position{line: 935, col: 8, offset: 25994},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7407,12 +7471,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 929, col: 1, offset: 25824},
+			pos:  position{line: 936, col: 1, offset: 26025},
 			expr: &actionExpr{
-				pos: position{line: 929, col: 8, offset: 25831},
+				pos: position{line: 936, col: 8, offset: 26032},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 929, col: 8, offset: 25831},
+					pos:        position{line: 936, col: 8, offset: 26032},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7420,12 +7484,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 930, col: 1, offset: 25862},
+			pos:  position{line: 937, col: 1, offset: 26063},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 9, offset: 25870},
+				pos: position{line: 937, col: 9, offset: 26071},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 930, col: 9, offset: 25870},
+					pos:        position{line: 937, col: 9, offset: 26071},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7433,12 +7497,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 931, col: 1, offset: 25903},
+			pos:  position{line: 938, col: 1, offset: 26104},
 			expr: &actionExpr{
-				pos: position{line: 931, col: 9, offset: 25911},
+				pos: position{line: 938, col: 9, offset: 26112},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 931, col: 9, offset: 25911},
+					pos:        position{line: 938, col: 9, offset: 26112},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7446,20 +7510,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 932, col: 1, offset: 25944},
+			pos:  position{line: 939, col: 1, offset: 26145},
 			expr: &ruleRefExpr{
-				pos:  position{line: 932, col: 6, offset: 25949},
+				pos:  position{line: 939, col: 6, offset: 26150},
 				name: "ByToken",
 			},
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 933, col: 1, offset: 25957},
+			pos:  position{line: 940, col: 1, offset: 26158},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 10, offset: 25966},
+				pos: position{line: 940, col: 10, offset: 26167},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 933, col: 10, offset: 25966},
+					pos:        position{line: 940, col: 10, offset: 26167},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7467,12 +7531,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 934, col: 1, offset: 26001},
+			pos:  position{line: 941, col: 1, offset: 26202},
 			expr: &actionExpr{
-				pos: position{line: 934, col: 9, offset: 26009},
+				pos: position{line: 941, col: 9, offset: 26210},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 934, col: 9, offset: 26009},
+					pos:        position{line: 941, col: 9, offset: 26210},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7480,12 +7544,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 935, col: 1, offset: 26042},
+			pos:  position{line: 942, col: 1, offset: 26243},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 6, offset: 26047},
+				pos: position{line: 942, col: 6, offset: 26248},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 935, col: 6, offset: 26047},
+					pos:        position{line: 942, col: 6, offset: 26248},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7493,12 +7557,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 936, col: 1, offset: 26074},
+			pos:  position{line: 943, col: 1, offset: 26275},
 			expr: &actionExpr{
-				pos: position{line: 936, col: 9, offset: 26082},
+				pos: position{line: 943, col: 9, offset: 26283},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 936, col: 9, offset: 26082},
+					pos:        position{line: 943, col: 9, offset: 26283},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7506,12 +7570,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 937, col: 1, offset: 26115},
+			pos:  position{line: 944, col: 1, offset: 26316},
 			expr: &actionExpr{
-				pos: position{line: 937, col: 7, offset: 26121},
+				pos: position{line: 944, col: 7, offset: 26322},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 937, col: 7, offset: 26121},
+					pos:        position{line: 944, col: 7, offset: 26322},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7519,12 +7583,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 938, col: 1, offset: 26150},
+			pos:  position{line: 945, col: 1, offset: 26351},
 			expr: &actionExpr{
-				pos: position{line: 938, col: 8, offset: 26157},
+				pos: position{line: 945, col: 8, offset: 26358},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 938, col: 8, offset: 26157},
+					pos:        position{line: 945, col: 8, offset: 26358},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7532,12 +7596,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 939, col: 1, offset: 26188},
+			pos:  position{line: 946, col: 1, offset: 26389},
 			expr: &actionExpr{
-				pos: position{line: 939, col: 8, offset: 26195},
+				pos: position{line: 946, col: 8, offset: 26396},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 939, col: 8, offset: 26195},
+					pos:        position{line: 946, col: 8, offset: 26396},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7545,12 +7609,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 940, col: 1, offset: 26226},
+			pos:  position{line: 947, col: 1, offset: 26427},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 8, offset: 26233},
+				pos: position{line: 947, col: 8, offset: 26434},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 940, col: 8, offset: 26233},
+					pos:        position{line: 947, col: 8, offset: 26434},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7558,12 +7622,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 941, col: 1, offset: 26264},
+			pos:  position{line: 948, col: 1, offset: 26465},
 			expr: &actionExpr{
-				pos: position{line: 941, col: 9, offset: 26272},
+				pos: position{line: 948, col: 9, offset: 26473},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 941, col: 9, offset: 26272},
+					pos:        position{line: 948, col: 9, offset: 26473},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7571,12 +7635,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 942, col: 1, offset: 26305},
+			pos:  position{line: 949, col: 1, offset: 26506},
 			expr: &actionExpr{
-				pos: position{line: 942, col: 9, offset: 26313},
+				pos: position{line: 949, col: 9, offset: 26514},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 942, col: 9, offset: 26313},
+					pos:        position{line: 949, col: 9, offset: 26514},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7584,48 +7648,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 944, col: 1, offset: 26347},
+			pos:  position{line: 951, col: 1, offset: 26548},
 			expr: &choiceExpr{
-				pos: position{line: 945, col: 5, offset: 26369},
+				pos: position{line: 952, col: 5, offset: 26570},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 5, offset: 26369},
+						pos:  position{line: 952, col: 5, offset: 26570},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 14, offset: 26378},
+						pos:  position{line: 952, col: 14, offset: 26579},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 19, offset: 26383},
+						pos:  position{line: 952, col: 19, offset: 26584},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 27, offset: 26391},
+						pos:  position{line: 952, col: 27, offset: 26592},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 34, offset: 26398},
+						pos:  position{line: 952, col: 34, offset: 26599},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 42, offset: 26406},
+						pos:  position{line: 952, col: 42, offset: 26607},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 50, offset: 26414},
+						pos:  position{line: 952, col: 50, offset: 26615},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 59, offset: 26423},
+						pos:  position{line: 952, col: 59, offset: 26624},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 67, offset: 26431},
+						pos:  position{line: 952, col: 67, offset: 26632},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 75, offset: 26439},
+						pos:  position{line: 952, col: 75, offset: 26640},
 						name: "ON",
 					},
 				},
@@ -7633,52 +7697,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 949, col: 1, offset: 26465},
+			pos:  position{line: 956, col: 1, offset: 26666},
 			expr: &choiceExpr{
-				pos: position{line: 950, col: 5, offset: 26477},
+				pos: position{line: 957, col: 5, offset: 26678},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 950, col: 5, offset: 26477},
+						pos:  position{line: 957, col: 5, offset: 26678},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 951, col: 5, offset: 26493},
+						pos:  position{line: 958, col: 5, offset: 26694},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 5, offset: 26513},
+						pos:  position{line: 959, col: 5, offset: 26714},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 953, col: 5, offset: 26531},
+						pos:  position{line: 960, col: 5, offset: 26732},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 954, col: 5, offset: 26550},
+						pos:  position{line: 961, col: 5, offset: 26751},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 955, col: 5, offset: 26567},
+						pos:  position{line: 962, col: 5, offset: 26768},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 956, col: 5, offset: 26580},
+						pos:  position{line: 963, col: 5, offset: 26781},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 5, offset: 26589},
+						pos:  position{line: 964, col: 5, offset: 26790},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 958, col: 5, offset: 26606},
+						pos:  position{line: 965, col: 5, offset: 26807},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 959, col: 5, offset: 26625},
+						pos:  position{line: 966, col: 5, offset: 26826},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 960, col: 5, offset: 26644},
+						pos:  position{line: 967, col: 5, offset: 26845},
 						name: "NullLiteral",
 					},
 				},
@@ -7686,28 +7750,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 962, col: 1, offset: 26657},
+			pos:  position{line: 969, col: 1, offset: 26858},
 			expr: &choiceExpr{
-				pos: position{line: 963, col: 5, offset: 26675},
+				pos: position{line: 970, col: 5, offset: 26876},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 963, col: 5, offset: 26675},
+						pos: position{line: 970, col: 5, offset: 26876},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 963, col: 5, offset: 26675},
+							pos: position{line: 970, col: 5, offset: 26876},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 963, col: 5, offset: 26675},
+									pos:   position{line: 970, col: 5, offset: 26876},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 963, col: 7, offset: 26677},
+										pos:  position{line: 970, col: 7, offset: 26878},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 963, col: 14, offset: 26684},
+									pos: position{line: 970, col: 14, offset: 26885},
 									expr: &ruleRefExpr{
-										pos:  position{line: 963, col: 15, offset: 26685},
+										pos:  position{line: 970, col: 15, offset: 26886},
 										name: "IdentifierRest",
 									},
 								},
@@ -7715,13 +7779,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 966, col: 5, offset: 26800},
+						pos: position{line: 973, col: 5, offset: 27001},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 966, col: 5, offset: 26800},
+							pos:   position{line: 973, col: 5, offset: 27001},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 966, col: 7, offset: 26802},
+								pos:  position{line: 973, col: 7, offset: 27003},
 								name: "IP4Net",
 							},
 						},
@@ -7731,28 +7795,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 970, col: 1, offset: 26906},
+			pos:  position{line: 977, col: 1, offset: 27107},
 			expr: &choiceExpr{
-				pos: position{line: 971, col: 5, offset: 26925},
+				pos: position{line: 978, col: 5, offset: 27126},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 971, col: 5, offset: 26925},
+						pos: position{line: 978, col: 5, offset: 27126},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 971, col: 5, offset: 26925},
+							pos: position{line: 978, col: 5, offset: 27126},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 971, col: 5, offset: 26925},
+									pos:   position{line: 978, col: 5, offset: 27126},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 971, col: 7, offset: 26927},
+										pos:  position{line: 978, col: 7, offset: 27128},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 971, col: 11, offset: 26931},
+									pos: position{line: 978, col: 11, offset: 27132},
 									expr: &ruleRefExpr{
-										pos:  position{line: 971, col: 12, offset: 26932},
+										pos:  position{line: 978, col: 12, offset: 27133},
 										name: "IdentifierRest",
 									},
 								},
@@ -7760,13 +7824,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 974, col: 5, offset: 27046},
+						pos: position{line: 981, col: 5, offset: 27247},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 974, col: 5, offset: 27046},
+							pos:   position{line: 981, col: 5, offset: 27247},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 974, col: 7, offset: 27048},
+								pos:  position{line: 981, col: 7, offset: 27249},
 								name: "IP",
 							},
 						},
@@ -7776,15 +7840,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 978, col: 1, offset: 27147},
+			pos:  position{line: 985, col: 1, offset: 27348},
 			expr: &actionExpr{
-				pos: position{line: 979, col: 5, offset: 27164},
+				pos: position{line: 986, col: 5, offset: 27365},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 979, col: 5, offset: 27164},
+					pos:   position{line: 986, col: 5, offset: 27365},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 979, col: 7, offset: 27166},
+						pos:  position{line: 986, col: 7, offset: 27367},
 						name: "FloatString",
 					},
 				},
@@ -7792,15 +7856,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 983, col: 1, offset: 27279},
+			pos:  position{line: 990, col: 1, offset: 27480},
 			expr: &actionExpr{
-				pos: position{line: 984, col: 5, offset: 27298},
+				pos: position{line: 991, col: 5, offset: 27499},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 984, col: 5, offset: 27298},
+					pos:   position{line: 991, col: 5, offset: 27499},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 984, col: 7, offset: 27300},
+						pos:  position{line: 991, col: 7, offset: 27501},
 						name: "IntString",
 					},
 				},
@@ -7808,24 +7872,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 988, col: 1, offset: 27409},
+			pos:  position{line: 995, col: 1, offset: 27610},
 			expr: &choiceExpr{
-				pos: position{line: 989, col: 5, offset: 27428},
+				pos: position{line: 996, col: 5, offset: 27629},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 989, col: 5, offset: 27428},
+						pos: position{line: 996, col: 5, offset: 27629},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 989, col: 5, offset: 27428},
+							pos:        position{line: 996, col: 5, offset: 27629},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 990, col: 5, offset: 27541},
+						pos: position{line: 997, col: 5, offset: 27742},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 990, col: 5, offset: 27541},
+							pos:        position{line: 997, col: 5, offset: 27742},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7835,12 +7899,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 992, col: 1, offset: 27652},
+			pos:  position{line: 999, col: 1, offset: 27853},
 			expr: &actionExpr{
-				pos: position{line: 993, col: 5, offset: 27668},
+				pos: position{line: 1000, col: 5, offset: 27869},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 993, col: 5, offset: 27668},
+					pos:        position{line: 1000, col: 5, offset: 27869},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7848,22 +7912,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 995, col: 1, offset: 27774},
+			pos:  position{line: 1002, col: 1, offset: 27975},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 5, offset: 27791},
+				pos: position{line: 1003, col: 5, offset: 27992},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 996, col: 5, offset: 27791},
+					pos: position{line: 1003, col: 5, offset: 27992},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 996, col: 5, offset: 27791},
+							pos:        position{line: 1003, col: 5, offset: 27992},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 996, col: 10, offset: 27796},
+							pos: position{line: 1003, col: 10, offset: 27997},
 							expr: &ruleRefExpr{
-								pos:  position{line: 996, col: 10, offset: 27796},
+								pos:  position{line: 1003, col: 10, offset: 27997},
 								name: "HexDigit",
 							},
 						},
@@ -7873,28 +7937,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1000, col: 1, offset: 27911},
+			pos:  position{line: 1007, col: 1, offset: 28112},
 			expr: &actionExpr{
-				pos: position{line: 1001, col: 5, offset: 27927},
+				pos: position{line: 1008, col: 5, offset: 28128},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1001, col: 5, offset: 27927},
+					pos: position{line: 1008, col: 5, offset: 28128},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1001, col: 5, offset: 27927},
+							pos:        position{line: 1008, col: 5, offset: 28128},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1001, col: 9, offset: 27931},
+							pos:   position{line: 1008, col: 9, offset: 28132},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1001, col: 13, offset: 27935},
+								pos:  position{line: 1008, col: 13, offset: 28136},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1001, col: 18, offset: 27940},
+							pos:        position{line: 1008, col: 18, offset: 28141},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -7904,16 +7968,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1005, col: 1, offset: 28029},
+			pos:  position{line: 1012, col: 1, offset: 28230},
 			expr: &choiceExpr{
-				pos: position{line: 1006, col: 5, offset: 28042},
+				pos: position{line: 1013, col: 5, offset: 28243},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 5, offset: 28042},
+						pos:  position{line: 1013, col: 5, offset: 28243},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 28058},
+						pos:  position{line: 1014, col: 5, offset: 28259},
 						name: "PrimitiveType",
 					},
 				},
@@ -7921,20 +7985,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1009, col: 1, offset: 28073},
+			pos:  position{line: 1016, col: 1, offset: 28274},
 			expr: &choiceExpr{
-				pos: position{line: 1010, col: 5, offset: 28082},
+				pos: position{line: 1017, col: 5, offset: 28283},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1010, col: 5, offset: 28082},
+						pos:  position{line: 1017, col: 5, offset: 28283},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1011, col: 5, offset: 28098},
+						pos:  position{line: 1018, col: 5, offset: 28299},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1012, col: 5, offset: 28116},
+						pos:  position{line: 1019, col: 5, offset: 28317},
 						name: "ComplexType",
 					},
 				},
@@ -7942,28 +8006,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1014, col: 1, offset: 28129},
+			pos:  position{line: 1021, col: 1, offset: 28330},
 			expr: &choiceExpr{
-				pos: position{line: 1015, col: 5, offset: 28147},
+				pos: position{line: 1022, col: 5, offset: 28348},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1015, col: 5, offset: 28147},
+						pos: position{line: 1022, col: 5, offset: 28348},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1015, col: 5, offset: 28147},
+							pos: position{line: 1022, col: 5, offset: 28348},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1015, col: 5, offset: 28147},
+									pos:   position{line: 1022, col: 5, offset: 28348},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1015, col: 10, offset: 28152},
+										pos:  position{line: 1022, col: 10, offset: 28353},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1015, col: 24, offset: 28166},
+									pos: position{line: 1022, col: 24, offset: 28367},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1015, col: 25, offset: 28167},
+										pos:  position{line: 1022, col: 25, offset: 28368},
 										name: "IdentifierRest",
 									},
 								},
@@ -7971,55 +8035,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1016, col: 5, offset: 28207},
+						pos: position{line: 1023, col: 5, offset: 28408},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1016, col: 5, offset: 28207},
+							pos: position{line: 1023, col: 5, offset: 28408},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1016, col: 5, offset: 28207},
+									pos:   position{line: 1023, col: 5, offset: 28408},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1016, col: 10, offset: 28212},
+										pos:  position{line: 1023, col: 10, offset: 28413},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1016, col: 25, offset: 28227},
+									pos:  position{line: 1023, col: 25, offset: 28428},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1016, col: 28, offset: 28230},
+									pos:        position{line: 1023, col: 28, offset: 28431},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1016, col: 32, offset: 28234},
+									pos:  position{line: 1023, col: 32, offset: 28435},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1016, col: 35, offset: 28237},
+									pos:        position{line: 1023, col: 35, offset: 28438},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1016, col: 39, offset: 28241},
+									pos:  position{line: 1023, col: 39, offset: 28442},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1016, col: 42, offset: 28244},
+									pos:   position{line: 1023, col: 42, offset: 28445},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1016, col: 46, offset: 28248},
+										pos:  position{line: 1023, col: 46, offset: 28449},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1016, col: 51, offset: 28253},
+									pos:  position{line: 1023, col: 51, offset: 28454},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1016, col: 54, offset: 28256},
+									pos:        position{line: 1023, col: 54, offset: 28457},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8027,42 +8091,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 28357},
+						pos: position{line: 1026, col: 5, offset: 28558},
 						run: (*parser).callonAmbiguousType21,
 						expr: &labeledExpr{
-							pos:   position{line: 1019, col: 5, offset: 28357},
+							pos:   position{line: 1026, col: 5, offset: 28558},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1019, col: 10, offset: 28362},
+								pos:  position{line: 1026, col: 10, offset: 28563},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1022, col: 5, offset: 28464},
+						pos: position{line: 1029, col: 5, offset: 28665},
 						run: (*parser).callonAmbiguousType24,
 						expr: &seqExpr{
-							pos: position{line: 1022, col: 5, offset: 28464},
+							pos: position{line: 1029, col: 5, offset: 28665},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1022, col: 5, offset: 28464},
+									pos:        position{line: 1029, col: 5, offset: 28665},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1022, col: 9, offset: 28468},
+									pos:  position{line: 1029, col: 9, offset: 28669},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1022, col: 12, offset: 28471},
+									pos:   position{line: 1029, col: 12, offset: 28672},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1022, col: 14, offset: 28473},
+										pos:  position{line: 1029, col: 14, offset: 28674},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1022, col: 25, offset: 28484},
+									pos:        position{line: 1029, col: 25, offset: 28685},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8074,15 +8138,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1024, col: 1, offset: 28507},
+			pos:  position{line: 1031, col: 1, offset: 28708},
 			expr: &actionExpr{
-				pos: position{line: 1025, col: 5, offset: 28521},
+				pos: position{line: 1032, col: 5, offset: 28722},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1025, col: 5, offset: 28521},
+					pos:   position{line: 1032, col: 5, offset: 28722},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1025, col: 11, offset: 28527},
+						pos:  position{line: 1032, col: 11, offset: 28728},
 						name: "TypeList",
 					},
 				},
@@ -8090,28 +8154,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1029, col: 1, offset: 28623},
+			pos:  position{line: 1036, col: 1, offset: 28824},
 			expr: &actionExpr{
-				pos: position{line: 1030, col: 5, offset: 28636},
+				pos: position{line: 1037, col: 5, offset: 28837},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1030, col: 5, offset: 28636},
+					pos: position{line: 1037, col: 5, offset: 28837},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1030, col: 5, offset: 28636},
+							pos:   position{line: 1037, col: 5, offset: 28837},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1030, col: 11, offset: 28642},
+								pos:  position{line: 1037, col: 11, offset: 28843},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1030, col: 16, offset: 28647},
+							pos:   position{line: 1037, col: 16, offset: 28848},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1030, col: 21, offset: 28652},
+								pos: position{line: 1037, col: 21, offset: 28853},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1030, col: 21, offset: 28652},
+									pos:  position{line: 1037, col: 21, offset: 28853},
 									name: "TypeListTail",
 								},
 							},
@@ -8122,31 +8186,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1034, col: 1, offset: 28746},
+			pos:  position{line: 1041, col: 1, offset: 28947},
 			expr: &actionExpr{
-				pos: position{line: 1034, col: 16, offset: 28761},
+				pos: position{line: 1041, col: 16, offset: 28962},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1034, col: 16, offset: 28761},
+					pos: position{line: 1041, col: 16, offset: 28962},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1034, col: 16, offset: 28761},
+							pos:  position{line: 1041, col: 16, offset: 28962},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1034, col: 19, offset: 28764},
+							pos:        position{line: 1041, col: 19, offset: 28965},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1034, col: 23, offset: 28768},
+							pos:  position{line: 1041, col: 23, offset: 28969},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1034, col: 26, offset: 28771},
+							pos:   position{line: 1041, col: 26, offset: 28972},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1034, col: 30, offset: 28775},
+								pos:  position{line: 1041, col: 30, offset: 28976},
 								name: "Type",
 							},
 						},
@@ -8156,39 +8220,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1036, col: 1, offset: 28801},
+			pos:  position{line: 1043, col: 1, offset: 29002},
 			expr: &choiceExpr{
-				pos: position{line: 1037, col: 5, offset: 28817},
+				pos: position{line: 1044, col: 5, offset: 29018},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1037, col: 5, offset: 28817},
+						pos: position{line: 1044, col: 5, offset: 29018},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1037, col: 5, offset: 28817},
+							pos: position{line: 1044, col: 5, offset: 29018},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1037, col: 5, offset: 28817},
+									pos:        position{line: 1044, col: 5, offset: 29018},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 9, offset: 28821},
+									pos:  position{line: 1044, col: 9, offset: 29022},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1037, col: 12, offset: 28824},
+									pos:   position{line: 1044, col: 12, offset: 29025},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1037, col: 19, offset: 28831},
+										pos:  position{line: 1044, col: 19, offset: 29032},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 33, offset: 28845},
+									pos:  position{line: 1044, col: 33, offset: 29046},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1037, col: 36, offset: 28848},
+									pos:        position{line: 1044, col: 36, offset: 29049},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8196,34 +8260,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1040, col: 5, offset: 28943},
+						pos: position{line: 1047, col: 5, offset: 29144},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1040, col: 5, offset: 28943},
+							pos: position{line: 1047, col: 5, offset: 29144},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1040, col: 5, offset: 28943},
+									pos:        position{line: 1047, col: 5, offset: 29144},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1040, col: 9, offset: 28947},
+									pos:  position{line: 1047, col: 9, offset: 29148},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1040, col: 12, offset: 28950},
+									pos:   position{line: 1047, col: 12, offset: 29151},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1040, col: 16, offset: 28954},
+										pos:  position{line: 1047, col: 16, offset: 29155},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1040, col: 21, offset: 28959},
+									pos:  position{line: 1047, col: 21, offset: 29160},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1040, col: 24, offset: 28962},
+									pos:        position{line: 1047, col: 24, offset: 29163},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8231,34 +8295,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 29051},
+						pos: position{line: 1050, col: 5, offset: 29252},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1043, col: 5, offset: 29051},
+							pos: position{line: 1050, col: 5, offset: 29252},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1043, col: 5, offset: 29051},
+									pos:        position{line: 1050, col: 5, offset: 29252},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 10, offset: 29056},
+									pos:  position{line: 1050, col: 10, offset: 29257},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 14, offset: 29060},
+									pos:   position{line: 1050, col: 14, offset: 29261},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 18, offset: 29064},
+										pos:  position{line: 1050, col: 18, offset: 29265},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 23, offset: 29069},
+									pos:  position{line: 1050, col: 23, offset: 29270},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 26, offset: 29072},
+									pos:        position{line: 1050, col: 26, offset: 29273},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8266,55 +8330,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1046, col: 5, offset: 29160},
+						pos: position{line: 1053, col: 5, offset: 29361},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1046, col: 5, offset: 29160},
+							pos: position{line: 1053, col: 5, offset: 29361},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1046, col: 5, offset: 29160},
+									pos:        position{line: 1053, col: 5, offset: 29361},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 10, offset: 29165},
+									pos:  position{line: 1053, col: 10, offset: 29366},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 13, offset: 29168},
+									pos:   position{line: 1053, col: 13, offset: 29369},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1046, col: 21, offset: 29176},
+										pos:  position{line: 1053, col: 21, offset: 29377},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 26, offset: 29181},
+									pos:  position{line: 1053, col: 26, offset: 29382},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1046, col: 29, offset: 29184},
+									pos:        position{line: 1053, col: 29, offset: 29385},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 33, offset: 29188},
+									pos:  position{line: 1053, col: 33, offset: 29389},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 36, offset: 29191},
+									pos:   position{line: 1053, col: 36, offset: 29392},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1046, col: 44, offset: 29199},
+										pos:  position{line: 1053, col: 44, offset: 29400},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 49, offset: 29204},
+									pos:  position{line: 1053, col: 49, offset: 29405},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1046, col: 52, offset: 29207},
+									pos:        position{line: 1053, col: 52, offset: 29408},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8326,15 +8390,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1050, col: 1, offset: 29321},
+			pos:  position{line: 1057, col: 1, offset: 29522},
 			expr: &actionExpr{
-				pos: position{line: 1051, col: 5, offset: 29341},
+				pos: position{line: 1058, col: 5, offset: 29542},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1051, col: 5, offset: 29341},
+					pos:   position{line: 1058, col: 5, offset: 29542},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1051, col: 7, offset: 29343},
+						pos:  position{line: 1058, col: 7, offset: 29544},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8342,34 +8406,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1058, col: 1, offset: 29538},
+			pos:  position{line: 1065, col: 1, offset: 29739},
 			expr: &choiceExpr{
-				pos: position{line: 1059, col: 5, offset: 29563},
+				pos: position{line: 1066, col: 5, offset: 29764},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1059, col: 5, offset: 29563},
+						pos: position{line: 1066, col: 5, offset: 29764},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1059, col: 5, offset: 29563},
+							pos: position{line: 1066, col: 5, offset: 29764},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1059, col: 5, offset: 29563},
+									pos:        position{line: 1066, col: 5, offset: 29764},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1059, col: 9, offset: 29567},
+									pos:   position{line: 1066, col: 9, offset: 29768},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1059, col: 11, offset: 29569},
+										pos: position{line: 1066, col: 11, offset: 29770},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1059, col: 11, offset: 29569},
+											pos:  position{line: 1066, col: 11, offset: 29770},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1059, col: 37, offset: 29595},
+									pos:        position{line: 1066, col: 37, offset: 29796},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8377,29 +8441,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1060, col: 5, offset: 29621},
+						pos: position{line: 1067, col: 5, offset: 29822},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1060, col: 5, offset: 29621},
+							pos: position{line: 1067, col: 5, offset: 29822},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1060, col: 5, offset: 29621},
+									pos:        position{line: 1067, col: 5, offset: 29822},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1060, col: 9, offset: 29625},
+									pos:   position{line: 1067, col: 9, offset: 29826},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1060, col: 11, offset: 29627},
+										pos: position{line: 1067, col: 11, offset: 29828},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1060, col: 11, offset: 29627},
+											pos:  position{line: 1067, col: 11, offset: 29828},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1060, col: 37, offset: 29653},
+									pos:        position{line: 1067, col: 37, offset: 29854},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8411,24 +8475,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1062, col: 1, offset: 29676},
+			pos:  position{line: 1069, col: 1, offset: 29877},
 			expr: &choiceExpr{
-				pos: position{line: 1063, col: 5, offset: 29705},
+				pos: position{line: 1070, col: 5, offset: 29906},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1063, col: 5, offset: 29705},
+						pos:  position{line: 1070, col: 5, offset: 29906},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1064, col: 5, offset: 29722},
+						pos: position{line: 1071, col: 5, offset: 29923},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1064, col: 5, offset: 29722},
+							pos:   position{line: 1071, col: 5, offset: 29923},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1064, col: 7, offset: 29724},
+								pos: position{line: 1071, col: 7, offset: 29925},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1064, col: 7, offset: 29724},
+									pos:  position{line: 1071, col: 7, offset: 29925},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8439,26 +8503,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1068, col: 1, offset: 29861},
+			pos:  position{line: 1075, col: 1, offset: 30062},
 			expr: &choiceExpr{
-				pos: position{line: 1069, col: 5, offset: 29890},
+				pos: position{line: 1076, col: 5, offset: 30091},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 29890},
+						pos: position{line: 1076, col: 5, offset: 30091},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1069, col: 5, offset: 29890},
+							pos: position{line: 1076, col: 5, offset: 30091},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1069, col: 5, offset: 29890},
+									pos:        position{line: 1076, col: 5, offset: 30091},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 10, offset: 29895},
+									pos:   position{line: 1076, col: 10, offset: 30096},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1069, col: 12, offset: 29897},
+										pos:        position{line: 1076, col: 12, offset: 30098},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8467,24 +8531,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 29924},
+						pos: position{line: 1077, col: 5, offset: 30125},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1070, col: 5, offset: 29924},
+							pos: position{line: 1077, col: 5, offset: 30125},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1070, col: 5, offset: 29924},
+									pos: position{line: 1077, col: 5, offset: 30125},
 									expr: &litMatcher{
-										pos:        position{line: 1070, col: 8, offset: 29927},
+										pos:        position{line: 1077, col: 8, offset: 30128},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1070, col: 15, offset: 29934},
+									pos:   position{line: 1077, col: 15, offset: 30135},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1070, col: 17, offset: 29936},
+										pos:  position{line: 1077, col: 17, offset: 30137},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8496,24 +8560,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1072, col: 1, offset: 29972},
+			pos:  position{line: 1079, col: 1, offset: 30173},
 			expr: &choiceExpr{
-				pos: position{line: 1073, col: 5, offset: 30001},
+				pos: position{line: 1080, col: 5, offset: 30202},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1073, col: 5, offset: 30001},
+						pos:  position{line: 1080, col: 5, offset: 30202},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1074, col: 5, offset: 30018},
+						pos: position{line: 1081, col: 5, offset: 30219},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1074, col: 5, offset: 30018},
+							pos:   position{line: 1081, col: 5, offset: 30219},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1074, col: 7, offset: 30020},
+								pos: position{line: 1081, col: 7, offset: 30221},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1074, col: 7, offset: 30020},
+									pos:  position{line: 1081, col: 7, offset: 30221},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8524,26 +8588,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1078, col: 1, offset: 30157},
+			pos:  position{line: 1085, col: 1, offset: 30358},
 			expr: &choiceExpr{
-				pos: position{line: 1079, col: 5, offset: 30186},
+				pos: position{line: 1086, col: 5, offset: 30387},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1079, col: 5, offset: 30186},
+						pos: position{line: 1086, col: 5, offset: 30387},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1079, col: 5, offset: 30186},
+							pos: position{line: 1086, col: 5, offset: 30387},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1079, col: 5, offset: 30186},
+									pos:        position{line: 1086, col: 5, offset: 30387},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1079, col: 10, offset: 30191},
+									pos:   position{line: 1086, col: 10, offset: 30392},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1079, col: 12, offset: 30193},
+										pos:        position{line: 1086, col: 12, offset: 30394},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8552,24 +8616,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 30220},
+						pos: position{line: 1087, col: 5, offset: 30421},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1080, col: 5, offset: 30220},
+							pos: position{line: 1087, col: 5, offset: 30421},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1080, col: 5, offset: 30220},
+									pos: position{line: 1087, col: 5, offset: 30421},
 									expr: &litMatcher{
-										pos:        position{line: 1080, col: 8, offset: 30223},
+										pos:        position{line: 1087, col: 8, offset: 30424},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 15, offset: 30230},
+									pos:   position{line: 1087, col: 15, offset: 30431},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1080, col: 17, offset: 30232},
+										pos:  position{line: 1087, col: 17, offset: 30433},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8581,36 +8645,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1082, col: 1, offset: 30268},
+			pos:  position{line: 1089, col: 1, offset: 30469},
 			expr: &actionExpr{
-				pos: position{line: 1083, col: 5, offset: 30285},
+				pos: position{line: 1090, col: 5, offset: 30486},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1083, col: 5, offset: 30285},
+					pos: position{line: 1090, col: 5, offset: 30486},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1083, col: 5, offset: 30285},
+							pos:        position{line: 1090, col: 5, offset: 30486},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1083, col: 10, offset: 30290},
+							pos:  position{line: 1090, col: 10, offset: 30491},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1083, col: 13, offset: 30293},
+							pos:   position{line: 1090, col: 13, offset: 30494},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1083, col: 15, offset: 30295},
+								pos:  position{line: 1090, col: 15, offset: 30496},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1083, col: 20, offset: 30300},
+							pos:  position{line: 1090, col: 20, offset: 30501},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 23, offset: 30303},
+							pos:        position{line: 1090, col: 23, offset: 30504},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8620,110 +8684,110 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1085, col: 1, offset: 30326},
+			pos:  position{line: 1092, col: 1, offset: 30527},
 			expr: &actionExpr{
-				pos: position{line: 1086, col: 5, offset: 30344},
+				pos: position{line: 1093, col: 5, offset: 30545},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1086, col: 9, offset: 30348},
+					pos: position{line: 1093, col: 9, offset: 30549},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1086, col: 9, offset: 30348},
+							pos:        position{line: 1093, col: 9, offset: 30549},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 19, offset: 30358},
+							pos:        position{line: 1093, col: 19, offset: 30559},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 30, offset: 30369},
+							pos:        position{line: 1093, col: 30, offset: 30570},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 41, offset: 30380},
+							pos:        position{line: 1093, col: 41, offset: 30581},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1087, col: 9, offset: 30397},
+							pos:        position{line: 1094, col: 9, offset: 30598},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1087, col: 18, offset: 30406},
+							pos:        position{line: 1094, col: 18, offset: 30607},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1087, col: 28, offset: 30416},
+							pos:        position{line: 1094, col: 28, offset: 30617},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1087, col: 38, offset: 30426},
+							pos:        position{line: 1094, col: 38, offset: 30627},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1088, col: 9, offset: 30442},
+							pos:        position{line: 1095, col: 9, offset: 30643},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1088, col: 21, offset: 30454},
+							pos:        position{line: 1095, col: 21, offset: 30655},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1089, col: 9, offset: 30472},
+							pos:        position{line: 1096, col: 9, offset: 30673},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1089, col: 18, offset: 30481},
+							pos:        position{line: 1096, col: 18, offset: 30682},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1090, col: 9, offset: 30498},
+							pos:        position{line: 1097, col: 9, offset: 30699},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1090, col: 22, offset: 30511},
+							pos:        position{line: 1097, col: 22, offset: 30712},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1091, col: 9, offset: 30526},
+							pos:        position{line: 1098, col: 9, offset: 30727},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1092, col: 9, offset: 30542},
+							pos:        position{line: 1099, col: 9, offset: 30743},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1092, col: 16, offset: 30549},
+							pos:        position{line: 1099, col: 16, offset: 30750},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 9, offset: 30563},
+							pos:        position{line: 1100, col: 9, offset: 30764},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 18, offset: 30572},
+							pos:        position{line: 1100, col: 18, offset: 30773},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 28, offset: 30582},
+							pos:        position{line: 1100, col: 28, offset: 30783},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8733,28 +8797,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1097, col: 1, offset: 30698},
+			pos:  position{line: 1104, col: 1, offset: 30899},
 			expr: &actionExpr{
-				pos: position{line: 1098, col: 5, offset: 30716},
+				pos: position{line: 1105, col: 5, offset: 30917},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1098, col: 5, offset: 30716},
+					pos: position{line: 1105, col: 5, offset: 30917},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1098, col: 5, offset: 30716},
+							pos:   position{line: 1105, col: 5, offset: 30917},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1098, col: 11, offset: 30722},
+								pos:  position{line: 1105, col: 11, offset: 30923},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1098, col: 21, offset: 30732},
+							pos:   position{line: 1105, col: 21, offset: 30933},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1098, col: 26, offset: 30737},
+								pos: position{line: 1105, col: 26, offset: 30938},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1098, col: 26, offset: 30737},
+									pos:  position{line: 1105, col: 26, offset: 30938},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -8765,31 +8829,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1102, col: 1, offset: 30836},
+			pos:  position{line: 1109, col: 1, offset: 31037},
 			expr: &actionExpr{
-				pos: position{line: 1102, col: 21, offset: 30856},
+				pos: position{line: 1109, col: 21, offset: 31057},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1102, col: 21, offset: 30856},
+					pos: position{line: 1109, col: 21, offset: 31057},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1102, col: 21, offset: 30856},
+							pos:  position{line: 1109, col: 21, offset: 31057},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1102, col: 24, offset: 30859},
+							pos:        position{line: 1109, col: 24, offset: 31060},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1102, col: 28, offset: 30863},
+							pos:  position{line: 1109, col: 28, offset: 31064},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1102, col: 31, offset: 30866},
+							pos:   position{line: 1109, col: 31, offset: 31067},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1102, col: 35, offset: 30870},
+								pos:  position{line: 1109, col: 35, offset: 31071},
 								name: "TypeField",
 							},
 						},
@@ -8799,39 +8863,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1104, col: 1, offset: 30901},
+			pos:  position{line: 1111, col: 1, offset: 31102},
 			expr: &actionExpr{
-				pos: position{line: 1105, col: 5, offset: 30915},
+				pos: position{line: 1112, col: 5, offset: 31116},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1105, col: 5, offset: 30915},
+					pos: position{line: 1112, col: 5, offset: 31116},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1105, col: 5, offset: 30915},
+							pos:   position{line: 1112, col: 5, offset: 31116},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1105, col: 10, offset: 30920},
+								pos:  position{line: 1112, col: 10, offset: 31121},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1105, col: 20, offset: 30930},
+							pos:  position{line: 1112, col: 20, offset: 31131},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1105, col: 23, offset: 30933},
+							pos:        position{line: 1112, col: 23, offset: 31134},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1105, col: 27, offset: 30937},
+							pos:  position{line: 1112, col: 27, offset: 31138},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1105, col: 30, offset: 30940},
+							pos:   position{line: 1112, col: 30, offset: 31141},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1105, col: 34, offset: 30944},
+								pos:  position{line: 1112, col: 34, offset: 31145},
 								name: "Type",
 							},
 						},
@@ -8841,16 +8905,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1109, col: 1, offset: 31026},
+			pos:  position{line: 1116, col: 1, offset: 31227},
 			expr: &choiceExpr{
-				pos: position{line: 1110, col: 5, offset: 31040},
+				pos: position{line: 1117, col: 5, offset: 31241},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1110, col: 5, offset: 31040},
+						pos:  position{line: 1117, col: 5, offset: 31241},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1111, col: 5, offset: 31059},
+						pos:  position{line: 1118, col: 5, offset: 31260},
 						name: "QuotedString",
 					},
 				},
@@ -8858,16 +8922,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 1113, col: 1, offset: 31073},
+			pos:  position{line: 1120, col: 1, offset: 31274},
 			expr: &choiceExpr{
-				pos: position{line: 1114, col: 5, offset: 31091},
+				pos: position{line: 1121, col: 5, offset: 31292},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1114, col: 5, offset: 31091},
+						pos:  position{line: 1121, col: 5, offset: 31292},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1114, col: 24, offset: 31110},
+						pos:  position{line: 1121, col: 24, offset: 31311},
 						name: "RelativeOperator",
 					},
 				},
@@ -8875,22 +8939,22 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1116, col: 1, offset: 31128},
+			pos:  position{line: 1123, col: 1, offset: 31329},
 			expr: &actionExpr{
-				pos: position{line: 1116, col: 12, offset: 31139},
+				pos: position{line: 1123, col: 12, offset: 31340},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1116, col: 12, offset: 31139},
+					pos: position{line: 1123, col: 12, offset: 31340},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1116, col: 12, offset: 31139},
+							pos:        position{line: 1123, col: 12, offset: 31340},
 							val:        "and",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1116, col: 19, offset: 31146},
+							pos: position{line: 1123, col: 19, offset: 31347},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1116, col: 20, offset: 31147},
+								pos:  position{line: 1123, col: 20, offset: 31348},
 								name: "IdentifierRest",
 							},
 						},
@@ -8900,22 +8964,22 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1117, col: 1, offset: 31184},
+			pos:  position{line: 1124, col: 1, offset: 31385},
 			expr: &actionExpr{
-				pos: position{line: 1117, col: 11, offset: 31194},
+				pos: position{line: 1124, col: 11, offset: 31395},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1117, col: 11, offset: 31194},
+					pos: position{line: 1124, col: 11, offset: 31395},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1117, col: 11, offset: 31194},
+							pos:        position{line: 1124, col: 11, offset: 31395},
 							val:        "or",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1117, col: 17, offset: 31200},
+							pos: position{line: 1124, col: 17, offset: 31401},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1117, col: 18, offset: 31201},
+								pos:  position{line: 1124, col: 18, offset: 31402},
 								name: "IdentifierRest",
 							},
 						},
@@ -8925,22 +8989,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1118, col: 1, offset: 31237},
+			pos:  position{line: 1125, col: 1, offset: 31438},
 			expr: &actionExpr{
-				pos: position{line: 1118, col: 11, offset: 31247},
+				pos: position{line: 1125, col: 11, offset: 31448},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1118, col: 11, offset: 31247},
+					pos: position{line: 1125, col: 11, offset: 31448},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1118, col: 11, offset: 31247},
+							pos:        position{line: 1125, col: 11, offset: 31448},
 							val:        "in",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1118, col: 17, offset: 31253},
+							pos: position{line: 1125, col: 17, offset: 31454},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1118, col: 18, offset: 31254},
+								pos:  position{line: 1125, col: 18, offset: 31455},
 								name: "IdentifierRest",
 							},
 						},
@@ -8950,22 +9014,22 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1119, col: 1, offset: 31290},
+			pos:  position{line: 1126, col: 1, offset: 31491},
 			expr: &actionExpr{
-				pos: position{line: 1119, col: 12, offset: 31301},
+				pos: position{line: 1126, col: 12, offset: 31502},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1119, col: 12, offset: 31301},
+					pos: position{line: 1126, col: 12, offset: 31502},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1119, col: 12, offset: 31301},
+							pos:        position{line: 1126, col: 12, offset: 31502},
 							val:        "not",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1119, col: 19, offset: 31308},
+							pos: position{line: 1126, col: 19, offset: 31509},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1119, col: 20, offset: 31309},
+								pos:  position{line: 1126, col: 20, offset: 31510},
 								name: "IdentifierRest",
 							},
 						},
@@ -8975,22 +9039,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1120, col: 1, offset: 31346},
+			pos:  position{line: 1127, col: 1, offset: 31547},
 			expr: &actionExpr{
-				pos: position{line: 1120, col: 11, offset: 31356},
+				pos: position{line: 1127, col: 11, offset: 31557},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1120, col: 11, offset: 31356},
+					pos: position{line: 1127, col: 11, offset: 31557},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1120, col: 11, offset: 31356},
+							pos:        position{line: 1127, col: 11, offset: 31557},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1120, col: 17, offset: 31362},
+							pos: position{line: 1127, col: 17, offset: 31563},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1120, col: 18, offset: 31363},
+								pos:  position{line: 1127, col: 18, offset: 31564},
 								name: "IdentifierRest",
 							},
 						},
@@ -9000,9 +9064,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1122, col: 1, offset: 31400},
+			pos:  position{line: 1129, col: 1, offset: 31601},
 			expr: &charClassMatcher{
-				pos:        position{line: 1122, col: 19, offset: 31418},
+				pos:        position{line: 1129, col: 19, offset: 31619},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9012,16 +9076,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1124, col: 1, offset: 31430},
+			pos:  position{line: 1131, col: 1, offset: 31631},
 			expr: &choiceExpr{
-				pos: position{line: 1124, col: 18, offset: 31447},
+				pos: position{line: 1131, col: 18, offset: 31648},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1124, col: 18, offset: 31447},
+						pos:  position{line: 1131, col: 18, offset: 31648},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1124, col: 36, offset: 31465},
+						pos:        position{line: 1131, col: 36, offset: 31666},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9032,15 +9096,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1126, col: 1, offset: 31472},
+			pos:  position{line: 1133, col: 1, offset: 31673},
 			expr: &actionExpr{
-				pos: position{line: 1127, col: 5, offset: 31487},
+				pos: position{line: 1134, col: 5, offset: 31688},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1127, col: 5, offset: 31487},
+					pos:   position{line: 1134, col: 5, offset: 31688},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1127, col: 8, offset: 31490},
+						pos:  position{line: 1134, col: 8, offset: 31691},
 						name: "IdentifierName",
 					},
 				},
@@ -9048,29 +9112,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1129, col: 1, offset: 31571},
+			pos:  position{line: 1136, col: 1, offset: 31772},
 			expr: &choiceExpr{
-				pos: position{line: 1130, col: 5, offset: 31590},
+				pos: position{line: 1137, col: 5, offset: 31791},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1130, col: 5, offset: 31590},
+						pos: position{line: 1137, col: 5, offset: 31791},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1130, col: 5, offset: 31590},
+							pos: position{line: 1137, col: 5, offset: 31791},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1130, col: 5, offset: 31590},
+									pos: position{line: 1137, col: 5, offset: 31791},
 									expr: &seqExpr{
-										pos: position{line: 1130, col: 7, offset: 31592},
+										pos: position{line: 1137, col: 7, offset: 31793},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1130, col: 7, offset: 31592},
+												pos:  position{line: 1137, col: 7, offset: 31793},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1130, col: 15, offset: 31600},
+												pos: position{line: 1137, col: 15, offset: 31801},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1130, col: 16, offset: 31601},
+													pos:  position{line: 1137, col: 16, offset: 31802},
 													name: "IdentifierRest",
 												},
 											},
@@ -9078,13 +9142,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1130, col: 32, offset: 31617},
+									pos:  position{line: 1137, col: 32, offset: 31818},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1130, col: 48, offset: 31633},
+									pos: position{line: 1137, col: 48, offset: 31834},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1130, col: 48, offset: 31633},
+										pos:  position{line: 1137, col: 48, offset: 31834},
 										name: "IdentifierRest",
 									},
 								},
@@ -9092,30 +9156,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1131, col: 5, offset: 31685},
+						pos: position{line: 1138, col: 5, offset: 31886},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1131, col: 5, offset: 31685},
+							pos:        position{line: 1138, col: 5, offset: 31886},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1132, col: 5, offset: 31724},
+						pos: position{line: 1139, col: 5, offset: 31925},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1132, col: 5, offset: 31724},
+							pos: position{line: 1139, col: 5, offset: 31925},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1132, col: 5, offset: 31724},
+									pos:        position{line: 1139, col: 5, offset: 31925},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1132, col: 10, offset: 31729},
+									pos:   position{line: 1139, col: 10, offset: 31930},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1132, col: 13, offset: 31732},
+										pos:  position{line: 1139, col: 13, offset: 31933},
 										name: "IDGuard",
 									},
 								},
@@ -9123,39 +9187,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1134, col: 5, offset: 31823},
+						pos: position{line: 1141, col: 5, offset: 32024},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1134, col: 5, offset: 31823},
+							pos:        position{line: 1141, col: 5, offset: 32024},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1135, col: 5, offset: 31865},
+						pos: position{line: 1142, col: 5, offset: 32066},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1135, col: 5, offset: 31865},
+							pos: position{line: 1142, col: 5, offset: 32066},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1135, col: 5, offset: 31865},
+									pos:   position{line: 1142, col: 5, offset: 32066},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1135, col: 8, offset: 31868},
+										pos:  position{line: 1142, col: 8, offset: 32069},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1135, col: 26, offset: 31886},
+									pos: position{line: 1142, col: 26, offset: 32087},
 									expr: &seqExpr{
-										pos: position{line: 1135, col: 28, offset: 31888},
+										pos: position{line: 1142, col: 28, offset: 32089},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1135, col: 28, offset: 31888},
+												pos:  position{line: 1142, col: 28, offset: 32089},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1135, col: 31, offset: 31891},
+												pos:        position{line: 1142, col: 31, offset: 32092},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9170,16 +9234,16 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1137, col: 1, offset: 31916},
+			pos:  position{line: 1144, col: 1, offset: 32117},
 			expr: &choiceExpr{
-				pos: position{line: 1138, col: 5, offset: 31928},
+				pos: position{line: 1145, col: 5, offset: 32129},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1138, col: 5, offset: 31928},
+						pos:  position{line: 1145, col: 5, offset: 32129},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1139, col: 5, offset: 31947},
+						pos:  position{line: 1146, col: 5, offset: 32148},
 						name: "NullLiteral",
 					},
 				},
@@ -9187,24 +9251,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1141, col: 1, offset: 31960},
+			pos:  position{line: 1148, col: 1, offset: 32161},
 			expr: &actionExpr{
-				pos: position{line: 1142, col: 5, offset: 31969},
+				pos: position{line: 1149, col: 5, offset: 32170},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1142, col: 5, offset: 31969},
+					pos: position{line: 1149, col: 5, offset: 32170},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1142, col: 5, offset: 31969},
+							pos:  position{line: 1149, col: 5, offset: 32170},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1142, col: 14, offset: 31978},
+							pos:        position{line: 1149, col: 14, offset: 32179},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1142, col: 18, offset: 31982},
+							pos:  position{line: 1149, col: 18, offset: 32183},
 							name: "FullTime",
 						},
 					},
@@ -9213,30 +9277,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1146, col: 1, offset: 32102},
+			pos:  position{line: 1153, col: 1, offset: 32303},
 			expr: &seqExpr{
-				pos: position{line: 1146, col: 12, offset: 32113},
+				pos: position{line: 1153, col: 12, offset: 32314},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1146, col: 12, offset: 32113},
+						pos:  position{line: 1153, col: 12, offset: 32314},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1146, col: 15, offset: 32116},
+						pos:        position{line: 1153, col: 15, offset: 32317},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1146, col: 19, offset: 32120},
+						pos:  position{line: 1153, col: 19, offset: 32321},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1146, col: 22, offset: 32123},
+						pos:        position{line: 1153, col: 22, offset: 32324},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1146, col: 26, offset: 32127},
+						pos:  position{line: 1153, col: 26, offset: 32328},
 						name: "D2",
 					},
 				},
@@ -9244,33 +9308,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1148, col: 1, offset: 32131},
+			pos:  position{line: 1155, col: 1, offset: 32332},
 			expr: &seqExpr{
-				pos: position{line: 1148, col: 6, offset: 32136},
+				pos: position{line: 1155, col: 6, offset: 32337},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1148, col: 6, offset: 32136},
+						pos:        position{line: 1155, col: 6, offset: 32337},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1148, col: 11, offset: 32141},
+						pos:        position{line: 1155, col: 11, offset: 32342},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1148, col: 16, offset: 32146},
+						pos:        position{line: 1155, col: 16, offset: 32347},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1148, col: 21, offset: 32151},
+						pos:        position{line: 1155, col: 21, offset: 32352},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9281,19 +9345,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1149, col: 1, offset: 32157},
+			pos:  position{line: 1156, col: 1, offset: 32358},
 			expr: &seqExpr{
-				pos: position{line: 1149, col: 6, offset: 32162},
+				pos: position{line: 1156, col: 6, offset: 32363},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1149, col: 6, offset: 32162},
+						pos:        position{line: 1156, col: 6, offset: 32363},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1149, col: 11, offset: 32167},
+						pos:        position{line: 1156, col: 11, offset: 32368},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9304,16 +9368,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1151, col: 1, offset: 32174},
+			pos:  position{line: 1158, col: 1, offset: 32375},
 			expr: &seqExpr{
-				pos: position{line: 1151, col: 12, offset: 32185},
+				pos: position{line: 1158, col: 12, offset: 32386},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1151, col: 12, offset: 32185},
+						pos:  position{line: 1158, col: 12, offset: 32386},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1151, col: 24, offset: 32197},
+						pos:  position{line: 1158, col: 24, offset: 32398},
 						name: "TimeOffset",
 					},
 				},
@@ -9321,46 +9385,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1153, col: 1, offset: 32209},
+			pos:  position{line: 1160, col: 1, offset: 32410},
 			expr: &seqExpr{
-				pos: position{line: 1153, col: 15, offset: 32223},
+				pos: position{line: 1160, col: 15, offset: 32424},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 15, offset: 32223},
+						pos:  position{line: 1160, col: 15, offset: 32424},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1153, col: 18, offset: 32226},
+						pos:        position{line: 1160, col: 18, offset: 32427},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 22, offset: 32230},
+						pos:  position{line: 1160, col: 22, offset: 32431},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1153, col: 25, offset: 32233},
+						pos:        position{line: 1160, col: 25, offset: 32434},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 29, offset: 32237},
+						pos:  position{line: 1160, col: 29, offset: 32438},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1153, col: 32, offset: 32240},
+						pos: position{line: 1160, col: 32, offset: 32441},
 						expr: &seqExpr{
-							pos: position{line: 1153, col: 33, offset: 32241},
+							pos: position{line: 1160, col: 33, offset: 32442},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1153, col: 33, offset: 32241},
+									pos:        position{line: 1160, col: 33, offset: 32442},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1153, col: 37, offset: 32245},
+									pos: position{line: 1160, col: 37, offset: 32446},
 									expr: &charClassMatcher{
-										pos:        position{line: 1153, col: 37, offset: 32245},
+										pos:        position{line: 1160, col: 37, offset: 32446},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9375,60 +9439,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1155, col: 1, offset: 32255},
+			pos:  position{line: 1162, col: 1, offset: 32456},
 			expr: &choiceExpr{
-				pos: position{line: 1156, col: 5, offset: 32270},
+				pos: position{line: 1163, col: 5, offset: 32471},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1156, col: 5, offset: 32270},
+						pos:        position{line: 1163, col: 5, offset: 32471},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1157, col: 5, offset: 32278},
+						pos: position{line: 1164, col: 5, offset: 32479},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1157, col: 6, offset: 32279},
+								pos: position{line: 1164, col: 6, offset: 32480},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1157, col: 6, offset: 32279},
+										pos:        position{line: 1164, col: 6, offset: 32480},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1157, col: 12, offset: 32285},
+										pos:        position{line: 1164, col: 12, offset: 32486},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1157, col: 17, offset: 32290},
+								pos:  position{line: 1164, col: 17, offset: 32491},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1157, col: 20, offset: 32293},
+								pos:        position{line: 1164, col: 20, offset: 32494},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1157, col: 24, offset: 32297},
+								pos:  position{line: 1164, col: 24, offset: 32498},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1157, col: 27, offset: 32300},
+								pos: position{line: 1164, col: 27, offset: 32501},
 								expr: &seqExpr{
-									pos: position{line: 1157, col: 28, offset: 32301},
+									pos: position{line: 1164, col: 28, offset: 32502},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1157, col: 28, offset: 32301},
+											pos:        position{line: 1164, col: 28, offset: 32502},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1157, col: 32, offset: 32305},
+											pos: position{line: 1164, col: 32, offset: 32506},
 											expr: &charClassMatcher{
-												pos:        position{line: 1157, col: 32, offset: 32305},
+												pos:        position{line: 1164, col: 32, offset: 32506},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9445,32 +9509,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1159, col: 1, offset: 32315},
+			pos:  position{line: 1166, col: 1, offset: 32516},
 			expr: &actionExpr{
-				pos: position{line: 1160, col: 5, offset: 32328},
+				pos: position{line: 1167, col: 5, offset: 32529},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1160, col: 5, offset: 32328},
+					pos: position{line: 1167, col: 5, offset: 32529},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1160, col: 5, offset: 32328},
+							pos: position{line: 1167, col: 5, offset: 32529},
 							expr: &litMatcher{
-								pos:        position{line: 1160, col: 5, offset: 32328},
+								pos:        position{line: 1167, col: 5, offset: 32529},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1160, col: 10, offset: 32333},
+							pos: position{line: 1167, col: 10, offset: 32534},
 							expr: &seqExpr{
-								pos: position{line: 1160, col: 11, offset: 32334},
+								pos: position{line: 1167, col: 11, offset: 32535},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1160, col: 11, offset: 32334},
+										pos:  position{line: 1167, col: 11, offset: 32535},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1160, col: 19, offset: 32342},
+										pos:  position{line: 1167, col: 19, offset: 32543},
 										name: "TimeUnit",
 									},
 								},
@@ -9482,26 +9546,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1164, col: 1, offset: 32468},
+			pos:  position{line: 1171, col: 1, offset: 32669},
 			expr: &seqExpr{
-				pos: position{line: 1164, col: 11, offset: 32478},
+				pos: position{line: 1171, col: 11, offset: 32679},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 11, offset: 32478},
+						pos:  position{line: 1171, col: 11, offset: 32679},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1164, col: 16, offset: 32483},
+						pos: position{line: 1171, col: 16, offset: 32684},
 						expr: &seqExpr{
-							pos: position{line: 1164, col: 17, offset: 32484},
+							pos: position{line: 1171, col: 17, offset: 32685},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1164, col: 17, offset: 32484},
+									pos:        position{line: 1171, col: 17, offset: 32685},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1164, col: 21, offset: 32488},
+									pos:  position{line: 1171, col: 21, offset: 32689},
 									name: "UInt",
 								},
 							},
@@ -9512,52 +9576,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1166, col: 1, offset: 32496},
+			pos:  position{line: 1173, col: 1, offset: 32697},
 			expr: &choiceExpr{
-				pos: position{line: 1167, col: 5, offset: 32509},
+				pos: position{line: 1174, col: 5, offset: 32710},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1167, col: 5, offset: 32509},
+						pos:        position{line: 1174, col: 5, offset: 32710},
 						val:        "ns",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1168, col: 5, offset: 32519},
+						pos:        position{line: 1175, col: 5, offset: 32720},
 						val:        "us",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1169, col: 5, offset: 32529},
+						pos:        position{line: 1176, col: 5, offset: 32730},
 						val:        "ms",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1170, col: 5, offset: 32539},
+						pos:        position{line: 1177, col: 5, offset: 32740},
 						val:        "s",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1171, col: 5, offset: 32548},
+						pos:        position{line: 1178, col: 5, offset: 32749},
 						val:        "m",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1172, col: 5, offset: 32557},
+						pos:        position{line: 1179, col: 5, offset: 32758},
 						val:        "h",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1173, col: 5, offset: 32566},
+						pos:        position{line: 1180, col: 5, offset: 32767},
 						val:        "d",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1174, col: 5, offset: 32575},
+						pos:        position{line: 1181, col: 5, offset: 32776},
 						val:        "w",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1175, col: 5, offset: 32584},
+						pos:        position{line: 1182, col: 5, offset: 32785},
 						val:        "y",
 						ignoreCase: true,
 					},
@@ -9566,42 +9630,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1177, col: 1, offset: 32590},
+			pos:  position{line: 1184, col: 1, offset: 32791},
 			expr: &actionExpr{
-				pos: position{line: 1178, col: 5, offset: 32597},
+				pos: position{line: 1185, col: 5, offset: 32798},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1178, col: 5, offset: 32597},
+					pos: position{line: 1185, col: 5, offset: 32798},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1178, col: 5, offset: 32597},
+							pos:  position{line: 1185, col: 5, offset: 32798},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1178, col: 10, offset: 32602},
+							pos:        position{line: 1185, col: 10, offset: 32803},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1178, col: 14, offset: 32606},
+							pos:  position{line: 1185, col: 14, offset: 32807},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1178, col: 19, offset: 32611},
+							pos:        position{line: 1185, col: 19, offset: 32812},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1178, col: 23, offset: 32615},
+							pos:  position{line: 1185, col: 23, offset: 32816},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1178, col: 28, offset: 32620},
+							pos:        position{line: 1185, col: 28, offset: 32821},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1178, col: 32, offset: 32624},
+							pos:  position{line: 1185, col: 32, offset: 32825},
 							name: "UInt",
 						},
 					},
@@ -9610,42 +9674,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1180, col: 1, offset: 32661},
+			pos:  position{line: 1187, col: 1, offset: 32862},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 5, offset: 32669},
+				pos: position{line: 1188, col: 5, offset: 32870},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1181, col: 5, offset: 32669},
+					pos: position{line: 1188, col: 5, offset: 32870},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1181, col: 5, offset: 32669},
+							pos: position{line: 1188, col: 5, offset: 32870},
 							expr: &seqExpr{
-								pos: position{line: 1181, col: 8, offset: 32672},
+								pos: position{line: 1188, col: 8, offset: 32873},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1181, col: 8, offset: 32672},
+										pos:  position{line: 1188, col: 8, offset: 32873},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1181, col: 12, offset: 32676},
+										pos:        position{line: 1188, col: 12, offset: 32877},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1181, col: 16, offset: 32680},
+										pos:  position{line: 1188, col: 16, offset: 32881},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1181, col: 20, offset: 32684},
+										pos: position{line: 1188, col: 20, offset: 32885},
 										expr: &choiceExpr{
-											pos: position{line: 1181, col: 22, offset: 32686},
+											pos: position{line: 1188, col: 22, offset: 32887},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1181, col: 22, offset: 32686},
+													pos:  position{line: 1188, col: 22, offset: 32887},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1181, col: 33, offset: 32697},
+													pos:        position{line: 1188, col: 33, offset: 32898},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9656,10 +9720,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 39, offset: 32703},
+							pos:   position{line: 1188, col: 39, offset: 32904},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 41, offset: 32705},
+								pos:  position{line: 1188, col: 41, offset: 32906},
 								name: "IP6Variations",
 							},
 						},
@@ -9669,32 +9733,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1185, col: 1, offset: 32869},
+			pos:  position{line: 1192, col: 1, offset: 33070},
 			expr: &choiceExpr{
-				pos: position{line: 1186, col: 5, offset: 32887},
+				pos: position{line: 1193, col: 5, offset: 33088},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1186, col: 5, offset: 32887},
+						pos: position{line: 1193, col: 5, offset: 33088},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1186, col: 5, offset: 32887},
+							pos: position{line: 1193, col: 5, offset: 33088},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1186, col: 5, offset: 32887},
+									pos:   position{line: 1193, col: 5, offset: 33088},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1186, col: 7, offset: 32889},
+										pos: position{line: 1193, col: 7, offset: 33090},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1186, col: 7, offset: 32889},
+											pos:  position{line: 1193, col: 7, offset: 33090},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1186, col: 17, offset: 32899},
+									pos:   position{line: 1193, col: 17, offset: 33100},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1186, col: 19, offset: 32901},
+										pos:  position{line: 1193, col: 19, offset: 33102},
 										name: "IP6Tail",
 									},
 								},
@@ -9702,51 +9766,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1189, col: 5, offset: 32965},
+						pos: position{line: 1196, col: 5, offset: 33166},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1189, col: 5, offset: 32965},
+							pos: position{line: 1196, col: 5, offset: 33166},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1189, col: 5, offset: 32965},
+									pos:   position{line: 1196, col: 5, offset: 33166},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1189, col: 7, offset: 32967},
+										pos:  position{line: 1196, col: 7, offset: 33168},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1189, col: 11, offset: 32971},
+									pos:   position{line: 1196, col: 11, offset: 33172},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1189, col: 13, offset: 32973},
+										pos: position{line: 1196, col: 13, offset: 33174},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1189, col: 13, offset: 32973},
+											pos:  position{line: 1196, col: 13, offset: 33174},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1189, col: 23, offset: 32983},
+									pos:        position{line: 1196, col: 23, offset: 33184},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1189, col: 28, offset: 32988},
+									pos:   position{line: 1196, col: 28, offset: 33189},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1189, col: 30, offset: 32990},
+										pos: position{line: 1196, col: 30, offset: 33191},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1189, col: 30, offset: 32990},
+											pos:  position{line: 1196, col: 30, offset: 33191},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1189, col: 40, offset: 33000},
+									pos:   position{line: 1196, col: 40, offset: 33201},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1189, col: 42, offset: 33002},
+										pos:  position{line: 1196, col: 42, offset: 33203},
 										name: "IP6Tail",
 									},
 								},
@@ -9754,32 +9818,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1192, col: 5, offset: 33101},
+						pos: position{line: 1199, col: 5, offset: 33302},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 5, offset: 33101},
+							pos: position{line: 1199, col: 5, offset: 33302},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1192, col: 5, offset: 33101},
+									pos:        position{line: 1199, col: 5, offset: 33302},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 10, offset: 33106},
+									pos:   position{line: 1199, col: 10, offset: 33307},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1192, col: 12, offset: 33108},
+										pos: position{line: 1199, col: 12, offset: 33309},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1192, col: 12, offset: 33108},
+											pos:  position{line: 1199, col: 12, offset: 33309},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 22, offset: 33118},
+									pos:   position{line: 1199, col: 22, offset: 33319},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 24, offset: 33120},
+										pos:  position{line: 1199, col: 24, offset: 33321},
 										name: "IP6Tail",
 									},
 								},
@@ -9787,32 +9851,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1195, col: 5, offset: 33191},
+						pos: position{line: 1202, col: 5, offset: 33392},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1195, col: 5, offset: 33191},
+							pos: position{line: 1202, col: 5, offset: 33392},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1195, col: 5, offset: 33191},
+									pos:   position{line: 1202, col: 5, offset: 33392},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1195, col: 7, offset: 33193},
+										pos:  position{line: 1202, col: 7, offset: 33394},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1195, col: 11, offset: 33197},
+									pos:   position{line: 1202, col: 11, offset: 33398},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1195, col: 13, offset: 33199},
+										pos: position{line: 1202, col: 13, offset: 33400},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1195, col: 13, offset: 33199},
+											pos:  position{line: 1202, col: 13, offset: 33400},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1195, col: 23, offset: 33209},
+									pos:        position{line: 1202, col: 23, offset: 33410},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -9820,10 +9884,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1198, col: 5, offset: 33277},
+						pos: position{line: 1205, col: 5, offset: 33478},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1198, col: 5, offset: 33277},
+							pos:        position{line: 1205, col: 5, offset: 33478},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -9833,16 +9897,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1202, col: 1, offset: 33314},
+			pos:  position{line: 1209, col: 1, offset: 33515},
 			expr: &choiceExpr{
-				pos: position{line: 1203, col: 5, offset: 33326},
+				pos: position{line: 1210, col: 5, offset: 33527},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1203, col: 5, offset: 33326},
+						pos:  position{line: 1210, col: 5, offset: 33527},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1204, col: 5, offset: 33333},
+						pos:  position{line: 1211, col: 5, offset: 33534},
 						name: "Hex",
 					},
 				},
@@ -9850,23 +9914,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1206, col: 1, offset: 33338},
+			pos:  position{line: 1213, col: 1, offset: 33539},
 			expr: &actionExpr{
-				pos: position{line: 1206, col: 12, offset: 33349},
+				pos: position{line: 1213, col: 12, offset: 33550},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1206, col: 12, offset: 33349},
+					pos: position{line: 1213, col: 12, offset: 33550},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1206, col: 12, offset: 33349},
+							pos:        position{line: 1213, col: 12, offset: 33550},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1206, col: 16, offset: 33353},
+							pos:   position{line: 1213, col: 16, offset: 33554},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1206, col: 18, offset: 33355},
+								pos:  position{line: 1213, col: 18, offset: 33556},
 								name: "Hex",
 							},
 						},
@@ -9876,23 +9940,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1208, col: 1, offset: 33393},
+			pos:  position{line: 1215, col: 1, offset: 33594},
 			expr: &actionExpr{
-				pos: position{line: 1208, col: 12, offset: 33404},
+				pos: position{line: 1215, col: 12, offset: 33605},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1208, col: 12, offset: 33404},
+					pos: position{line: 1215, col: 12, offset: 33605},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1208, col: 12, offset: 33404},
+							pos:   position{line: 1215, col: 12, offset: 33605},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1208, col: 14, offset: 33406},
+								pos:  position{line: 1215, col: 14, offset: 33607},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1208, col: 18, offset: 33410},
+							pos:        position{line: 1215, col: 18, offset: 33611},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -9902,31 +9966,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1210, col: 1, offset: 33448},
+			pos:  position{line: 1217, col: 1, offset: 33649},
 			expr: &actionExpr{
-				pos: position{line: 1211, col: 5, offset: 33459},
+				pos: position{line: 1218, col: 5, offset: 33660},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1211, col: 5, offset: 33459},
+					pos: position{line: 1218, col: 5, offset: 33660},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1211, col: 5, offset: 33459},
+							pos:   position{line: 1218, col: 5, offset: 33660},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1211, col: 7, offset: 33461},
+								pos:  position{line: 1218, col: 7, offset: 33662},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1211, col: 10, offset: 33464},
+							pos:        position{line: 1218, col: 10, offset: 33665},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1211, col: 14, offset: 33468},
+							pos:   position{line: 1218, col: 14, offset: 33669},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1211, col: 16, offset: 33470},
+								pos:  position{line: 1218, col: 16, offset: 33671},
 								name: "UInt",
 							},
 						},
@@ -9936,31 +10000,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1215, col: 1, offset: 33543},
+			pos:  position{line: 1222, col: 1, offset: 33744},
 			expr: &actionExpr{
-				pos: position{line: 1216, col: 5, offset: 33554},
+				pos: position{line: 1223, col: 5, offset: 33755},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1216, col: 5, offset: 33554},
+					pos: position{line: 1223, col: 5, offset: 33755},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1216, col: 5, offset: 33554},
+							pos:   position{line: 1223, col: 5, offset: 33755},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1216, col: 7, offset: 33556},
+								pos:  position{line: 1223, col: 7, offset: 33757},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1216, col: 11, offset: 33560},
+							pos:        position{line: 1223, col: 11, offset: 33761},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1216, col: 15, offset: 33564},
+							pos:   position{line: 1223, col: 15, offset: 33765},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1216, col: 17, offset: 33566},
+								pos:  position{line: 1223, col: 17, offset: 33767},
 								name: "UInt",
 							},
 						},
@@ -9970,15 +10034,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1220, col: 1, offset: 33629},
+			pos:  position{line: 1227, col: 1, offset: 33830},
 			expr: &actionExpr{
-				pos: position{line: 1221, col: 4, offset: 33637},
+				pos: position{line: 1228, col: 4, offset: 33838},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1221, col: 4, offset: 33637},
+					pos:   position{line: 1228, col: 4, offset: 33838},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1221, col: 6, offset: 33639},
+						pos:  position{line: 1228, col: 6, offset: 33840},
 						name: "UIntString",
 					},
 				},
@@ -9986,16 +10050,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1223, col: 1, offset: 33679},
+			pos:  position{line: 1230, col: 1, offset: 33880},
 			expr: &choiceExpr{
-				pos: position{line: 1224, col: 5, offset: 33693},
+				pos: position{line: 1231, col: 5, offset: 33894},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 5, offset: 33693},
+						pos:  position{line: 1231, col: 5, offset: 33894},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1225, col: 5, offset: 33708},
+						pos:  position{line: 1232, col: 5, offset: 33909},
 						name: "MinusIntString",
 					},
 				},
@@ -10003,14 +10067,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1227, col: 1, offset: 33724},
+			pos:  position{line: 1234, col: 1, offset: 33925},
 			expr: &actionExpr{
-				pos: position{line: 1227, col: 14, offset: 33737},
+				pos: position{line: 1234, col: 14, offset: 33938},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1227, col: 14, offset: 33737},
+					pos: position{line: 1234, col: 14, offset: 33938},
 					expr: &charClassMatcher{
-						pos:        position{line: 1227, col: 14, offset: 33737},
+						pos:        position{line: 1234, col: 14, offset: 33938},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10021,20 +10085,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1229, col: 1, offset: 33776},
+			pos:  position{line: 1236, col: 1, offset: 33977},
 			expr: &actionExpr{
-				pos: position{line: 1230, col: 5, offset: 33795},
+				pos: position{line: 1237, col: 5, offset: 33996},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1230, col: 5, offset: 33795},
+					pos: position{line: 1237, col: 5, offset: 33996},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1230, col: 5, offset: 33795},
+							pos:        position{line: 1237, col: 5, offset: 33996},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1230, col: 9, offset: 33799},
+							pos:  position{line: 1237, col: 9, offset: 34000},
 							name: "UIntString",
 						},
 					},
@@ -10043,28 +10107,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1232, col: 1, offset: 33842},
+			pos:  position{line: 1239, col: 1, offset: 34043},
 			expr: &choiceExpr{
-				pos: position{line: 1233, col: 5, offset: 33858},
+				pos: position{line: 1240, col: 5, offset: 34059},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1233, col: 5, offset: 33858},
+						pos: position{line: 1240, col: 5, offset: 34059},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1233, col: 5, offset: 33858},
+							pos: position{line: 1240, col: 5, offset: 34059},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1233, col: 5, offset: 33858},
+									pos: position{line: 1240, col: 5, offset: 34059},
 									expr: &litMatcher{
-										pos:        position{line: 1233, col: 5, offset: 33858},
+										pos:        position{line: 1240, col: 5, offset: 34059},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1233, col: 10, offset: 33863},
+									pos: position{line: 1240, col: 10, offset: 34064},
 									expr: &charClassMatcher{
-										pos:        position{line: 1233, col: 10, offset: 33863},
+										pos:        position{line: 1240, col: 10, offset: 34064},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10072,14 +10136,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1233, col: 17, offset: 33870},
+									pos:        position{line: 1240, col: 17, offset: 34071},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1233, col: 21, offset: 33874},
+									pos: position{line: 1240, col: 21, offset: 34075},
 									expr: &charClassMatcher{
-										pos:        position{line: 1233, col: 21, offset: 33874},
+										pos:        position{line: 1240, col: 21, offset: 34075},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10087,9 +10151,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1233, col: 28, offset: 33881},
+									pos: position{line: 1240, col: 28, offset: 34082},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1233, col: 28, offset: 33881},
+										pos:  position{line: 1240, col: 28, offset: 34082},
 										name: "ExponentPart",
 									},
 								},
@@ -10097,28 +10161,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1236, col: 5, offset: 33940},
+						pos: position{line: 1243, col: 5, offset: 34141},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1236, col: 5, offset: 33940},
+							pos: position{line: 1243, col: 5, offset: 34141},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1236, col: 5, offset: 33940},
+									pos: position{line: 1243, col: 5, offset: 34141},
 									expr: &litMatcher{
-										pos:        position{line: 1236, col: 5, offset: 33940},
+										pos:        position{line: 1243, col: 5, offset: 34141},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1236, col: 10, offset: 33945},
+									pos:        position{line: 1243, col: 10, offset: 34146},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1236, col: 14, offset: 33949},
+									pos: position{line: 1243, col: 14, offset: 34150},
 									expr: &charClassMatcher{
-										pos:        position{line: 1236, col: 14, offset: 33949},
+										pos:        position{line: 1243, col: 14, offset: 34150},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10126,9 +10190,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1236, col: 21, offset: 33956},
+									pos: position{line: 1243, col: 21, offset: 34157},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1236, col: 21, offset: 33956},
+										pos:  position{line: 1243, col: 21, offset: 34157},
 										name: "ExponentPart",
 									},
 								},
@@ -10140,19 +10204,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1240, col: 1, offset: 34012},
+			pos:  position{line: 1247, col: 1, offset: 34213},
 			expr: &seqExpr{
-				pos: position{line: 1240, col: 16, offset: 34027},
+				pos: position{line: 1247, col: 16, offset: 34228},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1240, col: 16, offset: 34027},
+						pos:        position{line: 1247, col: 16, offset: 34228},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1240, col: 21, offset: 34032},
+						pos: position{line: 1247, col: 21, offset: 34233},
 						expr: &charClassMatcher{
-							pos:        position{line: 1240, col: 21, offset: 34032},
+							pos:        position{line: 1247, col: 21, offset: 34233},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10160,7 +10224,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1240, col: 27, offset: 34038},
+						pos:  position{line: 1247, col: 27, offset: 34239},
 						name: "UIntString",
 					},
 				},
@@ -10168,14 +10232,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1242, col: 1, offset: 34050},
+			pos:  position{line: 1249, col: 1, offset: 34251},
 			expr: &actionExpr{
-				pos: position{line: 1242, col: 7, offset: 34056},
+				pos: position{line: 1249, col: 7, offset: 34257},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1242, col: 7, offset: 34056},
+					pos: position{line: 1249, col: 7, offset: 34257},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1242, col: 7, offset: 34056},
+						pos:  position{line: 1249, col: 7, offset: 34257},
 						name: "HexDigit",
 					},
 				},
@@ -10183,9 +10247,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1244, col: 1, offset: 34098},
+			pos:  position{line: 1251, col: 1, offset: 34299},
 			expr: &charClassMatcher{
-				pos:        position{line: 1244, col: 12, offset: 34109},
+				pos:        position{line: 1251, col: 12, offset: 34310},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10194,34 +10258,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1246, col: 1, offset: 34122},
+			pos:  position{line: 1253, col: 1, offset: 34323},
 			expr: &choiceExpr{
-				pos: position{line: 1247, col: 5, offset: 34139},
+				pos: position{line: 1254, col: 5, offset: 34340},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1247, col: 5, offset: 34139},
+						pos: position{line: 1254, col: 5, offset: 34340},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1247, col: 5, offset: 34139},
+							pos: position{line: 1254, col: 5, offset: 34340},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1247, col: 5, offset: 34139},
+									pos:        position{line: 1254, col: 5, offset: 34340},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1247, col: 9, offset: 34143},
+									pos:   position{line: 1254, col: 9, offset: 34344},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1247, col: 11, offset: 34145},
+										pos: position{line: 1254, col: 11, offset: 34346},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1247, col: 11, offset: 34145},
+											pos:  position{line: 1254, col: 11, offset: 34346},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1247, col: 29, offset: 34163},
+									pos:        position{line: 1254, col: 29, offset: 34364},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10229,29 +10293,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1248, col: 5, offset: 34200},
+						pos: position{line: 1255, col: 5, offset: 34401},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1248, col: 5, offset: 34200},
+							pos: position{line: 1255, col: 5, offset: 34401},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1248, col: 5, offset: 34200},
+									pos:        position{line: 1255, col: 5, offset: 34401},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1248, col: 9, offset: 34204},
+									pos:   position{line: 1255, col: 9, offset: 34405},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1248, col: 11, offset: 34206},
+										pos: position{line: 1255, col: 11, offset: 34407},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1248, col: 11, offset: 34206},
+											pos:  position{line: 1255, col: 11, offset: 34407},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1248, col: 29, offset: 34224},
+									pos:        position{line: 1255, col: 29, offset: 34425},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10263,55 +10327,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1250, col: 1, offset: 34258},
+			pos:  position{line: 1257, col: 1, offset: 34459},
 			expr: &choiceExpr{
-				pos: position{line: 1251, col: 5, offset: 34279},
+				pos: position{line: 1258, col: 5, offset: 34480},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1251, col: 5, offset: 34279},
+						pos: position{line: 1258, col: 5, offset: 34480},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1251, col: 5, offset: 34279},
+							pos: position{line: 1258, col: 5, offset: 34480},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1251, col: 5, offset: 34279},
+									pos: position{line: 1258, col: 5, offset: 34480},
 									expr: &choiceExpr{
-										pos: position{line: 1251, col: 7, offset: 34281},
+										pos: position{line: 1258, col: 7, offset: 34482},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1251, col: 7, offset: 34281},
+												pos:        position{line: 1258, col: 7, offset: 34482},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1251, col: 13, offset: 34287},
+												pos:  position{line: 1258, col: 13, offset: 34488},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1251, col: 26, offset: 34300,
+									line: 1258, col: 26, offset: 34501,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1252, col: 5, offset: 34337},
+						pos: position{line: 1259, col: 5, offset: 34538},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1252, col: 5, offset: 34337},
+							pos: position{line: 1259, col: 5, offset: 34538},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1252, col: 5, offset: 34337},
+									pos:        position{line: 1259, col: 5, offset: 34538},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1252, col: 10, offset: 34342},
+									pos:   position{line: 1259, col: 10, offset: 34543},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1252, col: 12, offset: 34344},
+										pos:  position{line: 1259, col: 12, offset: 34545},
 										name: "EscapeSequence",
 									},
 								},
@@ -10323,28 +10387,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1254, col: 1, offset: 34378},
+			pos:  position{line: 1261, col: 1, offset: 34579},
 			expr: &actionExpr{
-				pos: position{line: 1255, col: 5, offset: 34390},
+				pos: position{line: 1262, col: 5, offset: 34591},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1255, col: 5, offset: 34390},
+					pos: position{line: 1262, col: 5, offset: 34591},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1255, col: 5, offset: 34390},
+							pos:   position{line: 1262, col: 5, offset: 34591},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1255, col: 10, offset: 34395},
+								pos:  position{line: 1262, col: 10, offset: 34596},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1255, col: 23, offset: 34408},
+							pos:   position{line: 1262, col: 23, offset: 34609},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1255, col: 28, offset: 34413},
+								pos: position{line: 1262, col: 28, offset: 34614},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1255, col: 28, offset: 34413},
+									pos:  position{line: 1262, col: 28, offset: 34614},
 									name: "KeyWordRest",
 								},
 							},
@@ -10355,16 +10419,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1257, col: 1, offset: 34475},
+			pos:  position{line: 1264, col: 1, offset: 34676},
 			expr: &choiceExpr{
-				pos: position{line: 1258, col: 5, offset: 34492},
+				pos: position{line: 1265, col: 5, offset: 34693},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1258, col: 5, offset: 34492},
+						pos:  position{line: 1265, col: 5, offset: 34693},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 5, offset: 34509},
+						pos:  position{line: 1266, col: 5, offset: 34710},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10372,12 +10436,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1261, col: 1, offset: 34521},
+			pos:  position{line: 1268, col: 1, offset: 34722},
 			expr: &actionExpr{
-				pos: position{line: 1261, col: 16, offset: 34536},
+				pos: position{line: 1268, col: 16, offset: 34737},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1261, col: 16, offset: 34536},
+					pos:        position{line: 1268, col: 16, offset: 34737},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10388,16 +10452,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1263, col: 1, offset: 34585},
+			pos:  position{line: 1270, col: 1, offset: 34786},
 			expr: &choiceExpr{
-				pos: position{line: 1264, col: 5, offset: 34601},
+				pos: position{line: 1271, col: 5, offset: 34802},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1264, col: 5, offset: 34601},
+						pos:  position{line: 1271, col: 5, offset: 34802},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1265, col: 5, offset: 34618},
+						pos:        position{line: 1272, col: 5, offset: 34819},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10408,30 +10472,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1267, col: 1, offset: 34625},
+			pos:  position{line: 1274, col: 1, offset: 34826},
 			expr: &actionExpr{
-				pos: position{line: 1267, col: 14, offset: 34638},
+				pos: position{line: 1274, col: 14, offset: 34839},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1267, col: 14, offset: 34638},
+					pos: position{line: 1274, col: 14, offset: 34839},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1267, col: 14, offset: 34638},
+							pos:        position{line: 1274, col: 14, offset: 34839},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1267, col: 19, offset: 34643},
+							pos:   position{line: 1274, col: 19, offset: 34844},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1267, col: 22, offset: 34646},
+								pos: position{line: 1274, col: 22, offset: 34847},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1267, col: 22, offset: 34646},
+										pos:  position{line: 1274, col: 22, offset: 34847},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1267, col: 38, offset: 34662},
+										pos:  position{line: 1274, col: 38, offset: 34863},
 										name: "EscapeSequence",
 									},
 								},
@@ -10443,42 +10507,42 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 1269, col: 1, offset: 34698},
+			pos:  position{line: 1276, col: 1, offset: 34899},
 			expr: &actionExpr{
-				pos: position{line: 1270, col: 5, offset: 34707},
+				pos: position{line: 1277, col: 5, offset: 34908},
 				run: (*parser).callonGlob1,
 				expr: &seqExpr{
-					pos: position{line: 1270, col: 5, offset: 34707},
+					pos: position{line: 1277, col: 5, offset: 34908},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1270, col: 5, offset: 34707},
+							pos: position{line: 1277, col: 5, offset: 34908},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1270, col: 6, offset: 34708},
+								pos:  position{line: 1277, col: 6, offset: 34909},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1270, col: 22, offset: 34724},
+							pos: position{line: 1277, col: 22, offset: 34925},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1270, col: 23, offset: 34725},
+								pos:  position{line: 1277, col: 23, offset: 34926},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1270, col: 35, offset: 34737},
+							pos:   position{line: 1277, col: 35, offset: 34938},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1270, col: 40, offset: 34742},
+								pos:  position{line: 1277, col: 40, offset: 34943},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1270, col: 50, offset: 34752},
+							pos:   position{line: 1277, col: 50, offset: 34953},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1270, col: 55, offset: 34757},
+								pos: position{line: 1277, col: 55, offset: 34958},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1270, col: 55, offset: 34757},
+									pos:  position{line: 1277, col: 55, offset: 34958},
 									name: "GlobRest",
 								},
 							},
@@ -10489,20 +10553,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1274, col: 1, offset: 34841},
+			pos:  position{line: 1281, col: 1, offset: 35042},
 			expr: &seqExpr{
-				pos: position{line: 1274, col: 19, offset: 34859},
+				pos: position{line: 1281, col: 19, offset: 35060},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1274, col: 19, offset: 34859},
+						pos: position{line: 1281, col: 19, offset: 35060},
 						expr: &litMatcher{
-							pos:        position{line: 1274, col: 19, offset: 34859},
+							pos:        position{line: 1281, col: 19, offset: 35060},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1274, col: 24, offset: 34864},
+						pos:  position{line: 1281, col: 24, offset: 35065},
 						name: "KeyWordStart",
 					},
 				},
@@ -10510,19 +10574,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1275, col: 1, offset: 34877},
+			pos:  position{line: 1282, col: 1, offset: 35078},
 			expr: &seqExpr{
-				pos: position{line: 1275, col: 15, offset: 34891},
+				pos: position{line: 1282, col: 15, offset: 35092},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1275, col: 15, offset: 34891},
+						pos: position{line: 1282, col: 15, offset: 35092},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1275, col: 15, offset: 34891},
+							pos:  position{line: 1282, col: 15, offset: 35092},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1275, col: 28, offset: 34904},
+						pos:        position{line: 1282, col: 28, offset: 35105},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10531,23 +10595,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1277, col: 1, offset: 34909},
+			pos:  position{line: 1284, col: 1, offset: 35110},
 			expr: &choiceExpr{
-				pos: position{line: 1278, col: 5, offset: 34923},
+				pos: position{line: 1285, col: 5, offset: 35124},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 34923},
+						pos:  position{line: 1285, col: 5, offset: 35124},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 5, offset: 34940},
+						pos:  position{line: 1286, col: 5, offset: 35141},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1280, col: 5, offset: 34952},
+						pos: position{line: 1287, col: 5, offset: 35153},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1280, col: 5, offset: 34952},
+							pos:        position{line: 1287, col: 5, offset: 35153},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10557,16 +10621,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1282, col: 1, offset: 34976},
+			pos:  position{line: 1289, col: 1, offset: 35177},
 			expr: &choiceExpr{
-				pos: position{line: 1283, col: 5, offset: 34989},
+				pos: position{line: 1290, col: 5, offset: 35190},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1283, col: 5, offset: 34989},
+						pos:  position{line: 1290, col: 5, offset: 35190},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1284, col: 5, offset: 35003},
+						pos:        position{line: 1291, col: 5, offset: 35204},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10577,30 +10641,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1286, col: 1, offset: 35010},
+			pos:  position{line: 1293, col: 1, offset: 35211},
 			expr: &actionExpr{
-				pos: position{line: 1286, col: 11, offset: 35020},
+				pos: position{line: 1293, col: 11, offset: 35221},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1286, col: 11, offset: 35020},
+					pos: position{line: 1293, col: 11, offset: 35221},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1286, col: 11, offset: 35020},
+							pos:        position{line: 1293, col: 11, offset: 35221},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1286, col: 16, offset: 35025},
+							pos:   position{line: 1293, col: 16, offset: 35226},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1286, col: 19, offset: 35028},
+								pos: position{line: 1293, col: 19, offset: 35229},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1286, col: 19, offset: 35028},
+										pos:  position{line: 1293, col: 19, offset: 35229},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1286, col: 32, offset: 35041},
+										pos:  position{line: 1293, col: 32, offset: 35242},
 										name: "EscapeSequence",
 									},
 								},
@@ -10612,30 +10676,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1288, col: 1, offset: 35077},
+			pos:  position{line: 1295, col: 1, offset: 35278},
 			expr: &choiceExpr{
-				pos: position{line: 1289, col: 5, offset: 35092},
+				pos: position{line: 1296, col: 5, offset: 35293},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1289, col: 5, offset: 35092},
+						pos: position{line: 1296, col: 5, offset: 35293},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1289, col: 5, offset: 35092},
+							pos:        position{line: 1296, col: 5, offset: 35293},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 35120},
+						pos: position{line: 1297, col: 5, offset: 35321},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1290, col: 5, offset: 35120},
+							pos:        position{line: 1297, col: 5, offset: 35321},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1291, col: 5, offset: 35150},
+						pos:        position{line: 1298, col: 5, offset: 35351},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10646,55 +10710,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1294, col: 1, offset: 35157},
+			pos:  position{line: 1301, col: 1, offset: 35358},
 			expr: &choiceExpr{
-				pos: position{line: 1295, col: 5, offset: 35178},
+				pos: position{line: 1302, col: 5, offset: 35379},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1295, col: 5, offset: 35178},
+						pos: position{line: 1302, col: 5, offset: 35379},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1295, col: 5, offset: 35178},
+							pos: position{line: 1302, col: 5, offset: 35379},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1295, col: 5, offset: 35178},
+									pos: position{line: 1302, col: 5, offset: 35379},
 									expr: &choiceExpr{
-										pos: position{line: 1295, col: 7, offset: 35180},
+										pos: position{line: 1302, col: 7, offset: 35381},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1295, col: 7, offset: 35180},
+												pos:        position{line: 1302, col: 7, offset: 35381},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1295, col: 13, offset: 35186},
+												pos:  position{line: 1302, col: 13, offset: 35387},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1295, col: 26, offset: 35199,
+									line: 1302, col: 26, offset: 35400,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1296, col: 5, offset: 35236},
+						pos: position{line: 1303, col: 5, offset: 35437},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1296, col: 5, offset: 35236},
+							pos: position{line: 1303, col: 5, offset: 35437},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1296, col: 5, offset: 35236},
+									pos:        position{line: 1303, col: 5, offset: 35437},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 10, offset: 35241},
+									pos:   position{line: 1303, col: 10, offset: 35442},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1296, col: 12, offset: 35243},
+										pos:  position{line: 1303, col: 12, offset: 35444},
 										name: "EscapeSequence",
 									},
 								},
@@ -10706,16 +10770,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1298, col: 1, offset: 35277},
+			pos:  position{line: 1305, col: 1, offset: 35478},
 			expr: &choiceExpr{
-				pos: position{line: 1299, col: 5, offset: 35296},
+				pos: position{line: 1306, col: 5, offset: 35497},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1299, col: 5, offset: 35296},
+						pos:  position{line: 1306, col: 5, offset: 35497},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1300, col: 5, offset: 35317},
+						pos:  position{line: 1307, col: 5, offset: 35518},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10723,79 +10787,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1302, col: 1, offset: 35332},
+			pos:  position{line: 1309, col: 1, offset: 35533},
 			expr: &choiceExpr{
-				pos: position{line: 1303, col: 5, offset: 35353},
+				pos: position{line: 1310, col: 5, offset: 35554},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1303, col: 5, offset: 35353},
+						pos:        position{line: 1310, col: 5, offset: 35554},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1304, col: 5, offset: 35361},
+						pos: position{line: 1311, col: 5, offset: 35562},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1304, col: 5, offset: 35361},
+							pos:        position{line: 1311, col: 5, offset: 35562},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1305, col: 5, offset: 35401},
+						pos:        position{line: 1312, col: 5, offset: 35602},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1306, col: 5, offset: 35410},
+						pos: position{line: 1313, col: 5, offset: 35611},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1306, col: 5, offset: 35410},
+							pos:        position{line: 1313, col: 5, offset: 35611},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1307, col: 5, offset: 35439},
+						pos: position{line: 1314, col: 5, offset: 35640},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1307, col: 5, offset: 35439},
+							pos:        position{line: 1314, col: 5, offset: 35640},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1308, col: 5, offset: 35468},
+						pos: position{line: 1315, col: 5, offset: 35669},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1308, col: 5, offset: 35468},
+							pos:        position{line: 1315, col: 5, offset: 35669},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 35497},
+						pos: position{line: 1316, col: 5, offset: 35698},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1309, col: 5, offset: 35497},
+							pos:        position{line: 1316, col: 5, offset: 35698},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 35526},
+						pos: position{line: 1317, col: 5, offset: 35727},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1310, col: 5, offset: 35526},
+							pos:        position{line: 1317, col: 5, offset: 35727},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1311, col: 5, offset: 35555},
+						pos: position{line: 1318, col: 5, offset: 35756},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1311, col: 5, offset: 35555},
+							pos:        position{line: 1318, col: 5, offset: 35756},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -10805,30 +10869,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1313, col: 1, offset: 35581},
+			pos:  position{line: 1320, col: 1, offset: 35782},
 			expr: &choiceExpr{
-				pos: position{line: 1314, col: 5, offset: 35599},
+				pos: position{line: 1321, col: 5, offset: 35800},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 35599},
+						pos: position{line: 1321, col: 5, offset: 35800},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1314, col: 5, offset: 35599},
+							pos:        position{line: 1321, col: 5, offset: 35800},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1315, col: 5, offset: 35627},
+						pos: position{line: 1322, col: 5, offset: 35828},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1315, col: 5, offset: 35627},
+							pos:        position{line: 1322, col: 5, offset: 35828},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1316, col: 5, offset: 35655},
+						pos:        position{line: 1323, col: 5, offset: 35856},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10839,41 +10903,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1318, col: 1, offset: 35661},
+			pos:  position{line: 1325, col: 1, offset: 35862},
 			expr: &choiceExpr{
-				pos: position{line: 1319, col: 5, offset: 35679},
+				pos: position{line: 1326, col: 5, offset: 35880},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1319, col: 5, offset: 35679},
+						pos: position{line: 1326, col: 5, offset: 35880},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1319, col: 5, offset: 35679},
+							pos: position{line: 1326, col: 5, offset: 35880},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1319, col: 5, offset: 35679},
+									pos:        position{line: 1326, col: 5, offset: 35880},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1319, col: 9, offset: 35683},
+									pos:   position{line: 1326, col: 9, offset: 35884},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1319, col: 16, offset: 35690},
+										pos: position{line: 1326, col: 16, offset: 35891},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1319, col: 16, offset: 35690},
+												pos:  position{line: 1326, col: 16, offset: 35891},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1319, col: 25, offset: 35699},
+												pos:  position{line: 1326, col: 25, offset: 35900},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1319, col: 34, offset: 35708},
+												pos:  position{line: 1326, col: 34, offset: 35909},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1319, col: 43, offset: 35717},
+												pos:  position{line: 1326, col: 43, offset: 35918},
 												name: "HexDigit",
 											},
 										},
@@ -10883,63 +10947,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1322, col: 5, offset: 35780},
+						pos: position{line: 1329, col: 5, offset: 35981},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1322, col: 5, offset: 35780},
+							pos: position{line: 1329, col: 5, offset: 35981},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1322, col: 5, offset: 35780},
+									pos:        position{line: 1329, col: 5, offset: 35981},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1322, col: 9, offset: 35784},
+									pos:        position{line: 1329, col: 9, offset: 35985},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1322, col: 13, offset: 35788},
+									pos:   position{line: 1329, col: 13, offset: 35989},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1322, col: 20, offset: 35795},
+										pos: position{line: 1329, col: 20, offset: 35996},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1322, col: 20, offset: 35795},
+												pos:  position{line: 1329, col: 20, offset: 35996},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1322, col: 29, offset: 35804},
+												pos: position{line: 1329, col: 29, offset: 36005},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1322, col: 29, offset: 35804},
+													pos:  position{line: 1329, col: 29, offset: 36005},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1322, col: 39, offset: 35814},
+												pos: position{line: 1329, col: 39, offset: 36015},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1322, col: 39, offset: 35814},
+													pos:  position{line: 1329, col: 39, offset: 36015},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1322, col: 49, offset: 35824},
+												pos: position{line: 1329, col: 49, offset: 36025},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1322, col: 49, offset: 35824},
+													pos:  position{line: 1329, col: 49, offset: 36025},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1322, col: 59, offset: 35834},
+												pos: position{line: 1329, col: 59, offset: 36035},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1322, col: 59, offset: 35834},
+													pos:  position{line: 1329, col: 59, offset: 36035},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1322, col: 69, offset: 35844},
+												pos: position{line: 1329, col: 69, offset: 36045},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1322, col: 69, offset: 35844},
+													pos:  position{line: 1329, col: 69, offset: 36045},
 													name: "HexDigit",
 												},
 											},
@@ -10947,7 +11011,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1322, col: 80, offset: 35855},
+									pos:        position{line: 1329, col: 80, offset: 36056},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -10959,35 +11023,35 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1326, col: 1, offset: 35909},
+			pos:  position{line: 1333, col: 1, offset: 36110},
 			expr: &actionExpr{
-				pos: position{line: 1327, col: 5, offset: 35920},
+				pos: position{line: 1334, col: 5, offset: 36121},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1327, col: 5, offset: 35920},
+					pos: position{line: 1334, col: 5, offset: 36121},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1327, col: 5, offset: 35920},
+							pos:        position{line: 1334, col: 5, offset: 36121},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1327, col: 9, offset: 35924},
+							pos:   position{line: 1334, col: 9, offset: 36125},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1327, col: 14, offset: 35929},
+								pos:  position{line: 1334, col: 14, offset: 36130},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1327, col: 25, offset: 35940},
+							pos:        position{line: 1334, col: 25, offset: 36141},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1327, col: 29, offset: 35944},
+							pos: position{line: 1334, col: 29, offset: 36145},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1327, col: 30, offset: 35945},
+								pos:  position{line: 1334, col: 30, offset: 36146},
 								name: "KeyWordStart",
 							},
 						},
@@ -10997,32 +11061,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1329, col: 1, offset: 35980},
+			pos:  position{line: 1336, col: 1, offset: 36181},
 			expr: &actionExpr{
-				pos: position{line: 1330, col: 5, offset: 35995},
+				pos: position{line: 1337, col: 5, offset: 36196},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1330, col: 5, offset: 35995},
+					pos: position{line: 1337, col: 5, offset: 36196},
 					expr: &choiceExpr{
-						pos: position{line: 1330, col: 6, offset: 35996},
+						pos: position{line: 1337, col: 6, offset: 36197},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1330, col: 6, offset: 35996},
+								pos:        position{line: 1337, col: 6, offset: 36197},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1330, col: 15, offset: 36005},
+								pos: position{line: 1337, col: 15, offset: 36206},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1330, col: 15, offset: 36005},
+										pos:        position{line: 1337, col: 15, offset: 36206},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1330, col: 20, offset: 36010,
+										line: 1337, col: 20, offset: 36211,
 									},
 								},
 							},
@@ -11033,9 +11097,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1332, col: 1, offset: 36046},
+			pos:  position{line: 1339, col: 1, offset: 36247},
 			expr: &charClassMatcher{
-				pos:        position{line: 1333, col: 5, offset: 36062},
+				pos:        position{line: 1340, col: 5, offset: 36263},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11045,42 +11109,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1335, col: 1, offset: 36077},
+			pos:  position{line: 1342, col: 1, offset: 36278},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1335, col: 6, offset: 36082},
+				pos: position{line: 1342, col: 6, offset: 36283},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1335, col: 6, offset: 36082},
+					pos:  position{line: 1342, col: 6, offset: 36283},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1337, col: 1, offset: 36093},
+			pos:  position{line: 1344, col: 1, offset: 36294},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1337, col: 6, offset: 36098},
+				pos: position{line: 1344, col: 6, offset: 36299},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1337, col: 6, offset: 36098},
+					pos:  position{line: 1344, col: 6, offset: 36299},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1339, col: 1, offset: 36109},
+			pos:  position{line: 1346, col: 1, offset: 36310},
 			expr: &choiceExpr{
-				pos: position{line: 1340, col: 5, offset: 36122},
+				pos: position{line: 1347, col: 5, offset: 36323},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1340, col: 5, offset: 36122},
+						pos:  position{line: 1347, col: 5, offset: 36323},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1341, col: 5, offset: 36137},
+						pos:  position{line: 1348, col: 5, offset: 36338},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1342, col: 5, offset: 36156},
+						pos:  position{line: 1349, col: 5, offset: 36357},
 						name: "Comment",
 					},
 				},
@@ -11088,45 +11152,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1344, col: 1, offset: 36165},
+			pos:  position{line: 1351, col: 1, offset: 36366},
 			expr: &anyMatcher{
-				line: 1345, col: 5, offset: 36185,
+				line: 1352, col: 5, offset: 36386,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1347, col: 1, offset: 36188},
+			pos:         position{line: 1354, col: 1, offset: 36389},
 			expr: &choiceExpr{
-				pos: position{line: 1348, col: 5, offset: 36216},
+				pos: position{line: 1355, col: 5, offset: 36417},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1348, col: 5, offset: 36216},
+						pos:        position{line: 1355, col: 5, offset: 36417},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1349, col: 5, offset: 36225},
+						pos:        position{line: 1356, col: 5, offset: 36426},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1350, col: 5, offset: 36234},
+						pos:        position{line: 1357, col: 5, offset: 36435},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1351, col: 5, offset: 36243},
+						pos:        position{line: 1358, col: 5, offset: 36444},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1352, col: 5, offset: 36251},
+						pos:        position{line: 1359, col: 5, offset: 36452},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1353, col: 5, offset: 36264},
+						pos:        position{line: 1360, col: 5, offset: 36465},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11135,9 +11199,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1355, col: 1, offset: 36274},
+			pos:  position{line: 1362, col: 1, offset: 36475},
 			expr: &charClassMatcher{
-				pos:        position{line: 1356, col: 5, offset: 36293},
+				pos:        position{line: 1363, col: 5, offset: 36494},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11147,45 +11211,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1362, col: 1, offset: 36623},
+			pos:         position{line: 1369, col: 1, offset: 36824},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1365, col: 5, offset: 36694},
+				pos:  position{line: 1372, col: 5, offset: 36895},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1367, col: 1, offset: 36713},
+			pos:  position{line: 1374, col: 1, offset: 36914},
 			expr: &seqExpr{
-				pos: position{line: 1368, col: 5, offset: 36734},
+				pos: position{line: 1375, col: 5, offset: 36935},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1368, col: 5, offset: 36734},
+						pos:        position{line: 1375, col: 5, offset: 36935},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1368, col: 10, offset: 36739},
+						pos: position{line: 1375, col: 10, offset: 36940},
 						expr: &seqExpr{
-							pos: position{line: 1368, col: 11, offset: 36740},
+							pos: position{line: 1375, col: 11, offset: 36941},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1368, col: 11, offset: 36740},
+									pos: position{line: 1375, col: 11, offset: 36941},
 									expr: &litMatcher{
-										pos:        position{line: 1368, col: 12, offset: 36741},
+										pos:        position{line: 1375, col: 12, offset: 36942},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1368, col: 17, offset: 36746},
+									pos:  position{line: 1375, col: 17, offset: 36947},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1368, col: 35, offset: 36764},
+						pos:        position{line: 1375, col: 35, offset: 36965},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11194,29 +11258,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1370, col: 1, offset: 36770},
+			pos:  position{line: 1377, col: 1, offset: 36971},
 			expr: &seqExpr{
-				pos: position{line: 1371, col: 5, offset: 36792},
+				pos: position{line: 1378, col: 5, offset: 36993},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1371, col: 5, offset: 36792},
+						pos:        position{line: 1378, col: 5, offset: 36993},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1371, col: 10, offset: 36797},
+						pos: position{line: 1378, col: 10, offset: 36998},
 						expr: &seqExpr{
-							pos: position{line: 1371, col: 11, offset: 36798},
+							pos: position{line: 1378, col: 11, offset: 36999},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1371, col: 11, offset: 36798},
+									pos: position{line: 1378, col: 11, offset: 36999},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1371, col: 12, offset: 36799},
+										pos:  position{line: 1378, col: 12, offset: 37000},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1371, col: 27, offset: 36814},
+									pos:  position{line: 1378, col: 27, offset: 37015},
 									name: "SourceCharacter",
 								},
 							},
@@ -11227,19 +11291,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1373, col: 1, offset: 36833},
+			pos:  position{line: 1380, col: 1, offset: 37034},
 			expr: &seqExpr{
-				pos: position{line: 1373, col: 7, offset: 36839},
+				pos: position{line: 1380, col: 7, offset: 37040},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1373, col: 7, offset: 36839},
+						pos: position{line: 1380, col: 7, offset: 37040},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1373, col: 7, offset: 36839},
+							pos:  position{line: 1380, col: 7, offset: 37040},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1373, col: 19, offset: 36851},
+						pos:  position{line: 1380, col: 19, offset: 37052},
 						name: "LineTerminator",
 					},
 				},
@@ -11247,16 +11311,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1375, col: 1, offset: 36867},
+			pos:  position{line: 1382, col: 1, offset: 37068},
 			expr: &choiceExpr{
-				pos: position{line: 1375, col: 7, offset: 36873},
+				pos: position{line: 1382, col: 7, offset: 37074},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 7, offset: 36873},
+						pos:  position{line: 1382, col: 7, offset: 37074},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 11, offset: 36877},
+						pos:  position{line: 1382, col: 11, offset: 37078},
 						name: "EOF",
 					},
 				},
@@ -11264,11 +11328,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1377, col: 1, offset: 36882},
+			pos:  position{line: 1384, col: 1, offset: 37083},
 			expr: &notExpr{
-				pos: position{line: 1377, col: 7, offset: 36888},
+				pos: position{line: 1384, col: 7, offset: 37089},
 				expr: &anyMatcher{
-					line: 1377, col: 8, offset: 36889,
+					line: 1384, col: 8, offset: 37090,
 				},
 			},
 		},
@@ -12537,26 +12601,57 @@ func (p *parser) callonMergeProc1() (interface{}, error) {
 	return p.cur.onMergeProc1(stack["field"])
 }
 
-func (c *current) onOverProc3(exprs interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": nil}, nil
+func (c *current) onOverProc2(over interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Let", "locals": nil, "over": over}, nil
 
 }
 
-func (p *parser) callonOverProc3() (interface{}, error) {
+func (p *parser) callonOverProc2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOverProc3(stack["exprs"])
+	return p.cur.onOverProc2(stack["over"])
 }
 
-func (c *current) onScopedOver1(exprs, scope interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope}, nil
+func (c *current) onOverProc5(exprs interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": nil, "as": ""}, nil
+
+}
+
+func (p *parser) callonOverProc5() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOverProc5(stack["exprs"])
+}
+
+func (c *current) onScopedOver1(exprs, as, scope interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope, "as": as}, nil
 
 }
 
 func (p *parser) callonScopedOver1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onScopedOver1(stack["exprs"], stack["scope"])
+	return p.cur.onScopedOver1(stack["exprs"], stack["as"], stack["scope"])
+}
+
+func (c *current) onAs2(id interface{}) (interface{}, error) {
+	return id, nil
+}
+
+func (p *parser) callonAs2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onAs2(stack["id"])
+}
+
+func (c *current) onAs9() (interface{}, error) {
+	return "", nil
+}
+
+func (p *parser) callonAs9() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onAs9()
 }
 
 func (c *current) onLetProc1(locals, over interface{}) (interface{}, error) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -4189,39 +4189,39 @@ var g = &grammar{
 		},
 		{
 			name: "LetProc",
-			pos:  position{line: 544, col: 1, offset: 15909},
+			pos:  position{line: 543, col: 1, offset: 15908},
 			expr: &actionExpr{
-				pos: position{line: 545, col: 5, offset: 15921},
+				pos: position{line: 544, col: 5, offset: 15920},
 				run: (*parser).callonLetProc1,
 				expr: &seqExpr{
-					pos: position{line: 545, col: 5, offset: 15921},
+					pos: position{line: 544, col: 5, offset: 15920},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 545, col: 5, offset: 15921},
+							pos:        position{line: 544, col: 5, offset: 15920},
 							val:        "let",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 545, col: 12, offset: 15928},
+							pos:  position{line: 544, col: 12, offset: 15927},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 14, offset: 15930},
+							pos:   position{line: 544, col: 14, offset: 15929},
 							label: "locals",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 21, offset: 15937},
+								pos:  position{line: 544, col: 21, offset: 15936},
 								name: "LetAssignments",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 545, col: 36, offset: 15952},
+							pos:  position{line: 544, col: 36, offset: 15951},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 39, offset: 15955},
+							pos:   position{line: 544, col: 39, offset: 15954},
 							label: "over",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 44, offset: 15960},
+								pos:  position{line: 544, col: 44, offset: 15959},
 								name: "ScopedOver",
 							},
 						},
@@ -4231,45 +4231,45 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 549, col: 1, offset: 16066},
+			pos:  position{line: 548, col: 1, offset: 16064},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 9, offset: 16074},
+				pos: position{line: 548, col: 9, offset: 16072},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 549, col: 9, offset: 16074},
+					pos: position{line: 548, col: 9, offset: 16072},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 549, col: 9, offset: 16074},
+							pos:        position{line: 548, col: 9, offset: 16072},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 14, offset: 16079},
+							pos:  position{line: 548, col: 14, offset: 16077},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 549, col: 17, offset: 16082},
+							pos:        position{line: 548, col: 17, offset: 16080},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 21, offset: 16086},
+							pos:  position{line: 548, col: 21, offset: 16084},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 549, col: 24, offset: 16089},
+							pos:   position{line: 548, col: 24, offset: 16087},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 28, offset: 16093},
+								pos:  position{line: 548, col: 28, offset: 16091},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 39, offset: 16104},
+							pos:  position{line: 548, col: 39, offset: 16102},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 549, col: 42, offset: 16107},
+							pos:        position{line: 548, col: 42, offset: 16105},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4279,50 +4279,50 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignments",
-			pos:  position{line: 551, col: 1, offset: 16132},
+			pos:  position{line: 550, col: 1, offset: 16130},
 			expr: &actionExpr{
-				pos: position{line: 552, col: 5, offset: 16151},
+				pos: position{line: 551, col: 5, offset: 16149},
 				run: (*parser).callonLetAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 552, col: 5, offset: 16151},
+					pos: position{line: 551, col: 5, offset: 16149},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 552, col: 5, offset: 16151},
+							pos:   position{line: 551, col: 5, offset: 16149},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 552, col: 11, offset: 16157},
+								pos:  position{line: 551, col: 11, offset: 16155},
 								name: "LetAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 552, col: 25, offset: 16171},
+							pos:   position{line: 551, col: 25, offset: 16169},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 552, col: 30, offset: 16176},
+								pos: position{line: 551, col: 30, offset: 16174},
 								expr: &actionExpr{
-									pos: position{line: 552, col: 31, offset: 16177},
+									pos: position{line: 551, col: 31, offset: 16175},
 									run: (*parser).callonLetAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 552, col: 31, offset: 16177},
+										pos: position{line: 551, col: 31, offset: 16175},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 552, col: 31, offset: 16177},
+												pos:  position{line: 551, col: 31, offset: 16175},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 552, col: 34, offset: 16180},
+												pos:        position{line: 551, col: 34, offset: 16178},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 552, col: 38, offset: 16184},
+												pos:  position{line: 551, col: 38, offset: 16182},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 552, col: 41, offset: 16187},
+												pos:   position{line: 551, col: 41, offset: 16185},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 552, col: 43, offset: 16189},
+													pos:  position{line: 551, col: 43, offset: 16187},
 													name: "LetAssignment",
 												},
 											},
@@ -4337,39 +4337,39 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignment",
-			pos:  position{line: 556, col: 1, offset: 16307},
+			pos:  position{line: 555, col: 1, offset: 16305},
 			expr: &actionExpr{
-				pos: position{line: 556, col: 17, offset: 16323},
+				pos: position{line: 555, col: 17, offset: 16321},
 				run: (*parser).callonLetAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 556, col: 17, offset: 16323},
+					pos: position{line: 555, col: 17, offset: 16321},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 556, col: 17, offset: 16323},
+							pos:   position{line: 555, col: 17, offset: 16321},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 556, col: 20, offset: 16326},
+								pos:  position{line: 555, col: 20, offset: 16324},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 556, col: 35, offset: 16341},
+							pos:  position{line: 555, col: 35, offset: 16339},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 556, col: 38, offset: 16344},
+							pos:        position{line: 555, col: 38, offset: 16342},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 556, col: 42, offset: 16348},
+							pos:  position{line: 555, col: 42, offset: 16346},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 556, col: 45, offset: 16351},
+							pos:   position{line: 555, col: 45, offset: 16349},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 556, col: 50, offset: 16356},
+								pos:  position{line: 555, col: 50, offset: 16354},
 								name: "Expr",
 							},
 						},
@@ -4379,27 +4379,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldProc",
-			pos:  position{line: 560, col: 1, offset: 16435},
+			pos:  position{line: 559, col: 1, offset: 16433},
 			expr: &actionExpr{
-				pos: position{line: 561, col: 5, offset: 16449},
+				pos: position{line: 560, col: 5, offset: 16447},
 				run: (*parser).callonYieldProc1,
 				expr: &seqExpr{
-					pos: position{line: 561, col: 5, offset: 16449},
+					pos: position{line: 560, col: 5, offset: 16447},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 561, col: 5, offset: 16449},
+							pos:        position{line: 560, col: 5, offset: 16447},
 							val:        "yield",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 561, col: 14, offset: 16458},
+							pos:  position{line: 560, col: 14, offset: 16456},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 561, col: 16, offset: 16460},
+							pos:   position{line: 560, col: 16, offset: 16458},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 22, offset: 16466},
+								pos:  position{line: 560, col: 22, offset: 16464},
 								name: "Exprs",
 							},
 						},
@@ -4409,30 +4409,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 565, col: 1, offset: 16550},
+			pos:  position{line: 564, col: 1, offset: 16548},
 			expr: &actionExpr{
-				pos: position{line: 566, col: 5, offset: 16562},
+				pos: position{line: 565, col: 5, offset: 16560},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 566, col: 5, offset: 16562},
+					pos: position{line: 565, col: 5, offset: 16560},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 566, col: 5, offset: 16562},
+							pos:  position{line: 565, col: 5, offset: 16560},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 566, col: 7, offset: 16564},
+							pos:  position{line: 565, col: 7, offset: 16562},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 566, col: 10, offset: 16567},
+							pos:  position{line: 565, col: 10, offset: 16565},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 566, col: 12, offset: 16569},
+							pos:   position{line: 565, col: 12, offset: 16567},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 566, col: 16, offset: 16573},
+								pos:  position{line: 565, col: 16, offset: 16571},
 								name: "Type",
 							},
 						},
@@ -4442,30 +4442,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 568, col: 1, offset: 16598},
+			pos:  position{line: 567, col: 1, offset: 16596},
 			expr: &actionExpr{
-				pos: position{line: 569, col: 5, offset: 16608},
+				pos: position{line: 568, col: 5, offset: 16606},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 569, col: 5, offset: 16608},
+					pos: position{line: 568, col: 5, offset: 16606},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 569, col: 5, offset: 16608},
+							pos:  position{line: 568, col: 5, offset: 16606},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 569, col: 7, offset: 16610},
+							pos:  position{line: 568, col: 7, offset: 16608},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 569, col: 10, offset: 16613},
+							pos:  position{line: 568, col: 10, offset: 16611},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 569, col: 12, offset: 16615},
+							pos:   position{line: 568, col: 12, offset: 16613},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 569, col: 16, offset: 16619},
+								pos:  position{line: 568, col: 16, offset: 16617},
 								name: "Lval",
 							},
 						},
@@ -4475,58 +4475,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 573, col: 1, offset: 16670},
+			pos:  position{line: 572, col: 1, offset: 16668},
 			expr: &ruleRefExpr{
-				pos:  position{line: 573, col: 8, offset: 16677},
+				pos:  position{line: 572, col: 8, offset: 16675},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 575, col: 1, offset: 16688},
+			pos:  position{line: 574, col: 1, offset: 16686},
 			expr: &actionExpr{
-				pos: position{line: 576, col: 5, offset: 16698},
+				pos: position{line: 575, col: 5, offset: 16696},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 576, col: 5, offset: 16698},
+					pos: position{line: 575, col: 5, offset: 16696},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 576, col: 5, offset: 16698},
+							pos:   position{line: 575, col: 5, offset: 16696},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 576, col: 11, offset: 16704},
+								pos:  position{line: 575, col: 11, offset: 16702},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 576, col: 16, offset: 16709},
+							pos:   position{line: 575, col: 16, offset: 16707},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 576, col: 21, offset: 16714},
+								pos: position{line: 575, col: 21, offset: 16712},
 								expr: &actionExpr{
-									pos: position{line: 576, col: 22, offset: 16715},
+									pos: position{line: 575, col: 22, offset: 16713},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 576, col: 22, offset: 16715},
+										pos: position{line: 575, col: 22, offset: 16713},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 576, col: 22, offset: 16715},
+												pos:  position{line: 575, col: 22, offset: 16713},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 576, col: 25, offset: 16718},
+												pos:        position{line: 575, col: 25, offset: 16716},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 576, col: 29, offset: 16722},
+												pos:  position{line: 575, col: 29, offset: 16720},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 576, col: 32, offset: 16725},
+												pos:   position{line: 575, col: 32, offset: 16723},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 576, col: 37, offset: 16730},
+													pos:  position{line: 575, col: 37, offset: 16728},
 													name: "Lval",
 												},
 											},
@@ -4541,52 +4541,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 580, col: 1, offset: 16842},
+			pos:  position{line: 579, col: 1, offset: 16840},
 			expr: &ruleRefExpr{
-				pos:  position{line: 580, col: 13, offset: 16854},
+				pos:  position{line: 579, col: 13, offset: 16852},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 582, col: 1, offset: 16860},
+			pos:  position{line: 581, col: 1, offset: 16858},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 5, offset: 16875},
+				pos: position{line: 582, col: 5, offset: 16873},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 583, col: 5, offset: 16875},
+					pos: position{line: 582, col: 5, offset: 16873},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 583, col: 5, offset: 16875},
+							pos:   position{line: 582, col: 5, offset: 16873},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 11, offset: 16881},
+								pos:  position{line: 582, col: 11, offset: 16879},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 21, offset: 16891},
+							pos:   position{line: 582, col: 21, offset: 16889},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 583, col: 26, offset: 16896},
+								pos: position{line: 582, col: 26, offset: 16894},
 								expr: &seqExpr{
-									pos: position{line: 583, col: 27, offset: 16897},
+									pos: position{line: 582, col: 27, offset: 16895},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 583, col: 27, offset: 16897},
+											pos:  position{line: 582, col: 27, offset: 16895},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 583, col: 30, offset: 16900},
+											pos:        position{line: 582, col: 30, offset: 16898},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 583, col: 34, offset: 16904},
+											pos:  position{line: 582, col: 34, offset: 16902},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 583, col: 37, offset: 16907},
+											pos:  position{line: 582, col: 37, offset: 16905},
 											name: "FieldExpr",
 										},
 									},
@@ -4599,50 +4599,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 593, col: 1, offset: 17106},
+			pos:  position{line: 592, col: 1, offset: 17104},
 			expr: &actionExpr{
-				pos: position{line: 594, col: 5, offset: 17122},
+				pos: position{line: 593, col: 5, offset: 17120},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 594, col: 5, offset: 17122},
+					pos: position{line: 593, col: 5, offset: 17120},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 594, col: 5, offset: 17122},
+							pos:   position{line: 593, col: 5, offset: 17120},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 594, col: 11, offset: 17128},
+								pos:  position{line: 593, col: 11, offset: 17126},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 594, col: 22, offset: 17139},
+							pos:   position{line: 593, col: 22, offset: 17137},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 594, col: 27, offset: 17144},
+								pos: position{line: 593, col: 27, offset: 17142},
 								expr: &actionExpr{
-									pos: position{line: 594, col: 28, offset: 17145},
+									pos: position{line: 593, col: 28, offset: 17143},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 594, col: 28, offset: 17145},
+										pos: position{line: 593, col: 28, offset: 17143},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 594, col: 28, offset: 17145},
+												pos:  position{line: 593, col: 28, offset: 17143},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 594, col: 31, offset: 17148},
+												pos:        position{line: 593, col: 31, offset: 17146},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 594, col: 35, offset: 17152},
+												pos:  position{line: 593, col: 35, offset: 17150},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 594, col: 38, offset: 17155},
+												pos:   position{line: 593, col: 38, offset: 17153},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 594, col: 40, offset: 17157},
+													pos:  position{line: 593, col: 40, offset: 17155},
 													name: "Assignment",
 												},
 											},
@@ -4657,39 +4657,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 598, col: 1, offset: 17268},
+			pos:  position{line: 597, col: 1, offset: 17266},
 			expr: &actionExpr{
-				pos: position{line: 599, col: 5, offset: 17283},
+				pos: position{line: 598, col: 5, offset: 17281},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 599, col: 5, offset: 17283},
+					pos: position{line: 598, col: 5, offset: 17281},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 599, col: 5, offset: 17283},
+							pos:   position{line: 598, col: 5, offset: 17281},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 599, col: 9, offset: 17287},
+								pos:  position{line: 598, col: 9, offset: 17285},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 14, offset: 17292},
+							pos:  position{line: 598, col: 14, offset: 17290},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 599, col: 17, offset: 17295},
+							pos:        position{line: 598, col: 17, offset: 17293},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 22, offset: 17300},
+							pos:  position{line: 598, col: 22, offset: 17298},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 599, col: 25, offset: 17303},
+							pos:   position{line: 598, col: 25, offset: 17301},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 599, col: 29, offset: 17307},
+								pos:  position{line: 598, col: 29, offset: 17305},
 								name: "Expr",
 							},
 						},
@@ -4699,71 +4699,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 601, col: 1, offset: 17398},
+			pos:  position{line: 600, col: 1, offset: 17396},
 			expr: &ruleRefExpr{
-				pos:  position{line: 601, col: 8, offset: 17405},
+				pos:  position{line: 600, col: 8, offset: 17403},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 603, col: 1, offset: 17422},
+			pos:  position{line: 602, col: 1, offset: 17420},
 			expr: &choiceExpr{
-				pos: position{line: 604, col: 5, offset: 17442},
+				pos: position{line: 603, col: 5, offset: 17440},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 604, col: 5, offset: 17442},
+						pos: position{line: 603, col: 5, offset: 17440},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 604, col: 5, offset: 17442},
+							pos: position{line: 603, col: 5, offset: 17440},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 604, col: 5, offset: 17442},
+									pos:   position{line: 603, col: 5, offset: 17440},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 604, col: 15, offset: 17452},
+										pos:  position{line: 603, col: 15, offset: 17450},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 604, col: 29, offset: 17466},
+									pos:  position{line: 603, col: 29, offset: 17464},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 604, col: 32, offset: 17469},
+									pos:        position{line: 603, col: 32, offset: 17467},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 604, col: 36, offset: 17473},
+									pos:  position{line: 603, col: 36, offset: 17471},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 604, col: 39, offset: 17476},
+									pos:   position{line: 603, col: 39, offset: 17474},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 604, col: 50, offset: 17487},
+										pos:  position{line: 603, col: 50, offset: 17485},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 604, col: 55, offset: 17492},
+									pos:  position{line: 603, col: 55, offset: 17490},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 604, col: 58, offset: 17495},
+									pos:        position{line: 603, col: 58, offset: 17493},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 604, col: 62, offset: 17499},
+									pos:  position{line: 603, col: 62, offset: 17497},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 604, col: 65, offset: 17502},
+									pos:   position{line: 603, col: 65, offset: 17500},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 604, col: 76, offset: 17513},
+										pos:  position{line: 603, col: 76, offset: 17511},
 										name: "Expr",
 									},
 								},
@@ -4771,7 +4771,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 607, col: 5, offset: 17653},
+						pos:  position{line: 606, col: 5, offset: 17651},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4779,53 +4779,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 609, col: 1, offset: 17668},
+			pos:  position{line: 608, col: 1, offset: 17666},
 			expr: &actionExpr{
-				pos: position{line: 610, col: 5, offset: 17686},
+				pos: position{line: 609, col: 5, offset: 17684},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 610, col: 5, offset: 17686},
+					pos: position{line: 609, col: 5, offset: 17684},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 610, col: 5, offset: 17686},
+							pos:   position{line: 609, col: 5, offset: 17684},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 610, col: 11, offset: 17692},
+								pos:  position{line: 609, col: 11, offset: 17690},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 5, offset: 17711},
+							pos:   position{line: 610, col: 5, offset: 17709},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 611, col: 10, offset: 17716},
+								pos: position{line: 610, col: 10, offset: 17714},
 								expr: &actionExpr{
-									pos: position{line: 611, col: 11, offset: 17717},
+									pos: position{line: 610, col: 11, offset: 17715},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 611, col: 11, offset: 17717},
+										pos: position{line: 610, col: 11, offset: 17715},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 11, offset: 17717},
+												pos:  position{line: 610, col: 11, offset: 17715},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 611, col: 14, offset: 17720},
+												pos:   position{line: 610, col: 14, offset: 17718},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 611, col: 17, offset: 17723},
+													pos:  position{line: 610, col: 17, offset: 17721},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 25, offset: 17731},
+												pos:  position{line: 610, col: 25, offset: 17729},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 611, col: 28, offset: 17734},
+												pos:   position{line: 610, col: 28, offset: 17732},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 611, col: 33, offset: 17739},
+													pos:  position{line: 610, col: 33, offset: 17737},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4840,53 +4840,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 615, col: 1, offset: 17857},
+			pos:  position{line: 614, col: 1, offset: 17855},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 5, offset: 17876},
+				pos: position{line: 615, col: 5, offset: 17874},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 5, offset: 17876},
+					pos: position{line: 615, col: 5, offset: 17874},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 616, col: 5, offset: 17876},
+							pos:   position{line: 615, col: 5, offset: 17874},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 11, offset: 17882},
+								pos:  position{line: 615, col: 11, offset: 17880},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 617, col: 5, offset: 17906},
+							pos:   position{line: 616, col: 5, offset: 17904},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 617, col: 10, offset: 17911},
+								pos: position{line: 616, col: 10, offset: 17909},
 								expr: &actionExpr{
-									pos: position{line: 617, col: 11, offset: 17912},
+									pos: position{line: 616, col: 11, offset: 17910},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 617, col: 11, offset: 17912},
+										pos: position{line: 616, col: 11, offset: 17910},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 617, col: 11, offset: 17912},
+												pos:  position{line: 616, col: 11, offset: 17910},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 617, col: 14, offset: 17915},
+												pos:   position{line: 616, col: 14, offset: 17913},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 617, col: 17, offset: 17918},
+													pos:  position{line: 616, col: 17, offset: 17916},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 617, col: 26, offset: 17927},
+												pos:  position{line: 616, col: 26, offset: 17925},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 617, col: 29, offset: 17930},
+												pos:   position{line: 616, col: 29, offset: 17928},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 617, col: 34, offset: 17935},
+													pos:  position{line: 616, col: 34, offset: 17933},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -4901,60 +4901,60 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 621, col: 1, offset: 18058},
+			pos:  position{line: 620, col: 1, offset: 18056},
 			expr: &choiceExpr{
-				pos: position{line: 622, col: 5, offset: 18082},
+				pos: position{line: 621, col: 5, offset: 18080},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 622, col: 5, offset: 18082},
+						pos:  position{line: 621, col: 5, offset: 18080},
 						name: "PatternMatch",
 					},
 					&actionExpr{
-						pos: position{line: 623, col: 5, offset: 18099},
+						pos: position{line: 622, col: 5, offset: 18097},
 						run: (*parser).callonEqualityCompareExpr3,
 						expr: &seqExpr{
-							pos: position{line: 623, col: 5, offset: 18099},
+							pos: position{line: 622, col: 5, offset: 18097},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 623, col: 5, offset: 18099},
+									pos:   position{line: 622, col: 5, offset: 18097},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 623, col: 11, offset: 18105},
+										pos:  position{line: 622, col: 11, offset: 18103},
 										name: "RelativeExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 624, col: 5, offset: 18122},
+									pos:   position{line: 623, col: 5, offset: 18120},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 624, col: 10, offset: 18127},
+										pos: position{line: 623, col: 10, offset: 18125},
 										expr: &actionExpr{
-											pos: position{line: 624, col: 11, offset: 18128},
+											pos: position{line: 623, col: 11, offset: 18126},
 											run: (*parser).callonEqualityCompareExpr9,
 											expr: &seqExpr{
-												pos: position{line: 624, col: 11, offset: 18128},
+												pos: position{line: 623, col: 11, offset: 18126},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 624, col: 11, offset: 18128},
+														pos:  position{line: 623, col: 11, offset: 18126},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 624, col: 14, offset: 18131},
+														pos:   position{line: 623, col: 14, offset: 18129},
 														label: "comp",
 														expr: &ruleRefExpr{
-															pos:  position{line: 624, col: 19, offset: 18136},
+															pos:  position{line: 623, col: 19, offset: 18134},
 															name: "EqualityComparator",
 														},
 													},
 													&ruleRefExpr{
-														pos:  position{line: 624, col: 38, offset: 18155},
+														pos:  position{line: 623, col: 38, offset: 18153},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 624, col: 41, offset: 18158},
+														pos:   position{line: 623, col: 41, offset: 18156},
 														label: "expr",
 														expr: &ruleRefExpr{
-															pos:  position{line: 624, col: 46, offset: 18163},
+															pos:  position{line: 623, col: 46, offset: 18161},
 															name: "RelativeExpr",
 														},
 													},
@@ -4971,24 +4971,24 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 628, col: 1, offset: 18281},
+			pos:  position{line: 627, col: 1, offset: 18279},
 			expr: &choiceExpr{
-				pos: position{line: 629, col: 5, offset: 18302},
+				pos: position{line: 628, col: 5, offset: 18300},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 629, col: 5, offset: 18302},
+						pos: position{line: 628, col: 5, offset: 18300},
 						run: (*parser).callonEqualityOperator2,
 						expr: &litMatcher{
-							pos:        position{line: 629, col: 5, offset: 18302},
+							pos:        position{line: 628, col: 5, offset: 18300},
 							val:        "==",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 630, col: 5, offset: 18331},
+						pos: position{line: 629, col: 5, offset: 18329},
 						run: (*parser).callonEqualityOperator4,
 						expr: &litMatcher{
-							pos:        position{line: 630, col: 5, offset: 18331},
+							pos:        position{line: 629, col: 5, offset: 18329},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -4998,29 +4998,29 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 632, col: 1, offset: 18368},
+			pos:  position{line: 631, col: 1, offset: 18366},
 			expr: &choiceExpr{
-				pos: position{line: 633, col: 5, offset: 18391},
+				pos: position{line: 632, col: 5, offset: 18389},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 633, col: 5, offset: 18391},
+						pos:  position{line: 632, col: 5, offset: 18389},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 634, col: 5, offset: 18412},
+						pos: position{line: 633, col: 5, offset: 18410},
 						run: (*parser).callonEqualityComparator3,
 						expr: &seqExpr{
-							pos: position{line: 634, col: 5, offset: 18412},
+							pos: position{line: 633, col: 5, offset: 18410},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 634, col: 5, offset: 18412},
+									pos:        position{line: 633, col: 5, offset: 18410},
 									val:        "in",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 634, col: 10, offset: 18417},
+									pos: position{line: 633, col: 10, offset: 18415},
 									expr: &ruleRefExpr{
-										pos:  position{line: 634, col: 11, offset: 18418},
+										pos:  position{line: 633, col: 11, offset: 18416},
 										name: "IdentifierRest",
 									},
 								},
@@ -5032,53 +5032,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 636, col: 1, offset: 18465},
+			pos:  position{line: 635, col: 1, offset: 18463},
 			expr: &actionExpr{
-				pos: position{line: 637, col: 5, offset: 18482},
+				pos: position{line: 636, col: 5, offset: 18480},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 637, col: 5, offset: 18482},
+					pos: position{line: 636, col: 5, offset: 18480},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 637, col: 5, offset: 18482},
+							pos:   position{line: 636, col: 5, offset: 18480},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 637, col: 11, offset: 18488},
+								pos:  position{line: 636, col: 11, offset: 18486},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 638, col: 5, offset: 18505},
+							pos:   position{line: 637, col: 5, offset: 18503},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 638, col: 10, offset: 18510},
+								pos: position{line: 637, col: 10, offset: 18508},
 								expr: &actionExpr{
-									pos: position{line: 638, col: 11, offset: 18511},
+									pos: position{line: 637, col: 11, offset: 18509},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 638, col: 11, offset: 18511},
+										pos: position{line: 637, col: 11, offset: 18509},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 638, col: 11, offset: 18511},
+												pos:  position{line: 637, col: 11, offset: 18509},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 638, col: 14, offset: 18514},
+												pos:   position{line: 637, col: 14, offset: 18512},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 638, col: 17, offset: 18517},
+													pos:  position{line: 637, col: 17, offset: 18515},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 638, col: 34, offset: 18534},
+												pos:  position{line: 637, col: 34, offset: 18532},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 638, col: 37, offset: 18537},
+												pos:   position{line: 637, col: 37, offset: 18535},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 638, col: 42, offset: 18542},
+													pos:  position{line: 637, col: 42, offset: 18540},
 													name: "AdditiveExpr",
 												},
 											},
@@ -5093,30 +5093,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 642, col: 1, offset: 18658},
+			pos:  position{line: 641, col: 1, offset: 18656},
 			expr: &actionExpr{
-				pos: position{line: 642, col: 20, offset: 18677},
+				pos: position{line: 641, col: 20, offset: 18675},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 642, col: 21, offset: 18678},
+					pos: position{line: 641, col: 21, offset: 18676},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 642, col: 21, offset: 18678},
+							pos:        position{line: 641, col: 21, offset: 18676},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 642, col: 28, offset: 18685},
+							pos:        position{line: 641, col: 28, offset: 18683},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 642, col: 34, offset: 18691},
+							pos:        position{line: 641, col: 34, offset: 18689},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 642, col: 41, offset: 18698},
+							pos:        position{line: 641, col: 41, offset: 18696},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -5126,53 +5126,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 644, col: 1, offset: 18735},
+			pos:  position{line: 643, col: 1, offset: 18733},
 			expr: &actionExpr{
-				pos: position{line: 645, col: 5, offset: 18752},
+				pos: position{line: 644, col: 5, offset: 18750},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 645, col: 5, offset: 18752},
+					pos: position{line: 644, col: 5, offset: 18750},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 645, col: 5, offset: 18752},
+							pos:   position{line: 644, col: 5, offset: 18750},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 645, col: 11, offset: 18758},
+								pos:  position{line: 644, col: 11, offset: 18756},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 646, col: 5, offset: 18781},
+							pos:   position{line: 645, col: 5, offset: 18779},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 646, col: 10, offset: 18786},
+								pos: position{line: 645, col: 10, offset: 18784},
 								expr: &actionExpr{
-									pos: position{line: 646, col: 11, offset: 18787},
+									pos: position{line: 645, col: 11, offset: 18785},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 646, col: 11, offset: 18787},
+										pos: position{line: 645, col: 11, offset: 18785},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 646, col: 11, offset: 18787},
+												pos:  position{line: 645, col: 11, offset: 18785},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 646, col: 14, offset: 18790},
+												pos:   position{line: 645, col: 14, offset: 18788},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 646, col: 17, offset: 18793},
+													pos:  position{line: 645, col: 17, offset: 18791},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 646, col: 34, offset: 18810},
+												pos:  position{line: 645, col: 34, offset: 18808},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 646, col: 37, offset: 18813},
+												pos:   position{line: 645, col: 37, offset: 18811},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 646, col: 42, offset: 18818},
+													pos:  position{line: 645, col: 42, offset: 18816},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5187,20 +5187,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 650, col: 1, offset: 18940},
+			pos:  position{line: 649, col: 1, offset: 18938},
 			expr: &actionExpr{
-				pos: position{line: 650, col: 20, offset: 18959},
+				pos: position{line: 649, col: 20, offset: 18957},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 650, col: 21, offset: 18960},
+					pos: position{line: 649, col: 21, offset: 18958},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 650, col: 21, offset: 18960},
+							pos:        position{line: 649, col: 21, offset: 18958},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 650, col: 27, offset: 18966},
+							pos:        position{line: 649, col: 27, offset: 18964},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5210,53 +5210,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 652, col: 1, offset: 19003},
+			pos:  position{line: 651, col: 1, offset: 19001},
 			expr: &actionExpr{
-				pos: position{line: 653, col: 5, offset: 19026},
+				pos: position{line: 652, col: 5, offset: 19024},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 653, col: 5, offset: 19026},
+					pos: position{line: 652, col: 5, offset: 19024},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 653, col: 5, offset: 19026},
+							pos:   position{line: 652, col: 5, offset: 19024},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 653, col: 11, offset: 19032},
+								pos:  position{line: 652, col: 11, offset: 19030},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 654, col: 5, offset: 19044},
+							pos:   position{line: 653, col: 5, offset: 19042},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 654, col: 10, offset: 19049},
+								pos: position{line: 653, col: 10, offset: 19047},
 								expr: &actionExpr{
-									pos: position{line: 654, col: 11, offset: 19050},
+									pos: position{line: 653, col: 11, offset: 19048},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 654, col: 11, offset: 19050},
+										pos: position{line: 653, col: 11, offset: 19048},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 654, col: 11, offset: 19050},
+												pos:  position{line: 653, col: 11, offset: 19048},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 654, col: 14, offset: 19053},
+												pos:   position{line: 653, col: 14, offset: 19051},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 654, col: 17, offset: 19056},
+													pos:  position{line: 653, col: 17, offset: 19054},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 654, col: 40, offset: 19079},
+												pos:  position{line: 653, col: 40, offset: 19077},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 654, col: 43, offset: 19082},
+												pos:   position{line: 653, col: 43, offset: 19080},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 654, col: 48, offset: 19087},
+													pos:  position{line: 653, col: 48, offset: 19085},
 													name: "NotExpr",
 												},
 											},
@@ -5271,25 +5271,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 658, col: 1, offset: 19198},
+			pos:  position{line: 657, col: 1, offset: 19196},
 			expr: &actionExpr{
-				pos: position{line: 658, col: 26, offset: 19223},
+				pos: position{line: 657, col: 26, offset: 19221},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 658, col: 27, offset: 19224},
+					pos: position{line: 657, col: 27, offset: 19222},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 658, col: 27, offset: 19224},
+							pos:        position{line: 657, col: 27, offset: 19222},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 658, col: 33, offset: 19230},
+							pos:        position{line: 657, col: 33, offset: 19228},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 658, col: 39, offset: 19236},
+							pos:        position{line: 657, col: 39, offset: 19234},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5299,30 +5299,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 660, col: 1, offset: 19273},
+			pos:  position{line: 659, col: 1, offset: 19271},
 			expr: &choiceExpr{
-				pos: position{line: 661, col: 5, offset: 19285},
+				pos: position{line: 660, col: 5, offset: 19283},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 661, col: 5, offset: 19285},
+						pos: position{line: 660, col: 5, offset: 19283},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 661, col: 5, offset: 19285},
+							pos: position{line: 660, col: 5, offset: 19283},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 661, col: 5, offset: 19285},
+									pos:        position{line: 660, col: 5, offset: 19283},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 661, col: 9, offset: 19289},
+									pos:  position{line: 660, col: 9, offset: 19287},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 661, col: 12, offset: 19292},
+									pos:   position{line: 660, col: 12, offset: 19290},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 661, col: 14, offset: 19294},
+										pos:  position{line: 660, col: 14, offset: 19292},
 										name: "NotExpr",
 									},
 								},
@@ -5330,7 +5330,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 664, col: 5, offset: 19403},
+						pos:  position{line: 663, col: 5, offset: 19401},
 						name: "FuncExpr",
 					},
 				},
@@ -5338,35 +5338,35 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 666, col: 1, offset: 19413},
+			pos:  position{line: 665, col: 1, offset: 19411},
 			expr: &choiceExpr{
-				pos: position{line: 667, col: 5, offset: 19426},
+				pos: position{line: 666, col: 5, offset: 19424},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 19426},
+						pos:  position{line: 666, col: 5, offset: 19424},
 						name: "MatchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 19440},
+						pos: position{line: 667, col: 5, offset: 19438},
 						run: (*parser).callonFuncExpr3,
 						expr: &seqExpr{
-							pos: position{line: 668, col: 5, offset: 19440},
+							pos: position{line: 667, col: 5, offset: 19438},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 668, col: 5, offset: 19440},
+									pos:   position{line: 667, col: 5, offset: 19438},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 668, col: 11, offset: 19446},
+										pos:  position{line: 667, col: 11, offset: 19444},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 668, col: 16, offset: 19451},
+									pos:   position{line: 667, col: 16, offset: 19449},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 668, col: 21, offset: 19456},
+										pos: position{line: 667, col: 21, offset: 19454},
 										expr: &ruleRefExpr{
-											pos:  position{line: 668, col: 22, offset: 19457},
+											pos:  position{line: 667, col: 22, offset: 19455},
 											name: "Deref",
 										},
 									},
@@ -5375,26 +5375,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 671, col: 5, offset: 19528},
+						pos: position{line: 670, col: 5, offset: 19526},
 						run: (*parser).callonFuncExpr10,
 						expr: &seqExpr{
-							pos: position{line: 671, col: 5, offset: 19528},
+							pos: position{line: 670, col: 5, offset: 19526},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 671, col: 5, offset: 19528},
+									pos:   position{line: 670, col: 5, offset: 19526},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 671, col: 11, offset: 19534},
+										pos:  position{line: 670, col: 11, offset: 19532},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 671, col: 20, offset: 19543},
+									pos:   position{line: 670, col: 20, offset: 19541},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 671, col: 25, offset: 19548},
+										pos: position{line: 670, col: 25, offset: 19546},
 										expr: &ruleRefExpr{
-											pos:  position{line: 671, col: 26, offset: 19549},
+											pos:  position{line: 670, col: 26, offset: 19547},
 											name: "Deref",
 										},
 									},
@@ -5403,11 +5403,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 674, col: 5, offset: 19620},
+						pos:  position{line: 673, col: 5, offset: 19618},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 675, col: 5, offset: 19634},
+						pos:  position{line: 674, col: 5, offset: 19632},
 						name: "Primary",
 					},
 				},
@@ -5415,20 +5415,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 677, col: 1, offset: 19643},
+			pos:  position{line: 676, col: 1, offset: 19641},
 			expr: &seqExpr{
-				pos: position{line: 677, col: 13, offset: 19655},
+				pos: position{line: 676, col: 13, offset: 19653},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 13, offset: 19655},
+						pos:  position{line: 676, col: 13, offset: 19653},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 22, offset: 19664},
+						pos:  position{line: 676, col: 22, offset: 19662},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 677, col: 25, offset: 19667},
+						pos:        position{line: 676, col: 25, offset: 19665},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5437,27 +5437,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 679, col: 1, offset: 19672},
+			pos:  position{line: 678, col: 1, offset: 19670},
 			expr: &choiceExpr{
-				pos: position{line: 680, col: 5, offset: 19685},
+				pos: position{line: 679, col: 5, offset: 19683},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 680, col: 5, offset: 19685},
+						pos:        position{line: 679, col: 5, offset: 19683},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 681, col: 5, offset: 19695},
+						pos:        position{line: 680, col: 5, offset: 19693},
 						val:        "search",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 682, col: 5, offset: 19708},
+						pos:        position{line: 681, col: 5, offset: 19706},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 683, col: 5, offset: 19721},
+						pos:        position{line: 682, col: 5, offset: 19719},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -5466,37 +5466,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 685, col: 1, offset: 19729},
+			pos:  position{line: 684, col: 1, offset: 19727},
 			expr: &actionExpr{
-				pos: position{line: 686, col: 5, offset: 19743},
+				pos: position{line: 685, col: 5, offset: 19741},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 686, col: 5, offset: 19743},
+					pos: position{line: 685, col: 5, offset: 19741},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 686, col: 5, offset: 19743},
+							pos:        position{line: 685, col: 5, offset: 19741},
 							val:        "search",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 686, col: 14, offset: 19752},
+							pos:  position{line: 685, col: 14, offset: 19750},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 686, col: 17, offset: 19755},
+							pos:        position{line: 685, col: 17, offset: 19753},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 686, col: 21, offset: 19759},
+							pos:   position{line: 685, col: 21, offset: 19757},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 686, col: 26, offset: 19764},
+								pos:  position{line: 685, col: 26, offset: 19762},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 686, col: 40, offset: 19778},
+							pos:        position{line: 685, col: 40, offset: 19776},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5506,48 +5506,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 688, col: 1, offset: 19804},
+			pos:  position{line: 687, col: 1, offset: 19802},
 			expr: &actionExpr{
-				pos: position{line: 689, col: 5, offset: 19813},
+				pos: position{line: 688, col: 5, offset: 19811},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 689, col: 5, offset: 19813},
+					pos: position{line: 688, col: 5, offset: 19811},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 689, col: 5, offset: 19813},
+							pos:   position{line: 688, col: 5, offset: 19811},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 689, col: 9, offset: 19817},
+								pos:  position{line: 688, col: 9, offset: 19815},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 689, col: 18, offset: 19826},
+							pos:  position{line: 688, col: 18, offset: 19824},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 689, col: 21, offset: 19829},
+							pos:        position{line: 688, col: 21, offset: 19827},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 689, col: 25, offset: 19833},
+							pos:  position{line: 688, col: 25, offset: 19831},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 689, col: 28, offset: 19836},
+							pos:   position{line: 688, col: 28, offset: 19834},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 689, col: 33, offset: 19841},
+								pos:  position{line: 688, col: 33, offset: 19839},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 689, col: 38, offset: 19846},
+							pos:  position{line: 688, col: 38, offset: 19844},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 689, col: 41, offset: 19849},
+							pos:        position{line: 688, col: 41, offset: 19847},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5557,65 +5557,65 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 693, col: 1, offset: 19946},
+			pos:  position{line: 692, col: 1, offset: 19944},
 			expr: &actionExpr{
-				pos: position{line: 694, col: 5, offset: 19959},
+				pos: position{line: 693, col: 5, offset: 19957},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 694, col: 5, offset: 19959},
+					pos: position{line: 693, col: 5, offset: 19957},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 694, col: 5, offset: 19959},
+							pos: position{line: 693, col: 5, offset: 19957},
 							expr: &ruleRefExpr{
-								pos:  position{line: 694, col: 6, offset: 19960},
+								pos:  position{line: 693, col: 6, offset: 19958},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 694, col: 16, offset: 19970},
+							pos:   position{line: 693, col: 16, offset: 19968},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 694, col: 19, offset: 19973},
+								pos:  position{line: 693, col: 19, offset: 19971},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 694, col: 34, offset: 19988},
+							pos:  position{line: 693, col: 34, offset: 19986},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 694, col: 37, offset: 19991},
+							pos:        position{line: 693, col: 37, offset: 19989},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 694, col: 41, offset: 19995},
+							pos:  position{line: 693, col: 41, offset: 19993},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 694, col: 44, offset: 19998},
+							pos:   position{line: 693, col: 44, offset: 19996},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 694, col: 49, offset: 20003},
+								pos:  position{line: 693, col: 49, offset: 20001},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 694, col: 63, offset: 20017},
+							pos:  position{line: 693, col: 63, offset: 20015},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 694, col: 66, offset: 20020},
+							pos:        position{line: 693, col: 66, offset: 20018},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 694, col: 70, offset: 20024},
+							pos:   position{line: 693, col: 70, offset: 20022},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 694, col: 76, offset: 20030},
+								pos: position{line: 693, col: 76, offset: 20028},
 								expr: &ruleRefExpr{
-									pos:  position{line: 694, col: 76, offset: 20030},
+									pos:  position{line: 693, col: 76, offset: 20028},
 									name: "WhereClause",
 								},
 							},
@@ -5626,19 +5626,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 698, col: 1, offset: 20151},
+			pos:  position{line: 697, col: 1, offset: 20149},
 			expr: &choiceExpr{
-				pos: position{line: 699, col: 5, offset: 20169},
+				pos: position{line: 698, col: 5, offset: 20167},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 699, col: 5, offset: 20169},
+						pos:  position{line: 698, col: 5, offset: 20167},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20179},
+						pos: position{line: 699, col: 5, offset: 20177},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 700, col: 5, offset: 20179},
+							pos:  position{line: 699, col: 5, offset: 20177},
 							name: "__",
 						},
 					},
@@ -5647,50 +5647,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 702, col: 1, offset: 20215},
+			pos:  position{line: 701, col: 1, offset: 20213},
 			expr: &actionExpr{
-				pos: position{line: 703, col: 5, offset: 20225},
+				pos: position{line: 702, col: 5, offset: 20223},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 703, col: 5, offset: 20225},
+					pos: position{line: 702, col: 5, offset: 20223},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 703, col: 5, offset: 20225},
+							pos:   position{line: 702, col: 5, offset: 20223},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 703, col: 11, offset: 20231},
+								pos:  position{line: 702, col: 11, offset: 20229},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 703, col: 16, offset: 20236},
+							pos:   position{line: 702, col: 16, offset: 20234},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 703, col: 21, offset: 20241},
+								pos: position{line: 702, col: 21, offset: 20239},
 								expr: &actionExpr{
-									pos: position{line: 703, col: 22, offset: 20242},
+									pos: position{line: 702, col: 22, offset: 20240},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 703, col: 22, offset: 20242},
+										pos: position{line: 702, col: 22, offset: 20240},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 703, col: 22, offset: 20242},
+												pos:  position{line: 702, col: 22, offset: 20240},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 703, col: 25, offset: 20245},
+												pos:        position{line: 702, col: 25, offset: 20243},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 703, col: 29, offset: 20249},
+												pos:  position{line: 702, col: 29, offset: 20247},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 703, col: 32, offset: 20252},
+												pos:   position{line: 702, col: 32, offset: 20250},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 703, col: 34, offset: 20254},
+													pos:  position{line: 702, col: 34, offset: 20252},
 													name: "Expr",
 												},
 											},
@@ -5705,25 +5705,25 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 707, col: 1, offset: 20363},
+			pos:  position{line: 706, col: 1, offset: 20361},
 			expr: &actionExpr{
-				pos: position{line: 707, col: 13, offset: 20375},
+				pos: position{line: 706, col: 13, offset: 20373},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 707, col: 13, offset: 20375},
+					pos: position{line: 706, col: 13, offset: 20373},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 707, col: 13, offset: 20375},
+							pos: position{line: 706, col: 13, offset: 20373},
 							expr: &ruleRefExpr{
-								pos:  position{line: 707, col: 14, offset: 20376},
+								pos:  position{line: 706, col: 14, offset: 20374},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 707, col: 18, offset: 20380},
+							pos:   position{line: 706, col: 18, offset: 20378},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 707, col: 20, offset: 20382},
+								pos:  position{line: 706, col: 20, offset: 20380},
 								name: "DerefExprPattern",
 							},
 						},
@@ -5733,31 +5733,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExprPattern",
-			pos:  position{line: 709, col: 1, offset: 20418},
+			pos:  position{line: 708, col: 1, offset: 20416},
 			expr: &choiceExpr{
-				pos: position{line: 710, col: 5, offset: 20439},
+				pos: position{line: 709, col: 5, offset: 20437},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 710, col: 5, offset: 20439},
+						pos: position{line: 709, col: 5, offset: 20437},
 						run: (*parser).callonDerefExprPattern2,
 						expr: &seqExpr{
-							pos: position{line: 710, col: 5, offset: 20439},
+							pos: position{line: 709, col: 5, offset: 20437},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 710, col: 5, offset: 20439},
+									pos:   position{line: 709, col: 5, offset: 20437},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 710, col: 11, offset: 20445},
+										pos:  position{line: 709, col: 11, offset: 20443},
 										name: "DotID",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 710, col: 17, offset: 20451},
+									pos:   position{line: 709, col: 17, offset: 20449},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 710, col: 22, offset: 20456},
+										pos: position{line: 709, col: 22, offset: 20454},
 										expr: &ruleRefExpr{
-											pos:  position{line: 710, col: 23, offset: 20457},
+											pos:  position{line: 709, col: 23, offset: 20455},
 											name: "Deref",
 										},
 									},
@@ -5766,26 +5766,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 20528},
+						pos: position{line: 712, col: 5, offset: 20526},
 						run: (*parser).callonDerefExprPattern9,
 						expr: &seqExpr{
-							pos: position{line: 713, col: 5, offset: 20528},
+							pos: position{line: 712, col: 5, offset: 20526},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 713, col: 5, offset: 20528},
+									pos:   position{line: 712, col: 5, offset: 20526},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 713, col: 11, offset: 20534},
+										pos:  position{line: 712, col: 11, offset: 20532},
 										name: "This",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 713, col: 16, offset: 20539},
+									pos:   position{line: 712, col: 16, offset: 20537},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 713, col: 21, offset: 20544},
+										pos: position{line: 712, col: 21, offset: 20542},
 										expr: &ruleRefExpr{
-											pos:  position{line: 713, col: 22, offset: 20545},
+											pos:  position{line: 712, col: 22, offset: 20543},
 											name: "Deref",
 										},
 									},
@@ -5794,26 +5794,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 716, col: 5, offset: 20616},
+						pos: position{line: 715, col: 5, offset: 20614},
 						run: (*parser).callonDerefExprPattern16,
 						expr: &seqExpr{
-							pos: position{line: 716, col: 5, offset: 20616},
+							pos: position{line: 715, col: 5, offset: 20614},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 716, col: 5, offset: 20616},
+									pos:   position{line: 715, col: 5, offset: 20614},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 716, col: 11, offset: 20622},
+										pos:  position{line: 715, col: 11, offset: 20620},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 716, col: 22, offset: 20633},
+									pos:   position{line: 715, col: 22, offset: 20631},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 716, col: 27, offset: 20638},
+										pos: position{line: 715, col: 27, offset: 20636},
 										expr: &ruleRefExpr{
-											pos:  position{line: 716, col: 28, offset: 20639},
+											pos:  position{line: 715, col: 28, offset: 20637},
 											name: "Deref",
 										},
 									},
@@ -5822,10 +5822,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 20710},
+						pos: position{line: 718, col: 5, offset: 20708},
 						run: (*parser).callonDerefExprPattern23,
 						expr: &litMatcher{
-							pos:        position{line: 719, col: 5, offset: 20710},
+							pos:        position{line: 718, col: 5, offset: 20708},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -5835,12 +5835,12 @@ var g = &grammar{
 		},
 		{
 			name: "This",
-			pos:  position{line: 723, col: 1, offset: 20791},
+			pos:  position{line: 722, col: 1, offset: 20789},
 			expr: &actionExpr{
-				pos: position{line: 723, col: 8, offset: 20798},
+				pos: position{line: 722, col: 8, offset: 20796},
 				run: (*parser).callonThis1,
 				expr: &litMatcher{
-					pos:        position{line: 723, col: 8, offset: 20798},
+					pos:        position{line: 722, col: 8, offset: 20796},
 					val:        "this",
 					ignoreCase: false,
 				},
@@ -5848,26 +5848,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotID",
-			pos:  position{line: 725, col: 1, offset: 20872},
+			pos:  position{line: 724, col: 1, offset: 20870},
 			expr: &choiceExpr{
-				pos: position{line: 726, col: 5, offset: 20882},
+				pos: position{line: 725, col: 5, offset: 20880},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 726, col: 5, offset: 20882},
+						pos: position{line: 725, col: 5, offset: 20880},
 						run: (*parser).callonDotID2,
 						expr: &seqExpr{
-							pos: position{line: 726, col: 5, offset: 20882},
+							pos: position{line: 725, col: 5, offset: 20880},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 726, col: 5, offset: 20882},
+									pos:        position{line: 725, col: 5, offset: 20880},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 726, col: 9, offset: 20886},
+									pos:   position{line: 725, col: 9, offset: 20884},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 726, col: 15, offset: 20892},
+										pos:  position{line: 725, col: 15, offset: 20890},
 										name: "Identifier",
 									},
 								},
@@ -5875,31 +5875,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 735, col: 5, offset: 21120},
+						pos: position{line: 734, col: 5, offset: 21118},
 						run: (*parser).callonDotID7,
 						expr: &seqExpr{
-							pos: position{line: 735, col: 5, offset: 21120},
+							pos: position{line: 734, col: 5, offset: 21118},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 735, col: 5, offset: 21120},
+									pos:        position{line: 734, col: 5, offset: 21118},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 735, col: 9, offset: 21124},
+									pos:        position{line: 734, col: 9, offset: 21122},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 735, col: 13, offset: 21128},
+									pos:   position{line: 734, col: 13, offset: 21126},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 735, col: 18, offset: 21133},
+										pos:  position{line: 734, col: 18, offset: 21131},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 735, col: 23, offset: 21138},
+									pos:        position{line: 734, col: 23, offset: 21136},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5911,52 +5911,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 745, col: 1, offset: 21355},
+			pos:  position{line: 744, col: 1, offset: 21353},
 			expr: &choiceExpr{
-				pos: position{line: 746, col: 5, offset: 21365},
+				pos: position{line: 745, col: 5, offset: 21363},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 746, col: 5, offset: 21365},
+						pos: position{line: 745, col: 5, offset: 21363},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 746, col: 5, offset: 21365},
+							pos: position{line: 745, col: 5, offset: 21363},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 746, col: 5, offset: 21365},
+									pos:        position{line: 745, col: 5, offset: 21363},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 746, col: 9, offset: 21369},
+									pos:   position{line: 745, col: 9, offset: 21367},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 746, col: 14, offset: 21374},
+										pos:  position{line: 745, col: 14, offset: 21372},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 746, col: 27, offset: 21387},
+									pos:  position{line: 745, col: 27, offset: 21385},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 746, col: 30, offset: 21390},
+									pos:        position{line: 745, col: 30, offset: 21388},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 746, col: 34, offset: 21394},
+									pos:  position{line: 745, col: 34, offset: 21392},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 746, col: 37, offset: 21397},
+									pos:   position{line: 745, col: 37, offset: 21395},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 746, col: 40, offset: 21400},
+										pos:  position{line: 745, col: 40, offset: 21398},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 746, col: 53, offset: 21413},
+									pos:        position{line: 745, col: 53, offset: 21411},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5964,39 +5964,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 752, col: 5, offset: 21584},
+						pos: position{line: 751, col: 5, offset: 21582},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 752, col: 5, offset: 21584},
+							pos: position{line: 751, col: 5, offset: 21582},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 752, col: 5, offset: 21584},
+									pos:        position{line: 751, col: 5, offset: 21582},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 752, col: 9, offset: 21588},
+									pos:  position{line: 751, col: 9, offset: 21586},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 752, col: 12, offset: 21591},
+									pos:        position{line: 751, col: 12, offset: 21589},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 752, col: 16, offset: 21595},
+									pos:  position{line: 751, col: 16, offset: 21593},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 752, col: 19, offset: 21598},
+									pos:   position{line: 751, col: 19, offset: 21596},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 752, col: 22, offset: 21601},
+										pos:  position{line: 751, col: 22, offset: 21599},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 752, col: 35, offset: 21614},
+									pos:        position{line: 751, col: 35, offset: 21612},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6004,39 +6004,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 758, col: 5, offset: 21785},
+						pos: position{line: 757, col: 5, offset: 21783},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 758, col: 5, offset: 21785},
+							pos: position{line: 757, col: 5, offset: 21783},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 758, col: 5, offset: 21785},
+									pos:        position{line: 757, col: 5, offset: 21783},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 758, col: 9, offset: 21789},
+									pos:   position{line: 757, col: 9, offset: 21787},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 758, col: 14, offset: 21794},
+										pos:  position{line: 757, col: 14, offset: 21792},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 758, col: 27, offset: 21807},
+									pos:  position{line: 757, col: 27, offset: 21805},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 758, col: 30, offset: 21810},
+									pos:        position{line: 757, col: 30, offset: 21808},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 758, col: 34, offset: 21814},
+									pos:  position{line: 757, col: 34, offset: 21812},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 758, col: 37, offset: 21817},
+									pos:        position{line: 757, col: 37, offset: 21815},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6044,26 +6044,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 764, col: 5, offset: 21990},
+						pos: position{line: 763, col: 5, offset: 21988},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 764, col: 5, offset: 21990},
+							pos: position{line: 763, col: 5, offset: 21988},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 764, col: 5, offset: 21990},
+									pos:        position{line: 763, col: 5, offset: 21988},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 764, col: 9, offset: 21994},
+									pos:   position{line: 763, col: 9, offset: 21992},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 764, col: 14, offset: 21999},
+										pos:  position{line: 763, col: 14, offset: 21997},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 764, col: 19, offset: 22004},
+									pos:        position{line: 763, col: 19, offset: 22002},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6071,29 +6071,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 765, col: 5, offset: 22053},
+						pos: position{line: 764, col: 5, offset: 22051},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 765, col: 5, offset: 22053},
+							pos: position{line: 764, col: 5, offset: 22051},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 765, col: 5, offset: 22053},
+									pos:        position{line: 764, col: 5, offset: 22051},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 765, col: 9, offset: 22057},
+									pos: position{line: 764, col: 9, offset: 22055},
 									expr: &litMatcher{
-										pos:        position{line: 765, col: 11, offset: 22059},
+										pos:        position{line: 764, col: 11, offset: 22057},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 765, col: 16, offset: 22064},
+									pos:   position{line: 764, col: 16, offset: 22062},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 765, col: 19, offset: 22067},
+										pos:  position{line: 764, col: 19, offset: 22065},
 										name: "Identifier",
 									},
 								},
@@ -6105,59 +6105,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 767, col: 1, offset: 22118},
+			pos:  position{line: 766, col: 1, offset: 22116},
 			expr: &choiceExpr{
-				pos: position{line: 768, col: 5, offset: 22130},
+				pos: position{line: 767, col: 5, offset: 22128},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 768, col: 5, offset: 22130},
+						pos:  position{line: 767, col: 5, offset: 22128},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 769, col: 5, offset: 22141},
+						pos:  position{line: 768, col: 5, offset: 22139},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 770, col: 5, offset: 22151},
+						pos:  position{line: 769, col: 5, offset: 22149},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 771, col: 5, offset: 22159},
+						pos:  position{line: 770, col: 5, offset: 22157},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 772, col: 5, offset: 22167},
+						pos:  position{line: 771, col: 5, offset: 22165},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 773, col: 5, offset: 22179},
+						pos: position{line: 772, col: 5, offset: 22177},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 773, col: 5, offset: 22179},
+							pos: position{line: 772, col: 5, offset: 22177},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 773, col: 5, offset: 22179},
+									pos:        position{line: 772, col: 5, offset: 22177},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 773, col: 9, offset: 22183},
+									pos:  position{line: 772, col: 9, offset: 22181},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 773, col: 12, offset: 22186},
+									pos:   position{line: 772, col: 12, offset: 22184},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 773, col: 17, offset: 22191},
+										pos:  position{line: 772, col: 17, offset: 22189},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 773, col: 22, offset: 22196},
+									pos:  position{line: 772, col: 22, offset: 22194},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 773, col: 25, offset: 22199},
+									pos:        position{line: 772, col: 25, offset: 22197},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6169,36 +6169,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 775, col: 1, offset: 22225},
+			pos:  position{line: 774, col: 1, offset: 22223},
 			expr: &actionExpr{
-				pos: position{line: 776, col: 5, offset: 22236},
+				pos: position{line: 775, col: 5, offset: 22234},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 776, col: 5, offset: 22236},
+					pos: position{line: 775, col: 5, offset: 22234},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 776, col: 5, offset: 22236},
+							pos:        position{line: 775, col: 5, offset: 22234},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 776, col: 9, offset: 22240},
+							pos:  position{line: 775, col: 9, offset: 22238},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 776, col: 12, offset: 22243},
+							pos:   position{line: 775, col: 12, offset: 22241},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 776, col: 19, offset: 22250},
+								pos:  position{line: 775, col: 19, offset: 22248},
 								name: "Fields",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 776, col: 26, offset: 22257},
+							pos:  position{line: 775, col: 26, offset: 22255},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 776, col: 29, offset: 22260},
+							pos:        position{line: 775, col: 29, offset: 22258},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6208,31 +6208,31 @@ var g = &grammar{
 		},
 		{
 			name: "Fields",
-			pos:  position{line: 780, col: 1, offset: 22353},
+			pos:  position{line: 779, col: 1, offset: 22351},
 			expr: &choiceExpr{
-				pos: position{line: 781, col: 5, offset: 22364},
+				pos: position{line: 780, col: 5, offset: 22362},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 781, col: 5, offset: 22364},
+						pos: position{line: 780, col: 5, offset: 22362},
 						run: (*parser).callonFields2,
 						expr: &seqExpr{
-							pos: position{line: 781, col: 5, offset: 22364},
+							pos: position{line: 780, col: 5, offset: 22362},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 781, col: 5, offset: 22364},
+									pos:   position{line: 780, col: 5, offset: 22362},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 781, col: 11, offset: 22370},
+										pos:  position{line: 780, col: 11, offset: 22368},
 										name: "Field",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 781, col: 17, offset: 22376},
+									pos:   position{line: 780, col: 17, offset: 22374},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 781, col: 22, offset: 22381},
+										pos: position{line: 780, col: 22, offset: 22379},
 										expr: &ruleRefExpr{
-											pos:  position{line: 781, col: 22, offset: 22381},
+											pos:  position{line: 780, col: 22, offset: 22379},
 											name: "FieldTail",
 										},
 									},
@@ -6241,10 +6241,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 784, col: 5, offset: 22475},
+						pos: position{line: 783, col: 5, offset: 22473},
 						run: (*parser).callonFields9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 784, col: 5, offset: 22475},
+							pos:  position{line: 783, col: 5, offset: 22473},
 							name: "__",
 						},
 					},
@@ -6253,31 +6253,31 @@ var g = &grammar{
 		},
 		{
 			name: "FieldTail",
-			pos:  position{line: 786, col: 1, offset: 22511},
+			pos:  position{line: 785, col: 1, offset: 22509},
 			expr: &actionExpr{
-				pos: position{line: 786, col: 13, offset: 22523},
+				pos: position{line: 785, col: 13, offset: 22521},
 				run: (*parser).callonFieldTail1,
 				expr: &seqExpr{
-					pos: position{line: 786, col: 13, offset: 22523},
+					pos: position{line: 785, col: 13, offset: 22521},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 786, col: 13, offset: 22523},
+							pos:  position{line: 785, col: 13, offset: 22521},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 786, col: 16, offset: 22526},
+							pos:        position{line: 785, col: 16, offset: 22524},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 786, col: 20, offset: 22530},
+							pos:  position{line: 785, col: 20, offset: 22528},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 786, col: 23, offset: 22533},
+							pos:   position{line: 785, col: 23, offset: 22531},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 786, col: 25, offset: 22535},
+								pos:  position{line: 785, col: 25, offset: 22533},
 								name: "Field",
 							},
 						},
@@ -6287,39 +6287,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 788, col: 1, offset: 22560},
+			pos:  position{line: 787, col: 1, offset: 22558},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 5, offset: 22570},
+				pos: position{line: 788, col: 5, offset: 22568},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 5, offset: 22570},
+					pos: position{line: 788, col: 5, offset: 22568},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 789, col: 5, offset: 22570},
+							pos:   position{line: 788, col: 5, offset: 22568},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 10, offset: 22575},
+								pos:  position{line: 788, col: 10, offset: 22573},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 20, offset: 22585},
+							pos:  position{line: 788, col: 20, offset: 22583},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 789, col: 23, offset: 22588},
+							pos:        position{line: 788, col: 23, offset: 22586},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 27, offset: 22592},
+							pos:  position{line: 788, col: 27, offset: 22590},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 30, offset: 22595},
+							pos:   position{line: 788, col: 30, offset: 22593},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 36, offset: 22601},
+								pos:  position{line: 788, col: 36, offset: 22599},
 								name: "Expr",
 							},
 						},
@@ -6329,36 +6329,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 793, col: 1, offset: 22686},
+			pos:  position{line: 792, col: 1, offset: 22684},
 			expr: &actionExpr{
-				pos: position{line: 794, col: 5, offset: 22696},
+				pos: position{line: 793, col: 5, offset: 22694},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 794, col: 5, offset: 22696},
+					pos: position{line: 793, col: 5, offset: 22694},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 794, col: 5, offset: 22696},
+							pos:        position{line: 793, col: 5, offset: 22694},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 794, col: 9, offset: 22700},
+							pos:  position{line: 793, col: 9, offset: 22698},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 794, col: 12, offset: 22703},
+							pos:   position{line: 793, col: 12, offset: 22701},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 794, col: 18, offset: 22709},
+								pos:  position{line: 793, col: 18, offset: 22707},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 794, col: 32, offset: 22723},
+							pos:  position{line: 793, col: 32, offset: 22721},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 794, col: 35, offset: 22726},
+							pos:        position{line: 793, col: 35, offset: 22724},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6368,36 +6368,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 798, col: 1, offset: 22816},
+			pos:  position{line: 797, col: 1, offset: 22814},
 			expr: &actionExpr{
-				pos: position{line: 799, col: 5, offset: 22824},
+				pos: position{line: 798, col: 5, offset: 22822},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 799, col: 5, offset: 22824},
+					pos: position{line: 798, col: 5, offset: 22822},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 799, col: 5, offset: 22824},
+							pos:        position{line: 798, col: 5, offset: 22822},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 10, offset: 22829},
+							pos:  position{line: 798, col: 10, offset: 22827},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 799, col: 13, offset: 22832},
+							pos:   position{line: 798, col: 13, offset: 22830},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 799, col: 19, offset: 22838},
+								pos:  position{line: 798, col: 19, offset: 22836},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 33, offset: 22852},
+							pos:  position{line: 798, col: 33, offset: 22850},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 799, col: 36, offset: 22855},
+							pos:        position{line: 798, col: 36, offset: 22853},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6407,36 +6407,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 803, col: 1, offset: 22944},
+			pos:  position{line: 802, col: 1, offset: 22942},
 			expr: &actionExpr{
-				pos: position{line: 804, col: 5, offset: 22952},
+				pos: position{line: 803, col: 5, offset: 22950},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 804, col: 5, offset: 22952},
+					pos: position{line: 803, col: 5, offset: 22950},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 804, col: 5, offset: 22952},
+							pos:        position{line: 803, col: 5, offset: 22950},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 804, col: 10, offset: 22957},
+							pos:  position{line: 803, col: 10, offset: 22955},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 804, col: 13, offset: 22960},
+							pos:   position{line: 803, col: 13, offset: 22958},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 804, col: 19, offset: 22966},
+								pos:  position{line: 803, col: 19, offset: 22964},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 804, col: 27, offset: 22974},
+							pos:  position{line: 803, col: 27, offset: 22972},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 804, col: 30, offset: 22977},
+							pos:        position{line: 803, col: 30, offset: 22975},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6446,31 +6446,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 808, col: 1, offset: 23068},
+			pos:  position{line: 807, col: 1, offset: 23066},
 			expr: &choiceExpr{
-				pos: position{line: 809, col: 5, offset: 23080},
+				pos: position{line: 808, col: 5, offset: 23078},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 809, col: 5, offset: 23080},
+						pos: position{line: 808, col: 5, offset: 23078},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 809, col: 5, offset: 23080},
+							pos: position{line: 808, col: 5, offset: 23078},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 809, col: 5, offset: 23080},
+									pos:   position{line: 808, col: 5, offset: 23078},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 809, col: 11, offset: 23086},
+										pos:  position{line: 808, col: 11, offset: 23084},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 809, col: 17, offset: 23092},
+									pos:   position{line: 808, col: 17, offset: 23090},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 809, col: 22, offset: 23097},
+										pos: position{line: 808, col: 22, offset: 23095},
 										expr: &ruleRefExpr{
-											pos:  position{line: 809, col: 22, offset: 23097},
+											pos:  position{line: 808, col: 22, offset: 23095},
 											name: "EntryTail",
 										},
 									},
@@ -6479,10 +6479,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 812, col: 5, offset: 23191},
+						pos: position{line: 811, col: 5, offset: 23189},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 812, col: 5, offset: 23191},
+							pos:  position{line: 811, col: 5, offset: 23189},
 							name: "__",
 						},
 					},
@@ -6491,31 +6491,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 815, col: 1, offset: 23228},
+			pos:  position{line: 814, col: 1, offset: 23226},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 13, offset: 23240},
+				pos: position{line: 814, col: 13, offset: 23238},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 13, offset: 23240},
+					pos: position{line: 814, col: 13, offset: 23238},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 13, offset: 23240},
+							pos:  position{line: 814, col: 13, offset: 23238},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 815, col: 16, offset: 23243},
+							pos:        position{line: 814, col: 16, offset: 23241},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 20, offset: 23247},
+							pos:  position{line: 814, col: 20, offset: 23245},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 23, offset: 23250},
+							pos:   position{line: 814, col: 23, offset: 23248},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 25, offset: 23252},
+								pos:  position{line: 814, col: 25, offset: 23250},
 								name: "Entry",
 							},
 						},
@@ -6525,39 +6525,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 817, col: 1, offset: 23277},
+			pos:  position{line: 816, col: 1, offset: 23275},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 5, offset: 23287},
+				pos: position{line: 817, col: 5, offset: 23285},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 5, offset: 23287},
+					pos: position{line: 817, col: 5, offset: 23285},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 818, col: 5, offset: 23287},
+							pos:   position{line: 817, col: 5, offset: 23285},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 9, offset: 23291},
+								pos:  position{line: 817, col: 9, offset: 23289},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 818, col: 14, offset: 23296},
+							pos:  position{line: 817, col: 14, offset: 23294},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 818, col: 17, offset: 23299},
+							pos:        position{line: 817, col: 17, offset: 23297},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 818, col: 21, offset: 23303},
+							pos:  position{line: 817, col: 21, offset: 23301},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 24, offset: 23306},
+							pos:   position{line: 817, col: 24, offset: 23304},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 30, offset: 23312},
+								pos:  position{line: 817, col: 30, offset: 23310},
 								name: "Expr",
 							},
 						},
@@ -6567,92 +6567,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLProc",
-			pos:  position{line: 824, col: 1, offset: 23419},
+			pos:  position{line: 823, col: 1, offset: 23417},
 			expr: &actionExpr{
-				pos: position{line: 825, col: 5, offset: 23431},
+				pos: position{line: 824, col: 5, offset: 23429},
 				run: (*parser).callonSQLProc1,
 				expr: &seqExpr{
-					pos: position{line: 825, col: 5, offset: 23431},
+					pos: position{line: 824, col: 5, offset: 23429},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 825, col: 5, offset: 23431},
+							pos:   position{line: 824, col: 5, offset: 23429},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 825, col: 15, offset: 23441},
+								pos:  position{line: 824, col: 15, offset: 23439},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 826, col: 5, offset: 23455},
+							pos:   position{line: 825, col: 5, offset: 23453},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 826, col: 10, offset: 23460},
+								pos: position{line: 825, col: 10, offset: 23458},
 								expr: &ruleRefExpr{
-									pos:  position{line: 826, col: 10, offset: 23460},
+									pos:  position{line: 825, col: 10, offset: 23458},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 827, col: 5, offset: 23473},
+							pos:   position{line: 826, col: 5, offset: 23471},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 827, col: 11, offset: 23479},
+								pos: position{line: 826, col: 11, offset: 23477},
 								expr: &ruleRefExpr{
-									pos:  position{line: 827, col: 11, offset: 23479},
+									pos:  position{line: 826, col: 11, offset: 23477},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 828, col: 5, offset: 23493},
+							pos:   position{line: 827, col: 5, offset: 23491},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 828, col: 11, offset: 23499},
+								pos: position{line: 827, col: 11, offset: 23497},
 								expr: &ruleRefExpr{
-									pos:  position{line: 828, col: 11, offset: 23499},
+									pos:  position{line: 827, col: 11, offset: 23497},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 829, col: 5, offset: 23513},
+							pos:   position{line: 828, col: 5, offset: 23511},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 829, col: 13, offset: 23521},
+								pos: position{line: 828, col: 13, offset: 23519},
 								expr: &ruleRefExpr{
-									pos:  position{line: 829, col: 13, offset: 23521},
+									pos:  position{line: 828, col: 13, offset: 23519},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 830, col: 5, offset: 23537},
+							pos:   position{line: 829, col: 5, offset: 23535},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 830, col: 12, offset: 23544},
+								pos: position{line: 829, col: 12, offset: 23542},
 								expr: &ruleRefExpr{
-									pos:  position{line: 830, col: 12, offset: 23544},
+									pos:  position{line: 829, col: 12, offset: 23542},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 831, col: 5, offset: 23559},
+							pos:   position{line: 830, col: 5, offset: 23557},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 831, col: 13, offset: 23567},
+								pos: position{line: 830, col: 13, offset: 23565},
 								expr: &ruleRefExpr{
-									pos:  position{line: 831, col: 13, offset: 23567},
+									pos:  position{line: 830, col: 13, offset: 23565},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 5, offset: 23583},
+							pos:   position{line: 831, col: 5, offset: 23581},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 832, col: 11, offset: 23589},
+								pos:  position{line: 831, col: 11, offset: 23587},
 								name: "SQLLimit",
 							},
 						},
@@ -6662,26 +6662,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 856, col: 1, offset: 23956},
+			pos:  position{line: 855, col: 1, offset: 23954},
 			expr: &choiceExpr{
-				pos: position{line: 857, col: 5, offset: 23970},
+				pos: position{line: 856, col: 5, offset: 23968},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 857, col: 5, offset: 23970},
+						pos: position{line: 856, col: 5, offset: 23968},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 857, col: 5, offset: 23970},
+							pos: position{line: 856, col: 5, offset: 23968},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 857, col: 5, offset: 23970},
+									pos:  position{line: 856, col: 5, offset: 23968},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 857, col: 12, offset: 23977},
+									pos:  position{line: 856, col: 12, offset: 23975},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 857, col: 14, offset: 23979},
+									pos:        position{line: 856, col: 14, offset: 23977},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6689,24 +6689,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 858, col: 5, offset: 24007},
+						pos: position{line: 857, col: 5, offset: 24005},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 858, col: 5, offset: 24007},
+							pos: position{line: 857, col: 5, offset: 24005},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 858, col: 5, offset: 24007},
+									pos:  position{line: 857, col: 5, offset: 24005},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 858, col: 12, offset: 24014},
+									pos:  position{line: 857, col: 12, offset: 24012},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 858, col: 14, offset: 24016},
+									pos:   position{line: 857, col: 14, offset: 24014},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 858, col: 26, offset: 24028},
+										pos:  position{line: 857, col: 26, offset: 24026},
 										name: "SQLAssignments",
 									},
 								},
@@ -6718,41 +6718,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 860, col: 1, offset: 24072},
+			pos:  position{line: 859, col: 1, offset: 24070},
 			expr: &choiceExpr{
-				pos: position{line: 861, col: 5, offset: 24090},
+				pos: position{line: 860, col: 5, offset: 24088},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 861, col: 5, offset: 24090},
+						pos: position{line: 860, col: 5, offset: 24088},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 861, col: 5, offset: 24090},
+							pos: position{line: 860, col: 5, offset: 24088},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 861, col: 5, offset: 24090},
+									pos:   position{line: 860, col: 5, offset: 24088},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 861, col: 9, offset: 24094},
+										pos:  position{line: 860, col: 9, offset: 24092},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 14, offset: 24099},
+									pos:  position{line: 860, col: 14, offset: 24097},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 16, offset: 24101},
+									pos:  position{line: 860, col: 16, offset: 24099},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 19, offset: 24104},
+									pos:  position{line: 860, col: 19, offset: 24102},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 861, col: 21, offset: 24106},
+									pos:   position{line: 860, col: 21, offset: 24104},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 861, col: 25, offset: 24110},
+										pos:  position{line: 860, col: 25, offset: 24108},
 										name: "Lval",
 									},
 								},
@@ -6760,13 +6760,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 862, col: 5, offset: 24204},
+						pos: position{line: 861, col: 5, offset: 24202},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 862, col: 5, offset: 24204},
+							pos:   position{line: 861, col: 5, offset: 24202},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 10, offset: 24209},
+								pos:  position{line: 861, col: 10, offset: 24207},
 								name: "Expr",
 							},
 						},
@@ -6776,50 +6776,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 864, col: 1, offset: 24301},
+			pos:  position{line: 863, col: 1, offset: 24299},
 			expr: &actionExpr{
-				pos: position{line: 865, col: 5, offset: 24320},
+				pos: position{line: 864, col: 5, offset: 24318},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 865, col: 5, offset: 24320},
+					pos: position{line: 864, col: 5, offset: 24318},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 865, col: 5, offset: 24320},
+							pos:   position{line: 864, col: 5, offset: 24318},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 11, offset: 24326},
+								pos:  position{line: 864, col: 11, offset: 24324},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 865, col: 25, offset: 24340},
+							pos:   position{line: 864, col: 25, offset: 24338},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 865, col: 30, offset: 24345},
+								pos: position{line: 864, col: 30, offset: 24343},
 								expr: &actionExpr{
-									pos: position{line: 865, col: 31, offset: 24346},
+									pos: position{line: 864, col: 31, offset: 24344},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 865, col: 31, offset: 24346},
+										pos: position{line: 864, col: 31, offset: 24344},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 865, col: 31, offset: 24346},
+												pos:  position{line: 864, col: 31, offset: 24344},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 865, col: 34, offset: 24349},
+												pos:        position{line: 864, col: 34, offset: 24347},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 865, col: 38, offset: 24353},
+												pos:  position{line: 864, col: 38, offset: 24351},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 865, col: 41, offset: 24356},
+												pos:   position{line: 864, col: 41, offset: 24354},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 865, col: 46, offset: 24361},
+													pos:  position{line: 864, col: 46, offset: 24359},
 													name: "SQLAssignment",
 												},
 											},
@@ -6834,43 +6834,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 869, col: 1, offset: 24482},
+			pos:  position{line: 868, col: 1, offset: 24480},
 			expr: &choiceExpr{
-				pos: position{line: 870, col: 5, offset: 24494},
+				pos: position{line: 869, col: 5, offset: 24492},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 870, col: 5, offset: 24494},
+						pos: position{line: 869, col: 5, offset: 24492},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 870, col: 5, offset: 24494},
+							pos: position{line: 869, col: 5, offset: 24492},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 870, col: 5, offset: 24494},
+									pos:  position{line: 869, col: 5, offset: 24492},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 870, col: 7, offset: 24496},
+									pos:  position{line: 869, col: 7, offset: 24494},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 870, col: 12, offset: 24501},
+									pos:  position{line: 869, col: 12, offset: 24499},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 870, col: 14, offset: 24503},
+									pos:   position{line: 869, col: 14, offset: 24501},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 870, col: 20, offset: 24509},
+										pos:  position{line: 869, col: 20, offset: 24507},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 870, col: 29, offset: 24518},
+									pos:   position{line: 869, col: 29, offset: 24516},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 870, col: 35, offset: 24524},
+										pos: position{line: 869, col: 35, offset: 24522},
 										expr: &ruleRefExpr{
-											pos:  position{line: 870, col: 35, offset: 24524},
+											pos:  position{line: 869, col: 35, offset: 24522},
 											name: "SQLAlias",
 										},
 									},
@@ -6879,25 +6879,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 873, col: 5, offset: 24619},
+						pos: position{line: 872, col: 5, offset: 24617},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 873, col: 5, offset: 24619},
+							pos: position{line: 872, col: 5, offset: 24617},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 873, col: 5, offset: 24619},
+									pos:  position{line: 872, col: 5, offset: 24617},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 873, col: 7, offset: 24621},
+									pos:  position{line: 872, col: 7, offset: 24619},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 873, col: 12, offset: 24626},
+									pos:  position{line: 872, col: 12, offset: 24624},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 873, col: 14, offset: 24628},
+									pos:        position{line: 872, col: 14, offset: 24626},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6909,33 +6909,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 875, col: 1, offset: 24653},
+			pos:  position{line: 874, col: 1, offset: 24651},
 			expr: &choiceExpr{
-				pos: position{line: 876, col: 5, offset: 24666},
+				pos: position{line: 875, col: 5, offset: 24664},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 876, col: 5, offset: 24666},
+						pos: position{line: 875, col: 5, offset: 24664},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 876, col: 5, offset: 24666},
+							pos: position{line: 875, col: 5, offset: 24664},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 876, col: 5, offset: 24666},
+									pos:  position{line: 875, col: 5, offset: 24664},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 876, col: 7, offset: 24668},
+									pos:  position{line: 875, col: 7, offset: 24666},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 876, col: 10, offset: 24671},
+									pos:  position{line: 875, col: 10, offset: 24669},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 876, col: 12, offset: 24673},
+									pos:   position{line: 875, col: 12, offset: 24671},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 876, col: 15, offset: 24676},
+										pos:  position{line: 875, col: 15, offset: 24674},
 										name: "Lval",
 									},
 								},
@@ -6943,36 +6943,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 877, col: 5, offset: 24704},
+						pos: position{line: 876, col: 5, offset: 24702},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 877, col: 5, offset: 24704},
+							pos: position{line: 876, col: 5, offset: 24702},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 877, col: 5, offset: 24704},
+									pos:  position{line: 876, col: 5, offset: 24702},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 877, col: 7, offset: 24706},
+									pos: position{line: 876, col: 7, offset: 24704},
 									expr: &seqExpr{
-										pos: position{line: 877, col: 9, offset: 24708},
+										pos: position{line: 876, col: 9, offset: 24706},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 877, col: 9, offset: 24708},
+												pos:  position{line: 876, col: 9, offset: 24706},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 877, col: 27, offset: 24726},
+												pos:  position{line: 876, col: 27, offset: 24724},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 877, col: 30, offset: 24729},
+									pos:   position{line: 876, col: 30, offset: 24727},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 877, col: 33, offset: 24732},
+										pos:  position{line: 876, col: 33, offset: 24730},
 										name: "Lval",
 									},
 								},
@@ -6984,42 +6984,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 879, col: 1, offset: 24757},
+			pos:  position{line: 878, col: 1, offset: 24755},
 			expr: &ruleRefExpr{
-				pos:  position{line: 880, col: 5, offset: 24770},
+				pos:  position{line: 879, col: 5, offset: 24768},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 882, col: 1, offset: 24776},
+			pos:  position{line: 881, col: 1, offset: 24774},
 			expr: &actionExpr{
-				pos: position{line: 883, col: 5, offset: 24789},
+				pos: position{line: 882, col: 5, offset: 24787},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 883, col: 5, offset: 24789},
+					pos: position{line: 882, col: 5, offset: 24787},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 883, col: 5, offset: 24789},
+							pos:   position{line: 882, col: 5, offset: 24787},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 883, col: 11, offset: 24795},
+								pos:  position{line: 882, col: 11, offset: 24793},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 883, col: 19, offset: 24803},
+							pos:   position{line: 882, col: 19, offset: 24801},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 883, col: 24, offset: 24808},
+								pos: position{line: 882, col: 24, offset: 24806},
 								expr: &actionExpr{
-									pos: position{line: 883, col: 25, offset: 24809},
+									pos: position{line: 882, col: 25, offset: 24807},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 883, col: 25, offset: 24809},
+										pos:   position{line: 882, col: 25, offset: 24807},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 883, col: 30, offset: 24814},
+											pos:  position{line: 882, col: 30, offset: 24812},
 											name: "SQLJoin",
 										},
 									},
@@ -7032,90 +7032,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 887, col: 1, offset: 24929},
+			pos:  position{line: 886, col: 1, offset: 24927},
 			expr: &actionExpr{
-				pos: position{line: 888, col: 5, offset: 24941},
+				pos: position{line: 887, col: 5, offset: 24939},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 888, col: 5, offset: 24941},
+					pos: position{line: 887, col: 5, offset: 24939},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 888, col: 5, offset: 24941},
+							pos:   position{line: 887, col: 5, offset: 24939},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 888, col: 11, offset: 24947},
+								pos:  position{line: 887, col: 11, offset: 24945},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 24, offset: 24960},
+							pos:  position{line: 887, col: 24, offset: 24958},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 26, offset: 24962},
+							pos:  position{line: 887, col: 26, offset: 24960},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 31, offset: 24967},
+							pos:  position{line: 887, col: 31, offset: 24965},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 888, col: 33, offset: 24969},
+							pos:   position{line: 887, col: 33, offset: 24967},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 888, col: 39, offset: 24975},
+								pos:  position{line: 887, col: 39, offset: 24973},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 888, col: 48, offset: 24984},
+							pos:   position{line: 887, col: 48, offset: 24982},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 888, col: 54, offset: 24990},
+								pos: position{line: 887, col: 54, offset: 24988},
 								expr: &ruleRefExpr{
-									pos:  position{line: 888, col: 54, offset: 24990},
+									pos:  position{line: 887, col: 54, offset: 24988},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 64, offset: 25000},
+							pos:  position{line: 887, col: 64, offset: 24998},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 66, offset: 25002},
+							pos:  position{line: 887, col: 66, offset: 25000},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 69, offset: 25005},
+							pos:  position{line: 887, col: 69, offset: 25003},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 888, col: 71, offset: 25007},
+							pos:   position{line: 887, col: 71, offset: 25005},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 888, col: 79, offset: 25015},
+								pos:  position{line: 887, col: 79, offset: 25013},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 87, offset: 25023},
+							pos:  position{line: 887, col: 87, offset: 25021},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 888, col: 90, offset: 25026},
+							pos:        position{line: 887, col: 90, offset: 25024},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 94, offset: 25030},
+							pos:  position{line: 887, col: 94, offset: 25028},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 888, col: 97, offset: 25033},
+							pos:   position{line: 887, col: 97, offset: 25031},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 888, col: 106, offset: 25042},
+								pos:  position{line: 887, col: 106, offset: 25040},
 								name: "JoinKey",
 							},
 						},
@@ -7125,40 +7125,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 907, col: 1, offset: 25277},
+			pos:  position{line: 906, col: 1, offset: 25275},
 			expr: &choiceExpr{
-				pos: position{line: 908, col: 5, offset: 25294},
+				pos: position{line: 907, col: 5, offset: 25292},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 908, col: 5, offset: 25294},
+						pos: position{line: 907, col: 5, offset: 25292},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 908, col: 5, offset: 25294},
+							pos: position{line: 907, col: 5, offset: 25292},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 908, col: 5, offset: 25294},
+									pos:  position{line: 907, col: 5, offset: 25292},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 908, col: 7, offset: 25296},
+									pos:   position{line: 907, col: 7, offset: 25294},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 908, col: 14, offset: 25303},
+										pos: position{line: 907, col: 14, offset: 25301},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 908, col: 14, offset: 25303},
+												pos:  position{line: 907, col: 14, offset: 25301},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 908, col: 21, offset: 25310},
+												pos:  position{line: 907, col: 21, offset: 25308},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 908, col: 29, offset: 25318},
+												pos:  position{line: 907, col: 29, offset: 25316},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 908, col: 36, offset: 25325},
+												pos:  position{line: 907, col: 36, offset: 25323},
 												name: "RIGHT",
 											},
 										},
@@ -7168,10 +7168,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 909, col: 5, offset: 25358},
+						pos: position{line: 908, col: 5, offset: 25356},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 909, col: 5, offset: 25358},
+							pos:        position{line: 908, col: 5, offset: 25356},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7181,30 +7181,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 911, col: 1, offset: 25386},
+			pos:  position{line: 910, col: 1, offset: 25384},
 			expr: &actionExpr{
-				pos: position{line: 912, col: 5, offset: 25399},
+				pos: position{line: 911, col: 5, offset: 25397},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 912, col: 5, offset: 25399},
+					pos: position{line: 911, col: 5, offset: 25397},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 912, col: 5, offset: 25399},
+							pos:  position{line: 911, col: 5, offset: 25397},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 912, col: 7, offset: 25401},
+							pos:  position{line: 911, col: 7, offset: 25399},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 912, col: 13, offset: 25407},
+							pos:  position{line: 911, col: 13, offset: 25405},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 912, col: 15, offset: 25409},
+							pos:   position{line: 911, col: 15, offset: 25407},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 912, col: 20, offset: 25414},
+								pos:  position{line: 911, col: 20, offset: 25412},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7214,38 +7214,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 914, col: 1, offset: 25450},
+			pos:  position{line: 913, col: 1, offset: 25448},
 			expr: &actionExpr{
-				pos: position{line: 915, col: 5, offset: 25465},
+				pos: position{line: 914, col: 5, offset: 25463},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 915, col: 5, offset: 25465},
+					pos: position{line: 914, col: 5, offset: 25463},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 915, col: 5, offset: 25465},
+							pos:  position{line: 914, col: 5, offset: 25463},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 915, col: 7, offset: 25467},
+							pos:  position{line: 914, col: 7, offset: 25465},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 915, col: 13, offset: 25473},
+							pos:  position{line: 914, col: 13, offset: 25471},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 915, col: 15, offset: 25475},
+							pos:  position{line: 914, col: 15, offset: 25473},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 915, col: 18, offset: 25478},
+							pos:  position{line: 914, col: 18, offset: 25476},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 915, col: 20, offset: 25480},
+							pos:   position{line: 914, col: 20, offset: 25478},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 915, col: 28, offset: 25488},
+								pos:  position{line: 914, col: 28, offset: 25486},
 								name: "FieldExprs",
 							},
 						},
@@ -7255,30 +7255,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 917, col: 1, offset: 25524},
+			pos:  position{line: 916, col: 1, offset: 25522},
 			expr: &actionExpr{
-				pos: position{line: 918, col: 5, offset: 25538},
+				pos: position{line: 917, col: 5, offset: 25536},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 918, col: 5, offset: 25538},
+					pos: position{line: 917, col: 5, offset: 25536},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 918, col: 5, offset: 25538},
+							pos:  position{line: 917, col: 5, offset: 25536},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 918, col: 7, offset: 25540},
+							pos:  position{line: 917, col: 7, offset: 25538},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 918, col: 14, offset: 25547},
+							pos:  position{line: 917, col: 14, offset: 25545},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 918, col: 16, offset: 25549},
+							pos:   position{line: 917, col: 16, offset: 25547},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 918, col: 21, offset: 25554},
+								pos:  position{line: 917, col: 21, offset: 25552},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7288,46 +7288,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 920, col: 1, offset: 25590},
+			pos:  position{line: 919, col: 1, offset: 25588},
 			expr: &actionExpr{
-				pos: position{line: 921, col: 5, offset: 25605},
+				pos: position{line: 920, col: 5, offset: 25603},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 921, col: 5, offset: 25605},
+					pos: position{line: 920, col: 5, offset: 25603},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 5, offset: 25605},
+							pos:  position{line: 920, col: 5, offset: 25603},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 7, offset: 25607},
+							pos:  position{line: 920, col: 7, offset: 25605},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 13, offset: 25613},
+							pos:  position{line: 920, col: 13, offset: 25611},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 15, offset: 25615},
+							pos:  position{line: 920, col: 15, offset: 25613},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 921, col: 18, offset: 25618},
+							pos:  position{line: 920, col: 18, offset: 25616},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 921, col: 20, offset: 25620},
+							pos:   position{line: 920, col: 20, offset: 25618},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 921, col: 25, offset: 25625},
+								pos:  position{line: 920, col: 25, offset: 25623},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 921, col: 31, offset: 25631},
+							pos:   position{line: 920, col: 31, offset: 25629},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 921, col: 37, offset: 25637},
+								pos:  position{line: 920, col: 37, offset: 25635},
 								name: "SQLOrder",
 							},
 						},
@@ -7337,32 +7337,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 925, col: 1, offset: 25747},
+			pos:  position{line: 924, col: 1, offset: 25745},
 			expr: &choiceExpr{
-				pos: position{line: 926, col: 5, offset: 25760},
+				pos: position{line: 925, col: 5, offset: 25758},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 926, col: 5, offset: 25760},
+						pos: position{line: 925, col: 5, offset: 25758},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 926, col: 5, offset: 25760},
+							pos: position{line: 925, col: 5, offset: 25758},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 926, col: 5, offset: 25760},
+									pos:  position{line: 925, col: 5, offset: 25758},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 926, col: 7, offset: 25762},
+									pos:   position{line: 925, col: 7, offset: 25760},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 926, col: 12, offset: 25767},
+										pos: position{line: 925, col: 12, offset: 25765},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 926, col: 12, offset: 25767},
+												pos:  position{line: 925, col: 12, offset: 25765},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 926, col: 18, offset: 25773},
+												pos:  position{line: 925, col: 18, offset: 25771},
 												name: "DESC",
 											},
 										},
@@ -7372,10 +7372,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 927, col: 5, offset: 25803},
+						pos: position{line: 926, col: 5, offset: 25801},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 927, col: 5, offset: 25803},
+							pos:        position{line: 926, col: 5, offset: 25801},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7385,33 +7385,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 929, col: 1, offset: 25829},
+			pos:  position{line: 928, col: 1, offset: 25827},
 			expr: &choiceExpr{
-				pos: position{line: 930, col: 5, offset: 25842},
+				pos: position{line: 929, col: 5, offset: 25840},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 930, col: 5, offset: 25842},
+						pos: position{line: 929, col: 5, offset: 25840},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 930, col: 5, offset: 25842},
+							pos: position{line: 929, col: 5, offset: 25840},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 5, offset: 25842},
+									pos:  position{line: 929, col: 5, offset: 25840},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 7, offset: 25844},
+									pos:  position{line: 929, col: 7, offset: 25842},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 13, offset: 25850},
+									pos:  position{line: 929, col: 13, offset: 25848},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 930, col: 15, offset: 25852},
+									pos:   position{line: 929, col: 15, offset: 25850},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 930, col: 21, offset: 25858},
+										pos:  position{line: 929, col: 21, offset: 25856},
 										name: "UInt",
 									},
 								},
@@ -7419,10 +7419,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 931, col: 5, offset: 25889},
+						pos: position{line: 930, col: 5, offset: 25887},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 931, col: 5, offset: 25889},
+							pos:        position{line: 930, col: 5, offset: 25887},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7432,12 +7432,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 933, col: 1, offset: 25911},
+			pos:  position{line: 932, col: 1, offset: 25909},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 10, offset: 25920},
+				pos: position{line: 932, col: 10, offset: 25918},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 933, col: 10, offset: 25920},
+					pos:        position{line: 932, col: 10, offset: 25918},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7445,12 +7445,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 934, col: 1, offset: 25955},
+			pos:  position{line: 933, col: 1, offset: 25953},
 			expr: &actionExpr{
-				pos: position{line: 934, col: 6, offset: 25960},
+				pos: position{line: 933, col: 6, offset: 25958},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 934, col: 6, offset: 25960},
+					pos:        position{line: 933, col: 6, offset: 25958},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7458,12 +7458,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 935, col: 1, offset: 25987},
+			pos:  position{line: 934, col: 1, offset: 25985},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 8, offset: 25994},
+				pos: position{line: 934, col: 8, offset: 25992},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 935, col: 8, offset: 25994},
+					pos:        position{line: 934, col: 8, offset: 25992},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7471,12 +7471,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 936, col: 1, offset: 26025},
+			pos:  position{line: 935, col: 1, offset: 26023},
 			expr: &actionExpr{
-				pos: position{line: 936, col: 8, offset: 26032},
+				pos: position{line: 935, col: 8, offset: 26030},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 936, col: 8, offset: 26032},
+					pos:        position{line: 935, col: 8, offset: 26030},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7484,12 +7484,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 937, col: 1, offset: 26063},
+			pos:  position{line: 936, col: 1, offset: 26061},
 			expr: &actionExpr{
-				pos: position{line: 937, col: 9, offset: 26071},
+				pos: position{line: 936, col: 9, offset: 26069},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 937, col: 9, offset: 26071},
+					pos:        position{line: 936, col: 9, offset: 26069},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7497,12 +7497,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 938, col: 1, offset: 26104},
+			pos:  position{line: 937, col: 1, offset: 26102},
 			expr: &actionExpr{
-				pos: position{line: 938, col: 9, offset: 26112},
+				pos: position{line: 937, col: 9, offset: 26110},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 938, col: 9, offset: 26112},
+					pos:        position{line: 937, col: 9, offset: 26110},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7510,20 +7510,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 939, col: 1, offset: 26145},
+			pos:  position{line: 938, col: 1, offset: 26143},
 			expr: &ruleRefExpr{
-				pos:  position{line: 939, col: 6, offset: 26150},
+				pos:  position{line: 938, col: 6, offset: 26148},
 				name: "ByToken",
 			},
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 940, col: 1, offset: 26158},
+			pos:  position{line: 939, col: 1, offset: 26156},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 10, offset: 26167},
+				pos: position{line: 939, col: 10, offset: 26165},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 940, col: 10, offset: 26167},
+					pos:        position{line: 939, col: 10, offset: 26165},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7531,12 +7531,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 941, col: 1, offset: 26202},
+			pos:  position{line: 940, col: 1, offset: 26200},
 			expr: &actionExpr{
-				pos: position{line: 941, col: 9, offset: 26210},
+				pos: position{line: 940, col: 9, offset: 26208},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 941, col: 9, offset: 26210},
+					pos:        position{line: 940, col: 9, offset: 26208},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7544,12 +7544,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 942, col: 1, offset: 26243},
+			pos:  position{line: 941, col: 1, offset: 26241},
 			expr: &actionExpr{
-				pos: position{line: 942, col: 6, offset: 26248},
+				pos: position{line: 941, col: 6, offset: 26246},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 942, col: 6, offset: 26248},
+					pos:        position{line: 941, col: 6, offset: 26246},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7557,12 +7557,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 943, col: 1, offset: 26275},
+			pos:  position{line: 942, col: 1, offset: 26273},
 			expr: &actionExpr{
-				pos: position{line: 943, col: 9, offset: 26283},
+				pos: position{line: 942, col: 9, offset: 26281},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 943, col: 9, offset: 26283},
+					pos:        position{line: 942, col: 9, offset: 26281},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7570,12 +7570,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 944, col: 1, offset: 26316},
+			pos:  position{line: 943, col: 1, offset: 26314},
 			expr: &actionExpr{
-				pos: position{line: 944, col: 7, offset: 26322},
+				pos: position{line: 943, col: 7, offset: 26320},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 944, col: 7, offset: 26322},
+					pos:        position{line: 943, col: 7, offset: 26320},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7583,12 +7583,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 945, col: 1, offset: 26351},
+			pos:  position{line: 944, col: 1, offset: 26349},
 			expr: &actionExpr{
-				pos: position{line: 945, col: 8, offset: 26358},
+				pos: position{line: 944, col: 8, offset: 26356},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 945, col: 8, offset: 26358},
+					pos:        position{line: 944, col: 8, offset: 26356},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7596,12 +7596,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 946, col: 1, offset: 26389},
+			pos:  position{line: 945, col: 1, offset: 26387},
 			expr: &actionExpr{
-				pos: position{line: 946, col: 8, offset: 26396},
+				pos: position{line: 945, col: 8, offset: 26394},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 946, col: 8, offset: 26396},
+					pos:        position{line: 945, col: 8, offset: 26394},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7609,12 +7609,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 947, col: 1, offset: 26427},
+			pos:  position{line: 946, col: 1, offset: 26425},
 			expr: &actionExpr{
-				pos: position{line: 947, col: 8, offset: 26434},
+				pos: position{line: 946, col: 8, offset: 26432},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 947, col: 8, offset: 26434},
+					pos:        position{line: 946, col: 8, offset: 26432},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7622,12 +7622,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 948, col: 1, offset: 26465},
+			pos:  position{line: 947, col: 1, offset: 26463},
 			expr: &actionExpr{
-				pos: position{line: 948, col: 9, offset: 26473},
+				pos: position{line: 947, col: 9, offset: 26471},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 948, col: 9, offset: 26473},
+					pos:        position{line: 947, col: 9, offset: 26471},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7635,12 +7635,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 949, col: 1, offset: 26506},
+			pos:  position{line: 948, col: 1, offset: 26504},
 			expr: &actionExpr{
-				pos: position{line: 949, col: 9, offset: 26514},
+				pos: position{line: 948, col: 9, offset: 26512},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 949, col: 9, offset: 26514},
+					pos:        position{line: 948, col: 9, offset: 26512},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7648,48 +7648,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 951, col: 1, offset: 26548},
+			pos:  position{line: 950, col: 1, offset: 26546},
 			expr: &choiceExpr{
-				pos: position{line: 952, col: 5, offset: 26570},
+				pos: position{line: 951, col: 5, offset: 26568},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 5, offset: 26570},
+						pos:  position{line: 951, col: 5, offset: 26568},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 14, offset: 26579},
+						pos:  position{line: 951, col: 14, offset: 26577},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 19, offset: 26584},
+						pos:  position{line: 951, col: 19, offset: 26582},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 27, offset: 26592},
+						pos:  position{line: 951, col: 27, offset: 26590},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 34, offset: 26599},
+						pos:  position{line: 951, col: 34, offset: 26597},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 42, offset: 26607},
+						pos:  position{line: 951, col: 42, offset: 26605},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 50, offset: 26615},
+						pos:  position{line: 951, col: 50, offset: 26613},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 59, offset: 26624},
+						pos:  position{line: 951, col: 59, offset: 26622},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 67, offset: 26632},
+						pos:  position{line: 951, col: 67, offset: 26630},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 75, offset: 26640},
+						pos:  position{line: 951, col: 75, offset: 26638},
 						name: "ON",
 					},
 				},
@@ -7697,52 +7697,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 956, col: 1, offset: 26666},
+			pos:  position{line: 955, col: 1, offset: 26664},
 			expr: &choiceExpr{
-				pos: position{line: 957, col: 5, offset: 26678},
+				pos: position{line: 956, col: 5, offset: 26676},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 5, offset: 26678},
+						pos:  position{line: 956, col: 5, offset: 26676},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 958, col: 5, offset: 26694},
+						pos:  position{line: 957, col: 5, offset: 26692},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 959, col: 5, offset: 26714},
+						pos:  position{line: 958, col: 5, offset: 26712},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 960, col: 5, offset: 26732},
+						pos:  position{line: 959, col: 5, offset: 26730},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 961, col: 5, offset: 26751},
+						pos:  position{line: 960, col: 5, offset: 26749},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 962, col: 5, offset: 26768},
+						pos:  position{line: 961, col: 5, offset: 26766},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 963, col: 5, offset: 26781},
+						pos:  position{line: 962, col: 5, offset: 26779},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 964, col: 5, offset: 26790},
+						pos:  position{line: 963, col: 5, offset: 26788},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 965, col: 5, offset: 26807},
+						pos:  position{line: 964, col: 5, offset: 26805},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 966, col: 5, offset: 26826},
+						pos:  position{line: 965, col: 5, offset: 26824},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 967, col: 5, offset: 26845},
+						pos:  position{line: 966, col: 5, offset: 26843},
 						name: "NullLiteral",
 					},
 				},
@@ -7750,28 +7750,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 969, col: 1, offset: 26858},
+			pos:  position{line: 968, col: 1, offset: 26856},
 			expr: &choiceExpr{
-				pos: position{line: 970, col: 5, offset: 26876},
+				pos: position{line: 969, col: 5, offset: 26874},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 970, col: 5, offset: 26876},
+						pos: position{line: 969, col: 5, offset: 26874},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 970, col: 5, offset: 26876},
+							pos: position{line: 969, col: 5, offset: 26874},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 970, col: 5, offset: 26876},
+									pos:   position{line: 969, col: 5, offset: 26874},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 7, offset: 26878},
+										pos:  position{line: 969, col: 7, offset: 26876},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 970, col: 14, offset: 26885},
+									pos: position{line: 969, col: 14, offset: 26883},
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 15, offset: 26886},
+										pos:  position{line: 969, col: 15, offset: 26884},
 										name: "IdentifierRest",
 									},
 								},
@@ -7779,13 +7779,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 973, col: 5, offset: 27001},
+						pos: position{line: 972, col: 5, offset: 26999},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 973, col: 5, offset: 27001},
+							pos:   position{line: 972, col: 5, offset: 26999},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 973, col: 7, offset: 27003},
+								pos:  position{line: 972, col: 7, offset: 27001},
 								name: "IP4Net",
 							},
 						},
@@ -7795,28 +7795,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 977, col: 1, offset: 27107},
+			pos:  position{line: 976, col: 1, offset: 27105},
 			expr: &choiceExpr{
-				pos: position{line: 978, col: 5, offset: 27126},
+				pos: position{line: 977, col: 5, offset: 27124},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 27126},
+						pos: position{line: 977, col: 5, offset: 27124},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 978, col: 5, offset: 27126},
+							pos: position{line: 977, col: 5, offset: 27124},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 978, col: 5, offset: 27126},
+									pos:   position{line: 977, col: 5, offset: 27124},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 978, col: 7, offset: 27128},
+										pos:  position{line: 977, col: 7, offset: 27126},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 978, col: 11, offset: 27132},
+									pos: position{line: 977, col: 11, offset: 27130},
 									expr: &ruleRefExpr{
-										pos:  position{line: 978, col: 12, offset: 27133},
+										pos:  position{line: 977, col: 12, offset: 27131},
 										name: "IdentifierRest",
 									},
 								},
@@ -7824,13 +7824,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 981, col: 5, offset: 27247},
+						pos: position{line: 980, col: 5, offset: 27245},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 981, col: 5, offset: 27247},
+							pos:   position{line: 980, col: 5, offset: 27245},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 981, col: 7, offset: 27249},
+								pos:  position{line: 980, col: 7, offset: 27247},
 								name: "IP",
 							},
 						},
@@ -7840,15 +7840,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 985, col: 1, offset: 27348},
+			pos:  position{line: 984, col: 1, offset: 27346},
 			expr: &actionExpr{
-				pos: position{line: 986, col: 5, offset: 27365},
+				pos: position{line: 985, col: 5, offset: 27363},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 986, col: 5, offset: 27365},
+					pos:   position{line: 985, col: 5, offset: 27363},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 986, col: 7, offset: 27367},
+						pos:  position{line: 985, col: 7, offset: 27365},
 						name: "FloatString",
 					},
 				},
@@ -7856,15 +7856,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 990, col: 1, offset: 27480},
+			pos:  position{line: 989, col: 1, offset: 27478},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 5, offset: 27499},
+				pos: position{line: 990, col: 5, offset: 27497},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 991, col: 5, offset: 27499},
+					pos:   position{line: 990, col: 5, offset: 27497},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 991, col: 7, offset: 27501},
+						pos:  position{line: 990, col: 7, offset: 27499},
 						name: "IntString",
 					},
 				},
@@ -7872,24 +7872,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 995, col: 1, offset: 27610},
+			pos:  position{line: 994, col: 1, offset: 27608},
 			expr: &choiceExpr{
-				pos: position{line: 996, col: 5, offset: 27629},
+				pos: position{line: 995, col: 5, offset: 27627},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 996, col: 5, offset: 27629},
+						pos: position{line: 995, col: 5, offset: 27627},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 996, col: 5, offset: 27629},
+							pos:        position{line: 995, col: 5, offset: 27627},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 997, col: 5, offset: 27742},
+						pos: position{line: 996, col: 5, offset: 27740},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 997, col: 5, offset: 27742},
+							pos:        position{line: 996, col: 5, offset: 27740},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7899,12 +7899,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 999, col: 1, offset: 27853},
+			pos:  position{line: 998, col: 1, offset: 27851},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 5, offset: 27869},
+				pos: position{line: 999, col: 5, offset: 27867},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 1000, col: 5, offset: 27869},
+					pos:        position{line: 999, col: 5, offset: 27867},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7912,22 +7912,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1002, col: 1, offset: 27975},
+			pos:  position{line: 1001, col: 1, offset: 27973},
 			expr: &actionExpr{
-				pos: position{line: 1003, col: 5, offset: 27992},
+				pos: position{line: 1002, col: 5, offset: 27990},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1003, col: 5, offset: 27992},
+					pos: position{line: 1002, col: 5, offset: 27990},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1003, col: 5, offset: 27992},
+							pos:        position{line: 1002, col: 5, offset: 27990},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1003, col: 10, offset: 27997},
+							pos: position{line: 1002, col: 10, offset: 27995},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1003, col: 10, offset: 27997},
+								pos:  position{line: 1002, col: 10, offset: 27995},
 								name: "HexDigit",
 							},
 						},
@@ -7937,28 +7937,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1007, col: 1, offset: 28112},
+			pos:  position{line: 1006, col: 1, offset: 28110},
 			expr: &actionExpr{
-				pos: position{line: 1008, col: 5, offset: 28128},
+				pos: position{line: 1007, col: 5, offset: 28126},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1008, col: 5, offset: 28128},
+					pos: position{line: 1007, col: 5, offset: 28126},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1008, col: 5, offset: 28128},
+							pos:        position{line: 1007, col: 5, offset: 28126},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1008, col: 9, offset: 28132},
+							pos:   position{line: 1007, col: 9, offset: 28130},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1008, col: 13, offset: 28136},
+								pos:  position{line: 1007, col: 13, offset: 28134},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1008, col: 18, offset: 28141},
+							pos:        position{line: 1007, col: 18, offset: 28139},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -7968,16 +7968,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1012, col: 1, offset: 28230},
+			pos:  position{line: 1011, col: 1, offset: 28228},
 			expr: &choiceExpr{
-				pos: position{line: 1013, col: 5, offset: 28243},
+				pos: position{line: 1012, col: 5, offset: 28241},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 5, offset: 28243},
+						pos:  position{line: 1012, col: 5, offset: 28241},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1014, col: 5, offset: 28259},
+						pos:  position{line: 1013, col: 5, offset: 28257},
 						name: "PrimitiveType",
 					},
 				},
@@ -7985,20 +7985,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1016, col: 1, offset: 28274},
+			pos:  position{line: 1015, col: 1, offset: 28272},
 			expr: &choiceExpr{
-				pos: position{line: 1017, col: 5, offset: 28283},
+				pos: position{line: 1016, col: 5, offset: 28281},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1017, col: 5, offset: 28283},
+						pos:  position{line: 1016, col: 5, offset: 28281},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1018, col: 5, offset: 28299},
+						pos:  position{line: 1017, col: 5, offset: 28297},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1019, col: 5, offset: 28317},
+						pos:  position{line: 1018, col: 5, offset: 28315},
 						name: "ComplexType",
 					},
 				},
@@ -8006,28 +8006,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1021, col: 1, offset: 28330},
+			pos:  position{line: 1020, col: 1, offset: 28328},
 			expr: &choiceExpr{
-				pos: position{line: 1022, col: 5, offset: 28348},
+				pos: position{line: 1021, col: 5, offset: 28346},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1022, col: 5, offset: 28348},
+						pos: position{line: 1021, col: 5, offset: 28346},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1022, col: 5, offset: 28348},
+							pos: position{line: 1021, col: 5, offset: 28346},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1022, col: 5, offset: 28348},
+									pos:   position{line: 1021, col: 5, offset: 28346},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1022, col: 10, offset: 28353},
+										pos:  position{line: 1021, col: 10, offset: 28351},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1022, col: 24, offset: 28367},
+									pos: position{line: 1021, col: 24, offset: 28365},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1022, col: 25, offset: 28368},
+										pos:  position{line: 1021, col: 25, offset: 28366},
 										name: "IdentifierRest",
 									},
 								},
@@ -8035,55 +8035,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 28408},
+						pos: position{line: 1022, col: 5, offset: 28406},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 28408},
+							pos: position{line: 1022, col: 5, offset: 28406},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1023, col: 5, offset: 28408},
+									pos:   position{line: 1022, col: 5, offset: 28406},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 10, offset: 28413},
+										pos:  position{line: 1022, col: 10, offset: 28411},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 25, offset: 28428},
+									pos:  position{line: 1022, col: 25, offset: 28426},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 28, offset: 28431},
+									pos:        position{line: 1022, col: 28, offset: 28429},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 32, offset: 28435},
+									pos:  position{line: 1022, col: 32, offset: 28433},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 35, offset: 28438},
+									pos:        position{line: 1022, col: 35, offset: 28436},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 39, offset: 28442},
+									pos:  position{line: 1022, col: 39, offset: 28440},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 42, offset: 28445},
+									pos:   position{line: 1022, col: 42, offset: 28443},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 46, offset: 28449},
+										pos:  position{line: 1022, col: 46, offset: 28447},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 51, offset: 28454},
+									pos:  position{line: 1022, col: 51, offset: 28452},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 54, offset: 28457},
+									pos:        position{line: 1022, col: 54, offset: 28455},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8091,42 +8091,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1026, col: 5, offset: 28558},
+						pos: position{line: 1025, col: 5, offset: 28556},
 						run: (*parser).callonAmbiguousType21,
 						expr: &labeledExpr{
-							pos:   position{line: 1026, col: 5, offset: 28558},
+							pos:   position{line: 1025, col: 5, offset: 28556},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1026, col: 10, offset: 28563},
+								pos:  position{line: 1025, col: 10, offset: 28561},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1029, col: 5, offset: 28665},
+						pos: position{line: 1028, col: 5, offset: 28663},
 						run: (*parser).callonAmbiguousType24,
 						expr: &seqExpr{
-							pos: position{line: 1029, col: 5, offset: 28665},
+							pos: position{line: 1028, col: 5, offset: 28663},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1029, col: 5, offset: 28665},
+									pos:        position{line: 1028, col: 5, offset: 28663},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1029, col: 9, offset: 28669},
+									pos:  position{line: 1028, col: 9, offset: 28667},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1029, col: 12, offset: 28672},
+									pos:   position{line: 1028, col: 12, offset: 28670},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1029, col: 14, offset: 28674},
+										pos:  position{line: 1028, col: 14, offset: 28672},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1029, col: 25, offset: 28685},
+									pos:        position{line: 1028, col: 25, offset: 28683},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8138,15 +8138,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1031, col: 1, offset: 28708},
+			pos:  position{line: 1030, col: 1, offset: 28706},
 			expr: &actionExpr{
-				pos: position{line: 1032, col: 5, offset: 28722},
+				pos: position{line: 1031, col: 5, offset: 28720},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1032, col: 5, offset: 28722},
+					pos:   position{line: 1031, col: 5, offset: 28720},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1032, col: 11, offset: 28728},
+						pos:  position{line: 1031, col: 11, offset: 28726},
 						name: "TypeList",
 					},
 				},
@@ -8154,28 +8154,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1036, col: 1, offset: 28824},
+			pos:  position{line: 1035, col: 1, offset: 28822},
 			expr: &actionExpr{
-				pos: position{line: 1037, col: 5, offset: 28837},
+				pos: position{line: 1036, col: 5, offset: 28835},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1037, col: 5, offset: 28837},
+					pos: position{line: 1036, col: 5, offset: 28835},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1037, col: 5, offset: 28837},
+							pos:   position{line: 1036, col: 5, offset: 28835},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1037, col: 11, offset: 28843},
+								pos:  position{line: 1036, col: 11, offset: 28841},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1037, col: 16, offset: 28848},
+							pos:   position{line: 1036, col: 16, offset: 28846},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1037, col: 21, offset: 28853},
+								pos: position{line: 1036, col: 21, offset: 28851},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1037, col: 21, offset: 28853},
+									pos:  position{line: 1036, col: 21, offset: 28851},
 									name: "TypeListTail",
 								},
 							},
@@ -8186,31 +8186,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1041, col: 1, offset: 28947},
+			pos:  position{line: 1040, col: 1, offset: 28945},
 			expr: &actionExpr{
-				pos: position{line: 1041, col: 16, offset: 28962},
+				pos: position{line: 1040, col: 16, offset: 28960},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1041, col: 16, offset: 28962},
+					pos: position{line: 1040, col: 16, offset: 28960},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1041, col: 16, offset: 28962},
+							pos:  position{line: 1040, col: 16, offset: 28960},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1041, col: 19, offset: 28965},
+							pos:        position{line: 1040, col: 19, offset: 28963},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1041, col: 23, offset: 28969},
+							pos:  position{line: 1040, col: 23, offset: 28967},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1041, col: 26, offset: 28972},
+							pos:   position{line: 1040, col: 26, offset: 28970},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1041, col: 30, offset: 28976},
+								pos:  position{line: 1040, col: 30, offset: 28974},
 								name: "Type",
 							},
 						},
@@ -8220,39 +8220,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1043, col: 1, offset: 29002},
+			pos:  position{line: 1042, col: 1, offset: 29000},
 			expr: &choiceExpr{
-				pos: position{line: 1044, col: 5, offset: 29018},
+				pos: position{line: 1043, col: 5, offset: 29016},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1044, col: 5, offset: 29018},
+						pos: position{line: 1043, col: 5, offset: 29016},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1044, col: 5, offset: 29018},
+							pos: position{line: 1043, col: 5, offset: 29016},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1044, col: 5, offset: 29018},
+									pos:        position{line: 1043, col: 5, offset: 29016},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1044, col: 9, offset: 29022},
+									pos:  position{line: 1043, col: 9, offset: 29020},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1044, col: 12, offset: 29025},
+									pos:   position{line: 1043, col: 12, offset: 29023},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1044, col: 19, offset: 29032},
+										pos:  position{line: 1043, col: 19, offset: 29030},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1044, col: 33, offset: 29046},
+									pos:  position{line: 1043, col: 33, offset: 29044},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1044, col: 36, offset: 29049},
+									pos:        position{line: 1043, col: 36, offset: 29047},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8260,34 +8260,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1047, col: 5, offset: 29144},
+						pos: position{line: 1046, col: 5, offset: 29142},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1047, col: 5, offset: 29144},
+							pos: position{line: 1046, col: 5, offset: 29142},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1047, col: 5, offset: 29144},
+									pos:        position{line: 1046, col: 5, offset: 29142},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 9, offset: 29148},
+									pos:  position{line: 1046, col: 9, offset: 29146},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1047, col: 12, offset: 29151},
+									pos:   position{line: 1046, col: 12, offset: 29149},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1047, col: 16, offset: 29155},
+										pos:  position{line: 1046, col: 16, offset: 29153},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 21, offset: 29160},
+									pos:  position{line: 1046, col: 21, offset: 29158},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 24, offset: 29163},
+									pos:        position{line: 1046, col: 24, offset: 29161},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8295,34 +8295,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1050, col: 5, offset: 29252},
+						pos: position{line: 1049, col: 5, offset: 29250},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1050, col: 5, offset: 29252},
+							pos: position{line: 1049, col: 5, offset: 29250},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1050, col: 5, offset: 29252},
+									pos:        position{line: 1049, col: 5, offset: 29250},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 10, offset: 29257},
+									pos:  position{line: 1049, col: 10, offset: 29255},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1050, col: 14, offset: 29261},
+									pos:   position{line: 1049, col: 14, offset: 29259},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1050, col: 18, offset: 29265},
+										pos:  position{line: 1049, col: 18, offset: 29263},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 23, offset: 29270},
+									pos:  position{line: 1049, col: 23, offset: 29268},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1050, col: 26, offset: 29273},
+									pos:        position{line: 1049, col: 26, offset: 29271},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8330,55 +8330,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1053, col: 5, offset: 29361},
+						pos: position{line: 1052, col: 5, offset: 29359},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1053, col: 5, offset: 29361},
+							pos: position{line: 1052, col: 5, offset: 29359},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1053, col: 5, offset: 29361},
+									pos:        position{line: 1052, col: 5, offset: 29359},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1053, col: 10, offset: 29366},
+									pos:  position{line: 1052, col: 10, offset: 29364},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1053, col: 13, offset: 29369},
+									pos:   position{line: 1052, col: 13, offset: 29367},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1053, col: 21, offset: 29377},
+										pos:  position{line: 1052, col: 21, offset: 29375},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1053, col: 26, offset: 29382},
+									pos:  position{line: 1052, col: 26, offset: 29380},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1053, col: 29, offset: 29385},
+									pos:        position{line: 1052, col: 29, offset: 29383},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1053, col: 33, offset: 29389},
+									pos:  position{line: 1052, col: 33, offset: 29387},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1053, col: 36, offset: 29392},
+									pos:   position{line: 1052, col: 36, offset: 29390},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1053, col: 44, offset: 29400},
+										pos:  position{line: 1052, col: 44, offset: 29398},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1053, col: 49, offset: 29405},
+									pos:  position{line: 1052, col: 49, offset: 29403},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1053, col: 52, offset: 29408},
+									pos:        position{line: 1052, col: 52, offset: 29406},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8390,15 +8390,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1057, col: 1, offset: 29522},
+			pos:  position{line: 1056, col: 1, offset: 29520},
 			expr: &actionExpr{
-				pos: position{line: 1058, col: 5, offset: 29542},
+				pos: position{line: 1057, col: 5, offset: 29540},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1058, col: 5, offset: 29542},
+					pos:   position{line: 1057, col: 5, offset: 29540},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1058, col: 7, offset: 29544},
+						pos:  position{line: 1057, col: 7, offset: 29542},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8406,34 +8406,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1065, col: 1, offset: 29739},
+			pos:  position{line: 1064, col: 1, offset: 29737},
 			expr: &choiceExpr{
-				pos: position{line: 1066, col: 5, offset: 29764},
+				pos: position{line: 1065, col: 5, offset: 29762},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 29764},
+						pos: position{line: 1065, col: 5, offset: 29762},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1066, col: 5, offset: 29764},
+							pos: position{line: 1065, col: 5, offset: 29762},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1066, col: 5, offset: 29764},
+									pos:        position{line: 1065, col: 5, offset: 29762},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 9, offset: 29768},
+									pos:   position{line: 1065, col: 9, offset: 29766},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1066, col: 11, offset: 29770},
+										pos: position{line: 1065, col: 11, offset: 29768},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1066, col: 11, offset: 29770},
+											pos:  position{line: 1065, col: 11, offset: 29768},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1066, col: 37, offset: 29796},
+									pos:        position{line: 1065, col: 37, offset: 29794},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8441,29 +8441,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 29822},
+						pos: position{line: 1066, col: 5, offset: 29820},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1067, col: 5, offset: 29822},
+							pos: position{line: 1066, col: 5, offset: 29820},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1067, col: 5, offset: 29822},
+									pos:        position{line: 1066, col: 5, offset: 29820},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1067, col: 9, offset: 29826},
+									pos:   position{line: 1066, col: 9, offset: 29824},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1067, col: 11, offset: 29828},
+										pos: position{line: 1066, col: 11, offset: 29826},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1067, col: 11, offset: 29828},
+											pos:  position{line: 1066, col: 11, offset: 29826},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1067, col: 37, offset: 29854},
+									pos:        position{line: 1066, col: 37, offset: 29852},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8475,24 +8475,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1069, col: 1, offset: 29877},
+			pos:  position{line: 1068, col: 1, offset: 29875},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 5, offset: 29906},
+				pos: position{line: 1069, col: 5, offset: 29904},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1070, col: 5, offset: 29906},
+						pos:  position{line: 1069, col: 5, offset: 29904},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 29923},
+						pos: position{line: 1070, col: 5, offset: 29921},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1071, col: 5, offset: 29923},
+							pos:   position{line: 1070, col: 5, offset: 29921},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1071, col: 7, offset: 29925},
+								pos: position{line: 1070, col: 7, offset: 29923},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1071, col: 7, offset: 29925},
+									pos:  position{line: 1070, col: 7, offset: 29923},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8503,26 +8503,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1075, col: 1, offset: 30062},
+			pos:  position{line: 1074, col: 1, offset: 30060},
 			expr: &choiceExpr{
-				pos: position{line: 1076, col: 5, offset: 30091},
+				pos: position{line: 1075, col: 5, offset: 30089},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1076, col: 5, offset: 30091},
+						pos: position{line: 1075, col: 5, offset: 30089},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1076, col: 5, offset: 30091},
+							pos: position{line: 1075, col: 5, offset: 30089},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1076, col: 5, offset: 30091},
+									pos:        position{line: 1075, col: 5, offset: 30089},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1076, col: 10, offset: 30096},
+									pos:   position{line: 1075, col: 10, offset: 30094},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1076, col: 12, offset: 30098},
+										pos:        position{line: 1075, col: 12, offset: 30096},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8531,24 +8531,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 30125},
+						pos: position{line: 1076, col: 5, offset: 30123},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 30125},
+							pos: position{line: 1076, col: 5, offset: 30123},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1077, col: 5, offset: 30125},
+									pos: position{line: 1076, col: 5, offset: 30123},
 									expr: &litMatcher{
-										pos:        position{line: 1077, col: 8, offset: 30128},
+										pos:        position{line: 1076, col: 8, offset: 30126},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 15, offset: 30135},
+									pos:   position{line: 1076, col: 15, offset: 30133},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 17, offset: 30137},
+										pos:  position{line: 1076, col: 17, offset: 30135},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8560,24 +8560,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1079, col: 1, offset: 30173},
+			pos:  position{line: 1078, col: 1, offset: 30171},
 			expr: &choiceExpr{
-				pos: position{line: 1080, col: 5, offset: 30202},
+				pos: position{line: 1079, col: 5, offset: 30200},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1080, col: 5, offset: 30202},
+						pos:  position{line: 1079, col: 5, offset: 30200},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1081, col: 5, offset: 30219},
+						pos: position{line: 1080, col: 5, offset: 30217},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1081, col: 5, offset: 30219},
+							pos:   position{line: 1080, col: 5, offset: 30217},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1081, col: 7, offset: 30221},
+								pos: position{line: 1080, col: 7, offset: 30219},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1081, col: 7, offset: 30221},
+									pos:  position{line: 1080, col: 7, offset: 30219},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8588,26 +8588,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1085, col: 1, offset: 30358},
+			pos:  position{line: 1084, col: 1, offset: 30356},
 			expr: &choiceExpr{
-				pos: position{line: 1086, col: 5, offset: 30387},
+				pos: position{line: 1085, col: 5, offset: 30385},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1086, col: 5, offset: 30387},
+						pos: position{line: 1085, col: 5, offset: 30385},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1086, col: 5, offset: 30387},
+							pos: position{line: 1085, col: 5, offset: 30385},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1086, col: 5, offset: 30387},
+									pos:        position{line: 1085, col: 5, offset: 30385},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1086, col: 10, offset: 30392},
+									pos:   position{line: 1085, col: 10, offset: 30390},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1086, col: 12, offset: 30394},
+										pos:        position{line: 1085, col: 12, offset: 30392},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8616,24 +8616,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1087, col: 5, offset: 30421},
+						pos: position{line: 1086, col: 5, offset: 30419},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1087, col: 5, offset: 30421},
+							pos: position{line: 1086, col: 5, offset: 30419},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1087, col: 5, offset: 30421},
+									pos: position{line: 1086, col: 5, offset: 30419},
 									expr: &litMatcher{
-										pos:        position{line: 1087, col: 8, offset: 30424},
+										pos:        position{line: 1086, col: 8, offset: 30422},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1087, col: 15, offset: 30431},
+									pos:   position{line: 1086, col: 15, offset: 30429},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1087, col: 17, offset: 30433},
+										pos:  position{line: 1086, col: 17, offset: 30431},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8645,36 +8645,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1089, col: 1, offset: 30469},
+			pos:  position{line: 1088, col: 1, offset: 30467},
 			expr: &actionExpr{
-				pos: position{line: 1090, col: 5, offset: 30486},
+				pos: position{line: 1089, col: 5, offset: 30484},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1090, col: 5, offset: 30486},
+					pos: position{line: 1089, col: 5, offset: 30484},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1090, col: 5, offset: 30486},
+							pos:        position{line: 1089, col: 5, offset: 30484},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1090, col: 10, offset: 30491},
+							pos:  position{line: 1089, col: 10, offset: 30489},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1090, col: 13, offset: 30494},
+							pos:   position{line: 1089, col: 13, offset: 30492},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 15, offset: 30496},
+								pos:  position{line: 1089, col: 15, offset: 30494},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1090, col: 20, offset: 30501},
+							pos:  position{line: 1089, col: 20, offset: 30499},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1090, col: 23, offset: 30504},
+							pos:        position{line: 1089, col: 23, offset: 30502},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8684,110 +8684,110 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1092, col: 1, offset: 30527},
+			pos:  position{line: 1091, col: 1, offset: 30525},
 			expr: &actionExpr{
-				pos: position{line: 1093, col: 5, offset: 30545},
+				pos: position{line: 1092, col: 5, offset: 30543},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1093, col: 9, offset: 30549},
+					pos: position{line: 1092, col: 9, offset: 30547},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1093, col: 9, offset: 30549},
+							pos:        position{line: 1092, col: 9, offset: 30547},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 19, offset: 30559},
+							pos:        position{line: 1092, col: 19, offset: 30557},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 30, offset: 30570},
+							pos:        position{line: 1092, col: 30, offset: 30568},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1093, col: 41, offset: 30581},
+							pos:        position{line: 1092, col: 41, offset: 30579},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 9, offset: 30598},
+							pos:        position{line: 1093, col: 9, offset: 30596},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 18, offset: 30607},
+							pos:        position{line: 1093, col: 18, offset: 30605},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 28, offset: 30617},
+							pos:        position{line: 1093, col: 28, offset: 30615},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 38, offset: 30627},
+							pos:        position{line: 1093, col: 38, offset: 30625},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1095, col: 9, offset: 30643},
+							pos:        position{line: 1094, col: 9, offset: 30641},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1095, col: 21, offset: 30655},
+							pos:        position{line: 1094, col: 21, offset: 30653},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1096, col: 9, offset: 30673},
+							pos:        position{line: 1095, col: 9, offset: 30671},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1096, col: 18, offset: 30682},
+							pos:        position{line: 1095, col: 18, offset: 30680},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1097, col: 9, offset: 30699},
+							pos:        position{line: 1096, col: 9, offset: 30697},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1097, col: 22, offset: 30712},
+							pos:        position{line: 1096, col: 22, offset: 30710},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1098, col: 9, offset: 30727},
+							pos:        position{line: 1097, col: 9, offset: 30725},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1099, col: 9, offset: 30743},
+							pos:        position{line: 1098, col: 9, offset: 30741},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1099, col: 16, offset: 30750},
+							pos:        position{line: 1098, col: 16, offset: 30748},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 9, offset: 30764},
+							pos:        position{line: 1099, col: 9, offset: 30762},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 18, offset: 30773},
+							pos:        position{line: 1099, col: 18, offset: 30771},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 28, offset: 30783},
+							pos:        position{line: 1099, col: 28, offset: 30781},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8797,28 +8797,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1104, col: 1, offset: 30899},
+			pos:  position{line: 1103, col: 1, offset: 30897},
 			expr: &actionExpr{
-				pos: position{line: 1105, col: 5, offset: 30917},
+				pos: position{line: 1104, col: 5, offset: 30915},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1105, col: 5, offset: 30917},
+					pos: position{line: 1104, col: 5, offset: 30915},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1105, col: 5, offset: 30917},
+							pos:   position{line: 1104, col: 5, offset: 30915},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1105, col: 11, offset: 30923},
+								pos:  position{line: 1104, col: 11, offset: 30921},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1105, col: 21, offset: 30933},
+							pos:   position{line: 1104, col: 21, offset: 30931},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1105, col: 26, offset: 30938},
+								pos: position{line: 1104, col: 26, offset: 30936},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1105, col: 26, offset: 30938},
+									pos:  position{line: 1104, col: 26, offset: 30936},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -8829,31 +8829,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1109, col: 1, offset: 31037},
+			pos:  position{line: 1108, col: 1, offset: 31035},
 			expr: &actionExpr{
-				pos: position{line: 1109, col: 21, offset: 31057},
+				pos: position{line: 1108, col: 21, offset: 31055},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1109, col: 21, offset: 31057},
+					pos: position{line: 1108, col: 21, offset: 31055},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1109, col: 21, offset: 31057},
+							pos:  position{line: 1108, col: 21, offset: 31055},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1109, col: 24, offset: 31060},
+							pos:        position{line: 1108, col: 24, offset: 31058},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1109, col: 28, offset: 31064},
+							pos:  position{line: 1108, col: 28, offset: 31062},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1109, col: 31, offset: 31067},
+							pos:   position{line: 1108, col: 31, offset: 31065},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1109, col: 35, offset: 31071},
+								pos:  position{line: 1108, col: 35, offset: 31069},
 								name: "TypeField",
 							},
 						},
@@ -8863,39 +8863,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1111, col: 1, offset: 31102},
+			pos:  position{line: 1110, col: 1, offset: 31100},
 			expr: &actionExpr{
-				pos: position{line: 1112, col: 5, offset: 31116},
+				pos: position{line: 1111, col: 5, offset: 31114},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1112, col: 5, offset: 31116},
+					pos: position{line: 1111, col: 5, offset: 31114},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1112, col: 5, offset: 31116},
+							pos:   position{line: 1111, col: 5, offset: 31114},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1112, col: 10, offset: 31121},
+								pos:  position{line: 1111, col: 10, offset: 31119},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1112, col: 20, offset: 31131},
+							pos:  position{line: 1111, col: 20, offset: 31129},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1112, col: 23, offset: 31134},
+							pos:        position{line: 1111, col: 23, offset: 31132},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1112, col: 27, offset: 31138},
+							pos:  position{line: 1111, col: 27, offset: 31136},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1112, col: 30, offset: 31141},
+							pos:   position{line: 1111, col: 30, offset: 31139},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1112, col: 34, offset: 31145},
+								pos:  position{line: 1111, col: 34, offset: 31143},
 								name: "Type",
 							},
 						},
@@ -8905,16 +8905,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1116, col: 1, offset: 31227},
+			pos:  position{line: 1115, col: 1, offset: 31225},
 			expr: &choiceExpr{
-				pos: position{line: 1117, col: 5, offset: 31241},
+				pos: position{line: 1116, col: 5, offset: 31239},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1117, col: 5, offset: 31241},
+						pos:  position{line: 1116, col: 5, offset: 31239},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1118, col: 5, offset: 31260},
+						pos:  position{line: 1117, col: 5, offset: 31258},
 						name: "QuotedString",
 					},
 				},
@@ -8922,16 +8922,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 1120, col: 1, offset: 31274},
+			pos:  position{line: 1119, col: 1, offset: 31272},
 			expr: &choiceExpr{
-				pos: position{line: 1121, col: 5, offset: 31292},
+				pos: position{line: 1120, col: 5, offset: 31290},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1121, col: 5, offset: 31292},
+						pos:  position{line: 1120, col: 5, offset: 31290},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1121, col: 24, offset: 31311},
+						pos:  position{line: 1120, col: 24, offset: 31309},
 						name: "RelativeOperator",
 					},
 				},
@@ -8939,22 +8939,22 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1123, col: 1, offset: 31329},
+			pos:  position{line: 1122, col: 1, offset: 31327},
 			expr: &actionExpr{
-				pos: position{line: 1123, col: 12, offset: 31340},
+				pos: position{line: 1122, col: 12, offset: 31338},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1123, col: 12, offset: 31340},
+					pos: position{line: 1122, col: 12, offset: 31338},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1123, col: 12, offset: 31340},
+							pos:        position{line: 1122, col: 12, offset: 31338},
 							val:        "and",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1123, col: 19, offset: 31347},
+							pos: position{line: 1122, col: 19, offset: 31345},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1123, col: 20, offset: 31348},
+								pos:  position{line: 1122, col: 20, offset: 31346},
 								name: "IdentifierRest",
 							},
 						},
@@ -8964,22 +8964,22 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1124, col: 1, offset: 31385},
+			pos:  position{line: 1123, col: 1, offset: 31383},
 			expr: &actionExpr{
-				pos: position{line: 1124, col: 11, offset: 31395},
+				pos: position{line: 1123, col: 11, offset: 31393},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1124, col: 11, offset: 31395},
+					pos: position{line: 1123, col: 11, offset: 31393},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1124, col: 11, offset: 31395},
+							pos:        position{line: 1123, col: 11, offset: 31393},
 							val:        "or",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1124, col: 17, offset: 31401},
+							pos: position{line: 1123, col: 17, offset: 31399},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1124, col: 18, offset: 31402},
+								pos:  position{line: 1123, col: 18, offset: 31400},
 								name: "IdentifierRest",
 							},
 						},
@@ -8989,22 +8989,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1125, col: 1, offset: 31438},
+			pos:  position{line: 1124, col: 1, offset: 31436},
 			expr: &actionExpr{
-				pos: position{line: 1125, col: 11, offset: 31448},
+				pos: position{line: 1124, col: 11, offset: 31446},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1125, col: 11, offset: 31448},
+					pos: position{line: 1124, col: 11, offset: 31446},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1125, col: 11, offset: 31448},
+							pos:        position{line: 1124, col: 11, offset: 31446},
 							val:        "in",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1125, col: 17, offset: 31454},
+							pos: position{line: 1124, col: 17, offset: 31452},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1125, col: 18, offset: 31455},
+								pos:  position{line: 1124, col: 18, offset: 31453},
 								name: "IdentifierRest",
 							},
 						},
@@ -9014,22 +9014,22 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1126, col: 1, offset: 31491},
+			pos:  position{line: 1125, col: 1, offset: 31489},
 			expr: &actionExpr{
-				pos: position{line: 1126, col: 12, offset: 31502},
+				pos: position{line: 1125, col: 12, offset: 31500},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1126, col: 12, offset: 31502},
+					pos: position{line: 1125, col: 12, offset: 31500},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1126, col: 12, offset: 31502},
+							pos:        position{line: 1125, col: 12, offset: 31500},
 							val:        "not",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1126, col: 19, offset: 31509},
+							pos: position{line: 1125, col: 19, offset: 31507},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1126, col: 20, offset: 31510},
+								pos:  position{line: 1125, col: 20, offset: 31508},
 								name: "IdentifierRest",
 							},
 						},
@@ -9039,22 +9039,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1127, col: 1, offset: 31547},
+			pos:  position{line: 1126, col: 1, offset: 31545},
 			expr: &actionExpr{
-				pos: position{line: 1127, col: 11, offset: 31557},
+				pos: position{line: 1126, col: 11, offset: 31555},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1127, col: 11, offset: 31557},
+					pos: position{line: 1126, col: 11, offset: 31555},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1127, col: 11, offset: 31557},
+							pos:        position{line: 1126, col: 11, offset: 31555},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 1127, col: 17, offset: 31563},
+							pos: position{line: 1126, col: 17, offset: 31561},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1127, col: 18, offset: 31564},
+								pos:  position{line: 1126, col: 18, offset: 31562},
 								name: "IdentifierRest",
 							},
 						},
@@ -9064,9 +9064,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1129, col: 1, offset: 31601},
+			pos:  position{line: 1128, col: 1, offset: 31599},
 			expr: &charClassMatcher{
-				pos:        position{line: 1129, col: 19, offset: 31619},
+				pos:        position{line: 1128, col: 19, offset: 31617},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9076,16 +9076,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1131, col: 1, offset: 31631},
+			pos:  position{line: 1130, col: 1, offset: 31629},
 			expr: &choiceExpr{
-				pos: position{line: 1131, col: 18, offset: 31648},
+				pos: position{line: 1130, col: 18, offset: 31646},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1131, col: 18, offset: 31648},
+						pos:  position{line: 1130, col: 18, offset: 31646},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1131, col: 36, offset: 31666},
+						pos:        position{line: 1130, col: 36, offset: 31664},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9096,15 +9096,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1133, col: 1, offset: 31673},
+			pos:  position{line: 1132, col: 1, offset: 31671},
 			expr: &actionExpr{
-				pos: position{line: 1134, col: 5, offset: 31688},
+				pos: position{line: 1133, col: 5, offset: 31686},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1134, col: 5, offset: 31688},
+					pos:   position{line: 1133, col: 5, offset: 31686},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1134, col: 8, offset: 31691},
+						pos:  position{line: 1133, col: 8, offset: 31689},
 						name: "IdentifierName",
 					},
 				},
@@ -9112,29 +9112,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1136, col: 1, offset: 31772},
+			pos:  position{line: 1135, col: 1, offset: 31770},
 			expr: &choiceExpr{
-				pos: position{line: 1137, col: 5, offset: 31791},
+				pos: position{line: 1136, col: 5, offset: 31789},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1137, col: 5, offset: 31791},
+						pos: position{line: 1136, col: 5, offset: 31789},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1137, col: 5, offset: 31791},
+							pos: position{line: 1136, col: 5, offset: 31789},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1137, col: 5, offset: 31791},
+									pos: position{line: 1136, col: 5, offset: 31789},
 									expr: &seqExpr{
-										pos: position{line: 1137, col: 7, offset: 31793},
+										pos: position{line: 1136, col: 7, offset: 31791},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1137, col: 7, offset: 31793},
+												pos:  position{line: 1136, col: 7, offset: 31791},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1137, col: 15, offset: 31801},
+												pos: position{line: 1136, col: 15, offset: 31799},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1137, col: 16, offset: 31802},
+													pos:  position{line: 1136, col: 16, offset: 31800},
 													name: "IdentifierRest",
 												},
 											},
@@ -9142,13 +9142,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1137, col: 32, offset: 31818},
+									pos:  position{line: 1136, col: 32, offset: 31816},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1137, col: 48, offset: 31834},
+									pos: position{line: 1136, col: 48, offset: 31832},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1137, col: 48, offset: 31834},
+										pos:  position{line: 1136, col: 48, offset: 31832},
 										name: "IdentifierRest",
 									},
 								},
@@ -9156,30 +9156,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1138, col: 5, offset: 31886},
+						pos: position{line: 1137, col: 5, offset: 31884},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1138, col: 5, offset: 31886},
+							pos:        position{line: 1137, col: 5, offset: 31884},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1139, col: 5, offset: 31925},
+						pos: position{line: 1138, col: 5, offset: 31923},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1139, col: 5, offset: 31925},
+							pos: position{line: 1138, col: 5, offset: 31923},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1139, col: 5, offset: 31925},
+									pos:        position{line: 1138, col: 5, offset: 31923},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 10, offset: 31930},
+									pos:   position{line: 1138, col: 10, offset: 31928},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1139, col: 13, offset: 31933},
+										pos:  position{line: 1138, col: 13, offset: 31931},
 										name: "IDGuard",
 									},
 								},
@@ -9187,39 +9187,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1141, col: 5, offset: 32024},
+						pos: position{line: 1140, col: 5, offset: 32022},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1141, col: 5, offset: 32024},
+							pos:        position{line: 1140, col: 5, offset: 32022},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1142, col: 5, offset: 32066},
+						pos: position{line: 1141, col: 5, offset: 32064},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1142, col: 5, offset: 32066},
+							pos: position{line: 1141, col: 5, offset: 32064},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1142, col: 5, offset: 32066},
+									pos:   position{line: 1141, col: 5, offset: 32064},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1142, col: 8, offset: 32069},
+										pos:  position{line: 1141, col: 8, offset: 32067},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1142, col: 26, offset: 32087},
+									pos: position{line: 1141, col: 26, offset: 32085},
 									expr: &seqExpr{
-										pos: position{line: 1142, col: 28, offset: 32089},
+										pos: position{line: 1141, col: 28, offset: 32087},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1142, col: 28, offset: 32089},
+												pos:  position{line: 1141, col: 28, offset: 32087},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1142, col: 31, offset: 32092},
+												pos:        position{line: 1141, col: 31, offset: 32090},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9234,16 +9234,16 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1144, col: 1, offset: 32117},
+			pos:  position{line: 1143, col: 1, offset: 32115},
 			expr: &choiceExpr{
-				pos: position{line: 1145, col: 5, offset: 32129},
+				pos: position{line: 1144, col: 5, offset: 32127},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1145, col: 5, offset: 32129},
+						pos:  position{line: 1144, col: 5, offset: 32127},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1146, col: 5, offset: 32148},
+						pos:  position{line: 1145, col: 5, offset: 32146},
 						name: "NullLiteral",
 					},
 				},
@@ -9251,24 +9251,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1148, col: 1, offset: 32161},
+			pos:  position{line: 1147, col: 1, offset: 32159},
 			expr: &actionExpr{
-				pos: position{line: 1149, col: 5, offset: 32170},
+				pos: position{line: 1148, col: 5, offset: 32168},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1149, col: 5, offset: 32170},
+					pos: position{line: 1148, col: 5, offset: 32168},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 5, offset: 32170},
+							pos:  position{line: 1148, col: 5, offset: 32168},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1149, col: 14, offset: 32179},
+							pos:        position{line: 1148, col: 14, offset: 32177},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 18, offset: 32183},
+							pos:  position{line: 1148, col: 18, offset: 32181},
 							name: "FullTime",
 						},
 					},
@@ -9277,30 +9277,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1153, col: 1, offset: 32303},
+			pos:  position{line: 1152, col: 1, offset: 32301},
 			expr: &seqExpr{
-				pos: position{line: 1153, col: 12, offset: 32314},
+				pos: position{line: 1152, col: 12, offset: 32312},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 12, offset: 32314},
+						pos:  position{line: 1152, col: 12, offset: 32312},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1153, col: 15, offset: 32317},
+						pos:        position{line: 1152, col: 15, offset: 32315},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 19, offset: 32321},
+						pos:  position{line: 1152, col: 19, offset: 32319},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1153, col: 22, offset: 32324},
+						pos:        position{line: 1152, col: 22, offset: 32322},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 26, offset: 32328},
+						pos:  position{line: 1152, col: 26, offset: 32326},
 						name: "D2",
 					},
 				},
@@ -9308,33 +9308,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1155, col: 1, offset: 32332},
+			pos:  position{line: 1154, col: 1, offset: 32330},
 			expr: &seqExpr{
-				pos: position{line: 1155, col: 6, offset: 32337},
+				pos: position{line: 1154, col: 6, offset: 32335},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1155, col: 6, offset: 32337},
+						pos:        position{line: 1154, col: 6, offset: 32335},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1155, col: 11, offset: 32342},
+						pos:        position{line: 1154, col: 11, offset: 32340},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1155, col: 16, offset: 32347},
+						pos:        position{line: 1154, col: 16, offset: 32345},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1155, col: 21, offset: 32352},
+						pos:        position{line: 1154, col: 21, offset: 32350},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9345,19 +9345,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1156, col: 1, offset: 32358},
+			pos:  position{line: 1155, col: 1, offset: 32356},
 			expr: &seqExpr{
-				pos: position{line: 1156, col: 6, offset: 32363},
+				pos: position{line: 1155, col: 6, offset: 32361},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1156, col: 6, offset: 32363},
+						pos:        position{line: 1155, col: 6, offset: 32361},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1156, col: 11, offset: 32368},
+						pos:        position{line: 1155, col: 11, offset: 32366},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9368,16 +9368,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1158, col: 1, offset: 32375},
+			pos:  position{line: 1157, col: 1, offset: 32373},
 			expr: &seqExpr{
-				pos: position{line: 1158, col: 12, offset: 32386},
+				pos: position{line: 1157, col: 12, offset: 32384},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1158, col: 12, offset: 32386},
+						pos:  position{line: 1157, col: 12, offset: 32384},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1158, col: 24, offset: 32398},
+						pos:  position{line: 1157, col: 24, offset: 32396},
 						name: "TimeOffset",
 					},
 				},
@@ -9385,46 +9385,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1160, col: 1, offset: 32410},
+			pos:  position{line: 1159, col: 1, offset: 32408},
 			expr: &seqExpr{
-				pos: position{line: 1160, col: 15, offset: 32424},
+				pos: position{line: 1159, col: 15, offset: 32422},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 15, offset: 32424},
+						pos:  position{line: 1159, col: 15, offset: 32422},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1160, col: 18, offset: 32427},
+						pos:        position{line: 1159, col: 18, offset: 32425},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 22, offset: 32431},
+						pos:  position{line: 1159, col: 22, offset: 32429},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1160, col: 25, offset: 32434},
+						pos:        position{line: 1159, col: 25, offset: 32432},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 29, offset: 32438},
+						pos:  position{line: 1159, col: 29, offset: 32436},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1160, col: 32, offset: 32441},
+						pos: position{line: 1159, col: 32, offset: 32439},
 						expr: &seqExpr{
-							pos: position{line: 1160, col: 33, offset: 32442},
+							pos: position{line: 1159, col: 33, offset: 32440},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1160, col: 33, offset: 32442},
+									pos:        position{line: 1159, col: 33, offset: 32440},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1160, col: 37, offset: 32446},
+									pos: position{line: 1159, col: 37, offset: 32444},
 									expr: &charClassMatcher{
-										pos:        position{line: 1160, col: 37, offset: 32446},
+										pos:        position{line: 1159, col: 37, offset: 32444},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9439,60 +9439,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1162, col: 1, offset: 32456},
+			pos:  position{line: 1161, col: 1, offset: 32454},
 			expr: &choiceExpr{
-				pos: position{line: 1163, col: 5, offset: 32471},
+				pos: position{line: 1162, col: 5, offset: 32469},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1163, col: 5, offset: 32471},
+						pos:        position{line: 1162, col: 5, offset: 32469},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1164, col: 5, offset: 32479},
+						pos: position{line: 1163, col: 5, offset: 32477},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1164, col: 6, offset: 32480},
+								pos: position{line: 1163, col: 6, offset: 32478},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1164, col: 6, offset: 32480},
+										pos:        position{line: 1163, col: 6, offset: 32478},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1164, col: 12, offset: 32486},
+										pos:        position{line: 1163, col: 12, offset: 32484},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1164, col: 17, offset: 32491},
+								pos:  position{line: 1163, col: 17, offset: 32489},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1164, col: 20, offset: 32494},
+								pos:        position{line: 1163, col: 20, offset: 32492},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1164, col: 24, offset: 32498},
+								pos:  position{line: 1163, col: 24, offset: 32496},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1164, col: 27, offset: 32501},
+								pos: position{line: 1163, col: 27, offset: 32499},
 								expr: &seqExpr{
-									pos: position{line: 1164, col: 28, offset: 32502},
+									pos: position{line: 1163, col: 28, offset: 32500},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1164, col: 28, offset: 32502},
+											pos:        position{line: 1163, col: 28, offset: 32500},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1164, col: 32, offset: 32506},
+											pos: position{line: 1163, col: 32, offset: 32504},
 											expr: &charClassMatcher{
-												pos:        position{line: 1164, col: 32, offset: 32506},
+												pos:        position{line: 1163, col: 32, offset: 32504},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9509,32 +9509,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1166, col: 1, offset: 32516},
+			pos:  position{line: 1165, col: 1, offset: 32514},
 			expr: &actionExpr{
-				pos: position{line: 1167, col: 5, offset: 32529},
+				pos: position{line: 1166, col: 5, offset: 32527},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1167, col: 5, offset: 32529},
+					pos: position{line: 1166, col: 5, offset: 32527},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1167, col: 5, offset: 32529},
+							pos: position{line: 1166, col: 5, offset: 32527},
 							expr: &litMatcher{
-								pos:        position{line: 1167, col: 5, offset: 32529},
+								pos:        position{line: 1166, col: 5, offset: 32527},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1167, col: 10, offset: 32534},
+							pos: position{line: 1166, col: 10, offset: 32532},
 							expr: &seqExpr{
-								pos: position{line: 1167, col: 11, offset: 32535},
+								pos: position{line: 1166, col: 11, offset: 32533},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1167, col: 11, offset: 32535},
+										pos:  position{line: 1166, col: 11, offset: 32533},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1167, col: 19, offset: 32543},
+										pos:  position{line: 1166, col: 19, offset: 32541},
 										name: "TimeUnit",
 									},
 								},
@@ -9546,26 +9546,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1171, col: 1, offset: 32669},
+			pos:  position{line: 1170, col: 1, offset: 32667},
 			expr: &seqExpr{
-				pos: position{line: 1171, col: 11, offset: 32679},
+				pos: position{line: 1170, col: 11, offset: 32677},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1171, col: 11, offset: 32679},
+						pos:  position{line: 1170, col: 11, offset: 32677},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1171, col: 16, offset: 32684},
+						pos: position{line: 1170, col: 16, offset: 32682},
 						expr: &seqExpr{
-							pos: position{line: 1171, col: 17, offset: 32685},
+							pos: position{line: 1170, col: 17, offset: 32683},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1171, col: 17, offset: 32685},
+									pos:        position{line: 1170, col: 17, offset: 32683},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1171, col: 21, offset: 32689},
+									pos:  position{line: 1170, col: 21, offset: 32687},
 									name: "UInt",
 								},
 							},
@@ -9576,52 +9576,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1173, col: 1, offset: 32697},
+			pos:  position{line: 1172, col: 1, offset: 32695},
 			expr: &choiceExpr{
-				pos: position{line: 1174, col: 5, offset: 32710},
+				pos: position{line: 1173, col: 5, offset: 32708},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1174, col: 5, offset: 32710},
+						pos:        position{line: 1173, col: 5, offset: 32708},
 						val:        "ns",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1175, col: 5, offset: 32720},
+						pos:        position{line: 1174, col: 5, offset: 32718},
 						val:        "us",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1176, col: 5, offset: 32730},
+						pos:        position{line: 1175, col: 5, offset: 32728},
 						val:        "ms",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1177, col: 5, offset: 32740},
+						pos:        position{line: 1176, col: 5, offset: 32738},
 						val:        "s",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1178, col: 5, offset: 32749},
+						pos:        position{line: 1177, col: 5, offset: 32747},
 						val:        "m",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1179, col: 5, offset: 32758},
+						pos:        position{line: 1178, col: 5, offset: 32756},
 						val:        "h",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1180, col: 5, offset: 32767},
+						pos:        position{line: 1179, col: 5, offset: 32765},
 						val:        "d",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1181, col: 5, offset: 32776},
+						pos:        position{line: 1180, col: 5, offset: 32774},
 						val:        "w",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 1182, col: 5, offset: 32785},
+						pos:        position{line: 1181, col: 5, offset: 32783},
 						val:        "y",
 						ignoreCase: true,
 					},
@@ -9630,42 +9630,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1184, col: 1, offset: 32791},
+			pos:  position{line: 1183, col: 1, offset: 32789},
 			expr: &actionExpr{
-				pos: position{line: 1185, col: 5, offset: 32798},
+				pos: position{line: 1184, col: 5, offset: 32796},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1185, col: 5, offset: 32798},
+					pos: position{line: 1184, col: 5, offset: 32796},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1185, col: 5, offset: 32798},
+							pos:  position{line: 1184, col: 5, offset: 32796},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1185, col: 10, offset: 32803},
+							pos:        position{line: 1184, col: 10, offset: 32801},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1185, col: 14, offset: 32807},
+							pos:  position{line: 1184, col: 14, offset: 32805},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1185, col: 19, offset: 32812},
+							pos:        position{line: 1184, col: 19, offset: 32810},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1185, col: 23, offset: 32816},
+							pos:  position{line: 1184, col: 23, offset: 32814},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1185, col: 28, offset: 32821},
+							pos:        position{line: 1184, col: 28, offset: 32819},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1185, col: 32, offset: 32825},
+							pos:  position{line: 1184, col: 32, offset: 32823},
 							name: "UInt",
 						},
 					},
@@ -9674,42 +9674,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1187, col: 1, offset: 32862},
+			pos:  position{line: 1186, col: 1, offset: 32860},
 			expr: &actionExpr{
-				pos: position{line: 1188, col: 5, offset: 32870},
+				pos: position{line: 1187, col: 5, offset: 32868},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1188, col: 5, offset: 32870},
+					pos: position{line: 1187, col: 5, offset: 32868},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1188, col: 5, offset: 32870},
+							pos: position{line: 1187, col: 5, offset: 32868},
 							expr: &seqExpr{
-								pos: position{line: 1188, col: 8, offset: 32873},
+								pos: position{line: 1187, col: 8, offset: 32871},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1188, col: 8, offset: 32873},
+										pos:  position{line: 1187, col: 8, offset: 32871},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1188, col: 12, offset: 32877},
+										pos:        position{line: 1187, col: 12, offset: 32875},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1188, col: 16, offset: 32881},
+										pos:  position{line: 1187, col: 16, offset: 32879},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1188, col: 20, offset: 32885},
+										pos: position{line: 1187, col: 20, offset: 32883},
 										expr: &choiceExpr{
-											pos: position{line: 1188, col: 22, offset: 32887},
+											pos: position{line: 1187, col: 22, offset: 32885},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1188, col: 22, offset: 32887},
+													pos:  position{line: 1187, col: 22, offset: 32885},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1188, col: 33, offset: 32898},
+													pos:        position{line: 1187, col: 33, offset: 32896},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9720,10 +9720,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1188, col: 39, offset: 32904},
+							pos:   position{line: 1187, col: 39, offset: 32902},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1188, col: 41, offset: 32906},
+								pos:  position{line: 1187, col: 41, offset: 32904},
 								name: "IP6Variations",
 							},
 						},
@@ -9733,32 +9733,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1192, col: 1, offset: 33070},
+			pos:  position{line: 1191, col: 1, offset: 33068},
 			expr: &choiceExpr{
-				pos: position{line: 1193, col: 5, offset: 33088},
+				pos: position{line: 1192, col: 5, offset: 33086},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1193, col: 5, offset: 33088},
+						pos: position{line: 1192, col: 5, offset: 33086},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1193, col: 5, offset: 33088},
+							pos: position{line: 1192, col: 5, offset: 33086},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1193, col: 5, offset: 33088},
+									pos:   position{line: 1192, col: 5, offset: 33086},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1193, col: 7, offset: 33090},
+										pos: position{line: 1192, col: 7, offset: 33088},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1193, col: 7, offset: 33090},
+											pos:  position{line: 1192, col: 7, offset: 33088},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1193, col: 17, offset: 33100},
+									pos:   position{line: 1192, col: 17, offset: 33098},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1193, col: 19, offset: 33102},
+										pos:  position{line: 1192, col: 19, offset: 33100},
 										name: "IP6Tail",
 									},
 								},
@@ -9766,51 +9766,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1196, col: 5, offset: 33166},
+						pos: position{line: 1195, col: 5, offset: 33164},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1196, col: 5, offset: 33166},
+							pos: position{line: 1195, col: 5, offset: 33164},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1196, col: 5, offset: 33166},
+									pos:   position{line: 1195, col: 5, offset: 33164},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1196, col: 7, offset: 33168},
+										pos:  position{line: 1195, col: 7, offset: 33166},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1196, col: 11, offset: 33172},
+									pos:   position{line: 1195, col: 11, offset: 33170},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1196, col: 13, offset: 33174},
+										pos: position{line: 1195, col: 13, offset: 33172},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1196, col: 13, offset: 33174},
+											pos:  position{line: 1195, col: 13, offset: 33172},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1196, col: 23, offset: 33184},
+									pos:        position{line: 1195, col: 23, offset: 33182},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1196, col: 28, offset: 33189},
+									pos:   position{line: 1195, col: 28, offset: 33187},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1196, col: 30, offset: 33191},
+										pos: position{line: 1195, col: 30, offset: 33189},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1196, col: 30, offset: 33191},
+											pos:  position{line: 1195, col: 30, offset: 33189},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1196, col: 40, offset: 33201},
+									pos:   position{line: 1195, col: 40, offset: 33199},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1196, col: 42, offset: 33203},
+										pos:  position{line: 1195, col: 42, offset: 33201},
 										name: "IP6Tail",
 									},
 								},
@@ -9818,32 +9818,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1199, col: 5, offset: 33302},
+						pos: position{line: 1198, col: 5, offset: 33300},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1199, col: 5, offset: 33302},
+							pos: position{line: 1198, col: 5, offset: 33300},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1199, col: 5, offset: 33302},
+									pos:        position{line: 1198, col: 5, offset: 33300},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1199, col: 10, offset: 33307},
+									pos:   position{line: 1198, col: 10, offset: 33305},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1199, col: 12, offset: 33309},
+										pos: position{line: 1198, col: 12, offset: 33307},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1199, col: 12, offset: 33309},
+											pos:  position{line: 1198, col: 12, offset: 33307},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1199, col: 22, offset: 33319},
+									pos:   position{line: 1198, col: 22, offset: 33317},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1199, col: 24, offset: 33321},
+										pos:  position{line: 1198, col: 24, offset: 33319},
 										name: "IP6Tail",
 									},
 								},
@@ -9851,32 +9851,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1202, col: 5, offset: 33392},
+						pos: position{line: 1201, col: 5, offset: 33390},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1202, col: 5, offset: 33392},
+							pos: position{line: 1201, col: 5, offset: 33390},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1202, col: 5, offset: 33392},
+									pos:   position{line: 1201, col: 5, offset: 33390},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1202, col: 7, offset: 33394},
+										pos:  position{line: 1201, col: 7, offset: 33392},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1202, col: 11, offset: 33398},
+									pos:   position{line: 1201, col: 11, offset: 33396},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1202, col: 13, offset: 33400},
+										pos: position{line: 1201, col: 13, offset: 33398},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1202, col: 13, offset: 33400},
+											pos:  position{line: 1201, col: 13, offset: 33398},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1202, col: 23, offset: 33410},
+									pos:        position{line: 1201, col: 23, offset: 33408},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -9884,10 +9884,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1205, col: 5, offset: 33478},
+						pos: position{line: 1204, col: 5, offset: 33476},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1205, col: 5, offset: 33478},
+							pos:        position{line: 1204, col: 5, offset: 33476},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -9897,16 +9897,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1209, col: 1, offset: 33515},
+			pos:  position{line: 1208, col: 1, offset: 33513},
 			expr: &choiceExpr{
-				pos: position{line: 1210, col: 5, offset: 33527},
+				pos: position{line: 1209, col: 5, offset: 33525},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1210, col: 5, offset: 33527},
+						pos:  position{line: 1209, col: 5, offset: 33525},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1211, col: 5, offset: 33534},
+						pos:  position{line: 1210, col: 5, offset: 33532},
 						name: "Hex",
 					},
 				},
@@ -9914,23 +9914,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1213, col: 1, offset: 33539},
+			pos:  position{line: 1212, col: 1, offset: 33537},
 			expr: &actionExpr{
-				pos: position{line: 1213, col: 12, offset: 33550},
+				pos: position{line: 1212, col: 12, offset: 33548},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1213, col: 12, offset: 33550},
+					pos: position{line: 1212, col: 12, offset: 33548},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1213, col: 12, offset: 33550},
+							pos:        position{line: 1212, col: 12, offset: 33548},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1213, col: 16, offset: 33554},
+							pos:   position{line: 1212, col: 16, offset: 33552},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1213, col: 18, offset: 33556},
+								pos:  position{line: 1212, col: 18, offset: 33554},
 								name: "Hex",
 							},
 						},
@@ -9940,23 +9940,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1215, col: 1, offset: 33594},
+			pos:  position{line: 1214, col: 1, offset: 33592},
 			expr: &actionExpr{
-				pos: position{line: 1215, col: 12, offset: 33605},
+				pos: position{line: 1214, col: 12, offset: 33603},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1215, col: 12, offset: 33605},
+					pos: position{line: 1214, col: 12, offset: 33603},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1215, col: 12, offset: 33605},
+							pos:   position{line: 1214, col: 12, offset: 33603},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1215, col: 14, offset: 33607},
+								pos:  position{line: 1214, col: 14, offset: 33605},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1215, col: 18, offset: 33611},
+							pos:        position{line: 1214, col: 18, offset: 33609},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -9966,31 +9966,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1217, col: 1, offset: 33649},
+			pos:  position{line: 1216, col: 1, offset: 33647},
 			expr: &actionExpr{
-				pos: position{line: 1218, col: 5, offset: 33660},
+				pos: position{line: 1217, col: 5, offset: 33658},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1218, col: 5, offset: 33660},
+					pos: position{line: 1217, col: 5, offset: 33658},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1218, col: 5, offset: 33660},
+							pos:   position{line: 1217, col: 5, offset: 33658},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1218, col: 7, offset: 33662},
+								pos:  position{line: 1217, col: 7, offset: 33660},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1218, col: 10, offset: 33665},
+							pos:        position{line: 1217, col: 10, offset: 33663},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1218, col: 14, offset: 33669},
+							pos:   position{line: 1217, col: 14, offset: 33667},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1218, col: 16, offset: 33671},
+								pos:  position{line: 1217, col: 16, offset: 33669},
 								name: "UInt",
 							},
 						},
@@ -10000,31 +10000,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1222, col: 1, offset: 33744},
+			pos:  position{line: 1221, col: 1, offset: 33742},
 			expr: &actionExpr{
-				pos: position{line: 1223, col: 5, offset: 33755},
+				pos: position{line: 1222, col: 5, offset: 33753},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1223, col: 5, offset: 33755},
+					pos: position{line: 1222, col: 5, offset: 33753},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1223, col: 5, offset: 33755},
+							pos:   position{line: 1222, col: 5, offset: 33753},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1223, col: 7, offset: 33757},
+								pos:  position{line: 1222, col: 7, offset: 33755},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1223, col: 11, offset: 33761},
+							pos:        position{line: 1222, col: 11, offset: 33759},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1223, col: 15, offset: 33765},
+							pos:   position{line: 1222, col: 15, offset: 33763},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1223, col: 17, offset: 33767},
+								pos:  position{line: 1222, col: 17, offset: 33765},
 								name: "UInt",
 							},
 						},
@@ -10034,15 +10034,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1227, col: 1, offset: 33830},
+			pos:  position{line: 1226, col: 1, offset: 33828},
 			expr: &actionExpr{
-				pos: position{line: 1228, col: 4, offset: 33838},
+				pos: position{line: 1227, col: 4, offset: 33836},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1228, col: 4, offset: 33838},
+					pos:   position{line: 1227, col: 4, offset: 33836},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1228, col: 6, offset: 33840},
+						pos:  position{line: 1227, col: 6, offset: 33838},
 						name: "UIntString",
 					},
 				},
@@ -10050,16 +10050,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1230, col: 1, offset: 33880},
+			pos:  position{line: 1229, col: 1, offset: 33878},
 			expr: &choiceExpr{
-				pos: position{line: 1231, col: 5, offset: 33894},
+				pos: position{line: 1230, col: 5, offset: 33892},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 5, offset: 33894},
+						pos:  position{line: 1230, col: 5, offset: 33892},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1232, col: 5, offset: 33909},
+						pos:  position{line: 1231, col: 5, offset: 33907},
 						name: "MinusIntString",
 					},
 				},
@@ -10067,14 +10067,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1234, col: 1, offset: 33925},
+			pos:  position{line: 1233, col: 1, offset: 33923},
 			expr: &actionExpr{
-				pos: position{line: 1234, col: 14, offset: 33938},
+				pos: position{line: 1233, col: 14, offset: 33936},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1234, col: 14, offset: 33938},
+					pos: position{line: 1233, col: 14, offset: 33936},
 					expr: &charClassMatcher{
-						pos:        position{line: 1234, col: 14, offset: 33938},
+						pos:        position{line: 1233, col: 14, offset: 33936},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10085,20 +10085,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1236, col: 1, offset: 33977},
+			pos:  position{line: 1235, col: 1, offset: 33975},
 			expr: &actionExpr{
-				pos: position{line: 1237, col: 5, offset: 33996},
+				pos: position{line: 1236, col: 5, offset: 33994},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1237, col: 5, offset: 33996},
+					pos: position{line: 1236, col: 5, offset: 33994},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1237, col: 5, offset: 33996},
+							pos:        position{line: 1236, col: 5, offset: 33994},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1237, col: 9, offset: 34000},
+							pos:  position{line: 1236, col: 9, offset: 33998},
 							name: "UIntString",
 						},
 					},
@@ -10107,28 +10107,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1239, col: 1, offset: 34043},
+			pos:  position{line: 1238, col: 1, offset: 34041},
 			expr: &choiceExpr{
-				pos: position{line: 1240, col: 5, offset: 34059},
+				pos: position{line: 1239, col: 5, offset: 34057},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1240, col: 5, offset: 34059},
+						pos: position{line: 1239, col: 5, offset: 34057},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1240, col: 5, offset: 34059},
+							pos: position{line: 1239, col: 5, offset: 34057},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1240, col: 5, offset: 34059},
+									pos: position{line: 1239, col: 5, offset: 34057},
 									expr: &litMatcher{
-										pos:        position{line: 1240, col: 5, offset: 34059},
+										pos:        position{line: 1239, col: 5, offset: 34057},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1240, col: 10, offset: 34064},
+									pos: position{line: 1239, col: 10, offset: 34062},
 									expr: &charClassMatcher{
-										pos:        position{line: 1240, col: 10, offset: 34064},
+										pos:        position{line: 1239, col: 10, offset: 34062},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10136,14 +10136,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1240, col: 17, offset: 34071},
+									pos:        position{line: 1239, col: 17, offset: 34069},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1240, col: 21, offset: 34075},
+									pos: position{line: 1239, col: 21, offset: 34073},
 									expr: &charClassMatcher{
-										pos:        position{line: 1240, col: 21, offset: 34075},
+										pos:        position{line: 1239, col: 21, offset: 34073},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10151,9 +10151,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1240, col: 28, offset: 34082},
+									pos: position{line: 1239, col: 28, offset: 34080},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1240, col: 28, offset: 34082},
+										pos:  position{line: 1239, col: 28, offset: 34080},
 										name: "ExponentPart",
 									},
 								},
@@ -10161,28 +10161,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1243, col: 5, offset: 34141},
+						pos: position{line: 1242, col: 5, offset: 34139},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1243, col: 5, offset: 34141},
+							pos: position{line: 1242, col: 5, offset: 34139},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1243, col: 5, offset: 34141},
+									pos: position{line: 1242, col: 5, offset: 34139},
 									expr: &litMatcher{
-										pos:        position{line: 1243, col: 5, offset: 34141},
+										pos:        position{line: 1242, col: 5, offset: 34139},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1243, col: 10, offset: 34146},
+									pos:        position{line: 1242, col: 10, offset: 34144},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1243, col: 14, offset: 34150},
+									pos: position{line: 1242, col: 14, offset: 34148},
 									expr: &charClassMatcher{
-										pos:        position{line: 1243, col: 14, offset: 34150},
+										pos:        position{line: 1242, col: 14, offset: 34148},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10190,9 +10190,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1243, col: 21, offset: 34157},
+									pos: position{line: 1242, col: 21, offset: 34155},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1243, col: 21, offset: 34157},
+										pos:  position{line: 1242, col: 21, offset: 34155},
 										name: "ExponentPart",
 									},
 								},
@@ -10204,19 +10204,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1247, col: 1, offset: 34213},
+			pos:  position{line: 1246, col: 1, offset: 34211},
 			expr: &seqExpr{
-				pos: position{line: 1247, col: 16, offset: 34228},
+				pos: position{line: 1246, col: 16, offset: 34226},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1247, col: 16, offset: 34228},
+						pos:        position{line: 1246, col: 16, offset: 34226},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1247, col: 21, offset: 34233},
+						pos: position{line: 1246, col: 21, offset: 34231},
 						expr: &charClassMatcher{
-							pos:        position{line: 1247, col: 21, offset: 34233},
+							pos:        position{line: 1246, col: 21, offset: 34231},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10224,7 +10224,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1247, col: 27, offset: 34239},
+						pos:  position{line: 1246, col: 27, offset: 34237},
 						name: "UIntString",
 					},
 				},
@@ -10232,14 +10232,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1249, col: 1, offset: 34251},
+			pos:  position{line: 1248, col: 1, offset: 34249},
 			expr: &actionExpr{
-				pos: position{line: 1249, col: 7, offset: 34257},
+				pos: position{line: 1248, col: 7, offset: 34255},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1249, col: 7, offset: 34257},
+					pos: position{line: 1248, col: 7, offset: 34255},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1249, col: 7, offset: 34257},
+						pos:  position{line: 1248, col: 7, offset: 34255},
 						name: "HexDigit",
 					},
 				},
@@ -10247,9 +10247,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1251, col: 1, offset: 34299},
+			pos:  position{line: 1250, col: 1, offset: 34297},
 			expr: &charClassMatcher{
-				pos:        position{line: 1251, col: 12, offset: 34310},
+				pos:        position{line: 1250, col: 12, offset: 34308},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10258,34 +10258,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1253, col: 1, offset: 34323},
+			pos:  position{line: 1252, col: 1, offset: 34321},
 			expr: &choiceExpr{
-				pos: position{line: 1254, col: 5, offset: 34340},
+				pos: position{line: 1253, col: 5, offset: 34338},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1254, col: 5, offset: 34340},
+						pos: position{line: 1253, col: 5, offset: 34338},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1254, col: 5, offset: 34340},
+							pos: position{line: 1253, col: 5, offset: 34338},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1254, col: 5, offset: 34340},
+									pos:        position{line: 1253, col: 5, offset: 34338},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1254, col: 9, offset: 34344},
+									pos:   position{line: 1253, col: 9, offset: 34342},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1254, col: 11, offset: 34346},
+										pos: position{line: 1253, col: 11, offset: 34344},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1254, col: 11, offset: 34346},
+											pos:  position{line: 1253, col: 11, offset: 34344},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1254, col: 29, offset: 34364},
+									pos:        position{line: 1253, col: 29, offset: 34362},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10293,29 +10293,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1255, col: 5, offset: 34401},
+						pos: position{line: 1254, col: 5, offset: 34399},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1255, col: 5, offset: 34401},
+							pos: position{line: 1254, col: 5, offset: 34399},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1255, col: 5, offset: 34401},
+									pos:        position{line: 1254, col: 5, offset: 34399},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1255, col: 9, offset: 34405},
+									pos:   position{line: 1254, col: 9, offset: 34403},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1255, col: 11, offset: 34407},
+										pos: position{line: 1254, col: 11, offset: 34405},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1255, col: 11, offset: 34407},
+											pos:  position{line: 1254, col: 11, offset: 34405},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1255, col: 29, offset: 34425},
+									pos:        position{line: 1254, col: 29, offset: 34423},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10327,55 +10327,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1257, col: 1, offset: 34459},
+			pos:  position{line: 1256, col: 1, offset: 34457},
 			expr: &choiceExpr{
-				pos: position{line: 1258, col: 5, offset: 34480},
+				pos: position{line: 1257, col: 5, offset: 34478},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1258, col: 5, offset: 34480},
+						pos: position{line: 1257, col: 5, offset: 34478},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1258, col: 5, offset: 34480},
+							pos: position{line: 1257, col: 5, offset: 34478},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1258, col: 5, offset: 34480},
+									pos: position{line: 1257, col: 5, offset: 34478},
 									expr: &choiceExpr{
-										pos: position{line: 1258, col: 7, offset: 34482},
+										pos: position{line: 1257, col: 7, offset: 34480},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1258, col: 7, offset: 34482},
+												pos:        position{line: 1257, col: 7, offset: 34480},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1258, col: 13, offset: 34488},
+												pos:  position{line: 1257, col: 13, offset: 34486},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1258, col: 26, offset: 34501,
+									line: 1257, col: 26, offset: 34499,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1259, col: 5, offset: 34538},
+						pos: position{line: 1258, col: 5, offset: 34536},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1259, col: 5, offset: 34538},
+							pos: position{line: 1258, col: 5, offset: 34536},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1259, col: 5, offset: 34538},
+									pos:        position{line: 1258, col: 5, offset: 34536},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1259, col: 10, offset: 34543},
+									pos:   position{line: 1258, col: 10, offset: 34541},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1259, col: 12, offset: 34545},
+										pos:  position{line: 1258, col: 12, offset: 34543},
 										name: "EscapeSequence",
 									},
 								},
@@ -10387,28 +10387,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1261, col: 1, offset: 34579},
+			pos:  position{line: 1260, col: 1, offset: 34577},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 5, offset: 34591},
+				pos: position{line: 1261, col: 5, offset: 34589},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1262, col: 5, offset: 34591},
+					pos: position{line: 1261, col: 5, offset: 34589},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1262, col: 5, offset: 34591},
+							pos:   position{line: 1261, col: 5, offset: 34589},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1262, col: 10, offset: 34596},
+								pos:  position{line: 1261, col: 10, offset: 34594},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1262, col: 23, offset: 34609},
+							pos:   position{line: 1261, col: 23, offset: 34607},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1262, col: 28, offset: 34614},
+								pos: position{line: 1261, col: 28, offset: 34612},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1262, col: 28, offset: 34614},
+									pos:  position{line: 1261, col: 28, offset: 34612},
 									name: "KeyWordRest",
 								},
 							},
@@ -10419,16 +10419,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1264, col: 1, offset: 34676},
+			pos:  position{line: 1263, col: 1, offset: 34674},
 			expr: &choiceExpr{
-				pos: position{line: 1265, col: 5, offset: 34693},
+				pos: position{line: 1264, col: 5, offset: 34691},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1265, col: 5, offset: 34693},
+						pos:  position{line: 1264, col: 5, offset: 34691},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1266, col: 5, offset: 34710},
+						pos:  position{line: 1265, col: 5, offset: 34708},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10436,12 +10436,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1268, col: 1, offset: 34722},
+			pos:  position{line: 1267, col: 1, offset: 34720},
 			expr: &actionExpr{
-				pos: position{line: 1268, col: 16, offset: 34737},
+				pos: position{line: 1267, col: 16, offset: 34735},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1268, col: 16, offset: 34737},
+					pos:        position{line: 1267, col: 16, offset: 34735},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10452,16 +10452,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1270, col: 1, offset: 34786},
+			pos:  position{line: 1269, col: 1, offset: 34784},
 			expr: &choiceExpr{
-				pos: position{line: 1271, col: 5, offset: 34802},
+				pos: position{line: 1270, col: 5, offset: 34800},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1271, col: 5, offset: 34802},
+						pos:  position{line: 1270, col: 5, offset: 34800},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1272, col: 5, offset: 34819},
+						pos:        position{line: 1271, col: 5, offset: 34817},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10472,30 +10472,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1274, col: 1, offset: 34826},
+			pos:  position{line: 1273, col: 1, offset: 34824},
 			expr: &actionExpr{
-				pos: position{line: 1274, col: 14, offset: 34839},
+				pos: position{line: 1273, col: 14, offset: 34837},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1274, col: 14, offset: 34839},
+					pos: position{line: 1273, col: 14, offset: 34837},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1274, col: 14, offset: 34839},
+							pos:        position{line: 1273, col: 14, offset: 34837},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1274, col: 19, offset: 34844},
+							pos:   position{line: 1273, col: 19, offset: 34842},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1274, col: 22, offset: 34847},
+								pos: position{line: 1273, col: 22, offset: 34845},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1274, col: 22, offset: 34847},
+										pos:  position{line: 1273, col: 22, offset: 34845},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1274, col: 38, offset: 34863},
+										pos:  position{line: 1273, col: 38, offset: 34861},
 										name: "EscapeSequence",
 									},
 								},
@@ -10507,42 +10507,42 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 1276, col: 1, offset: 34899},
+			pos:  position{line: 1275, col: 1, offset: 34897},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 5, offset: 34908},
+				pos: position{line: 1276, col: 5, offset: 34906},
 				run: (*parser).callonGlob1,
 				expr: &seqExpr{
-					pos: position{line: 1277, col: 5, offset: 34908},
+					pos: position{line: 1276, col: 5, offset: 34906},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1277, col: 5, offset: 34908},
+							pos: position{line: 1276, col: 5, offset: 34906},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1277, col: 6, offset: 34909},
+								pos:  position{line: 1276, col: 6, offset: 34907},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1277, col: 22, offset: 34925},
+							pos: position{line: 1276, col: 22, offset: 34923},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1277, col: 23, offset: 34926},
+								pos:  position{line: 1276, col: 23, offset: 34924},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1277, col: 35, offset: 34938},
+							pos:   position{line: 1276, col: 35, offset: 34936},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1277, col: 40, offset: 34943},
+								pos:  position{line: 1276, col: 40, offset: 34941},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1277, col: 50, offset: 34953},
+							pos:   position{line: 1276, col: 50, offset: 34951},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1277, col: 55, offset: 34958},
+								pos: position{line: 1276, col: 55, offset: 34956},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1277, col: 55, offset: 34958},
+									pos:  position{line: 1276, col: 55, offset: 34956},
 									name: "GlobRest",
 								},
 							},
@@ -10553,20 +10553,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1281, col: 1, offset: 35042},
+			pos:  position{line: 1280, col: 1, offset: 35040},
 			expr: &seqExpr{
-				pos: position{line: 1281, col: 19, offset: 35060},
+				pos: position{line: 1280, col: 19, offset: 35058},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1281, col: 19, offset: 35060},
+						pos: position{line: 1280, col: 19, offset: 35058},
 						expr: &litMatcher{
-							pos:        position{line: 1281, col: 19, offset: 35060},
+							pos:        position{line: 1280, col: 19, offset: 35058},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1281, col: 24, offset: 35065},
+						pos:  position{line: 1280, col: 24, offset: 35063},
 						name: "KeyWordStart",
 					},
 				},
@@ -10574,19 +10574,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1282, col: 1, offset: 35078},
+			pos:  position{line: 1281, col: 1, offset: 35076},
 			expr: &seqExpr{
-				pos: position{line: 1282, col: 15, offset: 35092},
+				pos: position{line: 1281, col: 15, offset: 35090},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1282, col: 15, offset: 35092},
+						pos: position{line: 1281, col: 15, offset: 35090},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1282, col: 15, offset: 35092},
+							pos:  position{line: 1281, col: 15, offset: 35090},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1282, col: 28, offset: 35105},
+						pos:        position{line: 1281, col: 28, offset: 35103},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10595,23 +10595,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1284, col: 1, offset: 35110},
+			pos:  position{line: 1283, col: 1, offset: 35108},
 			expr: &choiceExpr{
-				pos: position{line: 1285, col: 5, offset: 35124},
+				pos: position{line: 1284, col: 5, offset: 35122},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1285, col: 5, offset: 35124},
+						pos:  position{line: 1284, col: 5, offset: 35122},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1286, col: 5, offset: 35141},
+						pos:  position{line: 1285, col: 5, offset: 35139},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1287, col: 5, offset: 35153},
+						pos: position{line: 1286, col: 5, offset: 35151},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1287, col: 5, offset: 35153},
+							pos:        position{line: 1286, col: 5, offset: 35151},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10621,16 +10621,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1289, col: 1, offset: 35177},
+			pos:  position{line: 1288, col: 1, offset: 35175},
 			expr: &choiceExpr{
-				pos: position{line: 1290, col: 5, offset: 35190},
+				pos: position{line: 1289, col: 5, offset: 35188},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1290, col: 5, offset: 35190},
+						pos:  position{line: 1289, col: 5, offset: 35188},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1291, col: 5, offset: 35204},
+						pos:        position{line: 1290, col: 5, offset: 35202},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10641,30 +10641,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1293, col: 1, offset: 35211},
+			pos:  position{line: 1292, col: 1, offset: 35209},
 			expr: &actionExpr{
-				pos: position{line: 1293, col: 11, offset: 35221},
+				pos: position{line: 1292, col: 11, offset: 35219},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1293, col: 11, offset: 35221},
+					pos: position{line: 1292, col: 11, offset: 35219},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1293, col: 11, offset: 35221},
+							pos:        position{line: 1292, col: 11, offset: 35219},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1293, col: 16, offset: 35226},
+							pos:   position{line: 1292, col: 16, offset: 35224},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1293, col: 19, offset: 35229},
+								pos: position{line: 1292, col: 19, offset: 35227},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1293, col: 19, offset: 35229},
+										pos:  position{line: 1292, col: 19, offset: 35227},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1293, col: 32, offset: 35242},
+										pos:  position{line: 1292, col: 32, offset: 35240},
 										name: "EscapeSequence",
 									},
 								},
@@ -10676,30 +10676,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1295, col: 1, offset: 35278},
+			pos:  position{line: 1294, col: 1, offset: 35276},
 			expr: &choiceExpr{
-				pos: position{line: 1296, col: 5, offset: 35293},
+				pos: position{line: 1295, col: 5, offset: 35291},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1296, col: 5, offset: 35293},
+						pos: position{line: 1295, col: 5, offset: 35291},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1296, col: 5, offset: 35293},
+							pos:        position{line: 1295, col: 5, offset: 35291},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1297, col: 5, offset: 35321},
+						pos: position{line: 1296, col: 5, offset: 35319},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1297, col: 5, offset: 35321},
+							pos:        position{line: 1296, col: 5, offset: 35319},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1298, col: 5, offset: 35351},
+						pos:        position{line: 1297, col: 5, offset: 35349},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10710,55 +10710,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1301, col: 1, offset: 35358},
+			pos:  position{line: 1300, col: 1, offset: 35356},
 			expr: &choiceExpr{
-				pos: position{line: 1302, col: 5, offset: 35379},
+				pos: position{line: 1301, col: 5, offset: 35377},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1302, col: 5, offset: 35379},
+						pos: position{line: 1301, col: 5, offset: 35377},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1302, col: 5, offset: 35379},
+							pos: position{line: 1301, col: 5, offset: 35377},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1302, col: 5, offset: 35379},
+									pos: position{line: 1301, col: 5, offset: 35377},
 									expr: &choiceExpr{
-										pos: position{line: 1302, col: 7, offset: 35381},
+										pos: position{line: 1301, col: 7, offset: 35379},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1302, col: 7, offset: 35381},
+												pos:        position{line: 1301, col: 7, offset: 35379},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1302, col: 13, offset: 35387},
+												pos:  position{line: 1301, col: 13, offset: 35385},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1302, col: 26, offset: 35400,
+									line: 1301, col: 26, offset: 35398,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1303, col: 5, offset: 35437},
+						pos: position{line: 1302, col: 5, offset: 35435},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1303, col: 5, offset: 35437},
+							pos: position{line: 1302, col: 5, offset: 35435},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1303, col: 5, offset: 35437},
+									pos:        position{line: 1302, col: 5, offset: 35435},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1303, col: 10, offset: 35442},
+									pos:   position{line: 1302, col: 10, offset: 35440},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1303, col: 12, offset: 35444},
+										pos:  position{line: 1302, col: 12, offset: 35442},
 										name: "EscapeSequence",
 									},
 								},
@@ -10770,16 +10770,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1305, col: 1, offset: 35478},
+			pos:  position{line: 1304, col: 1, offset: 35476},
 			expr: &choiceExpr{
-				pos: position{line: 1306, col: 5, offset: 35497},
+				pos: position{line: 1305, col: 5, offset: 35495},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1306, col: 5, offset: 35497},
+						pos:  position{line: 1305, col: 5, offset: 35495},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1307, col: 5, offset: 35518},
+						pos:  position{line: 1306, col: 5, offset: 35516},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10787,79 +10787,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1309, col: 1, offset: 35533},
+			pos:  position{line: 1308, col: 1, offset: 35531},
 			expr: &choiceExpr{
-				pos: position{line: 1310, col: 5, offset: 35554},
+				pos: position{line: 1309, col: 5, offset: 35552},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1310, col: 5, offset: 35554},
+						pos:        position{line: 1309, col: 5, offset: 35552},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1311, col: 5, offset: 35562},
+						pos: position{line: 1310, col: 5, offset: 35560},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1311, col: 5, offset: 35562},
+							pos:        position{line: 1310, col: 5, offset: 35560},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1312, col: 5, offset: 35602},
+						pos:        position{line: 1311, col: 5, offset: 35600},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 35611},
+						pos: position{line: 1312, col: 5, offset: 35609},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1313, col: 5, offset: 35611},
+							pos:        position{line: 1312, col: 5, offset: 35609},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 35640},
+						pos: position{line: 1313, col: 5, offset: 35638},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1314, col: 5, offset: 35640},
+							pos:        position{line: 1313, col: 5, offset: 35638},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1315, col: 5, offset: 35669},
+						pos: position{line: 1314, col: 5, offset: 35667},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1315, col: 5, offset: 35669},
+							pos:        position{line: 1314, col: 5, offset: 35667},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 35698},
+						pos: position{line: 1315, col: 5, offset: 35696},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1316, col: 5, offset: 35698},
+							pos:        position{line: 1315, col: 5, offset: 35696},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 35727},
+						pos: position{line: 1316, col: 5, offset: 35725},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1317, col: 5, offset: 35727},
+							pos:        position{line: 1316, col: 5, offset: 35725},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1318, col: 5, offset: 35756},
+						pos: position{line: 1317, col: 5, offset: 35754},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1318, col: 5, offset: 35756},
+							pos:        position{line: 1317, col: 5, offset: 35754},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -10869,30 +10869,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1320, col: 1, offset: 35782},
+			pos:  position{line: 1319, col: 1, offset: 35780},
 			expr: &choiceExpr{
-				pos: position{line: 1321, col: 5, offset: 35800},
+				pos: position{line: 1320, col: 5, offset: 35798},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1321, col: 5, offset: 35800},
+						pos: position{line: 1320, col: 5, offset: 35798},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1321, col: 5, offset: 35800},
+							pos:        position{line: 1320, col: 5, offset: 35798},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1322, col: 5, offset: 35828},
+						pos: position{line: 1321, col: 5, offset: 35826},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1322, col: 5, offset: 35828},
+							pos:        position{line: 1321, col: 5, offset: 35826},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1323, col: 5, offset: 35856},
+						pos:        position{line: 1322, col: 5, offset: 35854},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10903,41 +10903,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1325, col: 1, offset: 35862},
+			pos:  position{line: 1324, col: 1, offset: 35860},
 			expr: &choiceExpr{
-				pos: position{line: 1326, col: 5, offset: 35880},
+				pos: position{line: 1325, col: 5, offset: 35878},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1326, col: 5, offset: 35880},
+						pos: position{line: 1325, col: 5, offset: 35878},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1326, col: 5, offset: 35880},
+							pos: position{line: 1325, col: 5, offset: 35878},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1326, col: 5, offset: 35880},
+									pos:        position{line: 1325, col: 5, offset: 35878},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1326, col: 9, offset: 35884},
+									pos:   position{line: 1325, col: 9, offset: 35882},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1326, col: 16, offset: 35891},
+										pos: position{line: 1325, col: 16, offset: 35889},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1326, col: 16, offset: 35891},
+												pos:  position{line: 1325, col: 16, offset: 35889},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1326, col: 25, offset: 35900},
+												pos:  position{line: 1325, col: 25, offset: 35898},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1326, col: 34, offset: 35909},
+												pos:  position{line: 1325, col: 34, offset: 35907},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1326, col: 43, offset: 35918},
+												pos:  position{line: 1325, col: 43, offset: 35916},
 												name: "HexDigit",
 											},
 										},
@@ -10947,63 +10947,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 35981},
+						pos: position{line: 1328, col: 5, offset: 35979},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1329, col: 5, offset: 35981},
+							pos: position{line: 1328, col: 5, offset: 35979},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1329, col: 5, offset: 35981},
+									pos:        position{line: 1328, col: 5, offset: 35979},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1329, col: 9, offset: 35985},
+									pos:        position{line: 1328, col: 9, offset: 35983},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1329, col: 13, offset: 35989},
+									pos:   position{line: 1328, col: 13, offset: 35987},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1329, col: 20, offset: 35996},
+										pos: position{line: 1328, col: 20, offset: 35994},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1329, col: 20, offset: 35996},
+												pos:  position{line: 1328, col: 20, offset: 35994},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1329, col: 29, offset: 36005},
+												pos: position{line: 1328, col: 29, offset: 36003},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1329, col: 29, offset: 36005},
+													pos:  position{line: 1328, col: 29, offset: 36003},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1329, col: 39, offset: 36015},
+												pos: position{line: 1328, col: 39, offset: 36013},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1329, col: 39, offset: 36015},
+													pos:  position{line: 1328, col: 39, offset: 36013},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1329, col: 49, offset: 36025},
+												pos: position{line: 1328, col: 49, offset: 36023},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1329, col: 49, offset: 36025},
+													pos:  position{line: 1328, col: 49, offset: 36023},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1329, col: 59, offset: 36035},
+												pos: position{line: 1328, col: 59, offset: 36033},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1329, col: 59, offset: 36035},
+													pos:  position{line: 1328, col: 59, offset: 36033},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1329, col: 69, offset: 36045},
+												pos: position{line: 1328, col: 69, offset: 36043},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1329, col: 69, offset: 36045},
+													pos:  position{line: 1328, col: 69, offset: 36043},
 													name: "HexDigit",
 												},
 											},
@@ -11011,7 +11011,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1329, col: 80, offset: 36056},
+									pos:        position{line: 1328, col: 80, offset: 36054},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11023,35 +11023,35 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1333, col: 1, offset: 36110},
+			pos:  position{line: 1332, col: 1, offset: 36108},
 			expr: &actionExpr{
-				pos: position{line: 1334, col: 5, offset: 36121},
+				pos: position{line: 1333, col: 5, offset: 36119},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1334, col: 5, offset: 36121},
+					pos: position{line: 1333, col: 5, offset: 36119},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1334, col: 5, offset: 36121},
+							pos:        position{line: 1333, col: 5, offset: 36119},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1334, col: 9, offset: 36125},
+							pos:   position{line: 1333, col: 9, offset: 36123},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1334, col: 14, offset: 36130},
+								pos:  position{line: 1333, col: 14, offset: 36128},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1334, col: 25, offset: 36141},
+							pos:        position{line: 1333, col: 25, offset: 36139},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1334, col: 29, offset: 36145},
+							pos: position{line: 1333, col: 29, offset: 36143},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1334, col: 30, offset: 36146},
+								pos:  position{line: 1333, col: 30, offset: 36144},
 								name: "KeyWordStart",
 							},
 						},
@@ -11061,32 +11061,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1336, col: 1, offset: 36181},
+			pos:  position{line: 1335, col: 1, offset: 36179},
 			expr: &actionExpr{
-				pos: position{line: 1337, col: 5, offset: 36196},
+				pos: position{line: 1336, col: 5, offset: 36194},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1337, col: 5, offset: 36196},
+					pos: position{line: 1336, col: 5, offset: 36194},
 					expr: &choiceExpr{
-						pos: position{line: 1337, col: 6, offset: 36197},
+						pos: position{line: 1336, col: 6, offset: 36195},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1337, col: 6, offset: 36197},
+								pos:        position{line: 1336, col: 6, offset: 36195},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1337, col: 15, offset: 36206},
+								pos: position{line: 1336, col: 15, offset: 36204},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1337, col: 15, offset: 36206},
+										pos:        position{line: 1336, col: 15, offset: 36204},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1337, col: 20, offset: 36211,
+										line: 1336, col: 20, offset: 36209,
 									},
 								},
 							},
@@ -11097,9 +11097,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1339, col: 1, offset: 36247},
+			pos:  position{line: 1338, col: 1, offset: 36245},
 			expr: &charClassMatcher{
-				pos:        position{line: 1340, col: 5, offset: 36263},
+				pos:        position{line: 1339, col: 5, offset: 36261},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11109,42 +11109,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1342, col: 1, offset: 36278},
+			pos:  position{line: 1341, col: 1, offset: 36276},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1342, col: 6, offset: 36283},
+				pos: position{line: 1341, col: 6, offset: 36281},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1342, col: 6, offset: 36283},
+					pos:  position{line: 1341, col: 6, offset: 36281},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1344, col: 1, offset: 36294},
+			pos:  position{line: 1343, col: 1, offset: 36292},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1344, col: 6, offset: 36299},
+				pos: position{line: 1343, col: 6, offset: 36297},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1344, col: 6, offset: 36299},
+					pos:  position{line: 1343, col: 6, offset: 36297},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1346, col: 1, offset: 36310},
+			pos:  position{line: 1345, col: 1, offset: 36308},
 			expr: &choiceExpr{
-				pos: position{line: 1347, col: 5, offset: 36323},
+				pos: position{line: 1346, col: 5, offset: 36321},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1347, col: 5, offset: 36323},
+						pos:  position{line: 1346, col: 5, offset: 36321},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1348, col: 5, offset: 36338},
+						pos:  position{line: 1347, col: 5, offset: 36336},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1349, col: 5, offset: 36357},
+						pos:  position{line: 1348, col: 5, offset: 36355},
 						name: "Comment",
 					},
 				},
@@ -11152,45 +11152,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1351, col: 1, offset: 36366},
+			pos:  position{line: 1350, col: 1, offset: 36364},
 			expr: &anyMatcher{
-				line: 1352, col: 5, offset: 36386,
+				line: 1351, col: 5, offset: 36384,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1354, col: 1, offset: 36389},
+			pos:         position{line: 1353, col: 1, offset: 36387},
 			expr: &choiceExpr{
-				pos: position{line: 1355, col: 5, offset: 36417},
+				pos: position{line: 1354, col: 5, offset: 36415},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1355, col: 5, offset: 36417},
+						pos:        position{line: 1354, col: 5, offset: 36415},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1356, col: 5, offset: 36426},
+						pos:        position{line: 1355, col: 5, offset: 36424},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1357, col: 5, offset: 36435},
+						pos:        position{line: 1356, col: 5, offset: 36433},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1358, col: 5, offset: 36444},
+						pos:        position{line: 1357, col: 5, offset: 36442},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1359, col: 5, offset: 36452},
+						pos:        position{line: 1358, col: 5, offset: 36450},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1360, col: 5, offset: 36465},
+						pos:        position{line: 1359, col: 5, offset: 36463},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11199,9 +11199,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1362, col: 1, offset: 36475},
+			pos:  position{line: 1361, col: 1, offset: 36473},
 			expr: &charClassMatcher{
-				pos:        position{line: 1363, col: 5, offset: 36494},
+				pos:        position{line: 1362, col: 5, offset: 36492},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11211,45 +11211,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1369, col: 1, offset: 36824},
+			pos:         position{line: 1368, col: 1, offset: 36822},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1372, col: 5, offset: 36895},
+				pos:  position{line: 1371, col: 5, offset: 36893},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1374, col: 1, offset: 36914},
+			pos:  position{line: 1373, col: 1, offset: 36912},
 			expr: &seqExpr{
-				pos: position{line: 1375, col: 5, offset: 36935},
+				pos: position{line: 1374, col: 5, offset: 36933},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1375, col: 5, offset: 36935},
+						pos:        position{line: 1374, col: 5, offset: 36933},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1375, col: 10, offset: 36940},
+						pos: position{line: 1374, col: 10, offset: 36938},
 						expr: &seqExpr{
-							pos: position{line: 1375, col: 11, offset: 36941},
+							pos: position{line: 1374, col: 11, offset: 36939},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1375, col: 11, offset: 36941},
+									pos: position{line: 1374, col: 11, offset: 36939},
 									expr: &litMatcher{
-										pos:        position{line: 1375, col: 12, offset: 36942},
+										pos:        position{line: 1374, col: 12, offset: 36940},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1375, col: 17, offset: 36947},
+									pos:  position{line: 1374, col: 17, offset: 36945},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1375, col: 35, offset: 36965},
+						pos:        position{line: 1374, col: 35, offset: 36963},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11258,29 +11258,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1377, col: 1, offset: 36971},
+			pos:  position{line: 1376, col: 1, offset: 36969},
 			expr: &seqExpr{
-				pos: position{line: 1378, col: 5, offset: 36993},
+				pos: position{line: 1377, col: 5, offset: 36991},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1378, col: 5, offset: 36993},
+						pos:        position{line: 1377, col: 5, offset: 36991},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1378, col: 10, offset: 36998},
+						pos: position{line: 1377, col: 10, offset: 36996},
 						expr: &seqExpr{
-							pos: position{line: 1378, col: 11, offset: 36999},
+							pos: position{line: 1377, col: 11, offset: 36997},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1378, col: 11, offset: 36999},
+									pos: position{line: 1377, col: 11, offset: 36997},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1378, col: 12, offset: 37000},
+										pos:  position{line: 1377, col: 12, offset: 36998},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1378, col: 27, offset: 37015},
+									pos:  position{line: 1377, col: 27, offset: 37013},
 									name: "SourceCharacter",
 								},
 							},
@@ -11291,19 +11291,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1380, col: 1, offset: 37034},
+			pos:  position{line: 1379, col: 1, offset: 37032},
 			expr: &seqExpr{
-				pos: position{line: 1380, col: 7, offset: 37040},
+				pos: position{line: 1379, col: 7, offset: 37038},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1380, col: 7, offset: 37040},
+						pos: position{line: 1379, col: 7, offset: 37038},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1380, col: 7, offset: 37040},
+							pos:  position{line: 1379, col: 7, offset: 37038},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1380, col: 19, offset: 37052},
+						pos:  position{line: 1379, col: 19, offset: 37050},
 						name: "LineTerminator",
 					},
 				},
@@ -11311,16 +11311,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1382, col: 1, offset: 37068},
+			pos:  position{line: 1381, col: 1, offset: 37066},
 			expr: &choiceExpr{
-				pos: position{line: 1382, col: 7, offset: 37074},
+				pos: position{line: 1381, col: 7, offset: 37072},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1382, col: 7, offset: 37074},
+						pos:  position{line: 1381, col: 7, offset: 37072},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1382, col: 11, offset: 37078},
+						pos:  position{line: 1381, col: 11, offset: 37076},
 						name: "EOF",
 					},
 				},
@@ -11328,11 +11328,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1384, col: 1, offset: 37083},
+			pos:  position{line: 1383, col: 1, offset: 37081},
 			expr: &notExpr{
-				pos: position{line: 1384, col: 7, offset: 37089},
+				pos: position{line: 1383, col: 7, offset: 37087},
 				expr: &anyMatcher{
-					line: 1384, col: 8, offset: 37090,
+					line: 1383, col: 8, offset: 37088,
 				},
 			},
 		},

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -582,30 +582,36 @@ function peg$parse(input, options) {
       peg$c253 = function(field) {
       	  return {"kind":"Merge", "field":field}
           },
-      peg$c254 = "over",
-      peg$c255 = peg$literalExpectation("over", true),
-      peg$c256 = function(exprs) {
-            return {"kind":"Over", "exprs":exprs, "scope":null}
+      peg$c254 = function(over) {
+            return {"kind":"Let", "locals":null, "over":over}
           },
-      peg$c257 = function(exprs, scope) {
-            return {"kind":"Over", "exprs":exprs, "scope":scope}
+      peg$c255 = "over",
+      peg$c256 = peg$literalExpectation("over", true),
+      peg$c257 = function(exprs) {
+            return {"kind":"Over", "exprs":exprs, "scope":null, "as":""}
           },
-      peg$c258 = "let",
-      peg$c259 = peg$literalExpectation("let", true),
-      peg$c260 = function(locals, over) {
+      peg$c258 = function(exprs, as, scope) {
+            return {"kind":"Over", "exprs":exprs, "scope":scope, "as":as}
+          },
+      peg$c259 = "as",
+      peg$c260 = peg$literalExpectation("as", false),
+      peg$c261 = function() { return "" },
+      peg$c262 = "let",
+      peg$c263 = peg$literalExpectation("let", true),
+      peg$c264 = function(locals, over) {
             return {"kind":"Let", "locals":locals, "over":over}
           },
-      peg$c261 = function(seq) { return seq },
-      peg$c262 = function(first, a) { return a },
-      peg$c263 = "yield",
-      peg$c264 = peg$literalExpectation("yield", true),
-      peg$c265 = function(exprs) {
+      peg$c265 = function(seq) { return seq },
+      peg$c266 = function(first, a) { return a },
+      peg$c267 = "yield",
+      peg$c268 = peg$literalExpectation("yield", true),
+      peg$c269 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c266 = function(typ) { return typ},
-      peg$c267 = function(lhs) { return lhs },
-      peg$c268 = function(first, lval) { return lval },
-      peg$c269 = function(first, rest) {
+      peg$c270 = function(typ) { return typ},
+      peg$c271 = function(lhs) { return lhs },
+      peg$c272 = function(first, lval) { return lval },
+      peg$c273 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -614,53 +620,53 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c270 = function(first, rest) {
+      peg$c274 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c271 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c272 = "?",
-      peg$c273 = peg$literalExpectation("?", false),
-      peg$c274 = function(condition, thenClause, elseClause) {
+      peg$c275 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c276 = "?",
+      peg$c277 = peg$literalExpectation("?", false),
+      peg$c278 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c275 = function(first, op, expr) { return [op, expr] },
-      peg$c276 = function(first, rest) {
+      peg$c279 = function(first, op, expr) { return [op, expr] },
+      peg$c280 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c277 = function(first, comp, expr) { return [comp, expr] },
-      peg$c278 = function() { return "="},
-      peg$c279 = "+",
-      peg$c280 = peg$literalExpectation("+", false),
-      peg$c281 = "-",
-      peg$c282 = peg$literalExpectation("-", false),
-      peg$c283 = "/",
-      peg$c284 = peg$literalExpectation("/", false),
-      peg$c285 = "%",
-      peg$c286 = peg$literalExpectation("%", false),
-      peg$c287 = function(e) {
+      peg$c281 = function(first, comp, expr) { return [comp, expr] },
+      peg$c282 = function() { return "="},
+      peg$c283 = "+",
+      peg$c284 = peg$literalExpectation("+", false),
+      peg$c285 = "-",
+      peg$c286 = peg$literalExpectation("-", false),
+      peg$c287 = "/",
+      peg$c288 = peg$literalExpectation("/", false),
+      peg$c289 = "%",
+      peg$c290 = peg$literalExpectation("%", false),
+      peg$c291 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c288 = "not",
-      peg$c289 = peg$literalExpectation("not", false),
-      peg$c290 = "search",
-      peg$c291 = peg$literalExpectation("search", false),
-      peg$c292 = "select",
-      peg$c293 = peg$literalExpectation("select", false),
-      peg$c294 = function(typ, expr) {
+      peg$c292 = "not",
+      peg$c293 = peg$literalExpectation("not", false),
+      peg$c294 = "search",
+      peg$c295 = peg$literalExpectation("search", false),
+      peg$c296 = "select",
+      peg$c297 = peg$literalExpectation("select", false),
+      peg$c298 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c295 = function(fn, args, where) {
+      peg$c299 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c296 = function(first, e) { return e },
-      peg$c297 = function(e) { return e },
-      peg$c298 = function() {
+      peg$c300 = function(first, e) { return e },
+      peg$c301 = function(e) { return e },
+      peg$c302 = function() {
             return {"kind":"ID","name":"this"}
           },
-      peg$c299 = "this",
-      peg$c300 = peg$literalExpectation("this", false),
-      peg$c301 = function() { return {"kind":"ID","name":"this"} },
-      peg$c302 = function(field) {
+      peg$c303 = "this",
+      peg$c304 = peg$literalExpectation("this", false),
+      peg$c305 = function() { return {"kind":"ID","name":"this"} },
+      peg$c306 = function(field) {
             return {"kind": "BinaryExpr", "op":".",
                            
             "lhs":{"kind":"ID","name":"this"},
@@ -669,9 +675,9 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c303 = "]",
-      peg$c304 = peg$literalExpectation("]", false),
-      peg$c305 = function(expr) {
+      peg$c307 = "]",
+      peg$c308 = peg$literalExpectation("]", false),
+      peg$c309 = function(expr) {
             return {"kind": "BinaryExpr", "op":"[",
                            
             "lhs":{"kind":"ID","name":"this"},
@@ -680,55 +686,55 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c306 = function(from, to) {
+      peg$c310 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c307 = function(to) {
+      peg$c311 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c308 = function(from) {
+      peg$c312 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c309 = function(expr) { return ["[", expr] },
-      peg$c310 = function(id) { return [".", id] },
-      peg$c311 = "}",
-      peg$c312 = peg$literalExpectation("}", false),
-      peg$c313 = function(fields) {
+      peg$c313 = function(expr) { return ["[", expr] },
+      peg$c314 = function(id) { return [".", id] },
+      peg$c315 = "}",
+      peg$c316 = peg$literalExpectation("}", false),
+      peg$c317 = function(fields) {
             return {"kind":"RecordExpr", "fields":fields }
           },
-      peg$c314 = function(name, value) {
+      peg$c318 = function(name, value) {
             return {"name": name, "value": value}
           },
-      peg$c315 = function(exprs) {
+      peg$c319 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c316 = "|[",
-      peg$c317 = peg$literalExpectation("|[", false),
-      peg$c318 = "]|",
-      peg$c319 = peg$literalExpectation("]|", false),
-      peg$c320 = function(exprs) {
+      peg$c320 = "|[",
+      peg$c321 = peg$literalExpectation("|[", false),
+      peg$c322 = "]|",
+      peg$c323 = peg$literalExpectation("]|", false),
+      peg$c324 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c321 = "|{",
-      peg$c322 = peg$literalExpectation("|{", false),
-      peg$c323 = "}|",
-      peg$c324 = peg$literalExpectation("}|", false),
-      peg$c325 = function(exprs) {
+      peg$c325 = "|{",
+      peg$c326 = peg$literalExpectation("|{", false),
+      peg$c327 = "}|",
+      peg$c328 = peg$literalExpectation("}|", false),
+      peg$c329 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c326 = function(key, value) {
+      peg$c330 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c327 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c331 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -750,13 +756,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c328 = function(assignments) { return assignments },
-      peg$c329 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c330 = function(table, alias) {
+      peg$c332 = function(assignments) { return assignments },
+      peg$c333 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c334 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c331 = function(first, join) { return join },
-      peg$c332 = function(style, table, alias, leftKey, rightKey) {
+      peg$c335 = function(first, join) { return join },
+      peg$c336 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -774,290 +780,289 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c333 = function(style) { return style },
-      peg$c334 = function(keys, order) {
+      peg$c337 = function(style) { return style },
+      peg$c338 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c335 = function(dir) { return dir },
-      peg$c336 = function(count) { return count },
-      peg$c337 = peg$literalExpectation("select", true),
-      peg$c338 = function() { return "select" },
-      peg$c339 = "as",
-      peg$c340 = peg$literalExpectation("as", true),
-      peg$c341 = function() { return "as" },
-      peg$c342 = function() { return "from" },
-      peg$c343 = function() { return "join" },
-      peg$c344 = peg$literalExpectation("where", true),
-      peg$c345 = function() { return "where" },
-      peg$c346 = "group",
-      peg$c347 = peg$literalExpectation("group", true),
-      peg$c348 = function() { return "group" },
-      peg$c349 = "having",
-      peg$c350 = peg$literalExpectation("having", true),
-      peg$c351 = function() { return "having" },
-      peg$c352 = function() { return "order" },
-      peg$c353 = "on",
-      peg$c354 = peg$literalExpectation("on", true),
-      peg$c355 = function() { return "on" },
-      peg$c356 = "limit",
-      peg$c357 = peg$literalExpectation("limit", true),
-      peg$c358 = function() { return "limit" },
-      peg$c359 = function(v) {
+      peg$c339 = function(dir) { return dir },
+      peg$c340 = function(count) { return count },
+      peg$c341 = peg$literalExpectation("select", true),
+      peg$c342 = function() { return "select" },
+      peg$c343 = peg$literalExpectation("as", true),
+      peg$c344 = function() { return "as" },
+      peg$c345 = function() { return "from" },
+      peg$c346 = function() { return "join" },
+      peg$c347 = peg$literalExpectation("where", true),
+      peg$c348 = function() { return "where" },
+      peg$c349 = "group",
+      peg$c350 = peg$literalExpectation("group", true),
+      peg$c351 = function() { return "group" },
+      peg$c352 = "having",
+      peg$c353 = peg$literalExpectation("having", true),
+      peg$c354 = function() { return "having" },
+      peg$c355 = function() { return "order" },
+      peg$c356 = "on",
+      peg$c357 = peg$literalExpectation("on", true),
+      peg$c358 = function() { return "on" },
+      peg$c359 = "limit",
+      peg$c360 = peg$literalExpectation("limit", true),
+      peg$c361 = function() { return "limit" },
+      peg$c362 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c360 = function(v) {
+      peg$c363 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c361 = function(v) {
+      peg$c364 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c362 = function(v) {
+      peg$c365 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c363 = "true",
-      peg$c364 = peg$literalExpectation("true", false),
-      peg$c365 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c366 = "false",
-      peg$c367 = peg$literalExpectation("false", false),
-      peg$c368 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c369 = "null",
-      peg$c370 = peg$literalExpectation("null", false),
-      peg$c371 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c372 = "0x",
-      peg$c373 = peg$literalExpectation("0x", false),
-      peg$c374 = function() {
+      peg$c366 = "true",
+      peg$c367 = peg$literalExpectation("true", false),
+      peg$c368 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c369 = "false",
+      peg$c370 = peg$literalExpectation("false", false),
+      peg$c371 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c372 = "null",
+      peg$c373 = peg$literalExpectation("null", false),
+      peg$c374 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c375 = "0x",
+      peg$c376 = peg$literalExpectation("0x", false),
+      peg$c377 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c375 = function(typ) {
+      peg$c378 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c376 = function(name) { return name },
-      peg$c377 = function(name, typ) {
+      peg$c379 = function(name) { return name },
+      peg$c380 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c378 = function(name) {
+      peg$c381 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c379 = function(u) { return u },
-      peg$c380 = function(types) {
+      peg$c382 = function(u) { return u },
+      peg$c383 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c381 = function(typ) { return typ },
-      peg$c382 = function(fields) {
+      peg$c384 = function(typ) { return typ },
+      peg$c385 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c383 = function(typ) {
+      peg$c386 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c384 = function(typ) {
+      peg$c387 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c385 = function(keyType, valType) {
+      peg$c388 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c386 = function(v) {
+      peg$c389 = function(v) {
             if (!v) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c387 = "\"",
-      peg$c388 = peg$literalExpectation("\"", false),
-      peg$c389 = "'",
-      peg$c390 = peg$literalExpectation("'", false),
-      peg$c391 = function(v) {
+      peg$c390 = "\"",
+      peg$c391 = peg$literalExpectation("\"", false),
+      peg$c392 = "'",
+      peg$c393 = peg$literalExpectation("'", false),
+      peg$c394 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c392 = "\\",
-      peg$c393 = peg$literalExpectation("\\", false),
-      peg$c394 = "${",
-      peg$c395 = peg$literalExpectation("${", false),
-      peg$c396 = "uint8",
-      peg$c397 = peg$literalExpectation("uint8", false),
-      peg$c398 = "uint16",
-      peg$c399 = peg$literalExpectation("uint16", false),
-      peg$c400 = "uint32",
-      peg$c401 = peg$literalExpectation("uint32", false),
-      peg$c402 = "uint64",
-      peg$c403 = peg$literalExpectation("uint64", false),
-      peg$c404 = "int8",
-      peg$c405 = peg$literalExpectation("int8", false),
-      peg$c406 = "int16",
-      peg$c407 = peg$literalExpectation("int16", false),
-      peg$c408 = "int32",
-      peg$c409 = peg$literalExpectation("int32", false),
-      peg$c410 = "int64",
-      peg$c411 = peg$literalExpectation("int64", false),
-      peg$c412 = "float32",
-      peg$c413 = peg$literalExpectation("float32", false),
-      peg$c414 = "float64",
-      peg$c415 = peg$literalExpectation("float64", false),
-      peg$c416 = "bool",
-      peg$c417 = peg$literalExpectation("bool", false),
-      peg$c418 = "string",
-      peg$c419 = peg$literalExpectation("string", false),
-      peg$c420 = "duration",
-      peg$c421 = peg$literalExpectation("duration", false),
-      peg$c422 = "time",
-      peg$c423 = peg$literalExpectation("time", false),
-      peg$c424 = "bytes",
-      peg$c425 = peg$literalExpectation("bytes", false),
-      peg$c426 = "ip",
-      peg$c427 = peg$literalExpectation("ip", false),
-      peg$c428 = "net",
-      peg$c429 = peg$literalExpectation("net", false),
-      peg$c430 = "error",
-      peg$c431 = peg$literalExpectation("error", false),
-      peg$c432 = function() {
+      peg$c395 = "\\",
+      peg$c396 = peg$literalExpectation("\\", false),
+      peg$c397 = "${",
+      peg$c398 = peg$literalExpectation("${", false),
+      peg$c399 = "uint8",
+      peg$c400 = peg$literalExpectation("uint8", false),
+      peg$c401 = "uint16",
+      peg$c402 = peg$literalExpectation("uint16", false),
+      peg$c403 = "uint32",
+      peg$c404 = peg$literalExpectation("uint32", false),
+      peg$c405 = "uint64",
+      peg$c406 = peg$literalExpectation("uint64", false),
+      peg$c407 = "int8",
+      peg$c408 = peg$literalExpectation("int8", false),
+      peg$c409 = "int16",
+      peg$c410 = peg$literalExpectation("int16", false),
+      peg$c411 = "int32",
+      peg$c412 = peg$literalExpectation("int32", false),
+      peg$c413 = "int64",
+      peg$c414 = peg$literalExpectation("int64", false),
+      peg$c415 = "float32",
+      peg$c416 = peg$literalExpectation("float32", false),
+      peg$c417 = "float64",
+      peg$c418 = peg$literalExpectation("float64", false),
+      peg$c419 = "bool",
+      peg$c420 = peg$literalExpectation("bool", false),
+      peg$c421 = "string",
+      peg$c422 = peg$literalExpectation("string", false),
+      peg$c423 = "duration",
+      peg$c424 = peg$literalExpectation("duration", false),
+      peg$c425 = "time",
+      peg$c426 = peg$literalExpectation("time", false),
+      peg$c427 = "bytes",
+      peg$c428 = peg$literalExpectation("bytes", false),
+      peg$c429 = "ip",
+      peg$c430 = peg$literalExpectation("ip", false),
+      peg$c431 = "net",
+      peg$c432 = peg$literalExpectation("net", false),
+      peg$c433 = "error",
+      peg$c434 = peg$literalExpectation("error", false),
+      peg$c435 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c433 = function(name, typ) {
+      peg$c436 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c434 = "and",
-      peg$c435 = peg$literalExpectation("and", true),
-      peg$c436 = function() { return "and" },
-      peg$c437 = "or",
-      peg$c438 = peg$literalExpectation("or", true),
-      peg$c439 = function() { return "or" },
-      peg$c440 = peg$literalExpectation("in", true),
-      peg$c441 = function() { return "in" },
-      peg$c442 = peg$literalExpectation("not", true),
-      peg$c443 = function() { return "not" },
-      peg$c444 = "by",
-      peg$c445 = peg$literalExpectation("by", true),
-      peg$c446 = function() { return "by" },
-      peg$c447 = /^[A-Za-z_$]/,
-      peg$c448 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c449 = /^[0-9]/,
-      peg$c450 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c451 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c452 = "$",
-      peg$c453 = peg$literalExpectation("$", false),
-      peg$c454 = "T",
-      peg$c455 = peg$literalExpectation("T", false),
-      peg$c456 = function() {
+      peg$c437 = "and",
+      peg$c438 = peg$literalExpectation("and", true),
+      peg$c439 = function() { return "and" },
+      peg$c440 = "or",
+      peg$c441 = peg$literalExpectation("or", true),
+      peg$c442 = function() { return "or" },
+      peg$c443 = peg$literalExpectation("in", true),
+      peg$c444 = function() { return "in" },
+      peg$c445 = peg$literalExpectation("not", true),
+      peg$c446 = function() { return "not" },
+      peg$c447 = "by",
+      peg$c448 = peg$literalExpectation("by", true),
+      peg$c449 = function() { return "by" },
+      peg$c450 = /^[A-Za-z_$]/,
+      peg$c451 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c452 = /^[0-9]/,
+      peg$c453 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c454 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c455 = "$",
+      peg$c456 = peg$literalExpectation("$", false),
+      peg$c457 = "T",
+      peg$c458 = peg$literalExpectation("T", false),
+      peg$c459 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c457 = "Z",
-      peg$c458 = peg$literalExpectation("Z", false),
-      peg$c459 = function() {
+      peg$c460 = "Z",
+      peg$c461 = peg$literalExpectation("Z", false),
+      peg$c462 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c460 = "ns",
-      peg$c461 = peg$literalExpectation("ns", true),
-      peg$c462 = "us",
-      peg$c463 = peg$literalExpectation("us", true),
-      peg$c464 = "ms",
-      peg$c465 = peg$literalExpectation("ms", true),
-      peg$c466 = "s",
-      peg$c467 = peg$literalExpectation("s", true),
-      peg$c468 = "m",
-      peg$c469 = peg$literalExpectation("m", true),
-      peg$c470 = "h",
-      peg$c471 = peg$literalExpectation("h", true),
-      peg$c472 = "d",
-      peg$c473 = peg$literalExpectation("d", true),
-      peg$c474 = "w",
-      peg$c475 = peg$literalExpectation("w", true),
-      peg$c476 = "y",
-      peg$c477 = peg$literalExpectation("y", true),
-      peg$c478 = function(a, b) {
+      peg$c463 = "ns",
+      peg$c464 = peg$literalExpectation("ns", true),
+      peg$c465 = "us",
+      peg$c466 = peg$literalExpectation("us", true),
+      peg$c467 = "ms",
+      peg$c468 = peg$literalExpectation("ms", true),
+      peg$c469 = "s",
+      peg$c470 = peg$literalExpectation("s", true),
+      peg$c471 = "m",
+      peg$c472 = peg$literalExpectation("m", true),
+      peg$c473 = "h",
+      peg$c474 = peg$literalExpectation("h", true),
+      peg$c475 = "d",
+      peg$c476 = peg$literalExpectation("d", true),
+      peg$c477 = "w",
+      peg$c478 = peg$literalExpectation("w", true),
+      peg$c479 = "y",
+      peg$c480 = peg$literalExpectation("y", true),
+      peg$c481 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c479 = "::",
-      peg$c480 = peg$literalExpectation("::", false),
-      peg$c481 = function(a, b, d, e) {
+      peg$c482 = "::",
+      peg$c483 = peg$literalExpectation("::", false),
+      peg$c484 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c482 = function(a, b) {
+      peg$c485 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c483 = function(a, b) {
+      peg$c486 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c484 = function() {
+      peg$c487 = function() {
             return "::"
           },
-      peg$c485 = function(v) { return ":" + v },
-      peg$c486 = function(v) { return v + ":" },
-      peg$c487 = function(a, m) {
+      peg$c488 = function(v) { return ":" + v },
+      peg$c489 = function(v) { return v + ":" },
+      peg$c490 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c488 = function(a, m) {
+      peg$c491 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c489 = function(s) { return parseInt(s) },
-      peg$c490 = function() {
+      peg$c492 = function(s) { return parseInt(s) },
+      peg$c493 = function() {
             return text()
           },
-      peg$c491 = "e",
-      peg$c492 = peg$literalExpectation("e", true),
-      peg$c493 = /^[+\-]/,
-      peg$c494 = peg$classExpectation(["+", "-"], false, false),
-      peg$c495 = /^[0-9a-fA-F]/,
-      peg$c496 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c497 = function(v) { return joinChars(v) },
-      peg$c498 = peg$anyExpectation(),
-      peg$c499 = function(head, tail) { return head + joinChars(tail) },
-      peg$c500 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c501 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c502 = function(head, tail) {
+      peg$c494 = "e",
+      peg$c495 = peg$literalExpectation("e", true),
+      peg$c496 = /^[+\-]/,
+      peg$c497 = peg$classExpectation(["+", "-"], false, false),
+      peg$c498 = /^[0-9a-fA-F]/,
+      peg$c499 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c500 = function(v) { return joinChars(v) },
+      peg$c501 = peg$anyExpectation(),
+      peg$c502 = function(head, tail) { return head + joinChars(tail) },
+      peg$c503 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c504 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c505 = function(head, tail) {
             return reglob.Reglob(head + joinChars(tail))
           },
-      peg$c503 = function() { return "*"},
-      peg$c504 = function() { return "=" },
-      peg$c505 = function() { return "\\*" },
-      peg$c506 = "b",
-      peg$c507 = peg$literalExpectation("b", false),
-      peg$c508 = function() { return "\b" },
-      peg$c509 = "f",
-      peg$c510 = peg$literalExpectation("f", false),
-      peg$c511 = function() { return "\f" },
-      peg$c512 = "n",
-      peg$c513 = peg$literalExpectation("n", false),
-      peg$c514 = function() { return "\n" },
-      peg$c515 = "r",
-      peg$c516 = peg$literalExpectation("r", false),
-      peg$c517 = function() { return "\r" },
-      peg$c518 = "t",
-      peg$c519 = peg$literalExpectation("t", false),
-      peg$c520 = function() { return "\t" },
-      peg$c521 = "v",
-      peg$c522 = peg$literalExpectation("v", false),
-      peg$c523 = function() { return "\v" },
-      peg$c524 = function() { return "*" },
-      peg$c525 = "u",
-      peg$c526 = peg$literalExpectation("u", false),
-      peg$c527 = function(chars) {
+      peg$c506 = function() { return "*"},
+      peg$c507 = function() { return "=" },
+      peg$c508 = function() { return "\\*" },
+      peg$c509 = "b",
+      peg$c510 = peg$literalExpectation("b", false),
+      peg$c511 = function() { return "\b" },
+      peg$c512 = "f",
+      peg$c513 = peg$literalExpectation("f", false),
+      peg$c514 = function() { return "\f" },
+      peg$c515 = "n",
+      peg$c516 = peg$literalExpectation("n", false),
+      peg$c517 = function() { return "\n" },
+      peg$c518 = "r",
+      peg$c519 = peg$literalExpectation("r", false),
+      peg$c520 = function() { return "\r" },
+      peg$c521 = "t",
+      peg$c522 = peg$literalExpectation("t", false),
+      peg$c523 = function() { return "\t" },
+      peg$c524 = "v",
+      peg$c525 = peg$literalExpectation("v", false),
+      peg$c526 = function() { return "\v" },
+      peg$c527 = function() { return "*" },
+      peg$c528 = "u",
+      peg$c529 = peg$literalExpectation("u", false),
+      peg$c530 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c528 = /^[^\/\\]/,
-      peg$c529 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c530 = /^[\0-\x1F\\]/,
-      peg$c531 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c532 = peg$otherExpectation("whitespace"),
-      peg$c533 = "\t",
-      peg$c534 = peg$literalExpectation("\t", false),
-      peg$c535 = "\x0B",
-      peg$c536 = peg$literalExpectation("\x0B", false),
-      peg$c537 = "\f",
-      peg$c538 = peg$literalExpectation("\f", false),
-      peg$c539 = " ",
-      peg$c540 = peg$literalExpectation(" ", false),
-      peg$c541 = "\xA0",
-      peg$c542 = peg$literalExpectation("\xA0", false),
-      peg$c543 = "\uFEFF",
-      peg$c544 = peg$literalExpectation("\uFEFF", false),
-      peg$c545 = /^[\n\r\u2028\u2029]/,
-      peg$c546 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c547 = peg$otherExpectation("comment"),
-      peg$c548 = "/*",
-      peg$c549 = peg$literalExpectation("/*", false),
-      peg$c550 = "*/",
-      peg$c551 = peg$literalExpectation("*/", false),
-      peg$c552 = "//",
-      peg$c553 = peg$literalExpectation("//", false),
+      peg$c531 = /^[^\/\\]/,
+      peg$c532 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c533 = /^[\0-\x1F\\]/,
+      peg$c534 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c535 = peg$otherExpectation("whitespace"),
+      peg$c536 = "\t",
+      peg$c537 = peg$literalExpectation("\t", false),
+      peg$c538 = "\x0B",
+      peg$c539 = peg$literalExpectation("\x0B", false),
+      peg$c540 = "\f",
+      peg$c541 = peg$literalExpectation("\f", false),
+      peg$c542 = " ",
+      peg$c543 = peg$literalExpectation(" ", false),
+      peg$c544 = "\xA0",
+      peg$c545 = peg$literalExpectation("\xA0", false),
+      peg$c546 = "\uFEFF",
+      peg$c547 = peg$literalExpectation("\uFEFF", false),
+      peg$c548 = /^[\n\r\u2028\u2029]/,
+      peg$c549 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c550 = peg$otherExpectation("comment"),
+      peg$c551 = "/*",
+      peg$c552 = peg$literalExpectation("/*", false),
+      peg$c553 = "*/",
+      peg$c554 = peg$literalExpectation("*/", false),
+      peg$c555 = "//",
+      peg$c556 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -5897,15 +5902,21 @@ function peg$parse(input, options) {
   function peg$parseOverProc() {
     var s0, s1, s2, s3;
 
-    s0 = peg$parseScopedOver();
+    s0 = peg$currPos;
+    s1 = peg$parseScopedOver();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c254(s1);
+    }
+    s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c254) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c255) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c255); }
+        if (peg$silentFails === 0) { peg$fail(peg$c256); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5913,7 +5924,7 @@ function peg$parse(input, options) {
           s3 = peg$parseExprs();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c256(s3);
+            s1 = peg$c257(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5933,28 +5944,34 @@ function peg$parse(input, options) {
   }
 
   function peg$parseScopedOver() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c254) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c255) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          s4 = peg$parseAs();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseScope();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c257(s3, s5);
-              s0 = s1;
+              s6 = peg$parseScope();
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c258(s3, s4, s6);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -5979,16 +5996,66 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseAs() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c259) {
+        s2 = peg$c259;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c260); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseIdentifierName();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c214(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$c99;
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c261();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
   function peg$parseLetProc() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c258) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c262) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c259); }
+      if (peg$silentFails === 0) { peg$fail(peg$c263); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6000,7 +6067,7 @@ function peg$parse(input, options) {
             s5 = peg$parseScopedOver();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c260(s3, s5);
+              s1 = peg$c264(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6063,7 +6130,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c261(s5);
+                  s1 = peg$c265(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6120,7 +6187,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLetAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c262(s1, s7);
+              s4 = peg$c266(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6156,7 +6223,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLetAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c262(s1, s7);
+                s4 = peg$c266(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6242,12 +6309,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c263) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c267) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6255,7 +6322,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c265(s3);
+          s1 = peg$c269(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6286,7 +6353,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c266(s4);
+            s1 = peg$c270(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6321,7 +6388,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c267(s4);
+            s1 = peg$c271(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6366,7 +6433,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c268(s1, s7);
+              s4 = peg$c272(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6402,7 +6469,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c268(s1, s7);
+                s4 = peg$c272(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6515,7 +6582,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c269(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6552,7 +6619,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c262(s1, s7);
+              s4 = peg$c266(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6588,7 +6655,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c262(s1, s7);
+                s4 = peg$c266(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6609,7 +6676,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6644,7 +6711,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c271(s1, s5);
+              s1 = peg$c275(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6687,11 +6754,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c272;
+          s3 = peg$c276;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6713,7 +6780,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c274(s1, s5, s9);
+                      s1 = peg$c278(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6775,7 +6842,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6805,7 +6872,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6826,7 +6893,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6857,7 +6924,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6887,7 +6954,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6908,7 +6975,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6941,7 +7008,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c277(s1, s5, s7);
+                s4 = peg$c281(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6971,7 +7038,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRelativeExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s3;
-                  s4 = peg$c277(s1, s5, s7);
+                  s4 = peg$c281(s1, s5, s7);
                   s3 = s4;
                 } else {
                   peg$currPos = s3;
@@ -6992,7 +7059,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c276(s1, s2);
+          s1 = peg$c280(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7020,7 +7087,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c278();
+      s1 = peg$c282();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7100,7 +7167,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7130,7 +7197,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7151,7 +7218,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7229,7 +7296,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7259,7 +7326,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7280,7 +7347,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7299,19 +7366,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c279;
+      s1 = peg$c283;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c281;
+        s1 = peg$c285;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7340,7 +7407,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c279(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7370,7 +7437,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c279(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7391,7 +7458,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c280(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7418,19 +7485,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c283;
+        s1 = peg$c287;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c285;
+          s1 = peg$c289;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c290); }
         }
       }
     }
@@ -7460,7 +7527,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c287(s3);
+          s1 = peg$c291(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7578,28 +7645,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c288) {
-      s0 = peg$c288;
+    if (input.substr(peg$currPos, 3) === peg$c292) {
+      s0 = peg$c292;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c289); }
+      if (peg$silentFails === 0) { peg$fail(peg$c293); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c290) {
-        s0 = peg$c290;
+      if (input.substr(peg$currPos, 6) === peg$c294) {
+        s0 = peg$c294;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c291); }
+        if (peg$silentFails === 0) { peg$fail(peg$c295); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c292) {
-          s0 = peg$c292;
+        if (input.substr(peg$currPos, 6) === peg$c296) {
+          s0 = peg$c296;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c293); }
+          if (peg$silentFails === 0) { peg$fail(peg$c297); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c11) {
@@ -7620,12 +7687,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c290) {
-      s1 = peg$c290;
+    if (input.substr(peg$currPos, 6) === peg$c294) {
+      s1 = peg$c294;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7706,7 +7773,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c294(s1, s5);
+                  s1 = peg$c298(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7787,7 +7854,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c295(s2, s6, s9);
+                      s1 = peg$c299(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7869,7 +7936,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c296(s1, s7);
+              s4 = peg$c300(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7905,7 +7972,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c296(s1, s7);
+                s4 = peg$c300(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7958,7 +8025,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExprPattern();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c297(s2);
+        s1 = peg$c301(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8051,7 +8118,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298();
+            s1 = peg$c302();
           }
           s0 = s1;
         }
@@ -8065,16 +8132,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c299) {
-      s1 = peg$c299;
+    if (input.substr(peg$currPos, 4) === peg$c303) {
+      s1 = peg$c303;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
+      if (peg$silentFails === 0) { peg$fail(peg$c304); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c301();
+      s1 = peg$c305();
     }
     s0 = s1;
 
@@ -8096,7 +8163,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c302(s2);
+        s1 = peg$c306(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8127,15 +8194,15 @@ function peg$parse(input, options) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c303;
+              s4 = peg$c307;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c304); }
+              if (peg$silentFails === 0) { peg$fail(peg$c308); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305(s3);
+              s1 = peg$c309(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8187,15 +8254,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c303;
+                  s7 = peg$c307;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c308); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c306(s2, s6);
+                  s1 = peg$c310(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8250,15 +8317,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c303;
+                  s6 = peg$c307;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c308); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c307(s5);
+                  s1 = peg$c311(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8309,15 +8376,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c303;
+                    s6 = peg$c307;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c308); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c308(s2);
+                    s1 = peg$c312(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8356,15 +8423,15 @@ function peg$parse(input, options) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c303;
+                s3 = peg$c307;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                if (peg$silentFails === 0) { peg$fail(peg$c308); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c309(s2);
+                s1 = peg$c313(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8408,7 +8475,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c310(s3);
+                  s1 = peg$c314(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8517,15 +8584,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c315;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313(s3);
+              s1 = peg$c317(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8565,7 +8632,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8650,7 +8717,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314(s1, s5);
+              s1 = peg$c318(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8695,15 +8762,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c303;
+              s5 = peg$c307;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c304); }
+              if (peg$silentFails === 0) { peg$fail(peg$c308); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s3);
+              s1 = peg$c319(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8733,12 +8800,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c316) {
-      s1 = peg$c316;
+    if (input.substr(peg$currPos, 2) === peg$c320) {
+      s1 = peg$c320;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c321); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8747,16 +8814,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c318) {
-              s5 = peg$c318;
+            if (input.substr(peg$currPos, 2) === peg$c322) {
+              s5 = peg$c322;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c319); }
+              if (peg$silentFails === 0) { peg$fail(peg$c323); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s3);
+              s1 = peg$c324(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8786,12 +8853,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c321) {
-      s1 = peg$c321;
+    if (input.substr(peg$currPos, 2) === peg$c325) {
+      s1 = peg$c325;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c326); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8800,16 +8867,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c323) {
-              s5 = peg$c323;
+            if (input.substr(peg$currPos, 2) === peg$c327) {
+              s5 = peg$c327;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c324); }
+              if (peg$silentFails === 0) { peg$fail(peg$c328); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c325(s3);
+              s1 = peg$c329(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8849,7 +8916,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8891,7 +8958,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c297(s4);
+            s1 = peg$c301(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8934,7 +9001,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c326(s1, s5);
+              s1 = peg$c330(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8999,7 +9066,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c327(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c331(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9077,7 +9144,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c328(s3);
+            s1 = peg$c332(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9111,7 +9178,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c329(s1, s5);
+              s1 = peg$c333(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9258,7 +9325,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s4, s5);
+              s1 = peg$c334(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9413,7 +9480,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c331(s1, s4);
+        s4 = peg$c335(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9422,7 +9489,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c331(s1, s4);
+          s4 = peg$c335(s1, s4);
         }
         s3 = s4;
       }
@@ -9484,7 +9551,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c332(s1, s5, s6, s10, s14);
+                                s1 = peg$c336(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9564,7 +9631,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s2);
+        s1 = peg$c337(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9723,7 +9790,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c334(s6, s7);
+                  s1 = peg$c338(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9769,7 +9836,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c335(s2);
+        s1 = peg$c339(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9805,7 +9872,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c336(s4);
+            s1 = peg$c340(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9840,16 +9907,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c292) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c296) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c337); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c338();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -9860,16 +9927,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c259) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -9889,7 +9956,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c345();
     }
     s0 = s1;
 
@@ -9909,7 +9976,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c343();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -9925,26 +9992,6 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c345();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseGROUP() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
@@ -9956,13 +10003,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseHAVING() {
+  function peg$parseGROUP() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c349) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c350); }
@@ -9970,6 +10017,26 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
       s1 = peg$c351();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseHAVING() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c352) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c354();
     }
     s0 = s1;
 
@@ -9989,7 +10056,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c352();
+      s1 = peg$c355();
     }
     s0 = s1;
 
@@ -10000,16 +10067,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c353) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c356) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c355();
+      s1 = peg$c358();
     }
     s0 = s1;
 
@@ -10020,16 +10087,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c356) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c359) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c358();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10247,7 +10314,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359(s1);
+        s1 = peg$c362(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10262,7 +10329,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359(s1);
+        s1 = peg$c362(s1);
       }
       s0 = s1;
     }
@@ -10288,7 +10355,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c360(s1);
+        s1 = peg$c363(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10303,7 +10370,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c360(s1);
+        s1 = peg$c363(s1);
       }
       s0 = s1;
     }
@@ -10318,7 +10385,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c361(s1);
+      s1 = peg$c364(s1);
     }
     s0 = s1;
 
@@ -10332,7 +10399,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362(s1);
+      s1 = peg$c365(s1);
     }
     s0 = s1;
 
@@ -10343,30 +10410,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c363) {
-      s1 = peg$c363;
+    if (input.substr(peg$currPos, 4) === peg$c366) {
+      s1 = peg$c366;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c365();
+      s1 = peg$c368();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c366) {
-        s1 = peg$c366;
+      if (input.substr(peg$currPos, 5) === peg$c369) {
+        s1 = peg$c369;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c367); }
+        if (peg$silentFails === 0) { peg$fail(peg$c370); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c368();
+        s1 = peg$c371();
       }
       s0 = s1;
     }
@@ -10378,16 +10445,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c369) {
-      s1 = peg$c369;
+    if (input.substr(peg$currPos, 4) === peg$c372) {
+      s1 = peg$c372;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c371();
+      s1 = peg$c374();
     }
     s0 = s1;
 
@@ -10398,12 +10465,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c372) {
-      s1 = peg$c372;
+    if (input.substr(peg$currPos, 2) === peg$c375) {
+      s1 = peg$c375;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c376); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10414,7 +10481,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c374();
+        s1 = peg$c377();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10451,7 +10518,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c375(s2);
+          s1 = peg$c378(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10512,7 +10579,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c379(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10561,7 +10628,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c377(s1, s7);
+                        s1 = peg$c380(s1, s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10604,7 +10671,7 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c378(s1);
+          s1 = peg$c381(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10630,7 +10697,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c379(s3);
+                  s1 = peg$c382(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10662,7 +10729,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c380(s1);
+      s1 = peg$c383(s1);
     }
     s0 = s1;
 
@@ -10687,7 +10754,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10720,7 +10787,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c381(s4);
+            s1 = peg$c384(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10761,15 +10828,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c315;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c382(s3);
+              s1 = peg$c385(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10808,15 +10875,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c303;
+                s5 = peg$c307;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c304); }
+                if (peg$silentFails === 0) { peg$fail(peg$c308); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c383(s3);
+                s1 = peg$c386(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10840,12 +10907,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c316) {
-          s1 = peg$c316;
+        if (input.substr(peg$currPos, 2) === peg$c320) {
+          s1 = peg$c320;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c317); }
+          if (peg$silentFails === 0) { peg$fail(peg$c321); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10854,16 +10921,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c318) {
-                  s5 = peg$c318;
+                if (input.substr(peg$currPos, 2) === peg$c322) {
+                  s5 = peg$c322;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c323); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c384(s3);
+                  s1 = peg$c387(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10887,12 +10954,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c321) {
-            s1 = peg$c321;
+          if (input.substr(peg$currPos, 2) === peg$c325) {
+            s1 = peg$c325;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c322); }
+            if (peg$silentFails === 0) { peg$fail(peg$c326); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10915,16 +10982,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c323) {
-                            s9 = peg$c323;
+                          if (input.substr(peg$currPos, 2) === peg$c327) {
+                            s9 = peg$c327;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c328); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c385(s3, s7);
+                            s1 = peg$c388(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10976,7 +11043,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c386(s1);
+      s1 = peg$c389(s1);
     }
     s0 = s1;
 
@@ -10988,11 +11055,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c387;
+      s1 = peg$c390;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11003,11 +11070,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c387;
+          s3 = peg$c390;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c388); }
+          if (peg$silentFails === 0) { peg$fail(peg$c391); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11028,11 +11095,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c389;
+        s1 = peg$c392;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+        if (peg$silentFails === 0) { peg$fail(peg$c393); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11043,11 +11110,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c389;
+            s3 = peg$c392;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c390); }
+            if (peg$silentFails === 0) { peg$fail(peg$c393); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11088,7 +11155,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391(s1);
+        s1 = peg$c394(s1);
       }
       s0 = s1;
     }
@@ -11101,19 +11168,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c392;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c394) {
-        s2 = peg$c394;
+      if (input.substr(peg$currPos, 2) === peg$c397) {
+        s2 = peg$c397;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c395); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11131,12 +11198,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c394) {
-        s2 = peg$c394;
+      if (input.substr(peg$currPos, 2) === peg$c397) {
+        s2 = peg$c397;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c395); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11182,7 +11249,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391(s1);
+        s1 = peg$c394(s1);
       }
       s0 = s1;
     }
@@ -11195,19 +11262,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c392;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c394) {
-        s2 = peg$c394;
+      if (input.substr(peg$currPos, 2) === peg$c397) {
+        s2 = peg$c397;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c395); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11225,12 +11292,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c394) {
-        s2 = peg$c394;
+      if (input.substr(peg$currPos, 2) === peg$c397) {
+        s2 = peg$c397;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c395); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11262,12 +11329,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c394) {
-      s1 = peg$c394;
+    if (input.substr(peg$currPos, 2) === peg$c397) {
+      s1 = peg$c397;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11277,15 +11344,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c315;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c297(s3);
+              s1 = peg$c301(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11315,140 +11382,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c396) {
-      s1 = peg$c396;
+    if (input.substr(peg$currPos, 5) === peg$c399) {
+      s1 = peg$c399;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c397); }
+      if (peg$silentFails === 0) { peg$fail(peg$c400); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c398) {
-        s1 = peg$c398;
+      if (input.substr(peg$currPos, 6) === peg$c401) {
+        s1 = peg$c401;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c399); }
+        if (peg$silentFails === 0) { peg$fail(peg$c402); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c400) {
-          s1 = peg$c400;
+        if (input.substr(peg$currPos, 6) === peg$c403) {
+          s1 = peg$c403;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c402) {
-            s1 = peg$c402;
+          if (input.substr(peg$currPos, 6) === peg$c405) {
+            s1 = peg$c405;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c406); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c404) {
-              s1 = peg$c404;
+            if (input.substr(peg$currPos, 4) === peg$c407) {
+              s1 = peg$c407;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c405); }
+              if (peg$silentFails === 0) { peg$fail(peg$c408); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c406) {
-                s1 = peg$c406;
+              if (input.substr(peg$currPos, 5) === peg$c409) {
+                s1 = peg$c409;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c407); }
+                if (peg$silentFails === 0) { peg$fail(peg$c410); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c408) {
-                  s1 = peg$c408;
+                if (input.substr(peg$currPos, 5) === peg$c411) {
+                  s1 = peg$c411;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c409); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c412); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c410) {
-                    s1 = peg$c410;
+                  if (input.substr(peg$currPos, 5) === peg$c413) {
+                    s1 = peg$c413;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c411); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c414); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c412) {
-                      s1 = peg$c412;
+                    if (input.substr(peg$currPos, 7) === peg$c415) {
+                      s1 = peg$c415;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c413); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c416); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c414) {
-                        s1 = peg$c414;
+                      if (input.substr(peg$currPos, 7) === peg$c417) {
+                        s1 = peg$c417;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c415); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c418); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c416) {
-                          s1 = peg$c416;
+                        if (input.substr(peg$currPos, 4) === peg$c419) {
+                          s1 = peg$c419;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c417); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c420); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c418) {
-                            s1 = peg$c418;
+                          if (input.substr(peg$currPos, 6) === peg$c421) {
+                            s1 = peg$c421;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c419); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c422); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c420) {
-                              s1 = peg$c420;
+                            if (input.substr(peg$currPos, 8) === peg$c423) {
+                              s1 = peg$c423;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c424); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c422) {
-                                s1 = peg$c422;
+                              if (input.substr(peg$currPos, 4) === peg$c425) {
+                                s1 = peg$c425;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c426); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c424) {
-                                  s1 = peg$c424;
+                                if (input.substr(peg$currPos, 5) === peg$c427) {
+                                  s1 = peg$c427;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c428); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c426) {
-                                    s1 = peg$c426;
+                                  if (input.substr(peg$currPos, 2) === peg$c429) {
+                                    s1 = peg$c429;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c427); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c430); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c428) {
-                                      s1 = peg$c428;
+                                    if (input.substr(peg$currPos, 3) === peg$c431) {
+                                      s1 = peg$c431;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c432); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c11) {
@@ -11459,20 +11526,20 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c12); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 5) === peg$c430) {
-                                          s1 = peg$c430;
+                                        if (input.substr(peg$currPos, 5) === peg$c433) {
+                                          s1 = peg$c433;
                                           peg$currPos += 5;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c434); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4) === peg$c369) {
-                                            s1 = peg$c369;
+                                          if (input.substr(peg$currPos, 4) === peg$c372) {
+                                            s1 = peg$c372;
                                             peg$currPos += 4;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c370); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c373); }
                                           }
                                         }
                                       }
@@ -11495,7 +11562,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c432();
+      s1 = peg$c435();
     }
     s0 = s1;
 
@@ -11516,7 +11583,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c274(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11549,7 +11616,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c381(s4);
+            s1 = peg$c384(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11592,7 +11659,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c433(s1, s5);
+              s1 = peg$c436(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11644,47 +11711,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c434) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c437) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c435); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c436();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseOrToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c437) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c438); }
@@ -11716,16 +11745,16 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseInToken() {
+  function peg$parseOrToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c440) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c440); }
+      if (peg$silentFails === 0) { peg$fail(peg$c441); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11740,7 +11769,45 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c441();
+        s1 = peg$c442();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseInToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c444();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11758,47 +11825,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c288) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c292) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c442); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c443();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseByToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c444) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c445); }
@@ -11830,15 +11859,53 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseByToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c447) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c448); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c449();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c447.test(input.charAt(peg$currPos))) {
+    if (peg$c450.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c448); }
+      if (peg$silentFails === 0) { peg$fail(peg$c451); }
     }
 
     return s0;
@@ -11849,12 +11916,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
     }
 
@@ -11868,7 +11935,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c451(s1);
+      s1 = peg$c454(s1);
     }
     s0 = s1;
 
@@ -11940,11 +12007,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c452;
+        s1 = peg$c455;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c453); }
+        if (peg$silentFails === 0) { peg$fail(peg$c456); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11954,11 +12021,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c392;
+          s1 = peg$c395;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+          if (peg$silentFails === 0) { peg$fail(peg$c396); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12060,17 +12127,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c454;
+        s2 = peg$c457;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c455); }
+        if (peg$silentFails === 0) { peg$fail(peg$c458); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c456();
+          s1 = peg$c459();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12095,21 +12162,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c281;
+        s2 = peg$c285;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c281;
+            s4 = peg$c285;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c282); }
+            if (peg$silentFails === 0) { peg$fail(peg$c286); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12144,36 +12211,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c449.test(input.charAt(peg$currPos))) {
+    if (peg$c452.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+      if (peg$silentFails === 0) { peg$fail(peg$c453); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c449.test(input.charAt(peg$currPos))) {
+        if (peg$c452.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c450); }
+          if (peg$silentFails === 0) { peg$fail(peg$c453); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c449.test(input.charAt(peg$currPos))) {
+          if (peg$c452.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c450); }
+            if (peg$silentFails === 0) { peg$fail(peg$c453); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12202,20 +12269,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c449.test(input.charAt(peg$currPos))) {
+    if (peg$c452.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+      if (peg$silentFails === 0) { peg$fail(peg$c453); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12290,22 +12357,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c449.test(input.charAt(peg$currPos))) {
+                if (peg$c452.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c453); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c449.test(input.charAt(peg$currPos))) {
+                    if (peg$c452.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c453); }
                     }
                   }
                 } else {
@@ -12360,28 +12427,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c457;
+      s0 = peg$c460;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c458); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c279;
+        s1 = peg$c283;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c284); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c281;
+          s1 = peg$c285;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c282); }
+          if (peg$silentFails === 0) { peg$fail(peg$c286); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12407,22 +12474,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c449.test(input.charAt(peg$currPos))) {
+                if (peg$c452.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c453); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c449.test(input.charAt(peg$currPos))) {
+                    if (peg$c452.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c453); }
                     }
                   }
                 } else {
@@ -12475,11 +12542,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c285;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12525,7 +12592,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c459();
+        s1 = peg$c462();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12587,76 +12654,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c460) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c463) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c462) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c465) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c464) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c467) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c465); }
+          if (peg$silentFails === 0) { peg$fail(peg$c468); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c466) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c469) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c470); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c468) {
+            if (input.substr(peg$currPos, 1).toLowerCase() === peg$c471) {
               s0 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c469); }
+              if (peg$silentFails === 0) { peg$fail(peg$c472); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c470) {
+              if (input.substr(peg$currPos, 1).toLowerCase() === peg$c473) {
                 s0 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                if (peg$silentFails === 0) { peg$fail(peg$c474); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c472) {
+                if (input.substr(peg$currPos, 1).toLowerCase() === peg$c475) {
                   s0 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c473); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c476); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c474) {
+                  if (input.substr(peg$currPos, 1).toLowerCase() === peg$c477) {
                     s0 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c475); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c478); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c476) {
+                    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c479) {
                       s0 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c477); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c480); }
                     }
                   }
                 }
@@ -12841,7 +12908,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c478(s1, s2);
+        s1 = peg$c481(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12862,12 +12929,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c479) {
-            s3 = peg$c479;
+          if (input.substr(peg$currPos, 2) === peg$c482) {
+            s3 = peg$c482;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c480); }
+            if (peg$silentFails === 0) { peg$fail(peg$c483); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12880,7 +12947,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c481(s1, s2, s4, s5);
+                s1 = peg$c484(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12904,12 +12971,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c479) {
-          s1 = peg$c479;
+        if (input.substr(peg$currPos, 2) === peg$c482) {
+          s1 = peg$c482;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c480); }
+          if (peg$silentFails === 0) { peg$fail(peg$c483); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12922,7 +12989,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c482(s2, s3);
+              s1 = peg$c485(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12947,16 +13014,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c479) {
-                s3 = peg$c479;
+              if (input.substr(peg$currPos, 2) === peg$c482) {
+                s3 = peg$c482;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c480); }
+                if (peg$silentFails === 0) { peg$fail(peg$c483); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c483(s1, s2);
+                s1 = peg$c486(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12972,16 +13039,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c479) {
-              s1 = peg$c479;
+            if (input.substr(peg$currPos, 2) === peg$c482) {
+              s1 = peg$c482;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c480); }
+              if (peg$silentFails === 0) { peg$fail(peg$c483); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c484();
+              s1 = peg$c487();
             }
             s0 = s1;
           }
@@ -13018,7 +13085,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c485(s2);
+        s1 = peg$c488(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13047,7 +13114,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c486(s1);
+        s1 = peg$c489(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13068,17 +13135,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c283;
+        s2 = peg$c287;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c487(s1, s3);
+          s1 = peg$c490(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13103,17 +13170,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c283;
+        s2 = peg$c287;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c488(s1, s3);
+          s1 = peg$c491(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13138,7 +13205,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c489(s1);
+      s1 = peg$c492(s1);
     }
     s0 = s1;
 
@@ -13161,22 +13228,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c449.test(input.charAt(peg$currPos))) {
+    if (peg$c452.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+      if (peg$silentFails === 0) { peg$fail(peg$c453); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c449.test(input.charAt(peg$currPos))) {
+        if (peg$c452.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c450); }
+          if (peg$silentFails === 0) { peg$fail(peg$c453); }
         }
       }
     } else {
@@ -13196,11 +13263,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c285;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13225,33 +13292,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c285;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c449.test(input.charAt(peg$currPos))) {
+          if (peg$c452.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c450); }
+            if (peg$silentFails === 0) { peg$fail(peg$c453); }
           }
         }
       } else {
@@ -13267,22 +13334,22 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c449.test(input.charAt(peg$currPos))) {
+          if (peg$c452.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c450); }
+            if (peg$silentFails === 0) { peg$fail(peg$c453); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c449.test(input.charAt(peg$currPos))) {
+              if (peg$c452.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                if (peg$silentFails === 0) { peg$fail(peg$c453); }
               }
             }
           } else {
@@ -13295,7 +13362,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c490();
+              s1 = peg$c493();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13320,11 +13387,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c281;
+        s1 = peg$c285;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13339,22 +13406,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c449.test(input.charAt(peg$currPos))) {
+          if (peg$c452.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c450); }
+            if (peg$silentFails === 0) { peg$fail(peg$c453); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c449.test(input.charAt(peg$currPos))) {
+              if (peg$c452.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                if (peg$silentFails === 0) { peg$fail(peg$c453); }
               }
             }
           } else {
@@ -13367,7 +13434,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c490();
+              s1 = peg$c493();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13394,20 +13461,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c491) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c494) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c492); }
+      if (peg$silentFails === 0) { peg$fail(peg$c495); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c493.test(input.charAt(peg$currPos))) {
+      if (peg$c496.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c494); }
+        if (peg$silentFails === 0) { peg$fail(peg$c497); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13459,12 +13526,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c495.test(input.charAt(peg$currPos))) {
+    if (peg$c498.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c496); }
+      if (peg$silentFails === 0) { peg$fail(peg$c499); }
     }
 
     return s0;
@@ -13475,11 +13542,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c387;
+      s1 = peg$c390;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13490,15 +13557,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c387;
+          s3 = peg$c390;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c388); }
+          if (peg$silentFails === 0) { peg$fail(peg$c391); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c497(s2);
+          s1 = peg$c500(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13515,11 +13582,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c389;
+        s1 = peg$c392;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+        if (peg$silentFails === 0) { peg$fail(peg$c393); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13530,15 +13597,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c389;
+            s3 = peg$c392;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c390); }
+            if (peg$silentFails === 0) { peg$fail(peg$c393); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c497(s2);
+            s1 = peg$c500(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13564,11 +13631,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c387;
+      s2 = peg$c390;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13586,7 +13653,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c498); }
+        if (peg$silentFails === 0) { peg$fail(peg$c501); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13603,11 +13670,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c392;
+        s1 = peg$c395;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c396); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13642,7 +13709,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c499(s1, s2);
+        s1 = peg$c502(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13671,12 +13738,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c500.test(input.charAt(peg$currPos))) {
+    if (peg$c503.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c501); }
+      if (peg$silentFails === 0) { peg$fail(peg$c504); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13692,12 +13759,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
     }
 
@@ -13709,11 +13776,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c392;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13772,7 +13839,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c502(s3, s4);
+            s1 = peg$c505(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13883,7 +13950,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c503();
+          s1 = peg$c506();
         }
         s0 = s1;
       }
@@ -13897,12 +13964,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c449.test(input.charAt(peg$currPos))) {
+      if (peg$c452.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
     }
 
@@ -13914,11 +13981,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c392;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -13954,7 +14021,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c504();
+      s1 = peg$c507();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -13968,16 +14035,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c505();
+        s1 = peg$c508();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c493.test(input.charAt(peg$currPos))) {
+        if (peg$c496.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c494); }
+          if (peg$silentFails === 0) { peg$fail(peg$c497); }
         }
       }
     }
@@ -13992,11 +14059,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c389;
+      s2 = peg$c392;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14014,7 +14081,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c498); }
+        if (peg$silentFails === 0) { peg$fail(peg$c501); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14031,11 +14098,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c392;
+        s1 = peg$c395;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c396); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14071,20 +14138,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c389;
+      s0 = peg$c392;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c387;
+        s1 = peg$c390;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c388); }
+        if (peg$silentFails === 0) { peg$fail(peg$c391); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14093,94 +14160,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c392;
+          s0 = peg$c395;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+          if (peg$silentFails === 0) { peg$fail(peg$c396); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c506;
+            s1 = peg$c509;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c507); }
+            if (peg$silentFails === 0) { peg$fail(peg$c510); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c508();
+            s1 = peg$c511();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c509;
+              s1 = peg$c512;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c510); }
+              if (peg$silentFails === 0) { peg$fail(peg$c513); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c511();
+              s1 = peg$c514();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c512;
+                s1 = peg$c515;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c513); }
+                if (peg$silentFails === 0) { peg$fail(peg$c516); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c514();
+                s1 = peg$c517();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c515;
+                  s1 = peg$c518;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c516); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c519); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c517();
+                  s1 = peg$c520();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c518;
+                    s1 = peg$c521;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c519); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c522); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c520();
+                    s1 = peg$c523();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c521;
+                      s1 = peg$c524;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c525); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c523();
+                      s1 = peg$c526();
                     }
                     s0 = s1;
                   }
@@ -14208,7 +14275,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c504();
+      s1 = peg$c507();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14222,16 +14289,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c524();
+        s1 = peg$c527();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c493.test(input.charAt(peg$currPos))) {
+        if (peg$c496.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c494); }
+          if (peg$silentFails === 0) { peg$fail(peg$c497); }
         }
       }
     }
@@ -14244,11 +14311,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c525;
+      s1 = peg$c528;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c526); }
+      if (peg$silentFails === 0) { peg$fail(peg$c529); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14280,7 +14347,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c527(s2);
+        s1 = peg$c530(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14293,11 +14360,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c525;
+        s1 = peg$c528;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c526); }
+        if (peg$silentFails === 0) { peg$fail(peg$c529); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14364,15 +14431,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c311;
+              s4 = peg$c315;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c527(s3);
+              s1 = peg$c530(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14400,21 +14467,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c283;
+      s1 = peg$c287;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c283;
+          s3 = peg$c287;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c284); }
+          if (peg$silentFails === 0) { peg$fail(peg$c288); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14456,21 +14523,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c528.test(input.charAt(peg$currPos))) {
+    if (peg$c531.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c529); }
+      if (peg$silentFails === 0) { peg$fail(peg$c532); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c392;
+        s3 = peg$c395;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c396); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14478,7 +14545,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c498); }
+          if (peg$silentFails === 0) { peg$fail(peg$c501); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14495,21 +14562,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c528.test(input.charAt(peg$currPos))) {
+        if (peg$c531.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c529); }
+          if (peg$silentFails === 0) { peg$fail(peg$c532); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c392;
+            s3 = peg$c395;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c393); }
+            if (peg$silentFails === 0) { peg$fail(peg$c396); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14517,7 +14584,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c498); }
+              if (peg$silentFails === 0) { peg$fail(peg$c501); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14547,12 +14614,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c530.test(input.charAt(peg$currPos))) {
+    if (peg$c533.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c531); }
+      if (peg$silentFails === 0) { peg$fail(peg$c534); }
     }
 
     return s0;
@@ -14610,7 +14677,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c498); }
+      if (peg$silentFails === 0) { peg$fail(peg$c501); }
     }
 
     return s0;
@@ -14621,51 +14688,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c533;
+      s0 = peg$c536;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c534); }
+      if (peg$silentFails === 0) { peg$fail(peg$c537); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c535;
+        s0 = peg$c538;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c536); }
+        if (peg$silentFails === 0) { peg$fail(peg$c539); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c537;
+          s0 = peg$c540;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c538); }
+          if (peg$silentFails === 0) { peg$fail(peg$c541); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c539;
+            s0 = peg$c542;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c540); }
+            if (peg$silentFails === 0) { peg$fail(peg$c543); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c541;
+              s0 = peg$c544;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c542); }
+              if (peg$silentFails === 0) { peg$fail(peg$c545); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c543;
+                s0 = peg$c546;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c544); }
+                if (peg$silentFails === 0) { peg$fail(peg$c547); }
               }
             }
           }
@@ -14675,7 +14742,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c532); }
+      if (peg$silentFails === 0) { peg$fail(peg$c535); }
     }
 
     return s0;
@@ -14684,12 +14751,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c545.test(input.charAt(peg$currPos))) {
+    if (peg$c548.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c546); }
+      if (peg$silentFails === 0) { peg$fail(peg$c549); }
     }
 
     return s0;
@@ -14703,7 +14770,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
 
     return s0;
@@ -14713,24 +14780,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c548) {
-      s1 = peg$c548;
+    if (input.substr(peg$currPos, 2) === peg$c551) {
+      s1 = peg$c551;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c549); }
+      if (peg$silentFails === 0) { peg$fail(peg$c552); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c550) {
-        s5 = peg$c550;
+      if (input.substr(peg$currPos, 2) === peg$c553) {
+        s5 = peg$c553;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c551); }
+        if (peg$silentFails === 0) { peg$fail(peg$c554); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -14757,12 +14824,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c550) {
-          s5 = peg$c550;
+        if (input.substr(peg$currPos, 2) === peg$c553) {
+          s5 = peg$c553;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c551); }
+          if (peg$silentFails === 0) { peg$fail(peg$c554); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -14786,12 +14853,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c550) {
-          s3 = peg$c550;
+        if (input.substr(peg$currPos, 2) === peg$c553) {
+          s3 = peg$c553;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c551); }
+          if (peg$silentFails === 0) { peg$fail(peg$c554); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -14816,12 +14883,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c552) {
-      s1 = peg$c552;
+    if (input.substr(peg$currPos, 2) === peg$c555) {
+      s1 = peg$c555;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c553); }
+      if (peg$silentFails === 0) { peg$fail(peg$c556); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14939,7 +15006,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c498); }
+      if (peg$silentFails === 0) { peg$fail(peg$c501); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -560,9 +560,8 @@ As
   = _ "as" _ id:IdentifierName { RETURN(id) }
   / "" { RETURN("") }
 
-
 LetProc
-  = "let"i _ locals:LetAssignments __ over:ScopedOver  {
+  = "let"i _ locals:LetAssignments __ over:ScopedOver {
       RETURN(MAP("kind":"Let", "locals":locals, "over":over))
     }
 

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -544,18 +544,25 @@ MergeProc
     }
 
 OverProc
-  = ScopedOver
+  = over:ScopedOver {
+      RETURN(MAP("kind":"Let", "locals":NULL, "over":over))
+    }
   / "over"i _ exprs:Exprs {
-      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":NULL))
+      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":NULL, "as":""))
     }
 
 ScopedOver
-  = "over"i _ exprs:Exprs __ scope:Scope {
-      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":scope))
+  = "over"i _ exprs:Exprs as:As __ scope:Scope {
+      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":scope, "as":as))
     }
 
+As
+  = _ "as" _ id:IdentifierName { RETURN(id) }
+  / "" { RETURN("") }
+
+
 LetProc
-  = "let"i _ locals:LetAssignments __ over:ScopedOver {
+  = "let"i _ locals:LetAssignments __ over:ScopedOver  {
       RETURN(MAP("kind":"Let", "locals":locals, "over":over))
     }
 

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -48,7 +48,15 @@ func semExpr(scope *Scope, e ast.Expr) (dag.Expr, error) {
 			Value: zson.MustFormatValue(val),
 		}, nil
 	case *ast.ID:
-		return semField(scope, e, false)
+		// We use static scoping here to see if an identifier is
+		// a "var" reference to the name or a field access
+		// and transform the AST node appropriately.  The resulting DAG
+		// doesn't have Identifiers as they are resolved here
+		// one way or the other.
+		if ref := scope.Lookup(e.Name); ref != nil {
+			return ref, nil
+		}
+		return pathOf(e.Name), nil
 	case *ast.Search:
 		val, err := zson.ParsePrimitive(e.Value.Type, e.Value.Text)
 		if err != nil {
@@ -221,7 +229,23 @@ func dynamicTypeName(name string) *dag.Call {
 func semBinary(scope *Scope, e *ast.BinaryExpr) (dag.Expr, error) {
 	op := e.Op
 	if op == "." {
-		return semField(scope, e, false)
+		lhs, err := semExpr(scope, e.LHS)
+		if err != nil {
+			return nil, err
+		}
+		id, ok := e.RHS.(*ast.ID)
+		if !ok {
+			return nil, errors.New("RHS of dot operator is not an identifier")
+		}
+		if lhs, ok := lhs.(*dag.This); ok {
+			lhs.Path = append(lhs.Path, id.Name)
+			return lhs, nil
+		}
+		return &dag.Dot{
+			Kind: "Dot",
+			LHS:  lhs,
+			RHS:  id.Name,
+		}, nil
 	}
 	if slice, ok := e.RHS.(*ast.BinaryExpr); ok && slice.Op == ":" {
 		if op != "[" {
@@ -338,10 +362,10 @@ func semExprs(scope *Scope, in []ast.Expr) ([]dag.Expr, error) {
 	return exprs, nil
 }
 
-func semAssignments(scope *Scope, assignments []ast.Assignment) ([]dag.Assignment, error) {
+func semAssignments(scope *Scope, assignments []ast.Assignment, summarize bool) ([]dag.Assignment, error) {
 	out := make([]dag.Assignment, 0, len(assignments))
 	for _, e := range assignments {
-		a, err := semAssignment(scope, e)
+		a, err := semAssignment(scope, e, summarize)
 		if err != nil {
 			return nil, err
 		}
@@ -350,17 +374,17 @@ func semAssignments(scope *Scope, assignments []ast.Assignment) ([]dag.Assignmen
 	return out, nil
 }
 
-func semAssignment(scope *Scope, a ast.Assignment) (dag.Assignment, error) {
+func semAssignment(scope *Scope, a ast.Assignment, summarize bool) (dag.Assignment, error) {
 	rhs, err := semExpr(scope, a.RHS)
 	if err != nil {
 		return dag.Assignment{}, fmt.Errorf("rhs of assignment expression: %w", err)
 	}
+	if _, ok := rhs.(*dag.Agg); ok {
+		summarize = true
+	}
 	var lhs dag.Expr
 	if a.LHS != nil {
-		// XXX currently only support explicit field lvals
-		// (i.e., no assignments to array elements etc... instead
-		// you create a new array with modified contends)
-		lhs, err = semField(scope, a.LHS, true)
+		lhs, err = semExpr(scope, a.LHS)
 		if err != nil {
 			return dag.Assignment{}, fmt.Errorf("lhs of assigment expression: %w", err)
 		}
@@ -374,13 +398,31 @@ func semAssignment(scope *Scope, a ast.Assignment) (dag.Assignment, error) {
 		lhs = &dag.This{"This", []string{name}}
 	} else if agg, ok := a.RHS.(*ast.Agg); ok {
 		lhs = &dag.This{"This", []string{agg.Name}}
-	} else if isThis(a.RHS) {
-		return dag.Assignment{}, errors.New(`cannot assign to "this"`)
+	} else if v, ok := rhs.(*dag.Var); ok {
+		lhs = &dag.This{"This", []string{v.Name}}
 	} else {
-		lhs, err = semField(scope, a.RHS, true)
+		lhs, err = semExpr(scope, a.RHS)
 		if err != nil {
 			return dag.Assignment{}, errors.New("assignment name could not be inferred from rhs expression")
 		}
+	}
+	if summarize {
+		// Summarize always outputs its results as new records of "this"
+		// this so if we have an "as" that overrides "this", we just
+		// convert it back to a local this.
+		if dot, ok := lhs.(*dag.Dot); ok {
+			if v, ok := dot.LHS.(*dag.Var); ok && v.Name == "this" {
+				lhs = &dag.This{Kind: "This", Path: []string{dot.RHS}}
+			}
+		}
+	}
+	// Make sure we have a valid l-value for lhs.
+	this, ok := lhs.(*dag.This)
+	if !ok {
+		return dag.Assignment{}, errors.New("illegal left-hand side of assignment'")
+	}
+	if len(this.Path) == 0 {
+		return dag.Assignment{}, errors.New("cannot assign to \"this\"")
 	}
 	return dag.Assignment{"Assignment", lhs, rhs}, nil
 }
@@ -395,7 +437,7 @@ func isThis(e ast.Expr) bool {
 func semFields(scope *Scope, exprs []ast.Expr) ([]dag.Expr, error) {
 	fields := make([]dag.Expr, 0, len(exprs))
 	for _, e := range exprs {
-		f, err := semField(scope, e, false)
+		f, err := semField(scope, e)
 		if err != nil {
 			return nil, err
 		}
@@ -404,67 +446,21 @@ func semFields(scope *Scope, exprs []ast.Expr) ([]dag.Expr, error) {
 	return fields, nil
 }
 
-// semField checks that an expression is a field refernce and converts it
-// to a field path if possible.  It will convert any references to Refs.
-func semField(scope *Scope, e ast.Expr, lval bool) (dag.Expr, error) {
-	switch e := e.(type) {
-	case *ast.BinaryExpr:
-		if e.Op == "." {
-			lhs, err := semField(scope, e.LHS, lval)
-			if err != nil {
-				return nil, err
-			}
-			id, ok := e.RHS.(*ast.ID)
-			if !ok {
-				return nil, errors.New("RHS of dot operator is not an identifier")
-			}
-			if lhs, ok := lhs.(*dag.This); ok {
-				lhs.Path = append(lhs.Path, id.Name)
-				return lhs, nil
-			}
-			return &dag.Dot{
-				Kind: "Dot",
-				LHS:  lhs,
-				RHS:  id.Name,
-			}, nil
-		}
-		if e.Op == "[" {
-			lhs, err := semField(scope, e.LHS, lval)
-			if err != nil {
-				return nil, err
-			}
-			rhs, err := semExpr(scope, e.RHS)
-			if err != nil {
-				return nil, err
-			}
-			if path := isIndexOfThis(scope, lhs, rhs); path != nil {
-				return path, nil
-			}
-			return &dag.BinaryExpr{
-				Kind: "BinaryExpr",
-				Op:   "[",
-				LHS:  lhs,
-				RHS:  rhs,
-			}, nil
-		}
-	case *ast.ID:
-		if !lval {
-			// We use static scoping here to see if an identifier is
-			// a "var" reference to the name or a field access
-			// and transform the ast node appropriately.  The semantic AST
-			// should have no Identifiers in it as they should all be
-			// resolved one way or another.
-			// If field is an lval the "var" reference should not be
-			// substituted.
-			if ref := scope.Lookup(e.Name); ref != nil {
-				return ref, nil
-			}
-		}
-		return pathOf(e.Name), nil
+// semField analyzes the expression f and makes sure that it's
+// a field reference returning an error if not.
+func semField(scope *Scope, f ast.Expr) (*dag.This, error) {
+	e, err := semExpr(scope, f)
+	if err != nil {
+		return nil, errors.New("invalid expression used as a field")
 	}
-	// This includes a null Expr, which can happen if the AST is missing
-	// a field or sets it to null.
-	return nil, errors.New("expression is not a field reference.")
+	field, ok := e.(*dag.This)
+	if !ok {
+		return nil, errors.New("invalid expression used as a field")
+	}
+	if len(field.Path) == 0 {
+		return nil, errors.New("cannot use 'this' as a field reference")
+	}
+	return field, nil
 }
 
 func convertCallProc(scope *Scope, call *ast.Call) (dag.Op, error) {

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -408,7 +408,7 @@ func semAssignment(scope *Scope, a ast.Assignment, summarize bool) (dag.Assignme
 	}
 	if summarize {
 		// Summarize always outputs its results as new records of "this"
-		// this so if we have an "as" that overrides "this", we just
+		// so if we have an "as" that overrides "this", we just
 		// convert it back to a local this.
 		if dot, ok := lhs.(*dag.Dot); ok {
 			if v, ok := dot.LHS.(*dag.Var); ok && v.Name == "this" {
@@ -416,13 +416,13 @@ func semAssignment(scope *Scope, a ast.Assignment, summarize bool) (dag.Assignme
 			}
 		}
 	}
-	// Make sure we have a valid l-value for lhs.
+	// Make sure we have a valid lval for lhs.
 	this, ok := lhs.(*dag.This)
 	if !ok {
 		return dag.Assignment{}, errors.New("illegal left-hand side of assignment'")
 	}
 	if len(this.Path) == 0 {
-		return dag.Assignment{}, errors.New("cannot assign to \"this\"")
+		return dag.Assignment{}, errors.New("cannot assign to 'this'")
 	}
 	return dag.Assignment{"Assignment", lhs, rhs}, nil
 }

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -237,11 +237,11 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 	case *ast.From:
 		return semFrom(ctx, scope, p, adaptor, head)
 	case *ast.Summarize:
-		keys, err := semAssignments(scope, p.Keys)
+		keys, err := semAssignments(scope, p.Keys, true)
 		if err != nil {
 			return nil, err
 		}
-		aggs, err := semAssignments(scope, p.Aggs)
+		aggs, err := semAssignments(scope, p.Aggs, true)
 		if err != nil {
 			return nil, err
 		}
@@ -317,7 +317,7 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 	case *ast.Shape:
 		return &dag.Shape{"Shape"}, nil
 	case *ast.Cut:
-		assignments, err := semAssignments(scope, p.Args)
+		assignments, err := semAssignments(scope, p.Args, false)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +383,7 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 			Expr: e,
 		}, nil
 	case *ast.Top:
-		args, err := semFields(scope, p.Args)
+		args, err := semExprs(scope, p.Args)
 		if err != nil {
 			return nil, fmt.Errorf("top: %w", err)
 		}
@@ -397,7 +397,7 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 			Limit: p.Limit,
 		}, nil
 	case *ast.Put:
-		assignments, err := semAssignments(scope, p.Args)
+		assignments, err := semAssignments(scope, p.Args, false)
 		if err != nil {
 			return nil, err
 		}
@@ -410,30 +410,22 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 	case *ast.Rename:
 		var assignments []dag.Assignment
 		for _, fa := range p.Args {
-			dst, err := semField(scope, fa.LHS, false)
+			dst, err := semField(scope, fa.LHS)
 			if err != nil {
-				return nil, err
-			}
-			src, err := semField(scope, fa.RHS, false)
-			if err != nil {
-				return nil, err
-			}
-			dstField, ok := dst.(*dag.This)
-			if !ok {
 				return nil, errors.New("'rename' requires explicit field references")
 			}
-			srcField, ok := src.(*dag.This)
-			if !ok {
+			src, err := semField(scope, fa.RHS)
+			if err != nil {
 				return nil, errors.New("'rename' requires explicit field references")
 			}
-			if len(dstField.Path) != len(srcField.Path) {
+			if len(dst.Path) != len(src.Path) {
 				return nil, fmt.Errorf("cannot rename %s to %s", src, dst)
 			}
 			// Check that the prefixes match and, if not, report first place
 			// that they don't.
-			for i := 0; i <= len(srcField.Path)-2; i++ {
-				if srcField.Path[i] != dstField.Path[i] {
-					return nil, fmt.Errorf("cannot rename %s to %s (differ in %s vs %s)", srcField, dstField, srcField.Path[i], dstField.Path[i])
+			for i := 0; i <= len(src.Path)-2; i++ {
+				if src.Path[i] != dst.Path[i] {
+					return nil, fmt.Errorf("cannot rename %s to %s (differ in %s vs %s)", src, dst, src.Path[i], dst.Path[i])
 				}
 			}
 			assignments = append(assignments, dag.Assignment{"Assignment", dst, src})
@@ -453,7 +445,7 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 		if err != nil {
 			return nil, err
 		}
-		assignments, err := semAssignments(scope, p.Args)
+		assignments, err := semAssignments(scope, p.Args, false)
 		if err != nil {
 			return nil, err
 		}
@@ -503,13 +495,8 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 			As:   as,
 		}, nil
 	case *ast.Merge:
-		e, err := semField(scope, p.Field, false)
+		field, err := semField(scope, p.Field)
 		if err != nil {
-			return nil, err
-		}
-		field, ok := e.(*dag.This)
-		if !ok || len(field.Path) == 0 {
-			//XXX generalize to expr so you can merge this
 			return nil, fmt.Errorf("merge: key must be a field")
 		}
 		return &dag.Merge{
@@ -531,6 +518,27 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 		locals, err := semVars(scope, p.Locals)
 		if err != nil {
 			return nil, err
+		}
+		if as := p.Over.As; as != "" {
+			// If there is an "as" clause, then we bind the name
+			// to the sub-scope "this" and we bind "this" to the
+			// outer-scope "this".  Nested scopes are elegantly
+			// handle by this approach because the closest "as" name
+			// resolves to the real this and the next closest
+			// "as" name resolves to "this" in the scope above, which is
+			// where it was bound.
+			if err := scope.DefineAs(as); err != nil {
+				return nil, err
+			}
+			if err := scope.DefineVar("this"); err != nil {
+				return nil, err
+			}
+			// We append "this" to locals so it will be eval'd
+			// but we don't but it in the scope.
+			locals = append(locals, dag.Def{
+				Name: "this",
+				Expr: &dag.This{Kind: "This"},
+			})
 		}
 		over, err := semOver(ctx, scope, p.Over, adaptor, head)
 		if err != nil {
@@ -610,8 +618,10 @@ func semVars(scope *Scope, defs []ast.Def) ([]dag.Def, error) {
 func semOpAssignment(scope *Scope, p *ast.OpAssignment) (dag.Op, error) {
 	var aggs, puts []dag.Assignment
 	for _, a := range p.Assignments {
-		// Parition assignments into agg vs. puts
-		assignment, err := semAssignment(scope, a)
+		// Parition assignments into agg vs. puts.
+		// It's okay to pass false here for the summarize bool because
+		// semAssignment will check if the RHS is a dag.Agg and override.
+		assignment, err := semAssignment(scope, a, false)
 		if err != nil {
 			return nil, err
 		}

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -534,7 +534,7 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor proc.DataAda
 				return nil, err
 			}
 			// We append "this" to locals so it will be eval'd
-			// but we don't but it in the scope.
+			// but we don't put it in the scope.
 			locals = append(locals, dag.Def{
 				Name: "this",
 				Expr: &dag.This{Kind: "This"},

--- a/compiler/semantic/scope.go
+++ b/compiler/semantic/scope.go
@@ -45,6 +45,18 @@ func (s *Scope) DefineVar(name string) error {
 	return nil
 }
 
+func (s *Scope) DefineAs(name string) error {
+	b := s.tos()
+	if _, ok := b.symbols[name]; ok {
+		return fmt.Errorf("symbol %q redefined", name)
+	}
+	ref := &dag.This{Kind: "This"}
+	// We add the symbol to the table but don't bump nvars because
+	// it's not a var and doesn't take a slot in the batch vars.
+	b.Define(name, ref)
+	return nil
+}
+
 func (s *Scope) DefineConst(name string, def dag.Expr) error {
 	b := s.tos()
 	if _, ok := b.symbols[name]; ok {

--- a/compiler/semantic/scope.go
+++ b/compiler/semantic/scope.go
@@ -50,10 +50,9 @@ func (s *Scope) DefineAs(name string) error {
 	if _, ok := b.symbols[name]; ok {
 		return fmt.Errorf("symbol %q redefined", name)
 	}
-	ref := &dag.This{Kind: "This"}
 	// We add the symbol to the table but don't bump nvars because
 	// it's not a var and doesn't take a slot in the batch vars.
-	b.Define(name, ref)
+	b.Define(name, &dag.This{Kind: "This"})
 	return nil
 }
 

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -238,9 +238,9 @@ func convertSQLAlias(scope *Scope, e ast.Expr) (*dag.Cut, string, error) {
 	if e == nil {
 		return nil, "", nil
 	}
-	fld, err := semField(scope, e, false)
+	fld, err := semField(scope, e)
 	if err != nil {
-		return nil, "", fmt.Errorf("illegal alias: %w", err)
+		return nil, "", fmt.Errorf("illegal SQL alias: %w", err)
 	}
 	var id string
 	if idExpr, ok := e.(*ast.ID); ok {
@@ -456,7 +456,7 @@ func newSQLSelection(scope *Scope, assignments []ast.Assignment) (sqlSelection, 
 		if err != nil {
 			return nil, err
 		}
-		assignment, err := semAssignment(scope, a)
+		assignment, err := semAssignment(scope, a, false)
 		if err != nil {
 			return nil, err
 		}
@@ -538,7 +538,7 @@ func isAgg(scope *Scope, e ast.Expr) (*dag.Agg, error) {
 }
 
 func deriveAs(scope *Scope, a ast.Assignment) (field.Path, error) {
-	sa, err := semAssignment(scope, a)
+	sa, err := semAssignment(scope, a, false)
 	if err != nil {
 		return nil, fmt.Errorf("AS clause of SELECT: %w", err)
 	}
@@ -549,12 +549,9 @@ func deriveAs(scope *Scope, a ast.Assignment) (field.Path, error) {
 }
 
 func sqlField(scope *Scope, e ast.Expr) (field.Path, error) {
-	name, err := semField(scope, e, false)
+	f, err := semField(scope, e)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("expression is not a field reference")
 	}
-	if f, ok := name.(*dag.This); ok {
-		return f.Path, nil
-	}
-	return nil, errors.New("expression is not a field reference")
+	return f.Path, nil
 }

--- a/compiler/ztests/scoped-this.yaml
+++ b/compiler/ztests/scoped-this.yaml
@@ -1,0 +1,13 @@
+zed: |
+  over ids as id => (
+    ids:=collect(string(id))
+    | yield {name:this.name,ids:join(ids,',')}
+  )
+
+input: |
+  {name:"alice",ids:[1,2,3]}
+  {name:"bob",ids:[4,5]}
+
+output: |
+  {name:"alice",ids:"1,2,3"}
+  {name:"bob",ids:"4,5"}

--- a/expr/ztests/cut-to-root-error.yaml
+++ b/expr/ztests/cut-to-root-error.yaml
@@ -3,4 +3,4 @@ zed: 'cut this:=a'
 input: |
   {a:1(int32)}
 
-errorRE: "cut: 'this' not allowed \\(use record literal\\)"
+errorRE: cannot assign to \"this\"

--- a/expr/ztests/cut-to-root-error.yaml
+++ b/expr/ztests/cut-to-root-error.yaml
@@ -3,4 +3,4 @@ zed: 'cut this:=a'
 input: |
   {a:1(int32)}
 
-errorRE: cannot assign to \"this\"
+errorRE: cannot assign to 'this'

--- a/proc/groupby/ztests/count-by-this-err.yaml
+++ b/proc/groupby/ztests/count-by-this-err.yaml
@@ -1,3 +1,3 @@
 zed: count() by this
 
-errorRE: cannot assign to "this"
+errorRE: cannot assign to 'this'


### PR DESCRIPTION
This commit introduces an "as" clause to a scoped over, which
allows "this" to be renamed so the inner scope can access this
via the name and also access the outer this via the name "this".
The scoping technique here works recursively into a hierarchy
of nested scopes.

We also fixed some problems with the semantic analysis of field
l-values and eliminated redundant code in the analysis of
the dot operator.  This was needed to correctly drop in scoping
for "this".