### PR TITLE
remove apt-get commands from .github/workflows/release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ jobs:
     - run: go mod download
     - run: make fmt
     - run: make tidy
-    - run: |
-          sudo apt-get update
-          sudo apt-get install -y zip libnet1 libjansson4
     - run: make vet
     - run: make test-generate
     - run: make test-unit


### PR DESCRIPTION
The release workflow installs some OS packages that haven't been needed
for a long time.  Remove the apt-get commands that install them.