### PR TITLE
move escape.go and name.go into zson

### DIFF
--- a/zfmt/zed.go
+++ b/zfmt/zed.go
@@ -1,8 +1,8 @@
 package zfmt
 
 import (
-	"github.com/brimdata/zed"
 	astzed "github.com/brimdata/zed/compiler/ast/zed"
+	"github.com/brimdata/zed/zson"
 )
 
 type canonZed struct {
@@ -29,7 +29,7 @@ func (c *canonZed) fieldpath(path []string) {
 		return
 	}
 	for k, s := range path {
-		if zed.IsIdentifier(s) {
+		if zson.IsIdentifier(s) {
 			if k != 0 {
 				c.write(".")
 			}
@@ -89,7 +89,7 @@ func (c *canonZed) typeFields(fields []astzed.TypeField) {
 		if k != 0 {
 			c.write(",")
 		}
-		c.write("%s:", zed.QuotedName(f.Name))
+		c.write("%s:", zson.QuotedName(f.Name))
 		c.typ(f.Type)
 	}
 }

--- a/zio/zeekio/escape.go
+++ b/zio/zeekio/escape.go
@@ -5,7 +5,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zson"
 )
 
 // shouldEscape determines if the given code point at the given position
@@ -69,8 +69,8 @@ func unescapeZeekString(data []byte) []byte {
 
 func parseZeekEscape(data []byte) (byte, int) {
 	if len(data) >= 4 && data[1] == 'x' {
-		v1 := zed.Unhex(data[2])
-		v2 := zed.Unhex(data[3])
+		v1 := zson.Unhex(data[2])
+		v2 := zson.Unhex(data[3])
 		if v1 <= 0xf || v2 <= 0xf {
 			return v1<<4 | v2, 4
 		}

--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -173,7 +173,7 @@ func (a Analyzer) typeCheck(cast, parent zed.Type) error {
 
 func (a Analyzer) enterTypeDef(zctx *zed.Context, name string, typ zed.Type) (*zed.TypeNamed, error) {
 	var named *zed.TypeNamed
-	if zed.IsTypeName(name) {
+	if IsTypeName(name) {
 		var err error
 		if named, err = zctx.LookupTypeNamed(name, typ); err != nil {
 			return nil, err

--- a/zson/escape.go
+++ b/zson/escape.go
@@ -1,4 +1,4 @@
-package zed
+package zson
 
 import (
 	"strings"
@@ -7,7 +7,7 @@ import (
 
 func QuotedName(name string) string {
 	if !IsIdentifier(name) {
-		name = QuotedString([]byte(name), false)
+		name = QuotedString([]byte(name))
 	}
 	return name
 }
@@ -17,7 +17,7 @@ const hexdigits = "0123456789abcdef"
 // QuotedString quotes and escapes a ZSON string for serialization in accordance
 // with the ZSON spec.  It was copied and modified [with attribution](https://github.com/brimdata/zed/blob/main/acknowledgments.txt)
 // from the encoding/json package in the Go source code.
-func QuotedString(s []byte, _ bool) string {
+func QuotedString(s []byte) string {
 	var b strings.Builder
 	b.WriteByte('"')
 	for k := 0; k < len(s); {

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -256,7 +256,7 @@ func (f *Formatter) formatRecord(indent int, typ *zed.TypeRecord, bytes zcode.By
 		}
 		f.build(sep)
 		f.startColor(color.Blue)
-		f.indent(indent, zed.QuotedName(field.Name))
+		f.indent(indent, QuotedName(field.Name))
 		f.endColor()
 		f.build(":")
 		if f.tab > 0 {
@@ -444,7 +444,7 @@ func (f *Formatter) formatTypeRecord(typ *zed.TypeRecord) {
 		if k > 0 {
 			f.build(",")
 		}
-		f.build(zed.QuotedName(col.Name))
+		f.build(QuotedName(col.Name))
 		f.build(":")
 		f.formatType(col.Type)
 	}
@@ -468,7 +468,7 @@ func (f *Formatter) formatTypeEnum(typ *zed.TypeEnum) error {
 		if k > 0 {
 			f.build(",")
 		}
-		f.buildf("%s", zed.QuotedName(s))
+		f.buildf("%s", QuotedName(s))
 	}
 	f.build(">")
 	return nil
@@ -558,7 +558,7 @@ func formatType(b *strings.Builder, typedefs typemap, typ zed.Type) {
 			if k > 0 {
 				b.WriteByte(',')
 			}
-			b.WriteString(zed.QuotedName(col.Name))
+			b.WriteString(QuotedName(col.Name))
 			b.WriteString(":")
 			formatType(b, typedefs, col.Type)
 		}
@@ -593,7 +593,7 @@ func formatType(b *strings.Builder, typedefs typemap, typ zed.Type) {
 			if k > 0 {
 				b.WriteByte(',')
 			}
-			b.WriteString(zed.QuotedName(s))
+			b.WriteString(QuotedName(s))
 		}
 		b.WriteByte('>')
 	case *zed.TypeError:
@@ -648,7 +648,7 @@ func formatPrimitive(b *strings.Builder, typ zed.Type, bytes zcode.Bytes) {
 		b.WriteString("0x")
 		b.WriteString(hex.EncodeToString(bytes))
 	case *zed.TypeOfString:
-		b.WriteString(zed.QuotedString(bytes, false))
+		b.WriteString(QuotedString(bytes))
 	case *zed.TypeOfIP:
 		b.WriteString(zed.DecodeIP(bytes).String())
 	case *zed.TypeOfNet:
@@ -706,7 +706,7 @@ func formatTypeValue(tv zcode.Bytes, b *strings.Builder) zcode.Bytes {
 			}
 			var name string
 			name, tv = decodeNameAndCheck(tv, b)
-			b.WriteString(zed.QuotedName(name))
+			b.WriteString(QuotedName(name))
 			b.WriteString(":")
 			tv = formatTypeValue(tv, b)
 			if tv == nil {
@@ -760,7 +760,7 @@ func formatTypeValue(tv zcode.Bytes, b *strings.Builder) zcode.Bytes {
 			if tv == nil {
 				return nil
 			}
-			b.WriteString(zed.QuotedName(symbol))
+			b.WriteString(QuotedName(symbol))
 		}
 		b.WriteByte('>')
 	case zed.TypeValueError:

--- a/zson/lexer.go
+++ b/zson/lexer.go
@@ -10,8 +10,6 @@ import (
 	"unicode"
 	"unicode/utf16"
 	"unicode/utf8"
-
-	"github.com/brimdata/zed"
 )
 
 var ErrBufferOverflow = errors.New("zson scanner buffer size exceeded")
@@ -424,10 +422,10 @@ func unhexRune(b []byte) (rune, error) {
 	if len(b) < 4 {
 		return 0, errors.New("short \\u escape")
 	}
-	r0 := rune(zed.Unhex(b[0]))
-	r1 := rune(zed.Unhex(b[1]))
-	r2 := rune(zed.Unhex(b[2]))
-	r3 := rune(zed.Unhex(b[3]))
+	r0 := rune(Unhex(b[0]))
+	r1 := rune(Unhex(b[1]))
+	r2 := rune(Unhex(b[2]))
+	r3 := rune(Unhex(b[3]))
 	if r0 > 0xf || r1 > 0xf || r2 > 0xf || r3 > 0xf {
 		return 0, errors.New("invalid hex digits in \\u escape")
 	}
@@ -464,7 +462,7 @@ func (l *Lexer) scanTypeName() (string, error) {
 			}
 			return "", err
 		}
-		if !zed.TypeChar(r) {
+		if !typeChar(r) {
 			return s.String(), nil
 		}
 		s.WriteRune(r)
@@ -477,7 +475,7 @@ func (l *Lexer) scanIdentifier() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if !zed.IsIdentifier(s) {
+	if !IsIdentifier(s) {
 		return "", errors.New("malformed identifier")
 	}
 	return s, nil

--- a/zson/name.go
+++ b/zson/name.go
@@ -1,17 +1,9 @@
-package zed
+package zson
 
 import (
 	"strconv"
 	"unicode"
 )
-
-func IDChar(c rune) bool {
-	return unicode.IsLetter(c) || c == '_' || c == '$'
-}
-
-func TypeChar(c rune) bool {
-	return IDChar(c) || unicode.IsDigit(c) || c == '/' || c == '.'
-}
 
 func IsIdentifier(s string) bool {
 	if s == "" {
@@ -19,7 +11,7 @@ func IsIdentifier(s string) bool {
 	}
 	first := true
 	for _, c := range s {
-		if !IDChar(c) && (first || !unicode.IsDigit(c)) {
+		if !idChar(c) && (first || !unicode.IsDigit(c)) {
 			return false
 		}
 		first = false
@@ -27,14 +19,22 @@ func IsIdentifier(s string) bool {
 	return true
 }
 
+func idChar(c rune) bool {
+	return unicode.IsLetter(c) || c == '_' || c == '$'
+}
+
 // IsTypeName returns true iff s is a valid zson typedef name (exclusive
 // of integer names for locally-scoped typedefs).
 func IsTypeName(s string) bool {
 	for _, c := range s {
-		if !TypeChar(c) {
+		if !typeChar(c) {
 			return false
 		}
 	}
 	_, err := strconv.ParseInt(s, 10, 64)
 	return err != nil
+}
+
+func typeChar(c rune) bool {
+	return idChar(c) || unicode.IsDigit(c) || c == '/' || c == '.'
 }

--- a/zson/parser-types.go
+++ b/zson/parser-types.go
@@ -42,7 +42,7 @@ func (p *Parser) matchIdentifier() (string, error) {
 		return "", err
 	}
 	r, _, err := l.peekRune()
-	if err != nil || !zed.IDChar(r) {
+	if err != nil || !idChar(r) {
 		return "", err
 	}
 	return l.scanIdentifier()
@@ -57,7 +57,7 @@ func (p *Parser) matchTypeName() (astzed.Type, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !(zed.IDChar(r) || unicode.IsDigit(r)) {
+	if !(idChar(r) || unicode.IsDigit(r)) {
 		return nil, nil
 	}
 	name, err := l.scanTypeName()


### PR DESCRIPTION
Closes #3461.

Also for #3455 (does the move but doesn't add the error return parameter or the tests).