### PR TITLE
add some missing zbuf.Puller.Pull(true) calls

### DIFF
--- a/cli/zq/command.go
+++ b/cli/zq/command.go
@@ -148,6 +148,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	defer query.Pull(true)
 	err = zio.Copy(writer, zbuf.NoControl(query.AsReader()))
 	if closeErr := writer.Close(); err == nil {
 		err = closeErr

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -118,6 +118,7 @@ func TestNearest(t *testing.T) {
 		}
 	})
 	q, err := runtime.NewQueryOnReader(context.Background(), zed.NewContext(), compiler.MustParseProc("sort ts"), reader(records), nil)
+	defer q.Pull(true)
 	require.NoError(t, err)
 	asc := buildAndOpen(t, engine, q.AsReader(), field.DottedList("ts"), index.Order(order.Asc))
 	t.Run("Ascending", func(t *testing.T) {

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -62,6 +62,7 @@ func (i *Internal) Run() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer q.Pull(true)
 	if err := zio.Copy(output, q.AsReader()); err != nil {
 		return "", err
 	}

--- a/runtime/op/groupby/groupby_test.go
+++ b/runtime/op/groupby/groupby_test.go
@@ -327,6 +327,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 		layout := order.NewLayout(order.Asc, field.List{field.New(inputSortKey)})
 		query, err := runtime.NewQueryOnOrderedReader(context.Background(), zctx, proc, cr, layout, nil)
 		require.NoError(t, err)
+		defer query.Pull(true)
 		err = zio.Copy(checker, query.AsReader())
 		require.NoError(t, err)
 		outData := strings.Split(outbuf.String(), "\n")

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -535,6 +535,7 @@ func runzq(path, zedProgram, input string, outputFlags []string, inputFlags []st
 		zw.Close()
 		return "", err.Error(), err
 	}
+	defer q.Pull(true)
 	err = zio.Copy(zw, q.AsReader())
 	if err2 := zw.Close(); err == nil {
 		err = err2


### PR DESCRIPTION
Calling zbuf.Puller.Pull(true) helps prevent goroutine leaks by ensuring
pullers are shut down correctly.