### PR TITLE
speed up zio/jsonio.Reader with pkg/jsonlexer

### DIFF
--- a/pkg/jsonlexer/lexer.go
+++ b/pkg/jsonlexer/lexer.go
@@ -1,0 +1,171 @@
+package jsonlexer
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+)
+
+type Token byte
+
+const (
+	TokenErr Token = iota
+
+	TokenBeginArray
+	TokenBeginObject
+	TokenEndArray
+	TokenEndObject
+	TokenNameSeparator
+	TokenValueSeparator
+
+	TokenString
+	TokenNumber
+	TokenTrue
+	TokenFalse
+	TokenNull
+)
+
+type Lexer struct {
+	br  *bufio.Reader
+	buf []byte
+	err error
+}
+
+func New(br *bufio.Reader) *Lexer {
+	return &Lexer{
+		br:  br,
+		buf: make([]byte, 0, 128),
+	}
+}
+
+func (l *Lexer) Buf() []byte {
+	return l.buf
+}
+
+func (l *Lexer) Err() error {
+	return l.err
+}
+
+func (l *Lexer) Token() Token {
+	l.buf = l.buf[:1]
+	for {
+		c, err := l.br.ReadByte()
+		if err != nil {
+			l.err = err
+			return TokenErr
+		}
+		l.buf[0] = c
+		// Cases are ordered by decreasing expected frequency.
+		switch c {
+		case '"':
+			return l.readString()
+		case ',':
+			return TokenValueSeparator
+		case ':':
+			return TokenNameSeparator
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-':
+			return l.readNumber(c)
+		case 'f':
+			return l.readLiteral("alse", TokenFalse)
+		case 't':
+			return l.readLiteral("rue", TokenTrue)
+		case 'n':
+			return l.readLiteral("ull", TokenNull)
+		case '{':
+			return TokenBeginObject
+		case '}':
+			return TokenEndObject
+		case '[':
+			return TokenBeginArray
+		case ']':
+			return TokenEndArray
+		case ' ', '\n', '\r', '\t':
+			continue
+		default:
+			l.err = fmt.Errorf("invalid character %q looking for beginning of value", c)
+			return TokenErr
+		}
+	}
+}
+
+func (l *Lexer) readLiteral(s string, t Token) Token {
+	for i := range s {
+		c, err := l.br.ReadByte()
+		if err != nil {
+			l.err = err
+			return TokenErr
+		}
+		if s[i] != c {
+			l.err = errors.New("bad literal name")
+			return TokenErr
+		}
+	}
+	c, err := l.br.ReadByte()
+	if err != nil {
+		if err == io.EOF {
+			return t
+		}
+	}
+	if err := l.br.UnreadByte(); err != nil {
+		l.err = err
+		return TokenErr
+	}
+	if !isValueBoundaryChar(c) {
+		l.err = errors.New("bad literal name")
+		return TokenErr
+	}
+	return t
+}
+
+func isValueBoundaryChar(c byte) bool {
+	switch c {
+	case '[', '{', ']', '}', ',', '"':
+		return true
+	case 0x20, 0x0a, 0x0d, 0x09:
+		return true
+	}
+	return false
+}
+
+func (l *Lexer) readNumber(c byte) Token {
+	l.buf = append(l.buf[:0], c)
+	for {
+		c, err := l.br.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return TokenNumber
+			}
+			l.err = err
+			return TokenErr
+		}
+		if !isNumberChar(c) {
+			if err := l.br.UnreadByte(); err != nil {
+				l.err = err
+				return TokenErr
+			}
+			return TokenNumber
+		}
+		l.buf = append(l.buf, c)
+	}
+}
+
+func isNumberChar(c byte) bool {
+	return c-'0' < 10 || c == '.' || c == 'e' || c == 'E' || c == '-' || c == '+'
+}
+
+func (l *Lexer) readString() Token {
+	var escape bool
+	for {
+		c, err := l.br.ReadByte()
+		if err != nil {
+			l.err = err
+			return TokenErr
+		}
+		l.buf = append(l.buf, c)
+		if c == '"' && !escape {
+			return TokenString
+		}
+		escape = c == '\\' && !escape
+	}
+}

--- a/zio/jsonio/builder.go
+++ b/zio/jsonio/builder.go
@@ -1,12 +1,10 @@
 package jsonio
 
 import (
-	"encoding/json"
 	"sort"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/zcode"
-	"golang.org/x/text/unicode/norm"
 )
 
 type builder struct {
@@ -31,33 +29,6 @@ type item struct {
 func (b *builder) reset() {
 	b.containers = b.containers[:0]
 	b.items = b.items[:0]
-}
-
-func (b *builder) addPrimitive(fieldName string, v interface{}) bool {
-	b.bytes = b.bytes[:0]
-	switch v := v.(type) {
-	case bool:
-		b.bytes = zed.AppendBool(b.bytes, v)
-		b.pushPrimitiveItem(fieldName, zed.TypeBool, b.bytes)
-	case json.Number:
-		if i, err := v.Int64(); err == nil {
-			b.bytes = zed.AppendInt(b.bytes, i)
-			b.pushPrimitiveItem(fieldName, zed.TypeInt64, b.bytes)
-		} else if f, err := v.Float64(); err == nil {
-			b.bytes = zed.AppendFloat64(b.bytes, f)
-			b.pushPrimitiveItem(fieldName, zed.TypeFloat64, b.bytes)
-		} else {
-			return false
-		}
-	case string:
-		b.bytes = norm.NFC.AppendString(b.bytes, v)
-		b.pushPrimitiveItem(fieldName, zed.TypeString, b.bytes)
-	case nil:
-		b.pushPrimitiveItem(fieldName, zed.TypeNull, nil)
-	default:
-		return false
-	}
-	return true
 }
 
 func (b *builder) pushPrimitiveItem(fieldName string, typ zed.Type, bytes zcode.Bytes) {

--- a/zio/jsonio/decode.go
+++ b/zio/jsonio/decode.go
@@ -1,0 +1,163 @@
+// This file is derived from
+// https://github.com/golang/go/blob/master/src/encoding/json/decode.go
+// and is covered by the copyright reproduced below.
+//
+// Any changes are covered by the copyright and license in the LICENSE.txt file
+// in the root directory of this repository.
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package jsonio
+
+import (
+	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// getu4 decodes \uXXXX from the beginning of s, returning the hex value,
+// or it returns -1.
+func getu4(s []byte) rune {
+	if len(s) < 6 || s[0] != '\\' || s[1] != 'u' {
+		return -1
+	}
+	var r rune
+	for _, c := range s[2:6] {
+		switch {
+		case '0' <= c && c <= '9':
+			c = c - '0'
+		case 'a' <= c && c <= 'f':
+			c = c - 'a' + 10
+		case 'A' <= c && c <= 'F':
+			c = c - 'A' + 10
+		default:
+			return -1
+		}
+		r = r*16 + rune(c)
+	}
+	return r
+}
+
+// unquote converts a quoted JSON string literal s into an actual string t.
+// The rules are different than for Go, so cannot use strconv.Unquote.
+func unquote(s []byte) (t string, ok bool) {
+	s, ok = unquoteBytes(s)
+	t = string(s)
+	return
+}
+
+func unquoteBytes(s []byte) (t []byte, ok bool) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return
+	}
+	s = s[1 : len(s)-1]
+
+	// Check for unusual characters. If there are none,
+	// then no unquoting is needed, so return a slice of the
+	// original bytes.
+	r := 0
+	for r < len(s) {
+		c := s[r]
+		if c == '\\' || c == '"' || c < ' ' {
+			break
+		}
+		if c < utf8.RuneSelf {
+			r++
+			continue
+		}
+		rr, size := utf8.DecodeRune(s[r:])
+		if rr == utf8.RuneError && size == 1 {
+			break
+		}
+		r += size
+	}
+	if r == len(s) {
+		return s, true
+	}
+
+	b := make([]byte, len(s)+2*utf8.UTFMax)
+	w := copy(b, s[0:r])
+	for r < len(s) {
+		// Out of room? Can only happen if s is full of
+		// malformed UTF-8 and we're replacing each
+		// byte with RuneError.
+		if w >= len(b)-2*utf8.UTFMax {
+			nb := make([]byte, (len(b)+utf8.UTFMax)*2)
+			copy(nb, b[0:w])
+			b = nb
+		}
+		switch c := s[r]; {
+		case c == '\\':
+			r++
+			if r >= len(s) {
+				return
+			}
+			switch s[r] {
+			default:
+				return
+			case '"', '\\', '/', '\'':
+				b[w] = s[r]
+				r++
+				w++
+			case 'b':
+				b[w] = '\b'
+				r++
+				w++
+			case 'f':
+				b[w] = '\f'
+				r++
+				w++
+			case 'n':
+				b[w] = '\n'
+				r++
+				w++
+			case 'r':
+				b[w] = '\r'
+				r++
+				w++
+			case 't':
+				b[w] = '\t'
+				r++
+				w++
+			case 'u':
+				r--
+				rr := getu4(s[r:])
+				if rr < 0 {
+					return
+				}
+				r += 6
+				if utf16.IsSurrogate(rr) {
+					rr1 := getu4(s[r:])
+					if dec := utf16.DecodeRune(rr, rr1); dec != unicode.ReplacementChar {
+						// A valid pair; consume.
+						r += 6
+						w += utf8.EncodeRune(b[w:], dec)
+						break
+					}
+					// Invalid surrogate; fall back to replacement rune.
+					rr = unicode.ReplacementChar
+				}
+				w += utf8.EncodeRune(b[w:], rr)
+			}
+
+		// Quote, control characters are invalid.
+		case c == '"', c < ' ':
+			return
+
+		// ASCII
+		case c < utf8.RuneSelf:
+			b[w] = c
+			r++
+			w++
+
+		// Coerce to well-formed UTF-8.
+		default:
+			rr, size := utf8.DecodeRune(s[r:])
+			r += size
+			w += utf8.EncodeRune(b[w:], rr)
+		}
+	}
+	return b[0:w], true
+}

--- a/zio/jsonio/reader.go
+++ b/zio/jsonio/reader.go
@@ -1,97 +1,152 @@
 package jsonio
 
 import (
-	"encoding/json"
+	"bufio"
 	"fmt"
 	"io"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/pkg/byteconv"
+	"github.com/brimdata/zed/pkg/jsonlexer"
+	"golang.org/x/text/unicode/norm"
 )
 
 type Reader struct {
 	builder builder
-	decoder *json.Decoder
+	lexer   *jsonlexer.Lexer
+	buf     []byte
 }
 
 func NewReader(r io.Reader, zctx *zed.Context) *Reader {
-	d := json.NewDecoder(r)
-	d.UseNumber()
 	return &Reader{
 		builder: builder{zctx: zctx},
-		decoder: d,
+		// 64 KB gave the best performance when this was written.
+		lexer: jsonlexer.New(bufio.NewReaderSize(r, 64*1024)),
 	}
 }
 
 func (r *Reader) Read() (*zed.Value, error) {
-	token, err := r.decoder.Token()
-	if err != nil {
+	t := r.lexer.Token()
+	if t == jsonlexer.TokenErr {
+		err := r.lexer.Err()
 		if err == io.EOF {
 			return nil, nil
 		}
 		return nil, err
 	}
 	r.builder.reset()
-	if err := r.handleToken("", token); err != nil {
+	if err := r.handleToken("", t); err != nil {
 		return nil, err
 	}
 	return r.builder.value(), nil
 }
 
-func (r *Reader) handleToken(fieldName string, token json.Token) error {
-	switch token {
-	case json.Delim('['):
-		r.builder.beginContainer(fieldName)
-		if err := r.readArray(); err != nil {
+func (r *Reader) handleToken(fieldName string, t jsonlexer.Token) error {
+	r.buf = r.buf[:0]
+	switch t {
+	case jsonlexer.TokenString:
+		b, ok := unquoteBytes(r.lexer.Buf())
+		if !ok {
+			return fmt.Errorf("invalid JSON string %q", r.lexer.Buf())
+		}
+		r.buf = norm.NFC.Append(r.buf, b...)
+		r.builder.pushPrimitiveItem(fieldName, zed.TypeString, r.buf)
+	case jsonlexer.TokenNumber:
+		if i, err := byteconv.ParseInt64(r.lexer.Buf()); err == nil {
+			r.buf = zed.AppendInt(r.buf, i)
+			r.builder.pushPrimitiveItem(fieldName, zed.TypeInt64, r.buf)
+		} else if f, err := byteconv.ParseFloat64(r.lexer.Buf()); err == nil {
+			r.buf = zed.AppendFloat64(r.buf, f)
+			r.builder.pushPrimitiveItem(fieldName, zed.TypeFloat64, r.buf)
+		} else {
 			return err
 		}
-		r.builder.endArray()
-		return nil
-	case json.Delim('{'):
+	case jsonlexer.TokenBeginObject:
 		r.builder.beginContainer(fieldName)
 		if err := r.readRecord(); err != nil {
 			return err
 		}
 		r.builder.endRecord()
-		return nil
-	}
-	if !r.builder.addPrimitive(fieldName, token) {
-		return r.tokenError(token)
+	case jsonlexer.TokenBeginArray:
+		r.builder.beginContainer(fieldName)
+		if err := r.readArray(); err != nil {
+			return err
+		}
+		r.builder.endArray()
+	case jsonlexer.TokenNull:
+		r.builder.pushPrimitiveItem(fieldName, zed.TypeNull, nil)
+	case jsonlexer.TokenFalse, jsonlexer.TokenTrue:
+		r.buf = zed.AppendBool(r.buf, t == jsonlexer.TokenTrue)
+		r.builder.pushPrimitiveItem(fieldName, zed.TypeBool, r.buf)
+	default:
+		return r.error(t, "looking for beginning of value")
 	}
 	return nil
 }
 
 func (r *Reader) readArray() error {
-	for {
-		token, err := r.decoder.Token()
-		if token == json.Delim(']') || err != nil {
+	switch t := r.lexer.Token(); t {
+	case jsonlexer.TokenEndArray:
+		return nil
+	default:
+		if err := r.handleToken("", t); err != nil {
 			return err
 		}
-		if err := r.handleToken("", token); err != nil {
-			return err
+	}
+	for {
+		switch t := r.lexer.Token(); t {
+		case jsonlexer.TokenEndArray:
+			return nil
+		case jsonlexer.TokenValueSeparator:
+			if err := r.handleToken("", r.lexer.Token()); err != nil {
+				return err
+			}
+		default:
+			return r.error(t, "after array value")
 		}
 	}
 }
 
 func (r *Reader) readRecord() error {
+	switch t := r.lexer.Token(); t {
+	case jsonlexer.TokenEndObject:
+		return nil
+	default:
+		if err := r.readNameValuePair(t); err != nil {
+			return err
+		}
+	}
 	for {
-		token, err := r.decoder.Token()
-		if token == json.Delim('}') || err != nil {
-			return err
-		}
-		field, ok := token.(string)
-		if !ok {
-			return r.tokenError(token)
-		}
-		token, err = r.decoder.Token()
-		if err != nil {
-			return err
-		}
-		if err := r.handleToken(field, token); err != nil {
-			return err
+		switch t := r.lexer.Token(); t {
+		case jsonlexer.TokenEndObject:
+			return nil
+		case jsonlexer.TokenValueSeparator:
+			if err := r.readNameValuePair(r.lexer.Token()); err != nil {
+				return err
+			}
+		default:
+			return r.error(t, "after object key")
 		}
 	}
 }
 
-func (r *Reader) tokenError(token json.Token) error {
-	return fmt.Errorf("unexpected JSON token '%v' at offset %d", token, r.decoder.InputOffset())
+func (r *Reader) readNameValuePair(t jsonlexer.Token) error {
+	if t != jsonlexer.TokenString {
+		return r.error(t, "looking for beginning of object key string")
+	}
+	fieldName, ok := unquote(r.lexer.Buf())
+	if !ok {
+		return fmt.Errorf("invalid string %q", r.lexer.Buf())
+	}
+	if t := r.lexer.Token(); t != jsonlexer.TokenNameSeparator {
+		return r.error(t, "after object key")
+	}
+	return r.handleToken(fieldName, r.lexer.Token())
+}
+
+func (r *Reader) error(t jsonlexer.Token, msg string) error {
+	if t == jsonlexer.TokenErr {
+		return r.lexer.Err()
+	}
+	return fmt.Errorf("invalid character %q %s", r.lexer.Buf()[0], msg)
 }


### PR DESCRIPTION
zio/jsonio.Reader performance suffers from the large number of
allocations performed by encoding/json.Decoder.Token.  Replace it with
pkg/jsonlexer, a JSON lexer that minimizes the number of allocations.

There are a number of JSON lexers in Go out there, and I'd hoped to use one, but all were slower than I'd hoped.

Reading NDJSON with ~~`-f json`~~ `-i json` is about three times faster for me with this branch compared to main.