### PR TITLE
Simply ZSON formatting of mixed-type maps

### DIFF
--- a/runtime/expr/ztests/complex-unions.yaml
+++ b/runtime/expr/ztests/complex-unions.yaml
@@ -6,6 +6,6 @@ script: |
 outputs:
   - name: stdout
     data: |
-      |{1((int64,string)):"foo","bar"((int64,string)):"baz"}|
+      |{1:"foo","bar":"baz"}|
       |[null(ip),127.0.0.1]|
       ["foo",1.1,10.98]

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -285,27 +285,11 @@ func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type,
 	indent += f.tab
 	sep := f.newline
 	it := zv.Iter()
-	union, _ := zed.TypeUnder(inner).(*zed.TypeUnion)
-	seen := make(map[zed.Type]struct{})
+	elems := newElemBuilder(inner)
 	for !it.Done() {
 		f.build(sep)
 		f.indent(indent, "")
-		b := it.Next()
-		typ := inner
-		if union != nil {
-			if b == nil {
-				// The type returned from union.SplitZNG for a null value will
-				// be the union type. While this is the correct type, for
-				// display purposes we do not want to see the decorator so just
-				// set the type to null.
-				typ = zed.TypeNull
-			} else {
-				typ, b = union.SplitZNG(b)
-				if _, ok := seen[typ]; !ok {
-					seen[typ] = struct{}{}
-				}
-			}
-		}
+		typ, b := elems.add(it.Next())
 		if err := f.formatValue(indent, typ, b, known, parentImplied, true); err != nil {
 			return true, err
 		}
@@ -313,12 +297,47 @@ func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type,
 	}
 	f.build(f.newline)
 	f.indent(indent-f.tab, close)
-	if _, isnamed := inner.(*zed.TypeNamed); union != nil && (isnamed || len(seen) != len(union.Types)) {
+	if elems.needsDecoration() {
 		// If we haven't seen all the types in the union, print the decorator
 		// so the fullness of the union is persevered.
 		f.decorate(zv.Type, false, true)
 	}
 	return false, nil
+}
+
+type elemBuilder struct {
+	typ   zed.Type
+	union *zed.TypeUnion
+	seen  map[zed.Type]struct{}
+}
+
+func newElemBuilder(typ zed.Type) *elemBuilder {
+	union, _ := zed.TypeUnder(typ).(*zed.TypeUnion)
+	return &elemBuilder{typ: typ, union: union, seen: make(map[zed.Type]struct{})}
+}
+
+func (e *elemBuilder) add(b zcode.Bytes) (zed.Type, zcode.Bytes) {
+	if e.union != nil {
+		if b == nil {
+			// The type returned from union.SplitZNG for a null value will
+			// be the union type. While this is the correct type, for
+			// display purposes we do not want to see the decorator so just
+			// set the type to null.
+			return zed.TypeNull, b
+		} else {
+			typ, b := e.union.SplitZNG(b)
+			if _, ok := e.seen[typ]; !ok {
+				e.seen[typ] = struct{}{}
+			}
+			return typ, b
+		}
+	}
+	return e.typ, b
+}
+
+func (e *elemBuilder) needsDecoration() bool {
+	_, isnamed := e.typ.(*zed.TypeNamed)
+	return e.union != nil && (isnamed || len(e.seen) < len(e.union.Types))
 }
 
 func (f *Formatter) formatUnion(indent int, union *zed.TypeUnion, bytes zcode.Bytes) error {
@@ -341,19 +360,22 @@ func (f *Formatter) formatMap(indent int, typ *zed.TypeMap, bytes zcode.Bytes, k
 	f.build("|{")
 	indent += f.tab
 	sep := f.newline
+	keyElems := newElemBuilder(typ.KeyType)
+	valElems := newElemBuilder(typ.ValType)
 	for it := bytes.Iter(); !it.Done(); {
-		keyBytes := it.Next()
+		kbytes := it.Next()
 		if it.Done() {
 			return empty, errors.New("truncated map value")
 		}
 		empty = false
-		valBytes := it.Next()
 		f.build(sep)
 		f.indent(indent, "")
-		if err := f.formatValue(indent, typ.KeyType, keyBytes, known, parentImplied, true); err != nil {
+		var ktyp zed.Type
+		ktyp, kbytes = keyElems.add(kbytes)
+		if err := f.formatValue(indent, ktyp, kbytes, known, parentImplied, true); err != nil {
 			return empty, err
 		}
-		if zed.TypeUnder(typ.KeyType) == zed.TypeIP && len(keyBytes) == 16 {
+		if zed.TypeUnder(ktyp) == zed.TypeIP && len(kbytes) == 16 {
 			// To avoid ambiguity, whitespace must separate an IPv6
 			// map key from the colon that follows it.
 			f.build(" ")
@@ -362,13 +384,17 @@ func (f *Formatter) formatMap(indent int, typ *zed.TypeMap, bytes zcode.Bytes, k
 		if f.tab > 0 {
 			f.build(" ")
 		}
-		if err := f.formatValue(indent, typ.ValType, valBytes, known, parentImplied, true); err != nil {
+		vtyp, vb := valElems.add(it.Next())
+		if err := f.formatValue(indent, vtyp, vb, known, parentImplied, true); err != nil {
 			return empty, err
 		}
 		sep = "," + f.newline
 	}
 	f.build(f.newline)
 	f.indent(indent-f.tab, "}|")
+	if keyElems.needsDecoration() || valElems.needsDecoration() {
+		f.decorate(typ, false, true)
+	}
 	return empty, nil
 }
 

--- a/zson/ztests/map.yaml
+++ b/zson/ztests/map.yaml
@@ -15,6 +15,8 @@ input: |
   |{<int8>:<int8>}|
   |{null:null}|
   |{null:null,null(int64):null(int64),null(string):null(string)}|
+  |{"a":"foo"(named=(int64,string)),"b":1(named=(int64,string))}|
+  |{"a"((int64,string)):"foo","b"((int64,string)):"bar"}|
   {a:|{}|}
   {a:|{-1:-1,2:2}|}
   {a:|{1ns:1ns,2us:2us,3ms:3ms,4s:4s,5m:5m,6h:6h,7d:7d,8w:8w,9y:9y}|}
@@ -44,7 +46,9 @@ output: |
   |{3.3.3.0/24:3.3.3.0/24,::1/128:::1/128,2::/16:2::/16}|
   |{<int8>:<int8>}|
   |{null:null}|
-  |{null((int64,string)):null((int64,string)),null(int64)((int64,string)):null(int64)((int64,string)),null(string)((int64,string)):null(string)((int64,string))}|
+  |{null:null,null(int64):null(int64),null(string):null(string)}|
+  |{"a":"foo","b":1}|(|{string:named=(int64,string)}|)
+  |{"a":"foo","b":"bar"}|(|{(int64,string):string}|)
   {a:|{}|(|{null:null}|)}
   {a:|{-1:-1,2:2}|}
   {a:|{1ns:1ns,2us:2us,3ms:3ms,4s:4s,5m:5m,6h:6h,7d:7d,56d:56d,9y:9y}|}
@@ -58,4 +62,4 @@ output: |
   {a:|{3.3.3.0/24:3.3.3.0/24,::1/128:::1/128,2::/16:2::/16}|}
   {a:|{<int8>:<int8>}|}
   {a:|{null:null}|}
-  |{3((int64,string)):2((int64,string)),"foo"((int64,string)):"bar"((int64,string))}|
+  |{3:2,"foo":"bar"}|


### PR DESCRIPTION
Do not decorate the elements of a mixed-type map. Decorate a mixed
typed map if when the union type includes elements that are not in
the array or if elements are a named union.

Closes #3400