### PR TITLE
zson: Don't add null as a type to array unions

### DIFF
--- a/zson/ztests/map.yaml
+++ b/zson/ztests/map.yaml
@@ -14,6 +14,7 @@ input: |
   |{::1/128:::1/128,2::/16:2::/16,3.3.3.0/24:3.3.3.0/24}|
   |{<int8>:<int8>}|
   |{null:null}|
+  |{null:null,null(int64):null(int64),null(string):null(string)}|
   {a:|{}|}
   {a:|{-1:-1,2:2}|}
   {a:|{1ns:1ns,2us:2us,3ms:3ms,4s:4s,5m:5m,6h:6h,7d:7d,8w:8w,9y:9y}|}
@@ -43,6 +44,7 @@ output: |
   |{3.3.3.0/24:3.3.3.0/24,::1/128:::1/128,2::/16:2::/16}|
   |{<int8>:<int8>}|
   |{null:null}|
+  |{null((int64,string)):null((int64,string)),null(int64)((int64,string)):null(int64)((int64,string)),null(string)((int64,string)):null(string)((int64,string))}|
   {a:|{}|(|{null:null}|)}
   {a:|{-1:-1,2:2}|}
   {a:|{1ns:1ns,2us:2us,3ms:3ms,4s:4s,5m:5m,6h:6h,7d:7d,56d:56d,9y:9y}|}

--- a/zson/ztests/mixed-array.yaml
+++ b/zson/ztests/mixed-array.yaml
@@ -7,6 +7,7 @@ inputs:
       [1((int64,string)),"b"((int64,string)),2((int64,string))]
       [8((int64,string)),3((int64,string))]
       ["hello"((int64,string)),"goodbye"((int64,string))]
+      [null,1,"hello"]
       {version:[1((int64,string)),"b"((int64,string)),2((int64,string))]}
       {version:[8((int64,string)),3((int64,string))]}
       {version:["hello"((int64,string)),"goodbye"((int64,string))]}
@@ -17,6 +18,7 @@ outputs:
       [1((int64,string)),"b"((int64,string)),2((int64,string))]
       [8((int64,string)),3((int64,string))]
       ["hello"((int64,string)),"goodbye"((int64,string))]
+      [null((int64,string)),1((int64,string)),"hello"((int64,string))]
       {version:[1((int64,string)),"b"((int64,string)),2((int64,string))]}
       {version:[8((int64,string)),3((int64,string))]}
       {version:["hello"((int64,string)),"goodbye"((int64,string))]}

--- a/zson/ztests/mixed-null-array.yaml
+++ b/zson/ztests/mixed-null-array.yaml
@@ -8,6 +8,7 @@ inputs:
       [null(int64),2]
       [null,null]
       [null((int64,string,null)),"foo"((int64,string,null)),3((int64,string,null))]
+      [null,null(string),null(int64)]
       {version:[1,null(int64)]}
       {version:[null(int64),2]}
       {version:[null,null]}
@@ -20,6 +21,7 @@ outputs:
       [null(int64),2]
       [null,null]
       [null((int64,string,null)),"foo"((int64,string,null)),3((int64,string,null))]
+      [null((int64,string)),null(string)((int64,string)),null(int64)((int64,string))]
       {version:[1,null(int64)]}
       {version:[null(int64),2]}
       {version:[null,null]}

--- a/zson/ztests/set.yaml
+++ b/zson/ztests/set.yaml
@@ -4,8 +4,10 @@ input: |
   |[1,1,1,5,1]|
   |[null,127.0.0.1]|
   |[1.5,"foo",1.5]|
+  |[null,null(string),null(int64)]|
 
 output: |
   |[1,5]|
   |[null(ip),127.0.0.1]|
   |["foo"((float64,string)),1.5((float64,string))]|
+  |[null((int64,string)),null(int64)((int64,string)),null(string)((int64,string))]|


### PR DESCRIPTION
Do not add null as a union type to a mixed array/set/map.