### PR TITLE
fix empty batches in runtime/op/traverse.Over

### DIFF
--- a/runtime/op/traverse/ztests/bare-scoped.yaml
+++ b/runtime/op/traverse/ztests/bare-scoped.yaml
@@ -1,6 +1,7 @@
 zed: over a => (sum(this))
 
 input: |
+  {a:null([int64])}
   {a:[6,5,4]}
   {a:[3,2,1]}
 


### PR DESCRIPTION
The flowgraph for a scoped over operator (i.e., "over ... => (...)")
shuts down prematurely upon ingesting a null container in part because
the inner scope produces an empty batch.  Fix by modifying
runtime/op/traverse.Over so it does not produce empty batches.

There's still problem here because
```
echo '[1] [2]' | zq 'over this => (where this > 1)' -
```
produces no output, but I'm working on that.