### PR TITLE
collect: ensure correct selector for type

### DIFF
--- a/context.go
+++ b/context.go
@@ -184,6 +184,24 @@ func (c *Context) LookupTypeUnion(types []Type) *TypeUnion {
 	return typ
 }
 
+func (c *Context) LookupTypeOfValues(vals []Value) Type {
+	if len(vals) == 0 {
+		return TypeNull
+	}
+	var types []Type
+	m := make(map[Type]struct{})
+	for _, val := range vals {
+		if _, ok := m[val.Type]; !ok {
+			m[val.Type] = struct{}{}
+			types = append(types, val.Type)
+		}
+	}
+	if len(types) == 1 {
+		return types[0]
+	}
+	return c.LookupTypeUnion(types)
+}
+
 func (c *Context) LookupTypeEnum(symbols []string) *TypeEnum {
 	tv := EncodeTypeValue(&TypeEnum{Symbols: symbols})
 	c.mu.Lock()

--- a/union.go
+++ b/union.go
@@ -7,10 +7,20 @@ import (
 type TypeUnion struct {
 	id    int
 	Types []Type
+	LUT   map[Type]int
 }
 
 func NewTypeUnion(id int, types []Type) *TypeUnion {
-	return &TypeUnion{id, types}
+	t := &TypeUnion{id: id, Types: types}
+	t.createLUT()
+	return t
+}
+
+func (t *TypeUnion) createLUT() {
+	t.LUT = make(map[Type]int)
+	for i, typ := range t.Types {
+		t.LUT[typ] = i
+	}
 }
 
 func (t *TypeUnion) ID() int {
@@ -23,6 +33,15 @@ func (t *TypeUnion) Type(selector int) (Type, error) {
 		return nil, ErrUnionSelector
 	}
 	return t.Types[selector], nil
+}
+
+// Selector returns the selector for typ in the union. If no type exists -1 is
+// returned.
+func (t *TypeUnion) Selector(typ Type) int {
+	if s, ok := t.LUT[typ]; ok {
+		return s
+	}
+	return -1
 }
 
 // SplitZNG takes a zng encoding of a value of the receiver's union type and


### PR DESCRIPTION
With canonical unions the collect aggregation was not deriving the
correct selector index for a union of values since the type order may be
rearranged when the zed.Context creates the union type. Fix this and add
a lookup table to zed.TypeUnion so it's easier to find a type's
selector.