### PR TITLE
rework duplicate field error handling

### DIFF
--- a/columnbuilder.go
+++ b/columnbuilder.go
@@ -23,20 +23,6 @@ func (e errNonAdjacent) Unwrap() error {
 	return ErrNonAdjacent
 }
 
-var ErrDuplicateFields = errors.New("duplicate fields")
-
-type errDuplicateFields struct {
-	field string
-}
-
-func (e errDuplicateFields) Error() string {
-	return fmt.Sprintf("field %s is repeated", e.field)
-}
-
-func (e errDuplicateFields) Unwrap() error {
-	return ErrDuplicateFields
-}
-
 // fieldInfo encodes the structure of a particular proc that writes a
 // sequence of fields, which may potentially be inside nested records.
 // This encoding enables the runtime processing to happen as efficiently
@@ -136,7 +122,7 @@ func NewColumnBuilder(zctx *Context, fields field.List) (*ColumnBuilder, error) 
 			currentRecord = record
 		}
 		if isIn(field, fieldInfos) {
-			return nil, errDuplicateFields{strings.Join(field, ".")}
+			return nil, &DuplicateFieldError{strings.Join(field, ".")}
 		}
 		fieldInfos = append(fieldInfos, fieldInfo{field, containerBegins, 0})
 	}

--- a/context.go
+++ b/context.go
@@ -100,6 +100,14 @@ var tvPool = sync.Pool{
 	},
 }
 
+type DuplicateFieldError struct {
+	Name string
+}
+
+func (d *DuplicateFieldError) Error() string {
+	return fmt.Sprintf("duplicate field: %q", d.Name)
+}
+
 // LookupTypeRecord returns a TypeRecord within this context that binds with the
 // indicated columns.  Subsequent calls with the same columns will return the
 // same record pointer.  If the type doesn't exist, it's created, stored,
@@ -108,7 +116,7 @@ var tvPool = sync.Pool{
 // use TranslateTypeRecord.
 func (c *Context) LookupTypeRecord(columns []Column) (*TypeRecord, error) {
 	if name, ok := duplicateField(columns); ok {
-		return nil, fmt.Errorf("%w: %s", ErrDuplicateFields, name)
+		return nil, &DuplicateFieldError{name}
 	}
 	tv := tvPool.Get().(*[]byte)
 	*tv = AppendTypeValue((*tv)[:0], &TypeRecord{Columns: columns})

--- a/docs/zq/operators/rename.md
+++ b/docs/zq/operators/rename.md
@@ -74,6 +74,6 @@ echo '{b:1} {a:1,b:1} {c:1}' | zq -z 'rename a:=b' -
 =>
 ```mdtest-output
 {a:1}
-error({message:"rename: duplicate fields: a",on:{a:1,b:1}})
+error({message:"rename: duplicate field: \"a\"",on:{a:1,b:1}})
 {c:1}
 ```

--- a/runtime/expr/renamer.go
+++ b/runtime/expr/renamer.go
@@ -49,7 +49,8 @@ func (r *Renamer) dstType(typ *zed.TypeRecord, src, dst field.Path) (*zed.TypeRe
 	newcols[c] = zed.Column{Name: dst[0], Type: innerType}
 	typ, err := r.zctx.LookupTypeRecord(newcols)
 	if err != nil {
-		if errors.Is(err, zed.ErrDuplicateFields) {
+		var dferr *zed.DuplicateFieldError
+		if errors.As(err, &dferr) {
 			return nil, err
 		}
 		panic(err)

--- a/runtime/expr/ztests/cut-dup-fields.yaml
+++ b/runtime/expr/ztests/cut-dup-fields.yaml
@@ -12,7 +12,7 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      field rec is repeated
-      field rec.sub1 is repeated
-      field rec.sub.sub is repeated
-      field rec.sub is repeated
+      duplicate field: "rec"
+      duplicate field: "rec.sub1"
+      duplicate field: "rec.sub.sub"
+      duplicate field: "rec.sub"

--- a/runtime/expr/ztests/rename-error-dupe.yaml
+++ b/runtime/expr/ztests/rename-error-dupe.yaml
@@ -4,4 +4,4 @@ input: |
   {foo:"foo1",goo:"goo1"}
 
 output: |
-  error({message:"rename: duplicate fields: foo",on:{foo:"foo1",goo:"goo1"}})
+  error({message:"rename: duplicate field: \"foo\"",on:{foo:"foo1",goo:"goo1"}})

--- a/runtime/op/groupby/ztests/duplicate.yaml
+++ b/runtime/op/groupby/ztests/duplicate.yaml
@@ -4,4 +4,4 @@ input: |
   {x:1(int32)}
   {x:2(int32)}
 
-errorRE: field count is repeated
+errorRE: 'duplicate field: "count"'


### PR DESCRIPTION
Replace zed.ErrDuplicateFields and errDuplicateFields with
DuplicateFieldError, whose Name field offers access to the name of the
offending field.