### PR TITLE
remove zcode.Bytes.Body error return parameter

### DIFF
--- a/runtime/expr/shaper.go
+++ b/runtime/expr/shaper.go
@@ -111,11 +111,7 @@ func (c *ConstShaper) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if zerr := s.step.build(c.zctx, ectx, val.Bytes, &c.b); zerr != nil {
 		return zerr
 	}
-	body, err := c.b.Bytes().Body()
-	if err != nil {
-		panic(err)
-	}
-	return ectx.NewValue(s.typ, body)
+	return ectx.NewValue(s.typ, c.b.Bytes().Body())
 }
 
 // A shaper is a per-input type ID "spec" that contains the output

--- a/zcode/bytes.go
+++ b/zcode/bytes.go
@@ -30,13 +30,10 @@ func (b Bytes) Iter() Iter {
 	return Iter(b)
 }
 
-func (b Bytes) Body() (Bytes, error) {
+// Body returns b's body.
+func (b Bytes) Body() Bytes {
 	it := b.Iter()
-	body := it.Next()
-	if !it.Done() {
-		return nil, ErrNotSingleton
-	}
-	return body, nil
+	return it.Next()
 }
 
 // Append appends val to dst as a tagged value and returns the

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -58,11 +58,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err := r.decodeValue(r.builder, typ, object.Value); err != nil {
 		return nil, e(err)
 	}
-	bytes, err := r.builder.Bytes().Body()
-	if err != nil {
-		return nil, e(err)
-	}
-	return zed.NewValue(typ, bytes), nil
+	return zed.NewValue(typ, r.builder.Bytes().Body()), nil
 }
 
 func (r *Reader) decodeValue(b *zcode.Builder, typ zed.Type, body interface{}) error {

--- a/zio/zng21io/reader.go
+++ b/zio/zng21io/reader.go
@@ -87,11 +87,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 			}
 			r.types[val.Type] = typ
 		}
-		bytes, err := b.Bytes().Body()
-		if err != nil {
-			return nil, err
-		}
-		return zed.NewValue(typ, bytes), nil
+		return zed.NewValue(typ, b.Bytes().Body()), nil
 	}
 }
 

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -155,11 +155,7 @@ func (m *MarshalZNGContext) MarshalRecord(v interface{}) (*zed.Value, error) {
 	if !zed.IsRecordType(typ) {
 		return nil, errors.New("not a record")
 	}
-	body, err := m.Builder.Bytes().Body()
-	if err != nil {
-		return nil, err
-	}
-	return zed.NewValue(typ, body), nil
+	return zed.NewValue(typ, m.Builder.Bytes().Body()), nil
 }
 
 func (m *MarshalZNGContext) MarshalCustom(names []string, fields []interface{}) (*zed.Value, error) {

--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -68,13 +68,5 @@ func (a *Assembler) Read() (*zed.Value, error) {
 	if err = reader.Read(&a.builder); err != nil {
 		return nil, err
 	}
-	body, err := a.builder.Bytes().Body()
-	if err != nil {
-		return nil, err
-	}
-	rec := zed.NewValue(a.types[typeNo], body)
-	//XXX if we had a buffer pool where records could be built back to
-	// back in batches, then we could get rid of this extra allocation
-	// and copy on every record
-	return rec.Copy(), nil
+	return zed.NewValue(a.types[typeNo], a.builder.Bytes().Body()), nil
 }

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -2,7 +2,6 @@ package zst
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -181,11 +180,7 @@ func (w *Writer) finalize() error {
 	if err != nil {
 		return err
 	}
-	bytes, err := b.Bytes().Body()
-	if err != nil {
-		return errors.New("ZST: corrupt root reassembly")
-	}
-	root := zed.NewValue(typ, bytes)
+	root := zed.NewValue(typ, b.Bytes().Body())
 	if err := zw.Write(root); err != nil {
 		return err
 	}
@@ -199,11 +194,7 @@ func (w *Writer) finalize() error {
 		if err != nil {
 			return err
 		}
-		bytes, err := b.Bytes().Body()
-		if err != nil {
-			return err
-		}
-		val := zed.NewValue(typ, bytes)
+		val := zed.NewValue(typ, b.Bytes().Body())
 		if err := zw.Write(val); err != nil {
 			return err
 		}


### PR DESCRIPTION
zcode.Bytes.Body returns an error if its receiver's length is zero.
Remove the error return parameter and panic instead.