### PR TITLE
over: Make record keys a string array

### DIFF
--- a/runtime/op/traverse/over.go
+++ b/runtime/op/traverse/over.go
@@ -103,10 +103,12 @@ func appendOver(zctx *zed.Context, vals []zed.Value, zv zed.Value) []zed.Value {
 			builder.Reset()
 			col := columns[i]
 			typ := zctx.MustLookupTypeRecord([]zed.Column{
-				{Name: "key", Type: zed.TypeString},
+				{Name: "key", Type: zctx.LookupTypeArray(zed.TypeString)},
 				{Name: "value", Type: col.Type},
 			})
+			builder.BeginContainer()
 			builder.Append(zed.EncodeString(col.Name))
+			builder.EndContainer()
 			builder.Append(it.Next())
 			vals = append(vals, *zed.NewValue(typ, builder.Bytes()).Copy())
 

--- a/runtime/op/traverse/ztests/over-record.yaml
+++ b/runtime/op/traverse/ztests/over-record.yaml
@@ -1,7 +1,7 @@
 zed: |
   let d=date over this => (
-    key != 'date'
-    | yield {date: d, sym: key, price: value}
+    key[0] != 'date'
+    | yield {date: d, sym: key[0], price: value}
   )
 
 input: |


### PR DESCRIPTION
Change the behavior of over on a record so that the resultant key value
is a string array instead of a string.

Closes #3615