### PR TITLE
fix Parquet writer data corruption

### DIFF
--- a/zio/parquetio/data.go
+++ b/zio/parquetio/data.go
@@ -31,7 +31,8 @@ func newData(typ zed.Type, zb zcode.Bytes) (interface{}, error) {
 	case *zed.TypeOfBool:
 		return zed.DecodeBool(zb), nil
 	case *zed.TypeOfBytes, *zed.TypeOfString:
-		return zed.DecodeBytes(zb), nil
+		// Copy zb since we don't own it.
+		return append([]byte{}, zb...), nil
 	case *zed.TypeOfIP:
 		return []byte(zed.DecodeIP(zb).String()), nil
 	case *zed.TypeOfNet:


### PR DESCRIPTION
zio/parquetio.Writer.Write retains pointers into zed.Value.Bytes for Zed
bytes and string values.  This can lead to corruption if that storage is
reused before the current row group is flushed to the Parquet file.  Fix
by copying instead of retaining pointers for bytes and string values in
parquetio.newData.