### PR TITLE
uniq -c: wrap value in new record

### DIFF
--- a/proc/uniq/ztests/uniq.yaml
+++ b/proc/uniq/ztests/uniq.yaml
@@ -1,0 +1,10 @@
+zed: "uniq -c"
+
+input: |
+  1
+  1
+  {x:1}
+
+output: |
+  {value:1,count:2(uint64)}
+  {value:{x:1},count:1(uint64)}


### PR DESCRIPTION
For uniq -c wrap the output in {value:any,count:uint64}. This ensures
that uniq -c also works for non-record values.

Closes #3582