### PR TITLE
allow negative indexing

### DIFF
--- a/expr/dot.go
+++ b/expr/dot.go
@@ -75,7 +75,7 @@ func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return ectx.NewValue(typ, nil)
 	}
 	//XXX see PR #1071 to improve this (though we need this for Index anyway)
-	field := getNthFromContainer(val.Bytes, uint(idx))
+	field := getNthFromContainer(val.Bytes, idx)
 	return ectx.NewValue(recType.Columns[idx].Type, field)
 }
 

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -584,9 +584,19 @@ func (m *Modulo) Eval(ectx Context, this *zed.Value) *zed.Value {
 	return ectx.NewValue(typ, zed.EncodeUint(x%y))
 }
 
-func getNthFromContainer(container zcode.Bytes, idx uint) zcode.Bytes {
+func getNthFromContainer(container zcode.Bytes, idx int) zcode.Bytes {
+	if idx < 0 {
+		var length int
+		for it := container.Iter(); !it.Done(); it.Next() {
+			length++
+		}
+		idx = length + idx
+		if idx < 0 || idx >= length {
+			return nil
+		}
+	}
 	iter := container.Iter()
-	var i uint = 0
+	var i int
 	for ; !iter.Done(); i++ {
 		zv := iter.Next()
 		if i == idx {
@@ -640,15 +650,11 @@ func indexArray(zctx *zed.Context, ectx Context, typ *zed.TypeArray, array zcode
 	if !zed.IsInteger(id) {
 		return ectx.CopyValue(*zctx.NewErrorf("array index is not an integer"))
 	}
-	var idx uint
+	var idx int
 	if zed.IsSigned(id) {
-		v := zed.DecodeInt(index.Bytes)
-		if v < 0 {
-			return zctx.Missing()
-		}
-		idx = uint(v)
+		idx = int(zed.DecodeInt(index.Bytes))
 	} else {
-		idx = uint(zed.DecodeUint(index.Bytes))
+		idx = int(zed.DecodeUint(index.Bytes))
 	}
 	zv := getNthFromContainer(array, idx)
 	if zv == nil {

--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -416,7 +416,7 @@ func (s *step) buildRecord(zctx *zed.Context, ectx Context, in zcode.Bytes, b *z
 		// reordering) would be make direct use of a
 		// zcode.Iter along with keeping track of our
 		// position.
-		bytes := getNthFromContainer(in, uint(step.fromIndex))
+		bytes := getNthFromContainer(in, step.fromIndex)
 		if zerr := step.build(zctx, ectx, bytes, b); zerr != nil {
 			return zerr
 		}

--- a/expr/ztests/negative-index.yaml
+++ b/expr/ztests/negative-index.yaml
@@ -1,0 +1,7 @@
+zed: yield {a:this[-1],b:this[-2],c:this[-3],d:this[-4]}
+
+input: |
+  [1,2,3]
+
+output: |
+  {a:3,b:2,c:1,d:error("missing")}


### PR DESCRIPTION
This commit allows you to use a negative index to provide
end-of-array relative indexing, e.g., [1,2,3][-1] -> 3