### PR TITLE
fix zio/zngio.scanner.Pull hang

### DIFF
--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -141,6 +141,7 @@ func (s *scanner) start() {
 					select {
 					case worker.workCh <- w:
 					case <-s.ctx.Done():
+						close(w.resultCh)
 						return
 					}
 				case <-s.ctx.Done():


### PR DESCRIPTION
zio/zngio.scanner.Pull expects that a receive from a result channel will
not block, but it will if context cancelation prevents the result
channel from making its way to a worker in scanner.start.  Close the
result channel when this happens so the receive will not block.