### PR TITLE
preserve field order in zio/jsonio.Reader

### DIFF
--- a/zio/jsonio/ztests/duplicate-field.yaml
+++ b/zio/jsonio/ztests/duplicate-field.yaml
@@ -1,0 +1,9 @@
+zed: '*'
+
+input-flags: -i json
+
+input: |
+  {"b":null,"a":1,"a":2,"b":"3"}
+
+output: |
+  {b:"3",a:2}

--- a/zio/jsonio/ztests/json.yaml
+++ b/zio/jsonio/ztests/json.yaml
@@ -9,6 +9,6 @@ input: |
   { "obj1": { "null1": null } }
 
 output: |
-  {bool1:true,int1:4,string1:"value1",string2:"value1"}
-  {bool1:true,int1:4,string1:"value2",string2:"value2"}
+  {string1:"value1",string2:"value1",int1:4,bool1:true}
+  {int1:4,bool1:true,string2:"value2",string1:"value2"}
   {obj1:{null1:null}}

--- a/zio/jsonio/ztests/reader.yaml
+++ b/zio/jsonio/ztests/reader.yaml
@@ -19,13 +19,13 @@ output-flags: -pretty=4
 
 output: |
   {
+      ts: 1.521911721926018e+09,
       a: "hello, world",
       b: {
+          z: "&, <, and > should not be escaped",
           x: 4611686018427387904,
-          y: "127.0.0.1",
-          z: "&, <, and > should not be escaped"
-      },
-      ts: 1.521911721926018e+09
+          y: "127.0.0.1"
+      }
   }
   [
       {


### PR DESCRIPTION
zio/jsonio.Reader converts JSON objects into Zed records with fields in
a canonical order (viz., sorted by name).  Reordering fields like this
slows the reader and can be surprising to users.  Preserve field order
instead.