### PR TITLE
jsonio reader: preserve JSON attributes

### DIFF
--- a/zio/jsonio/ztests/reader.yaml
+++ b/zio/jsonio/ztests/reader.yaml
@@ -28,19 +28,19 @@ outputs:
   - name: stdout
     data: |
       {
+          ts: 1.521911721926018e+09,
           a: "hello, world",
           b: {
-              x: 4611686018427388000,
-              y: "127.0.0.1",
-              z: "&, <, and > should not be escaped"
-          },
-          ts: 1.521911721926018e+09
+              z: "&, <, and > should not be escaped",
+              x: 4611686018427387904.,
+              y: "127.0.0.1"
+          }
       }
       ===
-      {a:1}
+      {a:1.}
       {b:"hello"}
       {c:true}
       ===
-      {value:"foo"}
-      {value:1}
-      {a:1}
+      "foo"
+      1.
+      {a:1.}

--- a/zio/zsonio/reader.go
+++ b/zio/zsonio/reader.go
@@ -12,7 +12,7 @@ type Reader struct {
 	reader   io.Reader
 	zctx     *zed.Context
 	parser   *zson.Parser
-	analyzer zson.Analyzer
+	analyzer *zson.Analyzer
 	builder  *zcode.Builder
 }
 
@@ -23,6 +23,12 @@ func NewReader(r io.Reader, zctx *zed.Context) *Reader {
 		analyzer: zson.NewAnalyzer(),
 		builder:  zcode.NewBuilder(),
 	}
+}
+
+// JSONStrict adjusts the zson analyzer so all number values are interpreted as
+// float64s.
+func (r *Reader) JSONStrict() {
+	r.analyzer.JSONStrict = true
 }
 
 func (r *Reader) Read() (*zed.Value, error) {


### PR DESCRIPTION
Preserve json attributes when translating JSON to ZSON:
- Parse numbers as float64s.
- Maintain column ordering of the original JSON.
- Do not convert primitive values to records.

This changed also required some changes to zson.Unmarshal allowing
json parsed numbers to be appropriately cast to the correct go type
destination.

Closes #2122