### PR TITLE
fix bug compiler bug with regexp search in expressions

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -73,6 +73,8 @@ func compileExpr(zctx *zed.Context, e dag.Expr) (expr.Evaluator, error) {
 		return compileCast(zctx, *e)
 	case *dag.RegexpMatch:
 		return compileRegexpMatch(zctx, e)
+	case *dag.RegexpSearch:
+		return compileFilter(zctx, e)
 	case *dag.RecordExpr:
 		return compileRecordExpr(zctx, e)
 	case *dag.ArrayExpr:

--- a/compiler/ztests/regexp-search.yaml
+++ b/compiler/ztests/regexp-search.yaml
@@ -1,0 +1,13 @@
+zed: yield search(*foo*)
+
+input: |
+  "foo"
+  1
+  {s:"xfooy"}
+  true
+
+output: |
+  true
+  false
+  true
+  false


### PR DESCRIPTION
The compiler was missing a case for regexp search predicates used
inside of an expression.  This commit provides the trivial fix
and adds a test.