### PR TITLE
unions: Don't use selector for nulls

### DIFF
--- a/complex.go
+++ b/complex.go
@@ -376,14 +376,17 @@ func (t *TypeUnion) Selector(typ Type) int {
 // SplitZNG takes a zng encoding of a value of the receiver's union type and
 // returns the concrete type of the value, its selector, and the value encoding.
 // SplitZNG panics if the selector is invalid.
-func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, int64, zcode.Bytes) {
+func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, zcode.Bytes) {
 	it := zv.Iter()
+	if it.Done() {
+		return t, nil
+	}
 	selector := DecodeInt(it.Next())
 	inner, err := t.Type(int(selector))
 	if err != nil {
 		panic(err)
 	}
-	return inner, selector, it.Next()
+	return inner, it.Next()
 }
 
 func (t *TypeUnion) Kind() Kind {

--- a/complex.go
+++ b/complex.go
@@ -377,10 +377,10 @@ func (t *TypeUnion) Selector(typ Type) int {
 // returns the concrete type of the value, its selector, and the value encoding.
 // SplitZNG panics if the selector is invalid.
 func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, zcode.Bytes) {
-	it := zv.Iter()
-	if it.Done() {
+	if zv == nil {
 		return t, nil
 	}
+	it := zv.Iter()
 	selector := DecodeInt(it.Next())
 	inner, err := t.Type(int(selector))
 	if err != nil {

--- a/runtime/expr/agg/union.go
+++ b/runtime/expr/agg/union.go
@@ -94,7 +94,7 @@ func (u *Union) ConsumeAsPartial(val *zed.Value) {
 		typ := styp.Type
 		b := it.Next()
 		if union, ok := zed.TypeUnder(typ).(*zed.TypeUnion); ok {
-			typ, _, b = union.SplitZNG(b)
+			typ, b = union.SplitZNG(b)
 		}
 		u.update(typ, b)
 	}

--- a/runtime/expr/dot.go
+++ b/runtime/expr/dot.go
@@ -50,7 +50,7 @@ func ValueUnder(val *zed.Value) *zed.Value {
 		if !ok {
 			return &zed.Value{typ, bytes}
 		}
-		typ, _, bytes = union.SplitZNG(bytes)
+		typ, bytes = union.SplitZNG(bytes)
 	}
 }
 

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -689,7 +689,7 @@ func indexMap(zctx *zed.Context, ectx Context, typ *zed.TypeMap, mapBytes zcode.
 
 func deunion(ectx Context, typ zed.Type, b zcode.Bytes) *zed.Value {
 	if union, ok := typ.(*zed.TypeUnion); ok {
-		typ, _, b = union.SplitZNG(b)
+		typ, b = union.SplitZNG(b)
 	}
 	return ectx.NewValue(typ, b)
 }

--- a/runtime/expr/function/under.go
+++ b/runtime/expr/function/under.go
@@ -19,7 +19,7 @@ func (u *Under) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	case *zed.TypeError:
 		return ectx.NewValue(typ.Type, val.Bytes)
 	case *zed.TypeUnion:
-		t, _, bytes := typ.SplitZNG(val.Bytes)
+		t, bytes := typ.SplitZNG(val.Bytes)
 		return ectx.NewValue(t, bytes)
 	case *zed.TypeOfType:
 		t, err := u.zctx.LookupByValue(val.Bytes)

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -198,8 +198,11 @@ func unescape(r rune) []byte {
 }
 
 func formatUnion(t *zed.TypeUnion, zv zcode.Bytes) string {
-	typ, selector, iv := t.SplitZNG(zv)
-	s := strconv.FormatInt(selector, 10) + ":"
+	if len(zv) == 0 {
+		return FormatValue(zed.Value{zed.TypeNull, nil})
+	}
+	typ, iv := t.SplitZNG(zv)
+	s := strconv.FormatInt(int64(t.Selector(typ)), 10) + ":"
 	return s + formatAny(zed.Value{typ, iv}, false)
 }
 

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -198,7 +198,7 @@ func unescape(r rune) []byte {
 }
 
 func formatUnion(t *zed.TypeUnion, zv zcode.Bytes) string {
-	if len(zv) == 0 {
+	if zv == nil {
 		return FormatValue(zed.Value{zed.TypeNull, nil})
 	}
 	typ, iv := t.SplitZNG(zv)

--- a/zio/zjsonio/writer.go
+++ b/zio/zjsonio/writer.go
@@ -205,12 +205,12 @@ func (w *Writer) encodeUnion(zctx *zed.Context, union *zed.TypeUnion, bytes zcod
 	if bytes == nil {
 		return nil, nil
 	}
-	inner, selector, b := union.SplitZNG(bytes)
+	inner, b := union.SplitZNG(bytes)
 	val, err := w.encodeValue(zctx, inner, b)
 	if err != nil {
 		return nil, err
 	}
-	return []interface{}{strconv.Itoa(int(selector)), val}, nil
+	return []interface{}{strconv.Itoa(union.Selector(inner)), val}, nil
 }
 
 func (w *Writer) encodePrimitive(zctx *zed.Context, typ zed.Type, v zcode.Bytes) (interface{}, error) {

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -299,7 +299,7 @@ func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type,
 }
 
 func (f *Formatter) formatUnion(indent int, union *zed.TypeUnion, bytes zcode.Bytes) error {
-	typ, _, bytes := union.SplitZNG(bytes)
+	typ, bytes := union.SplitZNG(bytes)
 	// XXX For now, we always decorate a union value so that
 	// we can determine the selector from the value's explicit type.
 	// We can later optimize this so we only print the decorator if its

--- a/zst/column/union.go
+++ b/zst/column/union.go
@@ -30,7 +30,7 @@ func NewUnionWriter(typ *zed.TypeUnion, spiller *Spiller) *UnionWriter {
 }
 
 func (u *UnionWriter) Write(body zcode.Bytes) error {
-	if len(body) == 0 {
+	if body == nil {
 		u.presence.TouchNull()
 		return nil
 	}

--- a/zst/column/union.go
+++ b/zst/column/union.go
@@ -119,7 +119,7 @@ func NewUnionReader(utyp zed.Type, in zed.Value, r io.ReaderAt) (*UnionReader, e
 	}
 	presence := rec.Deref("presence").MissingAsNull()
 	if presence.IsNull() {
-		return nil, errors.New("ZST union mission presence")
+		return nil, errors.New("ZST union missing presence")
 	}
 	d, err := NewPrimitiveReader(*presence, r)
 	if err != nil {

--- a/zst/column/union.go
+++ b/zst/column/union.go
@@ -13,6 +13,7 @@ type UnionWriter struct {
 	typ      *zed.TypeUnion
 	values   []Writer
 	selector *IntWriter
+	presence *PresenceWriter
 }
 
 func NewUnionWriter(typ *zed.TypeUnion, spiller *Spiller) *UnionWriter {
@@ -24,11 +25,18 @@ func NewUnionWriter(typ *zed.TypeUnion, spiller *Spiller) *UnionWriter {
 		typ:      typ,
 		values:   values,
 		selector: NewIntWriter(spiller),
+		presence: NewPresenceWriter(spiller),
 	}
 }
 
 func (u *UnionWriter) Write(body zcode.Bytes) error {
-	_, selector, zv := u.typ.SplitZNG(body)
+	if len(body) == 0 {
+		u.presence.TouchNull()
+		return nil
+	}
+	u.presence.TouchValue()
+	typ, zv := u.typ.SplitZNG(body)
+	selector := u.typ.Selector(typ)
 	if err := u.selector.Write(int32(selector)); err != nil {
 		return err
 	}
@@ -64,6 +72,11 @@ func (u *UnionWriter) EncodeMap(zctx *zed.Context, b *zcode.Builder) (zed.Type, 
 		return nil, err
 	}
 	cols = append(cols, zed.Column{"selector", typ})
+	typ, err = u.presence.EncodeMap(zctx, b)
+	if err != nil {
+		return nil, err
+	}
+	cols = append(cols, zed.Column{"presence", typ})
 	b.EndContainer()
 	return zctx.LookupTypeRecord(cols)
 }
@@ -71,6 +84,7 @@ func (u *UnionWriter) EncodeMap(zctx *zed.Context, b *zcode.Builder) (zed.Type, 
 type UnionReader struct {
 	readers  []Reader
 	selector *IntReader
+	presence *PresenceReader
 }
 
 func NewUnionReader(utyp zed.Type, in zed.Value, r io.ReaderAt) (*UnionReader, error) {
@@ -103,13 +117,36 @@ func NewUnionReader(utyp zed.Type, in zed.Value, r io.ReaderAt) (*UnionReader, e
 	if err != nil {
 		return nil, err
 	}
+	presence := rec.Deref("presence").MissingAsNull()
+	if presence.IsNull() {
+		return nil, errors.New("ZST union mission presence")
+	}
+	d, err := NewPrimitiveReader(*presence, r)
+	if err != nil {
+		return nil, err
+	}
+	var pr *PresenceReader
+	if len(d.segmap) != 0 {
+		pr = NewPresence(IntReader{*d})
+	}
 	return &UnionReader{
 		readers:  readers,
 		selector: sr,
+		presence: pr,
 	}, nil
 }
 
 func (u *UnionReader) Read(b *zcode.Builder) error {
+	if u.presence != nil {
+		isval, err := u.presence.Read()
+		if err != nil {
+			return err
+		}
+		if !isval {
+			b.Append(nil)
+			return nil
+		}
+	}
 	selector, err := u.selector.Read()
 	if err != nil {
 		return err


### PR DESCRIPTION
Change union.SplitZNG so if the passed value is null (i.e. has no
selector) the returned type is the type of the union value.

This change has implications for unions in zst- the readers and writers
of which expected every value to have a selector. Add a presence
reader/writer to the union writer to handle null values in the union.