### PR TITLE
fix bug in data object writer

### DIFF
--- a/lake/writer.go
+++ b/lake/writer.go
@@ -145,8 +145,8 @@ func (w *Writer) writeObject(object *data.Object, recs []zed.Value) error {
 	}
 	// Set first and last key values after the sort.
 	key := poolKey(w.pool.Layout)
-	object.First = *recs[0].DerefPath(key).MissingAsNull()
-	object.Last = *recs[len(recs)-1].DerefPath(key).MissingAsNull()
+	object.First = *recs[0].DerefPath(key).MissingAsNull().Copy()
+	object.Last = *recs[len(recs)-1].DerefPath(key).MissingAsNull().Copy()
 	writer, err := object.NewWriter(w.ctx, w.pool.engine, w.pool.DataPath, w.pool.Layout.Order, key, w.pool.SeekStride)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit fixes a bug where the span range of the object was
clobbered because the zed.Value from the object's records would
be freed while the object data structure was held across objects.
The fix is to copy the zed.Values of the span.