### PR TITLE
dot expressions: work on type values

### DIFF
--- a/runtime/expr/dot.go
+++ b/runtime/expr/dot.go
@@ -57,10 +57,11 @@ func ValueUnder(val *zed.Value) *zed.Value {
 
 func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 	rec := d.record.Eval(ectx, this)
-	if _, ok := rec.Type.(*zed.TypeOfType); ok {
-		return d.evalTypeOfType(ectx, rec.Bytes)
-	}
 	val := ValueUnder(rec)
+	if _, ok := val.Type.(*zed.TypeOfType); ok {
+		return d.evalTypeOfType(ectx, val.Bytes)
+	}
+
 	recType, ok := val.Type.(*zed.TypeRecord)
 	if !ok {
 		return d.zctx.Missing()

--- a/runtime/expr/dot.go
+++ b/runtime/expr/dot.go
@@ -80,8 +80,8 @@ func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 	return ectx.NewValue(recType.Columns[idx].Type, field)
 }
 
-func (d *DotExpr) evalTypeOfType(ectx Context, vb zcode.Bytes) *zed.Value {
-	typ, _ := d.zctx.DecodeTypeValue(vb)
+func (d *DotExpr) evalTypeOfType(ectx Context, b zcode.Bytes) *zed.Value {
+	typ, _ := d.zctx.DecodeTypeValue(b)
 	if typ, ok := zed.TypeUnder(typ).(*zed.TypeRecord); ok {
 		if typ, ok := typ.TypeOfField(d.field); ok {
 			return d.zctx.LookupTypeValue(typ)

--- a/runtime/expr/ztests/dot-record-type.yaml
+++ b/runtime/expr/ztests/dot-record-type.yaml
@@ -1,0 +1,8 @@
+zed: yield foo, foo.bar
+
+input: |
+  <{foo:{bar:int64}}>
+
+output: |
+  <{bar:int64}>
+  <int64>


### PR DESCRIPTION
If a value passed into a dot expression is a type value of a record,
select the appropiated field in the record.

Closes #3562 