### PR TITLE
allow slicing for Zed bytes and string types

### DIFF
--- a/runtime/expr/slice.go
+++ b/runtime/expr/slice.go
@@ -6,7 +6,6 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/runtime/expr/coerce"
 	"github.com/brimdata/zed/zcode"
-	"github.com/brimdata/zed/zson"
 )
 
 type Slice struct {
@@ -25,10 +24,59 @@ func NewSlice(zctx *zed.Context, elem, from, to Evaluator) *Slice {
 	}
 }
 
-var ErrSliceIndex = errors.New("array slice is not a number")
-var ErrSliceIndexEmpty = errors.New("array slice is empty")
+var ErrSliceIndex = errors.New("slice index is not a number")
+var ErrSliceIndexEmpty = errors.New("slice index is empty")
 
-func sliceIndex(ectx Context, this *zed.Value, slot Evaluator, elem *zed.Value) (int, error) {
+func (s *Slice) Eval(ectx Context, this *zed.Value) *zed.Value {
+	elem := s.elem.Eval(ectx, this)
+	if elem.IsError() {
+		return elem
+	}
+	var length int
+	switch zed.TypeUnder(elem.Type).(type) {
+	case *zed.TypeOfBytes, *zed.TypeOfString:
+		length = len(elem.Bytes)
+	case *zed.TypeArray:
+		n, err := elem.ContainerLength()
+		if err != nil {
+			panic(err)
+		}
+		length = n
+	default:
+		return s.zctx.WrapError("sliced value is not array, bytes, or string", elem)
+	}
+	if elem.IsNull() {
+		return elem
+	}
+	from, err := sliceIndex(ectx, this, s.from, length)
+	if err != nil && err != ErrSliceIndexEmpty {
+		return s.zctx.NewError(err)
+	}
+	to, err := sliceIndex(ectx, this, s.to, length)
+	if err != nil {
+		if err != ErrSliceIndexEmpty {
+			return s.zctx.NewError(err)
+		}
+		to = length
+	}
+	bytes := elem.Bytes
+	if _, ok := zed.TypeUnder(elem.Type).(*zed.TypeArray); ok {
+		it := bytes.Iter()
+		for k := 0; k < to && !it.Done(); k++ {
+			if k == from {
+				bytes = zcode.Bytes(it)
+			}
+			it.Next()
+		}
+		bytes = bytes[:len(bytes)-len(it)]
+	} else {
+		bytes = bytes[from:to]
+	}
+	return ectx.NewValue(elem.Type, bytes)
+
+}
+
+func sliceIndex(ectx Context, this *zed.Value, slot Evaluator, length int) (int, error) {
 	if slot == nil {
 		//XXX
 		return 0, ErrSliceIndexEmpty
@@ -40,53 +88,13 @@ func sliceIndex(ectx Context, this *zed.Value, slot Evaluator, elem *zed.Value) 
 	}
 	index := int(v)
 	if index < 0 {
-		n, err := elem.ContainerLength()
-		if err != nil {
-			return 0, err
-		}
-		index += n
+		index += length
+	}
+	if index < 0 {
+		return 0, nil
+	}
+	if index > length {
+		return length, nil
 	}
 	return index, nil
-}
-
-func (s *Slice) Eval(ectx Context, this *zed.Value) *zed.Value {
-	elem := s.elem.Eval(ectx, this)
-	if elem.IsError() {
-		return elem
-	}
-	if _, ok := zed.TypeUnder(elem.Type).(*zed.TypeArray); !ok {
-		// XXX use structured error
-		return s.zctx.NewErrorf("sliced value is not an array: %s", zson.MustFormatValue(*elem))
-	}
-	if elem.IsNull() {
-		// If array is null, just return the null array.
-		return elem
-	}
-	from, err := sliceIndex(ectx, this, s.from, elem)
-	if err != nil && err != ErrSliceIndexEmpty {
-		return s.zctx.NewError(err)
-	}
-	to, err := sliceIndex(ectx, this, s.to, elem)
-	if err != nil {
-		if err != ErrSliceIndexEmpty {
-			return s.zctx.NewError(err)
-		}
-		n, err := elem.ContainerLength()
-		if err != nil {
-			panic(err)
-		}
-		to = int(n)
-	}
-	bytes := elem.Bytes
-	it := bytes.Iter()
-	if from < 0 {
-		from = 0
-	}
-	for k := 0; k < to && !it.Done(); k++ {
-		if k == from {
-			bytes = zcode.Bytes(it)
-		}
-		it.Next()
-	}
-	return ectx.NewValue(elem.Type, bytes[:len(bytes)-len(it)])
 }

--- a/runtime/expr/ztests/slice.yaml
+++ b/runtime/expr/ztests/slice.yaml
@@ -1,11 +1,25 @@
 zed: "cut a1:=a[1:-1],a2:=a[1:],a3:=a[:1],a4:=a[:-1],a5:=a[:-100],a6:=a[-1:],a7:=a[-2:-1],a8:=(a!=null and len(a)>0) ? a[:a[0]-8] : null"
 
 input: |
-  {a:[10(int32),11(int32),12(int32),13(int32)]}
+  {a:null}
+  {a:null(bytes)}
+  {a:null(string)}
   {a:null([int32])}
+  {a:0x}
+  {a:""}
   {a:[]([int32])}
+  {a:0x00112233}
+  {a:"0123"}
+  {a:[10(int32),11(int32),12(int32),13(int32)]}
 
 output: |
-  {a1:[11(int32),12(int32)],a2:[11(int32),12(int32),13(int32)],a3:[10(int32)],a4:[10(int32),11(int32),12(int32)],a5:[]([int32]),a6:[13(int32)],a7:[12(int32)],a8:[10(int32),11(int32)]}
+  {a1:error({message:"sliced value is not array, bytes, or string",on:null}),a2:error({message:"sliced value is not array, bytes, or string",on:null}),a3:error({message:"sliced value is not array, bytes, or string",on:null}),a4:error({message:"sliced value is not array, bytes, or string",on:null}),a5:error({message:"sliced value is not array, bytes, or string",on:null}),a6:error({message:"sliced value is not array, bytes, or string",on:null}),a7:error({message:"sliced value is not array, bytes, or string",on:null}),a8:null}
+  {a1:null(bytes),a2:null(bytes),a3:null(bytes),a4:null(bytes),a5:null(bytes),a6:null(bytes),a7:null(bytes),a8:null}
+  {a1:null(string),a2:null(string),a3:null(string),a4:null(string),a5:null(string),a6:null(string),a7:null(string),a8:null}
   {a1:null([int32]),a2:null([int32]),a3:null([int32]),a4:null([int32]),a5:null([int32]),a6:null([int32]),a7:null([int32]),a8:null}
+  {a1:0x,a2:0x,a3:0x,a4:0x,a5:0x,a6:0x,a7:0x,a8:null}
+  {a1:"",a2:"",a3:"",a4:"",a5:"",a6:"",a7:"",a8:null}
   {a1:[]([int32]),a2:[]([int32]),a3:[]([int32]),a4:[]([int32]),a5:[]([int32]),a6:[]([int32]),a7:[]([int32]),a8:null}
+  {a1:0x1122,a2:0x112233,a3:0x00,a4:0x001122,a5:0x,a6:0x33,a7:0x22,a8:error("slice index is not a number")}
+  {a1:"12",a2:"123",a3:"0",a4:"012",a5:"",a6:"3",a7:"2",a8:error("slice index is not a number")}
+  {a1:[11(int32),12(int32)],a2:[11(int32),12(int32),13(int32)],a3:[10(int32)],a4:[10(int32),11(int32),12(int32)],a5:[]([int32]),a6:[13(int32)],a7:[12(int32)],a8:[10(int32),11(int32)]}

--- a/runtime/expr/ztests/slice.yaml
+++ b/runtime/expr/ztests/slice.yaml
@@ -10,6 +10,8 @@ input: |
   {a:[]([int32])}
   {a:0x00112233}
   {a:"0123"}
+  {a:"0\u2071\u20723"}
+  {a:"\u2070\u2071\u2072\u2073"}
   {a:[10(int32),11(int32),12(int32),13(int32)]}
 
 output: |
@@ -22,4 +24,6 @@ output: |
   {a1:[]([int32]),a2:[]([int32]),a3:[]([int32]),a4:[]([int32]),a5:[]([int32]),a6:[]([int32]),a7:[]([int32]),a8:null}
   {a1:0x1122,a2:0x112233,a3:0x00,a4:0x001122,a5:0x,a6:0x33,a7:0x22,a8:error("slice index is not a number")}
   {a1:"12",a2:"123",a3:"0",a4:"012",a5:"",a6:"3",a7:"2",a8:error("slice index is not a number")}
+  {a1:"ⁱ⁲",a2:"ⁱ⁲3",a3:"0",a4:"0ⁱ⁲",a5:"",a6:"3",a7:"⁲",a8:error("slice index is not a number")}
+  {a1:"ⁱ⁲",a2:"ⁱ⁲⁳",a3:"⁰",a4:"⁰ⁱ⁲",a5:"",a6:"⁳",a7:"⁲",a8:error("slice index is not a number")}
   {a1:[11(int32),12(int32)],a2:[11(int32),12(int32),13(int32)],a3:[10(int32)],a4:[10(int32),11(int32),12(int32)],a5:[]([int32]),a6:[13(int32)],a7:[12(int32)],a8:[10(int32),11(int32)]}


### PR DESCRIPTION
A string slice index is interpreted as a rune (i.e., Unicode code point) index, not a a byte index.

Part of #1421.