### PR TITLE
emit missing errors in yield

### DIFF
--- a/proc/yield/yield.go
+++ b/proc/yield/yield.go
@@ -29,7 +29,7 @@ func (p *Proc) Pull(done bool) (zbuf.Batch, error) {
 		for i := range vals {
 			for _, e := range p.exprs {
 				val := e.Eval(batch, &vals[i])
-				if val.IsMissing() {
+				if val.IsQuiet() {
 					continue
 				}
 				// Copy is necessary because argument bytes

--- a/proc/yield/ztests/quiet.yaml
+++ b/proc/yield/ztests/quiet.yaml
@@ -1,4 +1,4 @@
-zed: yield a,123
+zed: yield quiet(a)
 
 input: |
   {a:1}
@@ -7,8 +7,4 @@ input: |
 
 output: |
   1
-  123
-  error("missing")
-  123
   [3,2,1,0]
-  123


### PR DESCRIPTION
Previously, the yield operator filtered missing errors and emitted
quiet errors.  This commit reverses this so quiet() works correctly
with yield (as was intended and documented in the quiet function).