### PR TITLE
handle non-record types in cast()

### DIFF
--- a/expr/ztests/cast-array.yaml
+++ b/expr/ztests/cast-array.yaml
@@ -1,0 +1,17 @@
+zed: yield cast(this, <[string]>)
+
+input: |
+  null
+  [null]
+  |[null]|
+  ["1","2"]
+  [1,2]
+  |[1,2]|
+
+output: |
+  null([string])
+  [null(string)]
+  [null(string)]
+  ["1","2"]
+  ["1","2"]
+  ["1","2"]

--- a/expr/ztests/cast-name-only.yaml
+++ b/expr/ztests/cast-name-only.yaml
@@ -1,7 +1,9 @@
 zed: type foo = {x:int64}  yield cast(this, <foo>)
 
 input: |
+  null
   {x:123}
 
 output: |
+  null(foo={x:int64})
   {x:123}(=foo)

--- a/expr/ztests/cast-union.yaml
+++ b/expr/ztests/cast-union.yaml
@@ -1,0 +1,21 @@
+zed: yield cast(this, <(int64,string)>)
+
+input: |
+  null
+  null(int64)
+  null(string)
+  null((int64,string))
+  1((int64,string))
+  1
+  "a"((int64,string))
+  "a"
+
+output: |
+  null((int64,string))
+  null((int64,string))
+  null((int64,string))
+  null((int64,string))
+  1((int64,string))
+  1((int64,string))
+  "a"((int64,string))
+  "a"((int64,string))

--- a/proc/fuse/fuser.go
+++ b/proc/fuse/fuser.go
@@ -98,7 +98,7 @@ func (f *Fuser) Read() (*zed.Value, error) {
 	if rec == nil || err != nil {
 		return nil, err
 	}
-	return f.shaper.Apply(f.ectx, rec), nil
+	return f.shaper.Eval(f.ectx, rec), nil
 }
 
 func (f *Fuser) next() (*zed.Value, error) {


### PR DESCRIPTION
The Zed cast() function requires record types for both arguments.  Relax
that to allow any type for either argument.