### PR TITLE
Simplify ZSON representation of mixed-type arrays

### DIFF
--- a/docs/zq/aggregates/collect.md
+++ b/docs/zq/aggregates/collect.md
@@ -40,5 +40,5 @@ echo '1 2 3 4 "foo"' | zq -z 'collect(this)' -
 ```
 =>
 ```mdtest-output
-{collect:[1((int64,string)),2((int64,string)),3((int64,string)),4((int64,string)),"foo"((int64,string))]}
+{collect:[1,2,3,4,"foo"]}
 ```

--- a/docs/zq/functions/flatten.md
+++ b/docs/zq/functions/flatten.md
@@ -21,5 +21,5 @@ echo '{a:1,b:{c:"foo"}}' | zq -z 'yield flatten(this)' -
 ```
 =>
 ```mdtest-output
-[{key:["a"],value:1}(({key:[string],value:int64},{key:[string],value:string})),{key:["b","c"],value:"foo"}(({key:[string],value:int64},{key:[string],value:string}))]
+[{key:["a"],value:1},{key:["b","c"],value:"foo"}]
 ```

--- a/runtime/expr/agg/ztests/collect-union.yaml
+++ b/runtime/expr/agg/ztests/collect-union.yaml
@@ -6,4 +6,4 @@ input: |
   {a:2}
 
 output: |
-  {collect:[{a:1}(({a:int64},{b:float64})),{b:1.5}(({a:int64},{b:float64})),{a:2}(({a:int64},{b:float64}))]}
+  {collect:[{a:1},{b:1.5},{a:2}]}

--- a/runtime/expr/agg/ztests/union.yaml
+++ b/runtime/expr/agg/ztests/union.yaml
@@ -15,5 +15,5 @@ input: |
 
 output: |
   |[{x:1,s:"a"},{x:2,s:"b"},{x:3,s:"e"}]|
-  |[1((int64,string)),"1"((int64,string))]|
+  |[1,"1"]|
   |[[]([string])]|

--- a/runtime/expr/function/ztests/flatten.yaml
+++ b/runtime/expr/function/ztests/flatten.yaml
@@ -8,6 +8,6 @@ input: |
 
 output: |
   127.0.0.1
-  [{key:["a"],value:1}(({key:[string],value:int64},{key:[string],value:null})),{key:["b"],value:null}(({key:[string],value:int64},{key:[string],value:null}))]
-  [{key:["a"],value:1}(({key:[string],value:int64},{key:[string],value:string},{key:[string],value:[int64]})),{key:["b","c"],value:"foo"}(({key:[string],value:int64},{key:[string],value:string},{key:[string],value:[int64]})),{key:["b","d"],value:[1,2,3]}(({key:[string],value:int64},{key:[string],value:string},{key:[string],value:[int64]}))]
+  [{key:["a"],value:1},{key:["b"],value:null}]
+  [{key:["a"],value:1},{key:["b","c"],value:"foo"},{key:["b","d"],value:[1,2,3]}]
   [{key:["a"],value:1},{key:["b","c"],value:2},{key:["b","d","e"],value:4},{key:["b","d","f"],value:5}]

--- a/runtime/expr/ztests/complex-unions.yaml
+++ b/runtime/expr/ztests/complex-unions.yaml
@@ -8,4 +8,4 @@ outputs:
     data: |
       |{1((int64,string)):"foo","bar"((int64,string)):"baz"}|
       |[null(ip),127.0.0.1]|
-      ["foo"((float64,string)),1.1((float64,string)),10.98((float64,string))]
+      ["foo",1.1,10.98]

--- a/runtime/expr/ztests/search-nested-field.yaml
+++ b/runtime/expr/ztests/search-nested-field.yaml
@@ -7,4 +7,4 @@ input: |
 
 output: |
   {a:[{b:"foo"}]}
-  {a:[{c:"foo"}(({b:int64},{c:string})),{b:1}(({b:int64},{c:string}))]}
+  {a:[{c:"foo"},{b:1}]}

--- a/zio/jsonio/ztests/reader.yaml
+++ b/zio/jsonio/ztests/reader.yaml
@@ -30,18 +30,18 @@ output: |
   [
       {
           a: 1
-      } (({a:int64},{b:string},{c:bool})),
+      },
       {
           b: "hello"
-      } (({a:int64},{b:string},{c:bool})),
+      },
       {
           c: true
-      } (({a:int64},{b:string},{c:bool}))
+      }
   ]
   [
-      "foo" ((int64,string,{a:int64})),
-      1 ((int64,string,{a:int64})),
+      "foo",
+      1,
       {
           a: 1
-      } ((int64,string,{a:int64}))
+      }
   ]

--- a/zio/jsonio/ztests/union-array.yaml
+++ b/zio/jsonio/ztests/union-array.yaml
@@ -25,53 +25,53 @@ output: |
       null (string)
   ]
   [
-      "b" ((int64,string)),
-      2 ((int64,string))
+      "b",
+      2
   ]
   [
-      "c" ((int64,string)),
-      100 ((int64,string)),
-      200 ((int64,string))
+      "c",
+      100,
+      200
   ]
   [
-      "d" ((int64,string)),
-      null ((int64,string)),
-      200 ((int64,string))
+      "d",
+      null,
+      200
   ]
   [
-      "e" ((string,[int64])),
+      "e",
       [
           1,
           2
-      ] ((string,[int64]))
+      ]
   ]
   [
-      "f" ((bool,string,{dd:[(int64,bool,string)]},[(int64,string)])),
-      false ((bool,string,{dd:[(int64,bool,string)]},[(int64,string)])),
+      "f",
+      false,
       [
-          "foo" ((int64,string)),
-          2 ((int64,string))
-      ] ((bool,string,{dd:[(int64,bool,string)]},[(int64,string)])),
+          "foo",
+          2
+      ],
       {
           dd: [
-              "foo" ((int64,bool,string)),
-              2 ((int64,bool,string)),
-              true ((int64,bool,string))
+              "foo",
+              2,
+              true
           ]
-      } ((bool,string,{dd:[(int64,bool,string)]},[(int64,string)]))
+      }
   ]
   [
-      "g" ((bool,string,{"d.d":[(int64,bool,string)]},[(int64,string)])),
-      false ((bool,string,{"d.d":[(int64,bool,string)]},[(int64,string)])),
+      "g",
+      false,
       [
-          "foo" ((int64,string)),
-          2 ((int64,string))
-      ] ((bool,string,{"d.d":[(int64,bool,string)]},[(int64,string)])),
+          "foo",
+          2
+      ],
       {
           "d.d": [
-              "foo" ((int64,bool,string)),
-              2 ((int64,bool,string)),
-              true ((int64,bool,string))
+              "foo",
+              2,
+              true
           ]
-      } ((bool,string,{"d.d":[(int64,bool,string)]},[(int64,string)]))
+      }
   ]

--- a/zio/zjsonio/ztests/union-array.yaml
+++ b/zio/zjsonio/ztests/union-array.yaml
@@ -5,5 +5,5 @@ input: |
   {"type":{"kind":"ref","id":32},"value":[null]}
 
 output: |
-  {a:["asdfasdf"((int32,string)),null((int32,string)),100(int32)((int32,string))]}
+  {a:["asdfasdf",null,100(int32)]}
   {a:null([(int32,string)])}

--- a/zio/zng21io/ztests/test.yaml
+++ b/zio/zng21io/ztests/test.yaml
@@ -32,6 +32,6 @@ outputs:
       [1,2,3]
       |[1,2,3]|
       |{1:"foo",2:"bar"}|
-      [123((int64,string)),"hello"((int64,string))]
+      [123,"hello"]
       {tv:<int8>}
       {tv:<port=uint16>}

--- a/zio/zngio/ztests/union-array.yaml
+++ b/zio/zngio/ztests/union-array.yaml
@@ -3,7 +3,7 @@ script: zq - | zq -z -
 inputs:
   - name: stdin
     data: &stdin |
-      {a:["asdfasdf"((int64,string)),null((int64,string)),100((int64,string))]}
+      {a:["asdfasdf",null,100]}
       {a:null([(int64,string)])}
 
 outputs:

--- a/zson/ztests/implied-nulls.yaml
+++ b/zson/ztests/implied-nulls.yaml
@@ -13,4 +13,4 @@ outputs:
     data: |
       {a:"hello",b:[{a:"a",b:"b"},{a:"c",b:"d"},{a:"e",b:"f"}]}
       {a:"world",b:null([{a:string,b:string}])}
-      {a:"goodnight",b:[{a:"a",b:"b"}(({a:string,b:string},{a:string,b:null})),{a:"c",b:null}(({a:string,b:string},{a:string,b:null})),{a:"e",b:"f"}(({a:string,b:string},{a:string,b:null}))]}
+      {a:"goodnight",b:[{a:"a",b:"b"},{a:"c",b:null},{a:"e",b:"f"}]}

--- a/zson/ztests/issue-2050.yaml
+++ b/zson/ztests/issue-2050.yaml
@@ -4,4 +4,4 @@ input: |
   {a:[[](2=[null])(3=(2,int64)),1(3)](=4)}(=5)
 
 output: |
-  {a:[[]([null])((int64,[null])),1((int64,[null]))]}
+  {a:[[]([null]),1]}

--- a/zson/ztests/mixed-array.yaml
+++ b/zson/ztests/mixed-array.yaml
@@ -1,24 +1,17 @@
-script: |
-  zq -f zson -i zson -pretty=0 in.zson
+zed: "*"
 
-inputs:
-  - name: in.zson
-    data: |
-      [1((int64,string)),"b"((int64,string)),2((int64,string))]
-      [8((int64,string)),3((int64,string))]
-      ["hello"((int64,string)),"goodbye"((int64,string))]
-      [null,1,"hello"]
-      {version:[1((int64,string)),"b"((int64,string)),2((int64,string))]}
-      {version:[8((int64,string)),3((int64,string))]}
-      {version:["hello"((int64,string)),"goodbye"((int64,string))]}
+input: |
+  [1((int64,string)),"b"((int64,string)),2((int64,string))]
+  [8((int64,string)),3((int64,string))]
+  ["hello"((int64,string)),"goodbye"((int64,string))]
+  {version:[1((int64,string)),"b"((int64,string)),2((int64,string))]}
+  {version:[8((int64,string)),3((int64,string))]}
+  {version:["hello"((int64,string)),"goodbye"((int64,string))]}
 
-outputs:
-  - name: stdout
-    data: |
-      [1((int64,string)),"b"((int64,string)),2((int64,string))]
-      [8((int64,string)),3((int64,string))]
-      ["hello"((int64,string)),"goodbye"((int64,string))]
-      [null((int64,string)),1((int64,string)),"hello"((int64,string))]
-      {version:[1((int64,string)),"b"((int64,string)),2((int64,string))]}
-      {version:[8((int64,string)),3((int64,string))]}
-      {version:["hello"((int64,string)),"goodbye"((int64,string))]}
+output: |
+  [1,"b",2]
+  [8,3]([(int64,string)])
+  ["hello","goodbye"]([(int64,string)])
+  {version:[1,"b",2]}
+  {version:[8,3]([(int64,string)])}
+  {version:["hello","goodbye"]([(int64,string)])}

--- a/zson/ztests/mixed-null-array.yaml
+++ b/zson/ztests/mixed-null-array.yaml
@@ -20,9 +20,9 @@ outputs:
       [1,null(int64)]
       [null(int64),2]
       [null,null]
-      [null((int64,string,null)),"foo"((int64,string,null)),3((int64,string,null))]
-      [null((int64,string)),null(string)((int64,string)),null(int64)((int64,string))]
+      [null,"foo",3]([(int64,string,null)])
+      [null,null(string),null(int64)]
       {version:[1,null(int64)]}
       {version:[null(int64),2]}
       {version:[null,null]}
-      {version:[null((int64,string,null)),"foo"((int64,string,null)),3((int64,string,null))]}
+      {version:[null,"foo",3]([(int64,string,null)])}

--- a/zson/ztests/set.yaml
+++ b/zson/ztests/set.yaml
@@ -9,5 +9,5 @@ input: |
 output: |
   |[1,5]|
   |[null(ip),127.0.0.1]|
-  |["foo"((float64,string)),1.5((float64,string))]|
-  |[null((int64,string)),null(int64)((int64,string)),null(string)((int64,string))]|
+  |["foo",1.5]|
+  |[null,null(int64),null(string)]|


### PR DESCRIPTION
Do not decorate the elements of a mixed-type array. Decorate a mixed
type array if when the union type includes elements that are not in
the array.

Closes #3507