### PR TITLE
remove cut() function

### DIFF
--- a/docs/language/functions.md
+++ b/docs/language/functions.md
@@ -22,7 +22,6 @@
   - [`parse_uri`](#parse_uri)
   - [`parse_zson`](#parse_zson)
 - [Records](#records)
-  - [`cut`](#cut)
   - [`fields`](#fields)
   - [`unflatten`](#unflatten)
 - [Strings](#strings)
@@ -390,27 +389,6 @@ echo '{foo:"{a:\"1\",b:2}"}' | zq -z 'foo := parse_zson(foo)' -
 
 ## Records
 
-### `cut`
-
-```
-cut(f ...<fields>) -> record
-```
-
-`cut` accepts one or more [field expressions](expressions.md) f and returns
-a record with only these fields. This is functionally equivalent to the [`cut`
-operator](operators.md#cut)
-
-#### Example:
-
-```mdtest-command
-echo '{foo:{a:1,b:2,c:3}}' | zq -z 'yield cut(foo.a,foo.c)' -
-```
-
-**Output:**
-```mdtest-output
-{foo:{a:1,c:3}}
-```
-
 ### `fields`
 
 ```
@@ -741,7 +719,7 @@ quiet(a <any>) -> type
 
 `quiet` returns `a` unless `a` is `error("missing")` in which case
 it returns `error("quiet")`.  Quiet errors are ignored by operators
-`cut`, `put`, `summarize`, and `yield`.
+`put`, `summarize`, and `yield`.
 
 #### Example:
 

--- a/expr/ztests/cut-root-error.yaml
+++ b/expr/ztests/cut-root-error.yaml
@@ -1,6 +1,0 @@
-zed: 'put x:=cut(this,b)'
-
-input: |
-  {a:1(int32),b:2(int32)}
-
-errorRE: "cut\\(\\): 'this' not allowed in cut argument \\(use record literal\\)"

--- a/expr/ztests/cut-union.yaml
+++ b/expr/ztests/cut-union.yaml
@@ -1,13 +1,13 @@
-zed: a:=union(cut(x)),b:=union(cut(x,s))
+zed: a:=union({x:x}),b:=union({x:x,s:s})
 
 input: |
-  {x:1(int32),s:"a"}
-  {x:2(int32),s:"b"}
+  {x:1,s:"a"}
+  {x:2,s:"b"}
   {s:"x"}
   {s:"b"}
   {none:"bad"}
-  {x:1(int32),s:"a"}
-  {x:3(int32),s:"e"}
+  {x:1,s:"a"}
+  {x:3,s:"e"}
 
 output: |
-  {a:|[{x:1(int32)},{x:2(int32)},{x:3(int32)}]|,b:|[{x:1(int32),s:"a"},{x:2(int32),s:"b"},{x:3(int32),s:"e"}]|}
+  {a:|[{x:1},{x:2},{x:3}]|,b:|[{x:1,s:"a"},{x:2,s:"b"},{x:3,s:"e"}]|}

--- a/expr/ztests/cut.yaml
+++ b/expr/ztests/cut.yaml
@@ -1,4 +1,4 @@
-zed: put v:=cut(s,x)
+zed: put v:={s:s,x:x}
 
 input: |
   {x:1(int32),s:"a"}


### PR DESCRIPTION
The cut() function was added to the Zed lanuage before it had
record expressions (and before it was called Zed). This commit
removes it and updates the tests to use record expressions.