### PR TITLE
Allow Authorization header in cors

### DIFF
--- a/service/middleware.go
+++ b/service/middleware.go
@@ -43,6 +43,7 @@ func corsMiddleware() mux.MiddlewareFunc {
 			http.MethodPatch,
 			http.MethodDelete,
 		},
+		AllowedHeaders: []string{"Authorization", "Accept", "Content-Type", "X-Requested-With"},
 		AllowCredentials: true,
 	}).Handler
 }

--- a/service/ztests/curl-cors.yaml
+++ b/service/ztests/curl-cors.yaml
@@ -4,14 +4,14 @@ script: |
   curl -sD - \
     -X OPTIONS \
     -H "Access-Control-Request-Method: POST" \
-    -H "Access-Control-Request-Headers: content-type" \
+    -H "Access-Control-Request-Headers: content-type, authorization" \
     -H "Origin: http://test.observableusercontent.com" \
     $ZED_LAKE/query | grep Access-Control-Allow | tr -d '\015'
   echo === OPTIONS: not allowed ===
   ! curl -sD - \
     -X OPTIONS \
     -H "Access-Control-Request-Method: POST" \
-    -H "Access-Control-Request-Headers: content-type" \
+    -H "Access-Control-Request-Headers: content-type, authorization" \
     -H "Origin: http://adversarialobservableusercontent.com" \
     $ZED_LAKE/query | grep Access-Control-Allow
   echo === POST: allowed ===
@@ -37,7 +37,7 @@ outputs:
     data: |
       === OPTIONS: allowed ===
       Access-Control-Allow-Credentials: true
-      Access-Control-Allow-Headers: Content-Type
+      Access-Control-Allow-Headers: Content-Type, Authorization
       Access-Control-Allow-Methods: POST
       Access-Control-Allow-Origin: http://test.observableusercontent.com
       === OPTIONS: not allowed ===


### PR DESCRIPTION
I hadn't previously tested our cors setup against an authenticated lake which requires the use of the "Authorization" header. With our previous setup, we did not specify the allowed headers which defaulted to [these](https://github.com/rs/cors/blob/27c7ce4275a3dcb3639dd45870f91c2bd59d862e/cors.go#L158). Moving forward we will continue to use those as well as admit the authorization header.