### PR TITLE
fix zio/zngio.worker.run goroutine leak

### DIFF
--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -134,7 +134,7 @@ func (s *scanner) start() {
 				w := work{
 					local:    s.parser.types.local,
 					frame:    frame,
-					resultCh: make(chan op.Result),
+					resultCh: make(chan op.Result, 1),
 				}
 				select {
 				case s.resultChCh <- w.resultCh:


### PR DESCRIPTION
zio/zngio.worker.run expects work.resultCh to be buffered so that a send
will not block, but it isn't, causing a zngio.scanner to leak goroutines
if not read to completion.  Fix by making the channel buffered.