### PR TITLE
format Zed type value as string in Parquet writer

### DIFF
--- a/zio/parquetio/data.go
+++ b/zio/parquetio/data.go
@@ -38,7 +38,7 @@ func newData(typ zed.Type, zb zcode.Bytes) (interface{}, error) {
 	case *zed.TypeOfNet:
 		return []byte(zed.DecodeNet(zb).String()), nil
 	case *zed.TypeOfType:
-		return zed.DecodeBytes(zb), nil
+		return []byte(zson.FormatTypeValue(zb)), nil
 	case *zed.TypeOfNull:
 		return nil, ErrNullType
 	case *zed.TypeRecord:

--- a/zio/parquetio/ztests/types.yaml
+++ b/zio/parquetio/ztests/types.yaml
@@ -1,0 +1,102 @@
+script: |
+  zq -f parquet -o f.parquet -
+  zq -Z -i parquet f.parquet
+
+inputs:
+  - name: stdin
+    data: |
+      {
+          u8: 8 (uint8),
+          u16: 16 (uint16),
+          u32: 32 (uint32),
+          u64: 64,
+          i8: -8 (int8),
+          i16: -16 (int16),
+          i32: -32 (int32),
+          i64: -64,
+          dur: 0s,
+          tim: 1970-01-01T00:00:00Z,
+          f32: 32. (float32),
+          f64: 64.,
+          boo: false,
+          byt: 0x01020304,
+          str: "1234",
+          ip: 1.2.3.4,
+          net: 5.6.7.0/24,
+          typ: <int8>,
+          err: error("err"),
+          rec: {a:1},
+      } (=0)
+      {
+          u8: null,
+          u16: null,
+          u32: null,
+          u64: null,
+          i8: null,
+          i16: null,
+          i32: null,
+          i64: null,
+          dur: null,
+          tim: null,
+          f32: null,
+          f64: null,
+          boo: null,
+          byt: null,
+          str: null,
+          ip: null,
+          net: null,
+          typ: null,
+          err: null,
+          rec: null,
+      } (0)
+
+
+outputs:
+  - name: stdout
+    data: |
+      {
+          u8: 8 (uint8),
+          u16: 16 (uint16),
+          u32: 32 (uint32),
+          u64: 64,
+          i8: -8 (int8),
+          i16: -16 (int16),
+          i32: -32 (int32),
+          i64: -64,
+          dur: 0,
+          tim: 1970-01-01T00:00:00Z,
+          f32: 32. (float32),
+          f64: 64.,
+          boo: false,
+          byt: 0x01020304,
+          str: "1234",
+          ip: "1.2.3.4",
+          net: "5.6.7.0/24",
+          typ: "int8",
+          err: "error(\"err\")",
+          rec: {
+              a: 1
+          }
+      }
+      {
+          u8: null (uint8),
+          u16: null (uint16),
+          u32: null (uint32),
+          u64: null (int64),
+          i8: null (int8),
+          i16: null (int16),
+          i32: null (int32),
+          i64: null (int64),
+          dur: null (int64),
+          tim: null (time),
+          f32: null (float32),
+          f64: null (float64),
+          boo: null (bool),
+          byt: null (bytes),
+          str: null (string),
+          ip: null (string),
+          net: null (string),
+          typ: null (string),
+          err: null (string),
+          rec: null ({a:int64})
+      }


### PR DESCRIPTION
For a Zed type value field, zio/parquetio.Writer creates a column with
the Parquet STRING logical type but writes the binary type value to it.
This doesn't make much sense.  Format the type value with
zson.FormatTypeValue so we write an actual string instead.