### PR TITLE
improve zed.Context.LookupType* performance

### DIFF
--- a/typetype.go
+++ b/typetype.go
@@ -15,12 +15,16 @@ func (t *TypeOfType) Kind() Kind {
 }
 
 func NewTypeValue(t Type) *Value {
-	return &Value{TypeType, EncodeTypeValue(t)}
+	return &Value{TypeType, AppendTypeValue(nil, t)}
 }
 
 func EncodeTypeValue(t Type) zcode.Bytes {
+	return AppendTypeValue(nil, t)
+}
+
+func AppendTypeValue(b zcode.Bytes, t Type) zcode.Bytes {
 	var typedefs map[string]Type
-	return appendTypeValue(nil, t, &typedefs)
+	return appendTypeValue(b, t, &typedefs)
 }
 
 func appendTypeValue(b zcode.Bytes, t Type, typedefs *map[string]Type) zcode.Bytes {


### PR DESCRIPTION
zio/jsonio.Reader tends to call at least one zed.Context.LookupType*
method per value read.  Speed up those methods with two improvements.

1. Some zed.Context.LookupType* methods allocate type values that are
   discarded if the type already exists in the the context.  Obtain type
   value storage from a sync.Pool to reduce allocations.

2. zed.Context.LookupTypeRecord uses a map to check for duplicate
   fields.  Replace with a faster sorted list obtained from a sync.Pool.