### PR TITLE
flatten: array of key/value records

### DIFF
--- a/docs/zq/functions/flatten.md
+++ b/docs/zq/functions/flatten.md
@@ -8,14 +8,11 @@
 flatten(val: record) -> |{[string]:<any>}|
 ```
 ### Description
-The _flatten_ function returns a map where each map key is a
-string array of the path of each record field of `val` and the map value
-is  the corresponding value of that field.
-If there are multiple types for the leaf values in `val`, then the map's value type is
-a union of the types present.
-
-Note that maps do not have an order for their keys so converting a record
-to a map in this fashion provides no means to retain the record's field order.
+The _flatten_ function returns an array of records `[{key:[string],value:<any>}]`
+where `key` is a string array of the path of each record field of `val` and
+`value` is the corresponding value of that field.
+If there are multiple types for the leaf values in `val`, then the array value
+inner type is a union of the record types present.
 
 ### Examples
 
@@ -24,5 +21,5 @@ echo '{a:1,b:{c:"foo"}}' | zq -z 'yield flatten(this)' -
 ```
 =>
 ```mdtest-output
-|{["a"]:1((int64,string)),["b","c"]:"foo"((int64,string))}|
+[{key:["a"],value:1}(({key:[string],value:int64},{key:[string],value:string})),{key:["b","c"],value:"foo"}(({key:[string],value:int64},{key:[string],value:string}))]
 ```

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -1,7 +1,6 @@
 package function
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/brimdata/zed"
@@ -20,7 +19,7 @@ type Flatten struct {
 
 func NewFlatten(zctx *zed.Context) *Flatten {
 	return &Flatten{
-		entryTypes: make(map[int]zed.Type),
+		entryTypes: make(map[zed.Type]zed.Type),
 		keyType:    zctx.LookupTypeArray(zed.TypeString),
 		mapper:     zed.NewMapper(zctx),
 		zctx:       zctx,
@@ -55,7 +54,7 @@ func (n *Flatten) collectTypes(cols []zed.Column) []zed.Type {
 		if typ := zed.TypeRecordOf(col.Type); typ != nil {
 			types = append(types, n.collectTypes(typ.Columns)...)
 		} else {
-			typ, ok := n.entryTypes[col.Type.ID()]
+			typ, ok := n.entryTypes[col.Type]
 			if !ok {
 				n.entryTypes[col.Type] = n.zctx.MustLookupTypeRecord([]zed.Column{
 					zed.NewColumn("key", n.keyType),
@@ -92,7 +91,7 @@ func (n *Flatten) encode(cols []zed.Column, inner zed.Type, base field.Path, b z
 			n.encode(typ.Columns, inner, key, val)
 			continue
 		}
-		typ := n.entryTypes[col.Type.ID()]
+		typ := n.entryTypes[col.Type]
 		union, _ := inner.(*zed.TypeUnion)
 		if union != nil {
 			n.BeginContainer()

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -56,10 +56,11 @@ func (n *Flatten) collectTypes(cols []zed.Column) []zed.Type {
 		} else {
 			typ, ok := n.entryTypes[col.Type]
 			if !ok {
-				n.entryTypes[col.Type] = n.zctx.MustLookupTypeRecord([]zed.Column{
+				typ = n.zctx.MustLookupTypeRecord([]zed.Column{
 					zed.NewColumn("key", n.keyType),
 					zed.NewColumn("value", col.Type),
 				})
+				n.entryTypes[col.Type] = typ
 			}
 			types = append(types, typ)
 		}

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -59,15 +59,10 @@ func (n *Flatten) collectTypes(cols []zed.Column) []zed.Type {
 		} else {
 			typ, ok := n.entryTypes[col.Type.ID()]
 			if !ok {
-				var err error
-				typ, err = n.zctx.LookupTypeRecord([]zed.Column{
+				n.entryTypes[col.Type] = n.zctx.MustLookupTypeRecord([]zed.Column{
 					zed.NewColumn("key", n.keyType),
 					zed.NewColumn("value", col.Type),
 				})
-				if err != nil {
-					panic(fmt.Errorf("flatten: error creating record type %w", err))
-				}
-				n.entryTypes[col.Type.ID()] = typ
 			}
 			types = append(types, typ)
 		}

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -14,7 +14,7 @@ type Flatten struct {
 	zcode.Builder
 	keyType    zed.Type
 	mapper     *zed.Mapper
-	entryTypes map[int]zed.Type
+	entryTypes map[zed.Type]zed.Type
 	zctx       *zed.Context
 }
 

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -1,6 +1,7 @@
 package function
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/brimdata/zed"
@@ -11,15 +12,18 @@ import (
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#flatten
 type Flatten struct {
 	zcode.Builder
-	keyType zed.Type
-	mapper  *zed.Mapper
-	zctx    *zed.Context
+	keyType    zed.Type
+	mapper     *zed.Mapper
+	entryTypes map[int]zed.Type
+	zctx       *zed.Context
 }
 
 func NewFlatten(zctx *zed.Context) *Flatten {
 	return &Flatten{
-		mapper: zed.NewMapper(zctx),
-		zctx:   zctx,
+		entryTypes: make(map[int]zed.Type),
+		keyType:    zctx.LookupTypeArray(zed.TypeString),
+		mapper:     zed.NewMapper(zctx),
+		zctx:       zctx,
 	}
 }
 
@@ -31,7 +35,7 @@ func (n *Flatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	}
 	valType := n.mapper.Lookup(typ.ID())
 	if valType == nil {
-		types := collectTypes(typ.Columns)
+		types := n.collectTypes(typ.Columns)
 		types = dedupeTypes(types)
 		if len(types) == 1 {
 			valType = types[0]
@@ -40,12 +44,35 @@ func (n *Flatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 		n.mapper.EnterType(typ.ID(), valType)
 	}
-	if n.keyType == nil {
-		n.keyType = n.zctx.LookupTypeArray(zed.TypeString)
-	}
 	n.Reset()
 	n.encode(typ.Columns, valType, field.Path{}, val.Bytes)
-	return ctx.NewValue(n.zctx.LookupTypeMap(n.keyType, valType), n.Bytes())
+	return ctx.NewValue(n.zctx.LookupTypeArray(valType), n.Bytes())
+}
+
+func (n *Flatten) collectTypes(cols []zed.Column) []zed.Type {
+	var types []zed.Type
+	for _, col := range cols {
+		if typ := zed.TypeRecordOf(col.Type); typ != nil {
+			for _, typ := range n.collectTypes(typ.Columns) {
+				types = append(types, typ)
+			}
+		} else {
+			typ, ok := n.entryTypes[col.Type.ID()]
+			if !ok {
+				var err error
+				typ, err = n.zctx.LookupTypeRecord([]zed.Column{
+					zed.NewColumn("key", n.keyType),
+					zed.NewColumn("value", col.Type),
+				})
+				if err != nil {
+					panic(fmt.Errorf("flatten: error creating record type %w", err))
+				}
+				n.entryTypes[col.Type.ID()] = typ
+			}
+			types = append(types, typ)
+		}
+	}
+	return types
 }
 
 func dedupeTypes(types []zed.Type) []zed.Type {
@@ -72,11 +99,18 @@ func (n *Flatten) encode(cols []zed.Column, inner zed.Type, base field.Path, b z
 			n.encode(typ.Columns, inner, key, val)
 			continue
 		}
+		typ := n.entryTypes[col.Type.ID()]
+		union, _ := inner.(*zed.TypeUnion)
+		if union != nil {
+			n.BeginContainer()
+			n.Append(zed.EncodeInt(int64(union.Selector(typ))))
+		}
+		n.BeginContainer()
 		n.encodeKey(key)
-		if union, ok := inner.(*zed.TypeUnion); ok {
-			zed.BuildUnion(&n.Builder, union.Selector(col.Type), val)
-		} else {
-			n.Append(val)
+		n.Append(val)
+		n.EndContainer()
+		if union != nil {
+			n.EndContainer()
 		}
 	}
 }
@@ -87,18 +121,4 @@ func (n *Flatten) encodeKey(key field.Path) {
 		n.Append(zed.EncodeString(name))
 	}
 	n.EndContainer()
-}
-
-func collectTypes(cols []zed.Column) []zed.Type {
-	var types []zed.Type
-	for _, col := range cols {
-		if typ := zed.TypeRecordOf(col.Type); typ != nil {
-			for _, typ := range collectTypes(typ.Columns) {
-				types = append(types, typ)
-			}
-		} else {
-			types = append(types, col.Type)
-		}
-	}
-	return types
 }

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -53,9 +53,7 @@ func (n *Flatten) collectTypes(cols []zed.Column) []zed.Type {
 	var types []zed.Type
 	for _, col := range cols {
 		if typ := zed.TypeRecordOf(col.Type); typ != nil {
-			for _, typ := range n.collectTypes(typ.Columns) {
-				types = append(types, typ)
-			}
+			types = append(types, n.collectTypes(typ.Columns)...)
 		} else {
 			typ, ok := n.entryTypes[col.Type.ID()]
 			if !ok {

--- a/runtime/expr/function/ztests/flatten.yaml
+++ b/runtime/expr/function/ztests/flatten.yaml
@@ -8,6 +8,6 @@ input: |
 
 output: |
   127.0.0.1
-  |{["a"]:1((int64,null)),["b"]:null((int64,null))}|
-  |{["a"]:1((int64,string,[int64])),["b","c"]:"foo"((int64,string,[int64])),["b","d"]:[1,2,3]((int64,string,[int64]))}|
-  |{["a"]:1,["b","c"]:2,["b","d","e"]:4,["b","d","f"]:5}|
+  [{key:["a"],value:1}(({key:[string],value:int64},{key:[string],value:null})),{key:["b"],value:null}(({key:[string],value:int64},{key:[string],value:null}))]
+  [{key:["a"],value:1}(({key:[string],value:int64},{key:[string],value:string},{key:[string],value:[int64]})),{key:["b","c"],value:"foo"}(({key:[string],value:int64},{key:[string],value:string},{key:[string],value:[int64]})),{key:["b","d"],value:[1,2,3]}(({key:[string],value:int64},{key:[string],value:string},{key:[string],value:[int64]}))]
+  [{key:["a"],value:1},{key:["b","c"],value:2},{key:["b","d","e"],value:4},{key:["b","d","f"],value:5}]


### PR DESCRIPTION
Change flatten to return an array of key/value records where the
key is a string array of the value path and value is the value (any
type).

Part of #3615