### PR TITLE
fig bug unmarshaling zed.Value

### DIFF
--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -681,7 +681,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zed.Value, v reflect.Value) error {
 	if _, ok := v.Interface().(zed.Value); ok {
 		// For zed.Values we simply set the reflect value to the
 		// zed.Value that has been decoded.
-		v.Set(reflect.ValueOf(zv))
+		v.Set(reflect.ValueOf(*zv.Copy()))
 		return nil
 	}
 	switch v.Kind() {

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -537,8 +537,7 @@ func TestEmbeddedInterface(t *testing.T) {
 }
 
 func TestMultipleZedValues(t *testing.T) {
-	bytes := make([]byte, 3)
-	copy(bytes, []byte("foo"))
+	bytes := []byte("foo")
 	u := zson.NewZNGUnmarshaler()
 	var foo zed.Value
 	err := u.Unmarshal(*zed.NewValue(zed.TypeString, bytes), &foo)

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -535,3 +535,19 @@ func TestEmbeddedInterface(t *testing.T) {
 	assert.Equal(t, true, ok)
 	assert.Equal(t, "It's a thing one", thingB.Who())
 }
+
+func TestMultipleZedValues(t *testing.T) {
+	bytes := make([]byte, 3)
+	copy(bytes, []byte("foo"))
+	u := zson.NewZNGUnmarshaler()
+	var foo zed.Value
+	err := u.Unmarshal(*zed.NewValue(zed.TypeString, bytes), &foo)
+	require.NoError(t, err)
+	// clobber bytes slice
+	copy(bytes, []byte("bar"))
+	var bar zed.Value
+	err = u.Unmarshal(*zed.NewValue(zed.TypeString, bytes), &bar)
+	require.NoError(t, err)
+	assert.Equal(t, "foo", string(foo.Bytes))
+	assert.Equal(t, "bar", string(bar.Bytes))
+}


### PR DESCRIPTION
This commit fixes a bug where the unmarshaler would utilize the bytes
buffer of the zed.Value being decoded when returning an unmarshaled
zed.Value.  This can cause corruption to that zed.Value whenever the
original byte slice is changed as ownership is unclear in this scenario.
The fix is top copy the needed bytes from the incoming Zed value when
unmarshaling zed.Values.

This code path is not used much but manifested in the unmarshaling of
the commit journal when creating the scan scnapshots.  It went
unnoticed because of the way the scan would get built: with all
of the buggy spans the same, every data object in the pool would be
merge-scanned for any query.  While  correct, this can obviously
cause really poor performance.