### PR TITLE
return closer from lake/api.Interface query methods

### DIFF
--- a/cmd/zed/branch/command.go
+++ b/cmd/zed/branch/command.go
@@ -135,6 +135,7 @@ func (c *Command) list(ctx context.Context, lake api.Interface) error {
 		w.Close()
 		return err
 	}
+	defer q.Close()
 	err = zio.Copy(w, q)
 	if closeErr := w.Close(); err == nil {
 		err = closeErr

--- a/cmd/zed/index/create.go
+++ b/cmd/zed/index/create.go
@@ -77,6 +77,7 @@ func (c *createCommand) Run(args []string) error {
 			w.Close()
 			return err
 		}
+		defer q.Close()
 		err = zio.Copy(w, q)
 		if err2 := w.Close(); err == nil {
 			err = err2

--- a/cmd/zed/index/ls.go
+++ b/cmd/zed/index/ls.go
@@ -52,5 +52,6 @@ func (c *lsCommand) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	defer r.Close()
 	return zio.Copy(w, r)
 }

--- a/cmd/zed/log/command.go
+++ b/cmd/zed/log/command.go
@@ -75,6 +75,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	defer q.Close()
 	err = zio.Copy(w, q)
 	if closeErr := w.Close(); err == nil {
 		err = closeErr

--- a/cmd/zed/ls/command.go
+++ b/cmd/zed/ls/command.go
@@ -89,6 +89,7 @@ func (c *Command) Run(args []string) error {
 		w.Close()
 		return err
 	}
+	defer q.Close()
 	err = zio.Copy(w, q)
 	if closeErr := w.Close(); err == nil {
 		err = closeErr

--- a/cmd/zed/query/command.go
+++ b/cmd/zed/query/command.go
@@ -71,6 +71,7 @@ func (c *Command) Run(args []string) error {
 		w.Close()
 		return err
 	}
+	defer query.Close()
 	err = zio.Copy(w, zbuf.NoControl(query))
 	if closeErr := w.Close(); err == nil {
 		err = closeErr

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -20,8 +20,8 @@ import (
 )
 
 type Interface interface {
-	Query(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zio.Reader, error)
-	QueryWithControl(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ProgressReader, error)
+	Query(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zio.ReadCloser, error)
+	QueryWithControl(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ProgressReadCloser, error)
 	PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error)
 	CreatePool(context.Context, string, order.Layout, int, int64) (ksuid.KSUID, error)
@@ -43,12 +43,8 @@ func IsLakeService(u *storage.URI) bool {
 	return u.Scheme == "http" || u.Scheme == "https"
 }
 
-func ScanIndexRules(ctx context.Context, api Interface) (zio.Reader, error) {
-	r, err := api.Query(ctx, nil, "from :index_rules")
-	if err != nil {
-		return nil, err
-	}
-	return zbuf.NoControl(r), nil
+func ScanIndexRules(ctx context.Context, api Interface) (zio.ReadCloser, error) {
+	return api.Query(ctx, nil, "from :index_rules")
 }
 
 func LookupPoolByName(ctx context.Context, api Interface, name string) (*pools.Config, error) {
@@ -58,6 +54,7 @@ func LookupPoolByName(ctx context.Context, api Interface, name string) (*pools.C
 	if err != nil {
 		return nil, err
 	}
+	defer q.Close()
 	if err := zio.Copy(b, zbuf.NoControl(q)); err != nil {
 		return nil, err
 	}
@@ -82,6 +79,7 @@ func LookupPoolByID(ctx context.Context, api Interface, id ksuid.KSUID) (*pools.
 	if err != nil {
 		return nil, err
 	}
+	defer q.Close()
 	if err := zio.Copy(b, zbuf.NoControl(q)); err != nil {
 		return nil, err
 	}
@@ -106,6 +104,7 @@ func LookupBranchByName(ctx context.Context, api Interface, poolName, branchName
 	if err != nil {
 		return nil, err
 	}
+	defer q.Close()
 	if err := zio.Copy(b, zbuf.NoControl(q)); err != nil {
 		return nil, err
 	}
@@ -130,6 +129,7 @@ func LookupBranchByID(ctx context.Context, api Interface, id ksuid.KSUID) (*lake
 	if err != nil {
 		return nil, err
 	}
+	defer q.Close()
 	if err := zio.Copy(b, zbuf.NoControl(q)); err != nil {
 		return nil, err
 	}

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -94,15 +94,15 @@ func (l *LocalSession) DeleteIndexRules(ctx context.Context, ids []ksuid.KSUID) 
 	return l.root.DeleteIndexRules(ctx, ids)
 }
 
-func (l *LocalSession) Query(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zio.Reader, error) {
+func (l *LocalSession) Query(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zio.ReadCloser, error) {
 	q, err := l.QueryWithControl(ctx, head, src, srcfiles...)
 	if err != nil {
 		return nil, err
 	}
-	return zbuf.NoControl(q), nil
+	return zio.NewReadCloser(zbuf.NoControl(q), q), nil
 }
 
-func (l *LocalSession) QueryWithControl(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ProgressReader, error) {
+func (l *LocalSession) QueryWithControl(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ProgressReadCloser, error) {
 	flowgraph, err := compiler.ParseProc(src, srcfiles...)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func (l *LocalSession) QueryWithControl(ctx context.Context, head *lakeparse.Com
 	if err != nil {
 		return nil, err
 	}
-	return q.AsProgressReader(), nil
+	return q.AsProgressReadCloser(), nil
 }
 
 func (l *LocalSession) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error) {

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -78,13 +78,12 @@ func (q *Query) AsReader() zio.Reader {
 	return zbuf.PullerReader(q)
 }
 
-type progressReader struct {
-	zio.Reader
-	zbuf.Meter
-}
-
-func (q *Query) AsProgressReader() zbuf.ProgressReader {
-	return &progressReader{zbuf.PullerReader(q), q}
+func (q *Query) AsProgressReadCloser() zbuf.ProgressReadCloser {
+	return struct {
+		zio.Reader
+		io.Closer
+		zbuf.Meter
+	}{q.AsReader(), q, q}
 }
 
 func (q *Query) Progress() zbuf.Progress {


### PR DESCRIPTION
Both lake/api.RemoteSession.Query and QueryWithControl return a reader
derived from a zio/zngio.Reader, which must be closed to avoid leaking
goroutines.  To support this,

1. Change api.Interface.Query to return a zio.ReadCloser.

2. Change api.Interface.QueryWithControl to return a new type,
   zbuf.ProgressReadCloser.

3. Update the implementations of these methods in api.LocalSession and
   api.RemoteSession to return the new types.

4. Add calls to the new Close method for all objects returned by these
   methods.