### PR TITLE
add zq -C flag

### DIFF
--- a/cmd/zq/ztests/ast.yaml
+++ b/cmd/zq/ztests/ast.yaml
@@ -1,0 +1,16 @@
+script: |
+  zq -C a
+  zq -C -I query.zed
+  zq -C -I query.zed a
+
+inputs:
+  - name: query.zed
+    data: |
+      q
+
+outputs:
+  - name: stdout
+    data: |
+      search a
+      search q
+      search q and a


### PR DESCRIPTION
The -C flag makes zq print the query as canonical Zed and exit, like
"zed dev compile -C".

Closes #3583.