### PR TITLE
propagate done in runtime/op/merge.Proc.Pull

### DIFF
--- a/runtime/op/merge/merge.go
+++ b/runtime/op/merge/merge.go
@@ -51,6 +51,9 @@ func (p *Proc) Pull(done bool) (zbuf.Batch, error) {
 	if err != nil {
 		return nil, err
 	}
+	if done {
+		return nil, p.propagateDone()
+	}
 	if p.Len() == 0 {
 		// No more batches in head of line.  So, let's resume
 		// everything and return an EOS.


### PR DESCRIPTION
When its done parameter is true, merge.Proc.Pull should call
Proc.propagateDone but does not.  Add the missing call.