### PR TITLE
remove FAQ temporarily

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,3 +1,0 @@
-# Zed FAQ
-
-Coming soon!

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ packaged up in the easy-to-understand
 [ZSON data format](docs/formats/zson.md) and the
 [Zed Lake API](docs/zed/api.md).
 
-Check out the [Zed FAQ](FAQ.md).
-
 ## Why?
 
 We think that you shouldn't have to set up one system


### PR DESCRIPTION
This commit removes the "coming soon" FAQ for the 1.0 release.
It will come soon after the 1.0 release per issue #3606.

Closes #3621