### PR TITLE
fix fuse aggregator bug

### DIFF
--- a/expr/agg/fuse.go
+++ b/expr/agg/fuse.go
@@ -22,7 +22,9 @@ func newFuse() *fuse {
 func (f *fuse) Consume(val *zed.Value) {
 	// only works for record types, e.g., fuse(foo.x) where foo.x is a record
 	if typ := zed.TypeRecordOf(val.Type); typ != nil {
-		f.shapes[typ] = len(f.shapes)
+		if _, ok := f.shapes[typ]; !ok {
+			f.shapes[typ] = len(f.shapes)
+		}
 	}
 }
 

--- a/expr/agg/ztests/fuse-simple.yaml
+++ b/expr/agg/ztests/fuse-simple.yaml
@@ -1,0 +1,8 @@
+zed: t:=fuse(r) by a
+
+input: |
+  {a:1,r:{a:1}}
+  {a:1,r:{a:2}}
+
+output: |
+  {a:1,t:<{a:int64}>}


### PR DESCRIPTION
This comimt fixes a bug in the fuse aggregator where duplicate
types would be assigned an illegal index in the types table.