### PR TITLE
fix cast bugs

### DIFF
--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -144,6 +144,9 @@ type casterNet struct {
 }
 
 func (c *casterNet) Eval(ectx Context, val *zed.Value) *zed.Value {
+	if val.Type.ID() == zed.IDNet {
+		return ectx.CopyValue(*val)
+	}
 	if !val.IsString() {
 		return ectx.CopyValue(*c.zctx.NewErrorf("cannot cast %s to type net", zson.MustFormatValue(*val)))
 	}
@@ -161,6 +164,9 @@ type casterDuration struct {
 
 func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
 	id := val.Type.ID()
+	if id == zed.IDDuration {
+		return ectx.CopyValue(*val)
+	}
 	if id == zed.IDString {
 		d, err := nano.ParseDuration(byteconv.UnsafeString(val.Bytes))
 		if err != nil {
@@ -191,6 +197,9 @@ type casterTime struct {
 
 func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
 	id := val.Type.ID()
+	if id == zed.IDTime {
+		return ectx.CopyValue(*val)
+	}
 	var ts nano.Ts
 	switch {
 	case val.Bytes == nil:

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -197,11 +197,10 @@ type casterTime struct {
 
 func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
 	id := val.Type.ID()
-	if id == zed.IDTime {
-		return ectx.CopyValue(*val)
-	}
 	var ts nano.Ts
 	switch {
+	case id == zed.IDTime:
+		return ectx.CopyValue(*val)
 	case val.Bytes == nil:
 		// Do nothing. Any nil value is cast to a zero time.
 	case id == zed.IDString:

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -797,10 +797,10 @@ type evalCast struct {
 
 func (c *evalCast) Eval(ectx Context, this *zed.Value) *zed.Value {
 	val := c.expr.Eval(ectx, this)
-	if val.IsNull() {
-		// Take care of null here so the casters don't have to
-		// worry about it.  Any value can be null after all.
-		return ectx.NewValue(c.typ, nil)
+	if val.IsNull() || val.Type == c.typ {
+		// If value is null or the type won't change, just return a
+		// copy of the value.
+		return ectx.NewValue(c.typ, val.Bytes)
 	}
 	return c.caster.Eval(ectx, val)
 }

--- a/runtime/expr/ztests/cast-dur-to-dur.yaml
+++ b/runtime/expr/ztests/cast-dur-to-dur.yaml
@@ -1,0 +1,6 @@
+zed: 'yield duration(this)'
+
+input: &input |
+  10d
+
+output: *input

--- a/runtime/expr/ztests/cast-net-to-net.yaml
+++ b/runtime/expr/ztests/cast-net-to-net.yaml
@@ -1,0 +1,6 @@
+zed: 'yield net(this)'
+
+input: &input |
+  10.0.0.0/8
+
+output: *input

--- a/runtime/expr/ztests/cast-time-to-time.yaml
+++ b/runtime/expr/ztests/cast-time-to-time.yaml
@@ -1,0 +1,6 @@
+zed: 'yield time(this)'
+
+input: &input |
+  2022-02-12T15:48:36.761595Z
+
+output: *input


### PR DESCRIPTION
This commit fixes bug where casts of type time, duration, and net would
fail when the input type was already the desired type.