### PR TITLE
tidy up the ksuid function

### DIFF
--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -49,6 +49,7 @@ func New(zctx *zed.Context, name string, narg int) (Interface, field.Path, error
 		argmax = 2
 		f = &Join{zctx: zctx}
 	case "ksuid":
+		argmin = 0
 		f = &KSUIDToString{zctx: zctx}
 	case "log":
 		f = &Log{zctx: zctx}
@@ -185,6 +186,10 @@ func newTime(ctx zed.Allocator, native nano.Ts) *zed.Value {
 
 func newString(ctx zed.Allocator, native string) *zed.Value {
 	return ctx.NewValue(zed.TypeString, zed.EncodeString(native))
+}
+
+func newBytes(ctx zed.Allocator, bytes []byte) *zed.Value {
+	return ctx.NewValue(zed.TypeBytes, bytes)
 }
 
 //XXX this should build the error in the allocator's memory but needs

--- a/expr/function/ztests/ksuid-new.yaml
+++ b/expr/function/ztests/ksuid-new.yaml
@@ -1,0 +1,7 @@
+zed: yield len(ksuid())
+
+input: |
+  null
+
+output: |
+  20

--- a/expr/function/ztests/ksuid.yaml
+++ b/expr/function/ztests/ksuid.yaml
@@ -1,0 +1,15 @@
+zed: yield ksuid(this)
+
+input: |
+  "24eT188EIisOiwVWwmej1h9t4Ms"
+  0x0e8afd4a5a0a2372e218818aa996ad96f5739dd2
+  null(bytes)
+  null(string)
+  null
+
+output: |
+  0x0e8afd4a5a0a2372e218818aa996ad96f5739dd2
+  "24eT188EIisOiwVWwmej1h9t4Ms"
+  error("ksuid: illegal null argument")
+  error("ksuid: Valid encoded KSUIDs are 27 characters (bad argument: null(string))")
+  error("ksuid: argument must a bytes or string type (bad argument: null)")


### PR DESCRIPTION
This commit updates the ksuid() function by allowing it to create
new KSUIDs (when called with no args) and to convert both ways from
bytes to string and from string to bytes.

Docs for ksuid will be updated in the docs-update branch and that PR
will be put up soon.

Closes #3564