### PR TITLE
over: work with maps and records

### DIFF
--- a/proc/traverse/ztests/over-map.yaml
+++ b/proc/traverse/ztests/over-map.yaml
@@ -1,0 +1,13 @@
+zed: "over this"
+
+input: |
+  |{
+    "amzn": 1900,
+    "goog": 1120,
+    "fb": 180,
+  }|
+
+output: |
+  {key:"fb",value:180}
+  {key:"amzn",value:1900}
+  {key:"goog",value:1120}

--- a/proc/traverse/ztests/over-record.yaml
+++ b/proc/traverse/ztests/over-record.yaml
@@ -1,0 +1,18 @@
+zed: |
+  let d=date over this => (
+    key != 'date'
+    | yield {date: d, sym: key, price: value}
+  )
+
+input: |
+  {
+    date: 2022-01-26T17:46:13.945103Z,
+    amzn: 1900,
+    goog: 1120,
+    fb: 180,
+  }
+
+output: |
+  {date:2022-01-26T17:46:13.945103Z,sym:"amzn",price:1900}
+  {date:2022-01-26T17:46:13.945103Z,sym:"goog",price:1120}
+  {date:2022-01-26T17:46:13.945103Z,sym:"fb",price:180}

--- a/proc/traverse/ztests/over-union.yaml
+++ b/proc/traverse/ztests/over-union.yaml
@@ -3,7 +3,12 @@ zed: |
 
 input: |
   [1, "foo"] ([(int64,string)])
+  [3, 4] (([int64],ip))
+  "bar" ((int64, string))
 
 output: |
   1
   "foo"
+  3
+  4
+  "bar"


### PR DESCRIPTION
Make over work with maps and records. For each element in an record/map
over will emit `{key:<key>,value:<value>}` as the context.

Also:
- Use un-union'd values for over.