### PR TITLE
fix panic in zio/zngio.Reader.Close

### DIFF
--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -73,7 +73,9 @@ func (r *Reader) NewScanner(ctx context.Context, filter zbuf.Filter) (zbuf.Scann
 
 // Close guarantees that the underlying io.Reader is not read after it returns.
 func (r *Reader) Close() error {
-	r.scanner.Pull(true)
+	if r.scanner != nil {
+		r.scanner.Pull(true)
+	}
 	return nil
 }
 


### PR DESCRIPTION
If zio.zngio.Reader.Read is never called, Reader.scanner remains nil and
Reader.Close will panic when it calls Reader.scanner.Pull.  Fix by
calling scanner.Pull only if scanner is not nil.