### PR TITLE
add some missing zio/zngio.Reader.Close calls

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -128,7 +128,9 @@ func (c *Connection) doAndUnmarshal(req *Request, v interface{}, templates ...in
 	if err != nil {
 		return err
 	}
-	rec, err := zngio.NewReader(res.Body, zed.NewContext()).Read()
+	zr := zngio.NewReader(res.Body, zed.NewContext())
+	defer zr.Close()
+	rec, err := zr.Read()
 	if err != nil || rec == nil {
 		return err
 	}

--- a/cmd/zed/dev/dig/section/command.go
+++ b/cmd/zed/dev/dig/section/command.go
@@ -80,6 +80,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	defer reader.Close()
 	writer, err := c.outputFlags.Open(ctx, engine)
 	if err != nil {
 		return err
@@ -91,7 +92,7 @@ func (c *Command) Run(args []string) error {
 	return writer.Close()
 }
 
-func newSectionReader(r io.ReaderAt, which int, sections []int64) (zio.Reader, error) {
+func newSectionReader(r io.ReaderAt, which int, sections []int64) (*zngio.Reader, error) {
 	if which >= len(sections) {
 		return nil, fmt.Errorf("section %d does not exist", which)
 	}

--- a/cmd/zed/dev/dig/trailer/command.go
+++ b/cmd/zed/dev/dig/trailer/command.go
@@ -72,12 +72,15 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	zr := zngio.NewReader(bytes.NewReader(b), zed.NewContext())
+	defer zr.Close()
 	writer, err := c.outputFlags.Open(ctx, engine)
 	if err != nil {
 		return err
 	}
-	if err := zio.Copy(writer, zngio.NewReader(bytes.NewReader(b), zed.NewContext())); err != nil {
-		return err
+	err = zio.Copy(writer, zr)
+	if err2 := writer.Close(); err == nil {
+		err = err2
 	}
-	return writer.Close()
+	return err
 }

--- a/index/finder.go
+++ b/index/finder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zson"
 )
 
@@ -126,7 +127,7 @@ func lookupDesc(reader zio.Reader, fn keyCompareFn, op Operator) (*zed.Value, er
 	}
 }
 
-func (f *Finder) search(compare keyCompareFn) (zio.Reader, error) {
+func (f *Finder) search(compare keyCompareFn) (*zngio.Reader, error) {
 	if f.reader == nil {
 		panic("finder hasn't been opened")
 	}
@@ -147,6 +148,7 @@ func (f *Finder) search(compare keyCompareFn) (zio.Reader, error) {
 			op = GTE
 		}
 		rec, err := lookup(reader, compare, f.meta.Order, op)
+		reader.Close()
 		if err != nil {
 			return nil, err
 		}
@@ -177,6 +179,7 @@ func (f *Finder) LookupAll(ctx context.Context, hits chan<- *zed.Value, kvs []Ke
 	if err != nil {
 		return err
 	}
+	defer reader.Close()
 	for {
 		// As long as we have an exact key-match, where unset key
 		// columns are "don't care", keep reading records and return
@@ -230,6 +233,7 @@ func (f *Finder) Nearest(operator string, kvs ...KeyValue) (*zed.Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
 	return lookup(reader, compare, f.meta.Order, op)
 }
 

--- a/index/reader.go
+++ b/index/reader.go
@@ -9,7 +9,6 @@ import (
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/pkg/storage"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/zngio"
 )
 
@@ -97,7 +96,7 @@ func (r *Reader) section(level int) (int64, int64) {
 	return off, r.sections[level]
 }
 
-func (r *Reader) newSectionReader(level int, sectionOff int64) (zio.Reader, error) {
+func (r *Reader) newSectionReader(level int, sectionOff int64) (*zngio.Reader, error) {
 	off, len := r.section(level)
 	off += sectionOff
 	len -= sectionOff
@@ -105,7 +104,7 @@ func (r *Reader) newSectionReader(level int, sectionOff int64) (zio.Reader, erro
 	return zngio.NewReaderWithOpts(sectionReader, r.zctx, zngio.ReaderOpts{Size: FrameBufSize}), nil
 }
 
-func (r *Reader) NewSectionReader(section int) (zio.Reader, error) {
+func (r *Reader) NewSectionReader(section int) (*zngio.Reader, error) {
 	n := len(r.sections)
 	if section < 0 || section >= n {
 		return nil, fmt.Errorf("section %d out of range (index has %d sections)", section, n)

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -354,6 +354,7 @@ func (b *Branch) indexObject(ctx context.Context, rules []index.Rule, id ksuid.K
 		return nil, err
 	}
 	reader := zngio.NewReader(r, zed.NewContext())
+	defer reader.Close()
 	w, err := index.NewCombiner(ctx, b.engine, b.pool.IndexPath, rules, id)
 	if err != nil {
 		r.Close()

--- a/lake/commits/object.go
+++ b/lake/commits/object.go
@@ -106,6 +106,7 @@ func (o Object) Serialize() ([]byte, error) {
 func DecodeObject(r io.Reader) (*Object, error) {
 	o := &Object{}
 	reader := zngbytes.NewDeserializer(r, ActionTypes)
+	defer reader.Close()
 	for {
 		entry, err := reader.Read()
 		if err != nil {

--- a/lake/commits/snapshot.go
+++ b/lake/commits/snapshot.go
@@ -247,6 +247,7 @@ func (s *Snapshot) serialize() ([]byte, error) {
 func decodeSnapshot(r io.Reader) (*Snapshot, error) {
 	s := NewSnapshot()
 	zd := zngbytes.NewDeserializer(r, ActionTypes)
+	defer zd.Close()
 	for {
 		entry, err := zd.Read()
 		if err != nil {

--- a/lake/commits/store.go
+++ b/lake/commits/store.go
@@ -225,6 +225,7 @@ func (s *Store) GetBytes(ctx context.Context, commit ksuid.KSUID) ([]byte, *Comm
 		return nil, nil, err
 	}
 	reader := zngbytes.NewDeserializer(bytes.NewReader(b), ActionTypes)
+	defer reader.Close()
 	entry, err := reader.Read()
 	if err != nil {
 		return nil, nil, err

--- a/lake/data/reader.go
+++ b/lake/data/reader.go
@@ -62,7 +62,9 @@ func (o *ObjectScan) NewReader(ctx context.Context, engine storage.Engine, path 
 			return nil, err
 		}
 		defer indexReader.Close()
-		rg, err = seekindex.Lookup(zngio.NewReader(indexReader, zed.NewContext()), scanRange.First(), scanRange.Last(), cmp)
+		zr := zngio.NewReader(indexReader, zed.NewContext())
+		defer zr.Close()
+		rg, err = seekindex.Lookup(zr, scanRange.First(), scanRange.Last(), cmp)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				return sr, nil

--- a/lake/index/index_test.go
+++ b/lake/index/index_test.go
@@ -19,6 +19,7 @@ func boomerang(t *testing.T, r1 Rule) (r2 Rule) {
 	b, err := serialize(r1)
 	require.NoError(t, err)
 	reader := zngio.NewReader(bytes.NewReader(b), zed.NewContext())
+	defer reader.Close()
 	rec, err := reader.Read()
 	require.NoError(t, err)
 	u := zson.NewZNGUnmarshaler()

--- a/lake/index/store.go
+++ b/lake/index/store.go
@@ -69,6 +69,7 @@ func (s *Store) load(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer r.Close()
 	table := make(map[ksuid.KSUID]Rule)
 	for {
 		rec, err := r.Read()

--- a/lake/journal/store.go
+++ b/lake/journal/store.go
@@ -83,6 +83,7 @@ func (s *Store) load(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer r.Close()
 	table := make(map[string]Entry)
 	for {
 		rec, err := r.Read()

--- a/lake/root.go
+++ b/lake/root.go
@@ -158,6 +158,7 @@ func (r *Root) readLakeMagic(ctx context.Context) error {
 	deserializer := zngbytes.NewDeserializer(reader, []interface{}{
 		LakeMagic{},
 	})
+	defer deserializer.Close()
 	v, err := deserializer.Read()
 	if err != nil {
 		return err

--- a/lake/scheduler.go
+++ b/lake/scheduler.go
@@ -184,6 +184,7 @@ func seekIndexByCount(ctx context.Context, pool *Pool, o *data.ObjectScan, span 
 	}
 	defer r.Close()
 	zr := zngio.NewReader(r, zed.NewContext())
+	defer zr.Close()
 	rg, err := seekindex.LookupByCount(zr, span.First(), span.Last())
 	if err != nil {
 		return err

--- a/lake/seekindex/seekindex_test.go
+++ b/lake/seekindex/seekindex_test.go
@@ -76,6 +76,7 @@ type testSeekIndex struct {
 
 func (t *testSeekIndex) Lookup(s nano.Span, expected Range, o order.Which) {
 	r := zngio.NewReader(bytes.NewReader(t.buffer.Bytes()), zed.NewContext())
+	defer r.Close()
 	cmp := extent.CompareFunc(o)
 	var first, last *zed.Value
 	if o == order.Asc {

--- a/runtime/op/spill/file.go
+++ b/runtime/op/spill/file.go
@@ -58,12 +58,18 @@ func (f *File) Rewind(zctx *zed.Context) error {
 	if _, err := f.file.Seek(0, 0); err != nil {
 		return err
 	}
+	if f.Reader != nil {
+		f.Reader.Close()
+	}
 	f.Reader = zngio.NewReader(bufio.NewReader(f.file), zctx)
 	return nil
 }
 
 // CloseAndRemove closes and removes the underlying file.
 func (r *File) CloseAndRemove() error {
+	if r.Reader != nil {
+		r.Reader.Close()
+	}
 	err := r.file.Close()
 	if rmErr := os.Remove(r.file.Name()); err == nil {
 		err = rmErr

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -52,6 +52,7 @@ func (c *testClient) TestPoolList() []pools.Config {
 	defer r.Body.Close()
 	var confs []pools.Config
 	zr := zngio.NewReader(r.Body, zed.NewContext())
+	defer zr.Close()
 	for {
 		rec, err := zr.Read()
 		require.NoError(c, err)
@@ -82,6 +83,7 @@ func (c *testClient) TestQuery(query string) string {
 	require.NoError(c, err)
 	defer r.Body.Close()
 	zr := zngio.NewReader(r.Body, zed.NewContext())
+	defer zr.Close()
 	var buf bytes.Buffer
 	zw := zsonio.NewWriter(zio.NopCloser(&buf), zsonio.WriterOpts{})
 	require.NoError(c, zio.Copy(zw, zr))

--- a/zio/zng_test.go
+++ b/zio/zng_test.go
@@ -40,6 +40,7 @@ func boomerang(t *testing.T, logs string, compress bool) {
 
 	var out Output
 	rawSrc := zngio.NewReader(bytes.NewReader(rawzng.Bytes()), zed.NewContext())
+	defer rawSrc.Close()
 	zsonDst := zsonio.NewWriter(&out, zsonio.WriterOpts{})
 	err := zio.Copy(zsonDst, rawSrc)
 	if assert.NoError(t, err) {

--- a/zngbytes/deserializer.go
+++ b/zngbytes/deserializer.go
@@ -26,6 +26,8 @@ func NewDeserializerWithContext(zctx *zed.Context, reader io.Reader, templates [
 	}
 }
 
+func (d *Deserializer) Close() error { return d.reader.Close() }
+
 func (d *Deserializer) Read() (interface{}, error) {
 	rec, err := d.reader.Read()
 	if err != nil || rec == nil {

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -215,6 +215,7 @@ func TestBug2575(t *testing.T) {
 
 	r := bytes.NewReader(buffer.Bytes())
 	reader := zngio.NewReader(r, zed.NewContext())
+	defer reader.Close()
 	recActual, err := reader.Read()
 	exp, err := zson.FormatValue(*recExpected)
 	require.NoError(t, err)

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -33,6 +33,7 @@ func boomerang(t *testing.T, in interface{}, out interface{}) {
 	require.NoError(t, err)
 	zctx := zed.NewContext()
 	zr := zngio.NewReader(&buf, zctx)
+	defer zr.Close()
 	rec, err = zr.Read()
 	require.NoError(t, err)
 	err = zson.UnmarshalZNGRecord(rec, out)

--- a/zst/object.go
+++ b/zst/object.go
@@ -30,7 +30,6 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zcode"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zson"
 	"github.com/brimdata/zed/zst/column"
@@ -115,6 +114,7 @@ func (o *Object) IsEmpty() bool {
 
 func (o *Object) readAssembly() (*Assembly, error) {
 	reader := o.NewReassemblyReader()
+	defer reader.Close()
 	assembly := &Assembly{}
 	var val *zed.Value
 	for {
@@ -163,7 +163,7 @@ func (o *Object) section(level int) (int64, int64) {
 	return off, o.sections[level]
 }
 
-func (o *Object) newSectionReader(level int, sectionOff int64) zio.Reader {
+func (o *Object) newSectionReader(level int, sectionOff int64) *zngio.Reader {
 	off, len := o.section(level)
 	off += sectionOff
 	len -= sectionOff
@@ -171,6 +171,6 @@ func (o *Object) newSectionReader(level int, sectionOff int64) zio.Reader {
 	return zngio.NewReader(reader, o.zctx)
 }
 
-func (o *Object) NewReassemblyReader() zio.Reader {
+func (o *Object) NewReassemblyReader() *zngio.Reader {
 	return o.newSectionReader(1, 0)
 }


### PR DESCRIPTION
A zio/zngio.Reader can leak goroutines if not closed.