### PR TITLE
rename iterators to "it"

### DIFF
--- a/expr/eval.go
+++ b/expr/eval.go
@@ -595,10 +595,8 @@ func getNthFromContainer(container zcode.Bytes, idx int) zcode.Bytes {
 			return nil
 		}
 	}
-	iter := container.Iter()
-	var i int
-	for ; !iter.Done(); i++ {
-		zv := iter.Next()
+	for i, it := 0, container.Iter(); !it.Done(); i++ {
+		zv := it.Next()
 		if i == idx {
 			return zv
 		}
@@ -607,10 +605,9 @@ func getNthFromContainer(container zcode.Bytes, idx int) zcode.Bytes {
 }
 
 func lookupKey(mapBytes, target zcode.Bytes) (zcode.Bytes, bool) {
-	iter := mapBytes.Iter()
-	for !iter.Done() {
-		key := iter.Next()
-		val := iter.Next()
+	for it := mapBytes.Iter(); !it.Done(); {
+		key := it.Next()
+		val := it.Next()
 		if bytes.Compare(key, target) == 0 {
 			return val, true
 		}

--- a/expr/putter.go
+++ b/expr/putter.go
@@ -149,22 +149,22 @@ func (p *putStep) buildRecord(in zcode.Bytes, b *zcode.Builder, vals []zed.Value
 type getter struct {
 	cursor    int
 	container zcode.Bytes
-	iter      zcode.Iter
+	it        zcode.Iter
 }
 
 func newGetter(cont zcode.Bytes) getter {
 	return getter{
 		cursor:    -1,
 		container: cont,
-		iter:      cont.Iter(),
+		it:        cont.Iter(),
 	}
 }
 func (ig *getter) nth(n int) (zcode.Bytes, error) {
 	if n < ig.cursor {
-		ig.iter = ig.container.Iter()
+		ig.it = ig.container.Iter()
 	}
-	for !ig.iter.Done() {
-		zv := ig.iter.Next()
+	for !ig.it.Done() {
+		zv := ig.it.Next()
 		ig.cursor++
 		if ig.cursor == n {
 			return zv, nil

--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -444,10 +444,8 @@ func (s *step) build(zctx *zed.Context, ectx Context, in zcode.Bytes, b *zcode.B
 			return nil
 		}
 		b.BeginContainer()
-		iter := in.Iter()
-		for !iter.Done() {
-			zv := iter.Next()
-			if zerr := s.children[0].build(zctx, ectx, zv, b); zerr != nil {
+		for it := in.Iter(); !it.Done(); {
+			if zerr := s.children[0].build(zctx, ectx, it.Next(), b); zerr != nil {
 				return zerr
 			}
 		}

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -403,8 +403,8 @@ func (m *MarshalZNGContext) encodeAny(v reflect.Value) (zed.Type, error) {
 func (m *MarshalZNGContext) encodeMap(v reflect.Value) (zed.Type, error) {
 	var lastKeyType, lastValType zed.Type
 	m.Builder.BeginContainer()
-	for iter := v.MapRange(); iter.Next(); {
-		keyType, err := m.encodeValue(iter.Key())
+	for it := v.MapRange(); it.Next(); {
+		keyType, err := m.encodeValue(it.Key())
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (m *MarshalZNGContext) encodeMap(v reflect.Value) (zed.Type, error) {
 			return nil, errors.New("map has mixed key types")
 		}
 		lastKeyType = keyType
-		valType, err := m.encodeValue(iter.Value())
+		valType, err := m.encodeValue(it.Value())
 		if err != nil {
 			return nil, err
 		}

--- a/zst/column/primitive.go
+++ b/zst/column/primitive.go
@@ -53,7 +53,7 @@ func (p *PrimitiveWriter) EncodeMap(zctx *zed.Context, b *zcode.Builder) (zed.Ty
 }
 
 type PrimitiveReader struct {
-	iter   zcode.Iter
+	it     zcode.Iter
 	segmap []Segment
 	reader io.ReaderAt
 }
@@ -78,7 +78,7 @@ func (p *PrimitiveReader) Read(b *zcode.Builder) error {
 }
 
 func (p *PrimitiveReader) read() (zcode.Bytes, error) {
-	if p.iter == nil || p.iter.Done() {
+	if p.it == nil || p.it.Done() {
 		if len(p.segmap) == 0 {
 			return nil, io.EOF
 		}
@@ -86,7 +86,7 @@ func (p *PrimitiveReader) read() (zcode.Bytes, error) {
 			return nil, err
 		}
 	}
-	return p.iter.Next(), nil
+	return p.it.Next(), nil
 }
 
 func (p *PrimitiveReader) next() error {
@@ -106,6 +106,6 @@ func (p *PrimitiveReader) next() error {
 	if n < int(segment.Length) {
 		return errors.New("truncated read of ZST column")
 	}
-	p.iter = zcode.Iter(b)
+	p.it = zcode.Iter(b)
 	return nil
 }


### PR DESCRIPTION
Nearly all iterator fields and variables in the code base are named
"it".  Rename the few that aren't for consistency with that convention.