### PR TITLE
fix shape operator and function ambiguity

### DIFF
--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -4508,7 +4508,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseShapeProc() {
-    var s0, s1;
+    var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 5) === peg$c167) {
@@ -4519,10 +4519,48 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c168); }
     }
     if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c169();
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s5 = peg$c16;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        }
+        if (s5 !== peg$FAILED) {
+          s4 = [s4, s5];
+          s3 = s4;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c169();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
-    s0 = s1;
 
     return s0;
   }

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -2822,93 +2822,115 @@ var g = &grammar{
 			expr: &actionExpr{
 				pos: position{line: 344, col: 5, offset: 9995},
 				run: (*parser).callonShapeProc1,
-				expr: &litMatcher{
-					pos:        position{line: 344, col: 5, offset: 9995},
-					val:        "shape",
-					ignoreCase: false,
+				expr: &seqExpr{
+					pos: position{line: 344, col: 5, offset: 9995},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 344, col: 5, offset: 9995},
+							val:        "shape",
+							ignoreCase: false,
+						},
+						&notExpr{
+							pos: position{line: 344, col: 13, offset: 10003},
+							expr: &seqExpr{
+								pos: position{line: 344, col: 15, offset: 10005},
+								exprs: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 344, col: 15, offset: 10005},
+										name: "__",
+									},
+									&litMatcher{
+										pos:        position{line: 344, col: 18, offset: 10008},
+										val:        "(",
+										ignoreCase: false,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 348, col: 1, offset: 10070},
+			pos:  position{line: 348, col: 1, offset: 10080},
 			expr: &choiceExpr{
-				pos: position{line: 349, col: 5, offset: 10083},
+				pos: position{line: 349, col: 5, offset: 10093},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 349, col: 5, offset: 10083},
+						pos: position{line: 349, col: 5, offset: 10093},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 349, col: 5, offset: 10083},
+							pos: position{line: 349, col: 5, offset: 10093},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 349, col: 5, offset: 10083},
+									pos:   position{line: 349, col: 5, offset: 10093},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 349, col: 11, offset: 10089},
+										pos:  position{line: 349, col: 11, offset: 10099},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 349, col: 21, offset: 10099},
+									pos:        position{line: 349, col: 21, offset: 10109},
 									val:        "join",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 349, col: 28, offset: 10106},
+									pos:  position{line: 349, col: 28, offset: 10116},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 349, col: 30, offset: 10108},
+									pos:  position{line: 349, col: 30, offset: 10118},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 349, col: 33, offset: 10111},
+									pos:  position{line: 349, col: 33, offset: 10121},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 349, col: 35, offset: 10113},
+									pos:   position{line: 349, col: 35, offset: 10123},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 349, col: 43, offset: 10121},
+										pos:  position{line: 349, col: 43, offset: 10131},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 349, col: 51, offset: 10129},
+									pos:  position{line: 349, col: 51, offset: 10139},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 349, col: 54, offset: 10132},
+									pos:        position{line: 349, col: 54, offset: 10142},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 349, col: 58, offset: 10136},
+									pos:  position{line: 349, col: 58, offset: 10146},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 349, col: 61, offset: 10139},
+									pos:   position{line: 349, col: 61, offset: 10149},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 349, col: 70, offset: 10148},
+										pos:  position{line: 349, col: 70, offset: 10158},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 349, col: 78, offset: 10156},
+									pos:   position{line: 349, col: 78, offset: 10166},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 349, col: 86, offset: 10164},
+										pos: position{line: 349, col: 86, offset: 10174},
 										expr: &seqExpr{
-											pos: position{line: 349, col: 87, offset: 10165},
+											pos: position{line: 349, col: 87, offset: 10175},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 349, col: 87, offset: 10165},
+													pos:  position{line: 349, col: 87, offset: 10175},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 349, col: 89, offset: 10167},
+													pos:  position{line: 349, col: 89, offset: 10177},
 													name: "FlexAssignments",
 												},
 											},
@@ -2919,58 +2941,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 356, col: 5, offset: 10433},
+						pos: position{line: 356, col: 5, offset: 10443},
 						run: (*parser).callonJoinProc22,
 						expr: &seqExpr{
-							pos: position{line: 356, col: 5, offset: 10433},
+							pos: position{line: 356, col: 5, offset: 10443},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 356, col: 5, offset: 10433},
+									pos:   position{line: 356, col: 5, offset: 10443},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 356, col: 11, offset: 10439},
+										pos:  position{line: 356, col: 11, offset: 10449},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 356, col: 22, offset: 10450},
+									pos:        position{line: 356, col: 22, offset: 10460},
 									val:        "join",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 356, col: 29, offset: 10457},
+									pos:  position{line: 356, col: 29, offset: 10467},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 356, col: 31, offset: 10459},
+									pos:  position{line: 356, col: 31, offset: 10469},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 356, col: 34, offset: 10462},
+									pos:  position{line: 356, col: 34, offset: 10472},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 356, col: 36, offset: 10464},
+									pos:   position{line: 356, col: 36, offset: 10474},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 356, col: 40, offset: 10468},
+										pos:  position{line: 356, col: 40, offset: 10478},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 356, col: 48, offset: 10476},
+									pos:   position{line: 356, col: 48, offset: 10486},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 356, col: 56, offset: 10484},
+										pos: position{line: 356, col: 56, offset: 10494},
 										expr: &seqExpr{
-											pos: position{line: 356, col: 57, offset: 10485},
+											pos: position{line: 356, col: 57, offset: 10495},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 356, col: 57, offset: 10485},
+													pos:  position{line: 356, col: 57, offset: 10495},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 356, col: 59, offset: 10487},
+													pos:  position{line: 356, col: 59, offset: 10497},
 													name: "FlexAssignments",
 												},
 											},
@@ -2985,87 +3007,87 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 364, col: 1, offset: 10741},
+			pos:  position{line: 364, col: 1, offset: 10751},
 			expr: &choiceExpr{
-				pos: position{line: 365, col: 5, offset: 10755},
+				pos: position{line: 365, col: 5, offset: 10765},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 365, col: 5, offset: 10755},
+						pos: position{line: 365, col: 5, offset: 10765},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 365, col: 5, offset: 10755},
+							pos: position{line: 365, col: 5, offset: 10765},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 365, col: 5, offset: 10755},
+									pos:        position{line: 365, col: 5, offset: 10765},
 									val:        "anti",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 365, col: 12, offset: 10762},
+									pos:  position{line: 365, col: 12, offset: 10772},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 366, col: 5, offset: 10792},
+						pos: position{line: 366, col: 5, offset: 10802},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 366, col: 5, offset: 10792},
+							pos: position{line: 366, col: 5, offset: 10802},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 366, col: 5, offset: 10792},
+									pos:        position{line: 366, col: 5, offset: 10802},
 									val:        "inner",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 366, col: 13, offset: 10800},
+									pos:  position{line: 366, col: 13, offset: 10810},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 367, col: 5, offset: 10830},
+						pos: position{line: 367, col: 5, offset: 10840},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 367, col: 5, offset: 10830},
+							pos: position{line: 367, col: 5, offset: 10840},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 367, col: 5, offset: 10830},
+									pos:        position{line: 367, col: 5, offset: 10840},
 									val:        "left",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 367, col: 13, offset: 10838},
+									pos:  position{line: 367, col: 13, offset: 10848},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 368, col: 5, offset: 10867},
+						pos: position{line: 368, col: 5, offset: 10877},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 368, col: 5, offset: 10867},
+							pos: position{line: 368, col: 5, offset: 10877},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 368, col: 5, offset: 10867},
+									pos:        position{line: 368, col: 5, offset: 10877},
 									val:        "right",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 368, col: 13, offset: 10875},
+									pos:  position{line: 368, col: 13, offset: 10885},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 369, col: 5, offset: 10905},
+						pos: position{line: 369, col: 5, offset: 10915},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 369, col: 5, offset: 10905},
+							pos:        position{line: 369, col: 5, offset: 10915},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3075,35 +3097,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 371, col: 1, offset: 10941},
+			pos:  position{line: 371, col: 1, offset: 10951},
 			expr: &choiceExpr{
-				pos: position{line: 372, col: 5, offset: 10953},
+				pos: position{line: 372, col: 5, offset: 10963},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 372, col: 5, offset: 10953},
+						pos:  position{line: 372, col: 5, offset: 10963},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 373, col: 5, offset: 10962},
+						pos: position{line: 373, col: 5, offset: 10972},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 373, col: 5, offset: 10962},
+							pos: position{line: 373, col: 5, offset: 10972},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 373, col: 5, offset: 10962},
+									pos:        position{line: 373, col: 5, offset: 10972},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 373, col: 9, offset: 10966},
+									pos:   position{line: 373, col: 9, offset: 10976},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 373, col: 14, offset: 10971},
+										pos:  position{line: 373, col: 14, offset: 10981},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 373, col: 19, offset: 10976},
+									pos:        position{line: 373, col: 19, offset: 10986},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3115,23 +3137,23 @@ var g = &grammar{
 		},
 		{
 			name: "SampleProc",
-			pos:  position{line: 375, col: 1, offset: 11002},
+			pos:  position{line: 375, col: 1, offset: 11012},
 			expr: &actionExpr{
-				pos: position{line: 376, col: 5, offset: 11017},
+				pos: position{line: 376, col: 5, offset: 11027},
 				run: (*parser).callonSampleProc1,
 				expr: &seqExpr{
-					pos: position{line: 376, col: 5, offset: 11017},
+					pos: position{line: 376, col: 5, offset: 11027},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 376, col: 5, offset: 11017},
+							pos:        position{line: 376, col: 5, offset: 11027},
 							val:        "sample",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 376, col: 14, offset: 11026},
+							pos:   position{line: 376, col: 14, offset: 11036},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 376, col: 16, offset: 11028},
+								pos:  position{line: 376, col: 16, offset: 11038},
 								name: "SampleExpr",
 							},
 						},
@@ -3141,15 +3163,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 420, col: 1, offset: 12644},
+			pos:  position{line: 420, col: 1, offset: 12654},
 			expr: &actionExpr{
-				pos: position{line: 421, col: 5, offset: 12661},
+				pos: position{line: 421, col: 5, offset: 12671},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 421, col: 5, offset: 12661},
+					pos:   position{line: 421, col: 5, offset: 12671},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 421, col: 7, offset: 12663},
+						pos:  position{line: 421, col: 7, offset: 12673},
 						name: "Assignments",
 					},
 				},
@@ -3157,25 +3179,25 @@ var g = &grammar{
 		},
 		{
 			name: "SampleExpr",
-			pos:  position{line: 425, col: 1, offset: 12763},
+			pos:  position{line: 425, col: 1, offset: 12773},
 			expr: &choiceExpr{
-				pos: position{line: 426, col: 5, offset: 12778},
+				pos: position{line: 426, col: 5, offset: 12788},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 426, col: 5, offset: 12778},
+						pos: position{line: 426, col: 5, offset: 12788},
 						run: (*parser).callonSampleExpr2,
 						expr: &seqExpr{
-							pos: position{line: 426, col: 5, offset: 12778},
+							pos: position{line: 426, col: 5, offset: 12788},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 426, col: 5, offset: 12778},
+									pos:  position{line: 426, col: 5, offset: 12788},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 426, col: 7, offset: 12780},
+									pos:   position{line: 426, col: 7, offset: 12790},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 426, col: 12, offset: 12785},
+										pos:  position{line: 426, col: 12, offset: 12795},
 										name: "Lval",
 									},
 								},
@@ -3183,10 +3205,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 427, col: 5, offset: 12814},
+						pos: position{line: 427, col: 5, offset: 12824},
 						run: (*parser).callonSampleExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 427, col: 5, offset: 12814},
+							pos:        position{line: 427, col: 5, offset: 12824},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3196,15 +3218,15 @@ var g = &grammar{
 		},
 		{
 			name: "FromProc",
-			pos:  position{line: 429, col: 1, offset: 12885},
+			pos:  position{line: 429, col: 1, offset: 12895},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 12898},
+				pos: position{line: 430, col: 5, offset: 12908},
 				run: (*parser).callonFromProc1,
 				expr: &labeledExpr{
-					pos:   position{line: 430, col: 5, offset: 12898},
+					pos:   position{line: 430, col: 5, offset: 12908},
 					label: "source",
 					expr: &ruleRefExpr{
-						pos:  position{line: 430, col: 12, offset: 12905},
+						pos:  position{line: 430, col: 12, offset: 12915},
 						name: "FromAny",
 					},
 				},
@@ -3212,20 +3234,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromAny",
-			pos:  position{line: 434, col: 1, offset: 13061},
+			pos:  position{line: 434, col: 1, offset: 13071},
 			expr: &choiceExpr{
-				pos: position{line: 435, col: 5, offset: 13073},
+				pos: position{line: 435, col: 5, offset: 13083},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 435, col: 5, offset: 13073},
+						pos:  position{line: 435, col: 5, offset: 13083},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 436, col: 5, offset: 13082},
+						pos:  position{line: 436, col: 5, offset: 13092},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 437, col: 5, offset: 13090},
+						pos:  position{line: 437, col: 5, offset: 13100},
 						name: "From",
 					},
 				},
@@ -3233,48 +3255,48 @@ var g = &grammar{
 		},
 		{
 			name: "File",
-			pos:  position{line: 439, col: 1, offset: 13096},
+			pos:  position{line: 439, col: 1, offset: 13106},
 			expr: &actionExpr{
-				pos: position{line: 440, col: 5, offset: 13105},
+				pos: position{line: 440, col: 5, offset: 13115},
 				run: (*parser).callonFile1,
 				expr: &seqExpr{
-					pos: position{line: 440, col: 5, offset: 13105},
+					pos: position{line: 440, col: 5, offset: 13115},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 440, col: 5, offset: 13105},
+							pos:        position{line: 440, col: 5, offset: 13115},
 							val:        "file",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 440, col: 12, offset: 13112},
+							pos:  position{line: 440, col: 12, offset: 13122},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 14, offset: 13114},
+							pos:   position{line: 440, col: 14, offset: 13124},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 440, col: 19, offset: 13119},
+								pos:  position{line: 440, col: 19, offset: 13129},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 24, offset: 13124},
+							pos:   position{line: 440, col: 24, offset: 13134},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 440, col: 31, offset: 13131},
+								pos: position{line: 440, col: 31, offset: 13141},
 								expr: &ruleRefExpr{
-									pos:  position{line: 440, col: 31, offset: 13131},
+									pos:  position{line: 440, col: 31, offset: 13141},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 42, offset: 13142},
+							pos:   position{line: 440, col: 42, offset: 13152},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 440, col: 49, offset: 13149},
+								pos: position{line: 440, col: 49, offset: 13159},
 								expr: &ruleRefExpr{
-									pos:  position{line: 440, col: 49, offset: 13149},
+									pos:  position{line: 440, col: 49, offset: 13159},
 									name: "LayoutArg",
 								},
 							},
@@ -3285,27 +3307,27 @@ var g = &grammar{
 		},
 		{
 			name: "From",
-			pos:  position{line: 444, col: 1, offset: 13278},
+			pos:  position{line: 444, col: 1, offset: 13288},
 			expr: &actionExpr{
-				pos: position{line: 445, col: 5, offset: 13287},
+				pos: position{line: 445, col: 5, offset: 13297},
 				run: (*parser).callonFrom1,
 				expr: &seqExpr{
-					pos: position{line: 445, col: 5, offset: 13287},
+					pos: position{line: 445, col: 5, offset: 13297},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 445, col: 5, offset: 13287},
+							pos:        position{line: 445, col: 5, offset: 13297},
 							val:        "from",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 445, col: 12, offset: 13294},
+							pos:  position{line: 445, col: 12, offset: 13304},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 14, offset: 13296},
+							pos:   position{line: 445, col: 14, offset: 13306},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 19, offset: 13301},
+								pos:  position{line: 445, col: 19, offset: 13311},
 								name: "PoolBody",
 							},
 						},
@@ -3315,27 +3337,27 @@ var g = &grammar{
 		},
 		{
 			name: "Pool",
-			pos:  position{line: 447, col: 1, offset: 13332},
+			pos:  position{line: 447, col: 1, offset: 13342},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 5, offset: 13341},
+				pos: position{line: 448, col: 5, offset: 13351},
 				run: (*parser).callonPool1,
 				expr: &seqExpr{
-					pos: position{line: 448, col: 5, offset: 13341},
+					pos: position{line: 448, col: 5, offset: 13351},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 448, col: 5, offset: 13341},
+							pos:        position{line: 448, col: 5, offset: 13351},
 							val:        "pool",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 448, col: 12, offset: 13348},
+							pos:  position{line: 448, col: 12, offset: 13358},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 448, col: 14, offset: 13350},
+							pos:   position{line: 448, col: 14, offset: 13360},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 448, col: 19, offset: 13355},
+								pos:  position{line: 448, col: 19, offset: 13365},
 								name: "PoolBody",
 							},
 						},
@@ -3345,50 +3367,50 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBody",
-			pos:  position{line: 450, col: 1, offset: 13386},
+			pos:  position{line: 450, col: 1, offset: 13396},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 13399},
+				pos: position{line: 451, col: 5, offset: 13409},
 				run: (*parser).callonPoolBody1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 13399},
+					pos: position{line: 451, col: 5, offset: 13409},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 13399},
+							pos:   position{line: 451, col: 5, offset: 13409},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 10, offset: 13404},
+								pos:  position{line: 451, col: 10, offset: 13414},
 								name: "PoolSpec",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 19, offset: 13413},
+							pos:   position{line: 451, col: 19, offset: 13423},
 							label: "at",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 22, offset: 13416},
+								pos: position{line: 451, col: 22, offset: 13426},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 22, offset: 13416},
+									pos:  position{line: 451, col: 22, offset: 13426},
 									name: "PoolAt",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 30, offset: 13424},
+							pos:   position{line: 451, col: 30, offset: 13434},
 							label: "over",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 35, offset: 13429},
+								pos: position{line: 451, col: 35, offset: 13439},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 35, offset: 13429},
+									pos:  position{line: 451, col: 35, offset: 13439},
 									name: "PoolRange",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 46, offset: 13440},
+							pos:   position{line: 451, col: 46, offset: 13450},
 							label: "order",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 52, offset: 13446},
+								pos: position{line: 451, col: 52, offset: 13456},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 52, offset: 13446},
+									pos:  position{line: 451, col: 52, offset: 13456},
 									name: "OrderArg",
 								},
 							},
@@ -3399,48 +3421,48 @@ var g = &grammar{
 		},
 		{
 			name: "Get",
-			pos:  position{line: 455, col: 1, offset: 13582},
+			pos:  position{line: 455, col: 1, offset: 13592},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 5, offset: 13590},
+				pos: position{line: 456, col: 5, offset: 13600},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 456, col: 5, offset: 13590},
+					pos: position{line: 456, col: 5, offset: 13600},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 456, col: 5, offset: 13590},
+							pos:        position{line: 456, col: 5, offset: 13600},
 							val:        "get",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 456, col: 11, offset: 13596},
+							pos:  position{line: 456, col: 11, offset: 13606},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 13, offset: 13598},
+							pos:   position{line: 456, col: 13, offset: 13608},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 456, col: 17, offset: 13602},
+								pos:  position{line: 456, col: 17, offset: 13612},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 21, offset: 13606},
+							pos:   position{line: 456, col: 21, offset: 13616},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 456, col: 28, offset: 13613},
+								pos: position{line: 456, col: 28, offset: 13623},
 								expr: &ruleRefExpr{
-									pos:  position{line: 456, col: 28, offset: 13613},
+									pos:  position{line: 456, col: 28, offset: 13623},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 39, offset: 13624},
+							pos:   position{line: 456, col: 39, offset: 13634},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 456, col: 46, offset: 13631},
+								pos: position{line: 456, col: 46, offset: 13641},
 								expr: &ruleRefExpr{
-									pos:  position{line: 456, col: 46, offset: 13631},
+									pos:  position{line: 456, col: 46, offset: 13641},
 									name: "LayoutArg",
 								},
 							},
@@ -3451,30 +3473,30 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 460, col: 1, offset: 13757},
+			pos:  position{line: 460, col: 1, offset: 13767},
 			expr: &actionExpr{
-				pos: position{line: 460, col: 7, offset: 13763},
+				pos: position{line: 460, col: 7, offset: 13773},
 				run: (*parser).callonURL1,
 				expr: &seqExpr{
-					pos: position{line: 460, col: 7, offset: 13763},
+					pos: position{line: 460, col: 7, offset: 13773},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 460, col: 8, offset: 13764},
+							pos: position{line: 460, col: 8, offset: 13774},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 460, col: 8, offset: 13764},
+									pos:        position{line: 460, col: 8, offset: 13774},
 									val:        "http:",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 460, col: 18, offset: 13774},
+									pos:        position{line: 460, col: 18, offset: 13784},
 									val:        "https:",
 									ignoreCase: false,
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 460, col: 28, offset: 13784},
+							pos:  position{line: 460, col: 28, offset: 13794},
 							name: "Path",
 						},
 					},
@@ -3483,29 +3505,29 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 462, col: 1, offset: 13821},
+			pos:  position{line: 462, col: 1, offset: 13831},
 			expr: &choiceExpr{
-				pos: position{line: 463, col: 5, offset: 13830},
+				pos: position{line: 463, col: 5, offset: 13840},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 463, col: 5, offset: 13830},
+						pos: position{line: 463, col: 5, offset: 13840},
 						run: (*parser).callonPath2,
 						expr: &labeledExpr{
-							pos:   position{line: 463, col: 5, offset: 13830},
+							pos:   position{line: 463, col: 5, offset: 13840},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 463, col: 7, offset: 13832},
+								pos:  position{line: 463, col: 7, offset: 13842},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 464, col: 5, offset: 13867},
+						pos: position{line: 464, col: 5, offset: 13877},
 						run: (*parser).callonPath5,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 464, col: 5, offset: 13867},
+							pos: position{line: 464, col: 5, offset: 13877},
 							expr: &charClassMatcher{
-								pos:        position{line: 464, col: 5, offset: 13867},
+								pos:        position{line: 464, col: 5, offset: 13877},
 								val:        "[0-9a-zA-Z!@$%^&*()_=<>,./?:[\\]{}~|+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '(', ')', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '|', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -3519,31 +3541,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 467, col: 1, offset: 13972},
+			pos:  position{line: 467, col: 1, offset: 13982},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 5, offset: 13983},
+				pos: position{line: 468, col: 5, offset: 13993},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 468, col: 5, offset: 13983},
+					pos: position{line: 468, col: 5, offset: 13993},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 5, offset: 13983},
+							pos:  position{line: 468, col: 5, offset: 13993},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 468, col: 7, offset: 13985},
+							pos:        position{line: 468, col: 7, offset: 13995},
 							val:        "at",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 12, offset: 13990},
+							pos:  position{line: 468, col: 12, offset: 14000},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 14, offset: 13992},
+							pos:   position{line: 468, col: 14, offset: 14002},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 17, offset: 13995},
+								pos:  position{line: 468, col: 17, offset: 14005},
 								name: "KSUID",
 							},
 						},
@@ -3553,14 +3575,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 471, col: 1, offset: 14061},
+			pos:  position{line: 471, col: 1, offset: 14071},
 			expr: &actionExpr{
-				pos: position{line: 471, col: 9, offset: 14069},
+				pos: position{line: 471, col: 9, offset: 14079},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 471, col: 9, offset: 14069},
+					pos: position{line: 471, col: 9, offset: 14079},
 					expr: &charClassMatcher{
-						pos:        position{line: 471, col: 10, offset: 14070},
+						pos:        position{line: 471, col: 10, offset: 14080},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -3571,52 +3593,52 @@ var g = &grammar{
 		},
 		{
 			name: "PoolRange",
-			pos:  position{line: 473, col: 1, offset: 14116},
+			pos:  position{line: 473, col: 1, offset: 14126},
 			expr: &actionExpr{
-				pos: position{line: 474, col: 5, offset: 14130},
+				pos: position{line: 474, col: 5, offset: 14140},
 				run: (*parser).callonPoolRange1,
 				expr: &seqExpr{
-					pos: position{line: 474, col: 5, offset: 14130},
+					pos: position{line: 474, col: 5, offset: 14140},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 5, offset: 14130},
+							pos:  position{line: 474, col: 5, offset: 14140},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 7, offset: 14132},
+							pos:        position{line: 474, col: 7, offset: 14142},
 							val:        "range",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 15, offset: 14140},
+							pos:  position{line: 474, col: 15, offset: 14150},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 17, offset: 14142},
+							pos:   position{line: 474, col: 17, offset: 14152},
 							label: "lower",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 23, offset: 14148},
+								pos:  position{line: 474, col: 23, offset: 14158},
 								name: "Literal",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 31, offset: 14156},
+							pos:  position{line: 474, col: 31, offset: 14166},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 33, offset: 14158},
+							pos:        position{line: 474, col: 33, offset: 14168},
 							val:        "to",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 38, offset: 14163},
+							pos:  position{line: 474, col: 38, offset: 14173},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 40, offset: 14165},
+							pos:   position{line: 474, col: 40, offset: 14175},
 							label: "upper",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 46, offset: 14171},
+								pos:  position{line: 474, col: 46, offset: 14181},
 								name: "Literal",
 							},
 						},
@@ -3626,42 +3648,42 @@ var g = &grammar{
 		},
 		{
 			name: "PoolSpec",
-			pos:  position{line: 478, col: 1, offset: 14276},
+			pos:  position{line: 478, col: 1, offset: 14286},
 			expr: &choiceExpr{
-				pos: position{line: 479, col: 5, offset: 14289},
+				pos: position{line: 479, col: 5, offset: 14299},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 479, col: 5, offset: 14289},
+						pos: position{line: 479, col: 5, offset: 14299},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 479, col: 5, offset: 14289},
+							pos: position{line: 479, col: 5, offset: 14299},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 479, col: 5, offset: 14289},
+									pos:   position{line: 479, col: 5, offset: 14299},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 10, offset: 14294},
+										pos:  position{line: 479, col: 10, offset: 14304},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 19, offset: 14303},
+									pos:   position{line: 479, col: 19, offset: 14313},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 479, col: 26, offset: 14310},
+										pos: position{line: 479, col: 26, offset: 14320},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 26, offset: 14310},
+											pos:  position{line: 479, col: 26, offset: 14320},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 38, offset: 14322},
+									pos:   position{line: 479, col: 38, offset: 14332},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 479, col: 43, offset: 14327},
+										pos: position{line: 479, col: 43, offset: 14337},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 43, offset: 14327},
+											pos:  position{line: 479, col: 43, offset: 14337},
 											name: "PoolMeta",
 										},
 									},
@@ -3670,13 +3692,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 14436},
+						pos: position{line: 482, col: 5, offset: 14446},
 						run: (*parser).callonPoolSpec12,
 						expr: &labeledExpr{
-							pos:   position{line: 482, col: 5, offset: 14436},
+							pos:   position{line: 482, col: 5, offset: 14446},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 482, col: 10, offset: 14441},
+								pos:  position{line: 482, col: 10, offset: 14451},
 								name: "PoolMeta",
 							},
 						},
@@ -3686,23 +3708,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 486, col: 1, offset: 14542},
+			pos:  position{line: 486, col: 1, offset: 14552},
 			expr: &actionExpr{
-				pos: position{line: 487, col: 5, offset: 14557},
+				pos: position{line: 487, col: 5, offset: 14567},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 487, col: 5, offset: 14557},
+					pos: position{line: 487, col: 5, offset: 14567},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 487, col: 5, offset: 14557},
+							pos:        position{line: 487, col: 5, offset: 14567},
 							val:        "@",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 487, col: 9, offset: 14561},
+							pos:   position{line: 487, col: 9, offset: 14571},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 487, col: 16, offset: 14568},
+								pos:  position{line: 487, col: 16, offset: 14578},
 								name: "PoolName",
 							},
 						},
@@ -3712,23 +3734,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 489, col: 1, offset: 14601},
+			pos:  position{line: 489, col: 1, offset: 14611},
 			expr: &actionExpr{
-				pos: position{line: 490, col: 5, offset: 14614},
+				pos: position{line: 490, col: 5, offset: 14624},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 490, col: 5, offset: 14614},
+					pos: position{line: 490, col: 5, offset: 14624},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 490, col: 5, offset: 14614},
+							pos:        position{line: 490, col: 5, offset: 14624},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 490, col: 9, offset: 14618},
+							pos:   position{line: 490, col: 9, offset: 14628},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 490, col: 14, offset: 14623},
+								pos:  position{line: 490, col: 14, offset: 14633},
 								name: "PoolIdentifier",
 							},
 						},
@@ -3738,20 +3760,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 492, col: 1, offset: 14660},
+			pos:  position{line: 492, col: 1, offset: 14670},
 			expr: &choiceExpr{
-				pos: position{line: 493, col: 5, offset: 14673},
+				pos: position{line: 493, col: 5, offset: 14683},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 493, col: 5, offset: 14673},
+						pos:  position{line: 493, col: 5, offset: 14683},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 494, col: 5, offset: 14692},
+						pos:  position{line: 494, col: 5, offset: 14702},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 495, col: 5, offset: 14702},
+						pos:  position{line: 495, col: 5, offset: 14712},
 						name: "QuotedString",
 					},
 				},
@@ -3759,38 +3781,38 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 497, col: 1, offset: 14716},
+			pos:  position{line: 497, col: 1, offset: 14726},
 			expr: &actionExpr{
-				pos: position{line: 498, col: 5, offset: 14735},
+				pos: position{line: 498, col: 5, offset: 14745},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 498, col: 5, offset: 14735},
+					pos: position{line: 498, col: 5, offset: 14745},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 498, col: 6, offset: 14736},
+							pos: position{line: 498, col: 6, offset: 14746},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 498, col: 6, offset: 14736},
+									pos:  position{line: 498, col: 6, offset: 14746},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 498, col: 24, offset: 14754},
+									pos:        position{line: 498, col: 24, offset: 14764},
 									val:        ".",
 									ignoreCase: false,
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 498, col: 29, offset: 14759},
+							pos: position{line: 498, col: 29, offset: 14769},
 							expr: &choiceExpr{
-								pos: position{line: 498, col: 30, offset: 14760},
+								pos: position{line: 498, col: 30, offset: 14770},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 498, col: 30, offset: 14760},
+										pos:  position{line: 498, col: 30, offset: 14770},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 498, col: 47, offset: 14777},
+										pos:        position{line: 498, col: 47, offset: 14787},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -3803,39 +3825,39 @@ var g = &grammar{
 		},
 		{
 			name: "LayoutArg",
-			pos:  position{line: 500, col: 1, offset: 14816},
+			pos:  position{line: 500, col: 1, offset: 14826},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 14830},
+				pos: position{line: 501, col: 5, offset: 14840},
 				run: (*parser).callonLayoutArg1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 14830},
+					pos: position{line: 501, col: 5, offset: 14840},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 5, offset: 14830},
+							pos:  position{line: 501, col: 5, offset: 14840},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 7, offset: 14832},
+							pos:        position{line: 501, col: 7, offset: 14842},
 							val:        "order",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 15, offset: 14840},
+							pos:  position{line: 501, col: 15, offset: 14850},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 17, offset: 14842},
+							pos:   position{line: 501, col: 17, offset: 14852},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 22, offset: 14847},
+								pos:  position{line: 501, col: 22, offset: 14857},
 								name: "FieldExprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 33, offset: 14858},
+							pos:   position{line: 501, col: 33, offset: 14868},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 39, offset: 14864},
+								pos:  position{line: 501, col: 39, offset: 14874},
 								name: "OrderSuffix",
 							},
 						},
@@ -3845,31 +3867,31 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 505, col: 1, offset: 14974},
+			pos:  position{line: 505, col: 1, offset: 14984},
 			expr: &actionExpr{
-				pos: position{line: 506, col: 5, offset: 14988},
+				pos: position{line: 506, col: 5, offset: 14998},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 506, col: 5, offset: 14988},
+					pos: position{line: 506, col: 5, offset: 14998},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 5, offset: 14988},
+							pos:  position{line: 506, col: 5, offset: 14998},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 506, col: 7, offset: 14990},
+							pos:        position{line: 506, col: 7, offset: 15000},
 							val:        "format",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 16, offset: 14999},
+							pos:  position{line: 506, col: 16, offset: 15009},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 506, col: 18, offset: 15001},
+							pos:   position{line: 506, col: 18, offset: 15011},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 506, col: 22, offset: 15005},
+								pos:  position{line: 506, col: 22, offset: 15015},
 								name: "IdentifierName",
 							},
 						},
@@ -3879,33 +3901,33 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 508, col: 1, offset: 15041},
+			pos:  position{line: 508, col: 1, offset: 15051},
 			expr: &choiceExpr{
-				pos: position{line: 509, col: 5, offset: 15057},
+				pos: position{line: 509, col: 5, offset: 15067},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 509, col: 5, offset: 15057},
+						pos: position{line: 509, col: 5, offset: 15067},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 509, col: 5, offset: 15057},
+							pos:        position{line: 509, col: 5, offset: 15067},
 							val:        ":asc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 15091},
+						pos: position{line: 510, col: 5, offset: 15101},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 510, col: 5, offset: 15091},
+							pos:        position{line: 510, col: 5, offset: 15101},
 							val:        ":desc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 511, col: 5, offset: 15127},
+						pos: position{line: 511, col: 5, offset: 15137},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 511, col: 5, offset: 15127},
+							pos:        position{line: 511, col: 5, offset: 15137},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3915,31 +3937,31 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 513, col: 1, offset: 15153},
+			pos:  position{line: 513, col: 1, offset: 15163},
 			expr: &choiceExpr{
-				pos: position{line: 514, col: 5, offset: 15166},
+				pos: position{line: 514, col: 5, offset: 15176},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 15166},
+						pos: position{line: 514, col: 5, offset: 15176},
 						run: (*parser).callonOrderArg2,
 						expr: &seqExpr{
-							pos: position{line: 514, col: 5, offset: 15166},
+							pos: position{line: 514, col: 5, offset: 15176},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 5, offset: 15166},
+									pos:  position{line: 514, col: 5, offset: 15176},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 7, offset: 15168},
+									pos:        position{line: 514, col: 7, offset: 15178},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 15, offset: 15176},
+									pos:  position{line: 514, col: 15, offset: 15186},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 17, offset: 15178},
+									pos:        position{line: 514, col: 17, offset: 15188},
 									val:        "asc",
 									ignoreCase: false,
 								},
@@ -3947,26 +3969,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 515, col: 5, offset: 15211},
+						pos: position{line: 515, col: 5, offset: 15221},
 						run: (*parser).callonOrderArg8,
 						expr: &seqExpr{
-							pos: position{line: 515, col: 5, offset: 15211},
+							pos: position{line: 515, col: 5, offset: 15221},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 515, col: 5, offset: 15211},
+									pos:  position{line: 515, col: 5, offset: 15221},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 515, col: 7, offset: 15213},
+									pos:        position{line: 515, col: 7, offset: 15223},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 515, col: 15, offset: 15221},
+									pos:  position{line: 515, col: 15, offset: 15231},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 515, col: 17, offset: 15223},
+									pos:        position{line: 515, col: 17, offset: 15233},
 									val:        "desc",
 									ignoreCase: false,
 								},
@@ -3978,12 +4000,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassProc",
-			pos:  position{line: 517, col: 1, offset: 15255},
+			pos:  position{line: 517, col: 1, offset: 15265},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 5, offset: 15268},
+				pos: position{line: 518, col: 5, offset: 15278},
 				run: (*parser).callonPassProc1,
 				expr: &litMatcher{
-					pos:        position{line: 518, col: 5, offset: 15268},
+					pos:        position{line: 518, col: 5, offset: 15278},
 					val:        "pass",
 					ignoreCase: false,
 				},
@@ -3991,45 +4013,45 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeProc",
-			pos:  position{line: 524, col: 1, offset: 15462},
+			pos:  position{line: 524, col: 1, offset: 15472},
 			expr: &actionExpr{
-				pos: position{line: 525, col: 5, offset: 15478},
+				pos: position{line: 525, col: 5, offset: 15488},
 				run: (*parser).callonExplodeProc1,
 				expr: &seqExpr{
-					pos: position{line: 525, col: 5, offset: 15478},
+					pos: position{line: 525, col: 5, offset: 15488},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 525, col: 5, offset: 15478},
+							pos:        position{line: 525, col: 5, offset: 15488},
 							val:        "explode",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 525, col: 15, offset: 15488},
+							pos:  position{line: 525, col: 15, offset: 15498},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 17, offset: 15490},
+							pos:   position{line: 525, col: 17, offset: 15500},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 22, offset: 15495},
+								pos:  position{line: 525, col: 22, offset: 15505},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 28, offset: 15501},
+							pos:   position{line: 525, col: 28, offset: 15511},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 32, offset: 15505},
+								pos:  position{line: 525, col: 32, offset: 15515},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 40, offset: 15513},
+							pos:   position{line: 525, col: 40, offset: 15523},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 525, col: 43, offset: 15516},
+								pos: position{line: 525, col: 43, offset: 15526},
 								expr: &ruleRefExpr{
-									pos:  position{line: 525, col: 43, offset: 15516},
+									pos:  position{line: 525, col: 43, offset: 15526},
 									name: "AsArg",
 								},
 							},
@@ -4040,27 +4062,27 @@ var g = &grammar{
 		},
 		{
 			name: "MergeProc",
-			pos:  position{line: 529, col: 1, offset: 15628},
+			pos:  position{line: 529, col: 1, offset: 15638},
 			expr: &actionExpr{
-				pos: position{line: 530, col: 5, offset: 15642},
+				pos: position{line: 530, col: 5, offset: 15652},
 				run: (*parser).callonMergeProc1,
 				expr: &seqExpr{
-					pos: position{line: 530, col: 5, offset: 15642},
+					pos: position{line: 530, col: 5, offset: 15652},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 530, col: 5, offset: 15642},
+							pos:        position{line: 530, col: 5, offset: 15652},
 							val:        "merge",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 530, col: 13, offset: 15650},
+							pos:  position{line: 530, col: 13, offset: 15660},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 15, offset: 15652},
+							pos:   position{line: 530, col: 15, offset: 15662},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 21, offset: 15658},
+								pos:  position{line: 530, col: 21, offset: 15668},
 								name: "Expr",
 							},
 						},
@@ -4070,42 +4092,42 @@ var g = &grammar{
 		},
 		{
 			name: "OverProc",
-			pos:  position{line: 534, col: 1, offset: 15741},
+			pos:  position{line: 534, col: 1, offset: 15751},
 			expr: &choiceExpr{
-				pos: position{line: 535, col: 5, offset: 15754},
+				pos: position{line: 535, col: 5, offset: 15764},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 535, col: 5, offset: 15754},
+						pos: position{line: 535, col: 5, offset: 15764},
 						run: (*parser).callonOverProc2,
 						expr: &labeledExpr{
-							pos:   position{line: 535, col: 5, offset: 15754},
+							pos:   position{line: 535, col: 5, offset: 15764},
 							label: "over",
 							expr: &ruleRefExpr{
-								pos:  position{line: 535, col: 10, offset: 15759},
+								pos:  position{line: 535, col: 10, offset: 15769},
 								name: "ScopedOver",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 15864},
+						pos: position{line: 538, col: 5, offset: 15874},
 						run: (*parser).callonOverProc5,
 						expr: &seqExpr{
-							pos: position{line: 538, col: 5, offset: 15864},
+							pos: position{line: 538, col: 5, offset: 15874},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 538, col: 5, offset: 15864},
+									pos:        position{line: 538, col: 5, offset: 15874},
 									val:        "over",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 538, col: 12, offset: 15871},
+									pos:  position{line: 538, col: 12, offset: 15881},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 538, col: 14, offset: 15873},
+									pos:   position{line: 538, col: 14, offset: 15883},
 									label: "exprs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 538, col: 20, offset: 15879},
+										pos:  position{line: 538, col: 20, offset: 15889},
 										name: "Exprs",
 									},
 								},
@@ -4117,47 +4139,47 @@ var g = &grammar{
 		},
 		{
 			name: "ScopedOver",
-			pos:  position{line: 542, col: 1, offset: 15987},
+			pos:  position{line: 542, col: 1, offset: 15997},
 			expr: &actionExpr{
-				pos: position{line: 543, col: 5, offset: 16002},
+				pos: position{line: 543, col: 5, offset: 16012},
 				run: (*parser).callonScopedOver1,
 				expr: &seqExpr{
-					pos: position{line: 543, col: 5, offset: 16002},
+					pos: position{line: 543, col: 5, offset: 16012},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 543, col: 5, offset: 16002},
+							pos:        position{line: 543, col: 5, offset: 16012},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 12, offset: 16009},
+							pos:  position{line: 543, col: 12, offset: 16019},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 543, col: 14, offset: 16011},
+							pos:   position{line: 543, col: 14, offset: 16021},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 20, offset: 16017},
+								pos:  position{line: 543, col: 20, offset: 16027},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 543, col: 26, offset: 16023},
+							pos:   position{line: 543, col: 26, offset: 16033},
 							label: "as",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 29, offset: 16026},
+								pos:  position{line: 543, col: 29, offset: 16036},
 								name: "As",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 32, offset: 16029},
+							pos:  position{line: 543, col: 32, offset: 16039},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 543, col: 35, offset: 16032},
+							pos:   position{line: 543, col: 35, offset: 16042},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 41, offset: 16038},
+								pos:  position{line: 543, col: 41, offset: 16048},
 								name: "Scope",
 							},
 						},
@@ -4167,60 +4189,60 @@ var g = &grammar{
 		},
 		{
 			name: "OverWith",
-			pos:  position{line: 547, col: 1, offset: 16148},
+			pos:  position{line: 547, col: 1, offset: 16158},
 			expr: &actionExpr{
-				pos: position{line: 548, col: 5, offset: 16161},
+				pos: position{line: 548, col: 5, offset: 16171},
 				run: (*parser).callonOverWith1,
 				expr: &seqExpr{
-					pos: position{line: 548, col: 5, offset: 16161},
+					pos: position{line: 548, col: 5, offset: 16171},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 548, col: 5, offset: 16161},
+							pos:        position{line: 548, col: 5, offset: 16171},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 548, col: 12, offset: 16168},
+							pos:  position{line: 548, col: 12, offset: 16178},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 548, col: 14, offset: 16170},
+							pos:   position{line: 548, col: 14, offset: 16180},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 20, offset: 16176},
+								pos:  position{line: 548, col: 20, offset: 16186},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 548, col: 26, offset: 16182},
+							pos:  position{line: 548, col: 26, offset: 16192},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 548, col: 28, offset: 16184},
+							pos:        position{line: 548, col: 28, offset: 16194},
 							val:        "with",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 548, col: 35, offset: 16191},
+							pos:  position{line: 548, col: 35, offset: 16201},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 548, col: 37, offset: 16193},
+							pos:   position{line: 548, col: 37, offset: 16203},
 							label: "locals",
 							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 44, offset: 16200},
+								pos:  position{line: 548, col: 44, offset: 16210},
 								name: "LetAssignments",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 548, col: 59, offset: 16215},
+							pos:  position{line: 548, col: 59, offset: 16225},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 548, col: 62, offset: 16218},
+							pos:   position{line: 548, col: 62, offset: 16228},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 68, offset: 16224},
+								pos:  position{line: 548, col: 68, offset: 16234},
 								name: "Scope",
 							},
 						},
@@ -4230,34 +4252,34 @@ var g = &grammar{
 		},
 		{
 			name: "As",
-			pos:  position{line: 552, col: 1, offset: 16396},
+			pos:  position{line: 552, col: 1, offset: 16406},
 			expr: &choiceExpr{
-				pos: position{line: 553, col: 5, offset: 16403},
+				pos: position{line: 553, col: 5, offset: 16413},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 553, col: 5, offset: 16403},
+						pos: position{line: 553, col: 5, offset: 16413},
 						run: (*parser).callonAs2,
 						expr: &seqExpr{
-							pos: position{line: 553, col: 5, offset: 16403},
+							pos: position{line: 553, col: 5, offset: 16413},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 5, offset: 16403},
+									pos:  position{line: 553, col: 5, offset: 16413},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 553, col: 7, offset: 16405},
+									pos:        position{line: 553, col: 7, offset: 16415},
 									val:        "as",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 12, offset: 16410},
+									pos:  position{line: 553, col: 12, offset: 16420},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 553, col: 14, offset: 16412},
+									pos:   position{line: 553, col: 14, offset: 16422},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 553, col: 17, offset: 16415},
+										pos:  position{line: 553, col: 17, offset: 16425},
 										name: "IdentifierName",
 									},
 								},
@@ -4265,10 +4287,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 16453},
+						pos: position{line: 554, col: 5, offset: 16463},
 						run: (*parser).callonAs9,
 						expr: &litMatcher{
-							pos:        position{line: 554, col: 5, offset: 16453},
+							pos:        position{line: 554, col: 5, offset: 16463},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4278,42 +4300,42 @@ var g = &grammar{
 		},
 		{
 			name: "LetProc",
-			pos:  position{line: 556, col: 1, offset: 16476},
+			pos:  position{line: 556, col: 1, offset: 16486},
 			expr: &choiceExpr{
-				pos: position{line: 557, col: 5, offset: 16488},
+				pos: position{line: 557, col: 5, offset: 16498},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 557, col: 5, offset: 16488},
+						pos: position{line: 557, col: 5, offset: 16498},
 						run: (*parser).callonLetProc2,
 						expr: &seqExpr{
-							pos: position{line: 557, col: 5, offset: 16488},
+							pos: position{line: 557, col: 5, offset: 16498},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 557, col: 5, offset: 16488},
+									pos:        position{line: 557, col: 5, offset: 16498},
 									val:        "let",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 557, col: 11, offset: 16494},
+									pos:  position{line: 557, col: 11, offset: 16504},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 557, col: 13, offset: 16496},
+									pos:   position{line: 557, col: 13, offset: 16506},
 									label: "locals",
 									expr: &ruleRefExpr{
-										pos:  position{line: 557, col: 20, offset: 16503},
+										pos:  position{line: 557, col: 20, offset: 16513},
 										name: "LetAssignments",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 557, col: 35, offset: 16518},
+									pos:  position{line: 557, col: 35, offset: 16528},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 557, col: 38, offset: 16521},
+									pos:   position{line: 557, col: 38, offset: 16531},
 									label: "over",
 									expr: &ruleRefExpr{
-										pos:  position{line: 557, col: 43, offset: 16526},
+										pos:  position{line: 557, col: 43, offset: 16536},
 										name: "ScopedOver",
 									},
 								},
@@ -4321,7 +4343,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 560, col: 5, offset: 16634},
+						pos:  position{line: 560, col: 5, offset: 16644},
 						name: "OverWith",
 					},
 				},
@@ -4329,45 +4351,45 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 562, col: 1, offset: 16644},
+			pos:  position{line: 562, col: 1, offset: 16654},
 			expr: &actionExpr{
-				pos: position{line: 562, col: 9, offset: 16652},
+				pos: position{line: 562, col: 9, offset: 16662},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 562, col: 9, offset: 16652},
+					pos: position{line: 562, col: 9, offset: 16662},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 562, col: 9, offset: 16652},
+							pos:        position{line: 562, col: 9, offset: 16662},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 14, offset: 16657},
+							pos:  position{line: 562, col: 14, offset: 16667},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 562, col: 17, offset: 16660},
+							pos:        position{line: 562, col: 17, offset: 16670},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 21, offset: 16664},
+							pos:  position{line: 562, col: 21, offset: 16674},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 562, col: 24, offset: 16667},
+							pos:   position{line: 562, col: 24, offset: 16677},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 28, offset: 16671},
+								pos:  position{line: 562, col: 28, offset: 16681},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 39, offset: 16682},
+							pos:  position{line: 562, col: 39, offset: 16692},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 562, col: 42, offset: 16685},
+							pos:        position{line: 562, col: 42, offset: 16695},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4377,50 +4399,50 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignments",
-			pos:  position{line: 564, col: 1, offset: 16710},
+			pos:  position{line: 564, col: 1, offset: 16720},
 			expr: &actionExpr{
-				pos: position{line: 565, col: 5, offset: 16729},
+				pos: position{line: 565, col: 5, offset: 16739},
 				run: (*parser).callonLetAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 565, col: 5, offset: 16729},
+					pos: position{line: 565, col: 5, offset: 16739},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 565, col: 5, offset: 16729},
+							pos:   position{line: 565, col: 5, offset: 16739},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 565, col: 11, offset: 16735},
+								pos:  position{line: 565, col: 11, offset: 16745},
 								name: "LetAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 565, col: 25, offset: 16749},
+							pos:   position{line: 565, col: 25, offset: 16759},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 565, col: 30, offset: 16754},
+								pos: position{line: 565, col: 30, offset: 16764},
 								expr: &actionExpr{
-									pos: position{line: 565, col: 31, offset: 16755},
+									pos: position{line: 565, col: 31, offset: 16765},
 									run: (*parser).callonLetAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 565, col: 31, offset: 16755},
+										pos: position{line: 565, col: 31, offset: 16765},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 565, col: 31, offset: 16755},
+												pos:  position{line: 565, col: 31, offset: 16765},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 565, col: 34, offset: 16758},
+												pos:        position{line: 565, col: 34, offset: 16768},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 565, col: 38, offset: 16762},
+												pos:  position{line: 565, col: 38, offset: 16772},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 565, col: 41, offset: 16765},
+												pos:   position{line: 565, col: 41, offset: 16775},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 565, col: 43, offset: 16767},
+													pos:  position{line: 565, col: 43, offset: 16777},
 													name: "LetAssignment",
 												},
 											},
@@ -4435,42 +4457,42 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignment",
-			pos:  position{line: 569, col: 1, offset: 16885},
+			pos:  position{line: 569, col: 1, offset: 16895},
 			expr: &choiceExpr{
-				pos: position{line: 570, col: 5, offset: 16903},
+				pos: position{line: 570, col: 5, offset: 16913},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 570, col: 5, offset: 16903},
+						pos: position{line: 570, col: 5, offset: 16913},
 						run: (*parser).callonLetAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 570, col: 5, offset: 16903},
+							pos: position{line: 570, col: 5, offset: 16913},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 570, col: 5, offset: 16903},
+									pos:   position{line: 570, col: 5, offset: 16913},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 570, col: 8, offset: 16906},
+										pos:  position{line: 570, col: 8, offset: 16916},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 23, offset: 16921},
+									pos:  position{line: 570, col: 23, offset: 16931},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 570, col: 26, offset: 16924},
+									pos:        position{line: 570, col: 26, offset: 16934},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 30, offset: 16928},
+									pos:  position{line: 570, col: 30, offset: 16938},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 570, col: 33, offset: 16931},
+									pos:   position{line: 570, col: 33, offset: 16941},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 570, col: 38, offset: 16936},
+										pos:  position{line: 570, col: 38, offset: 16946},
 										name: "Expr",
 									},
 								},
@@ -4478,13 +4500,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 573, col: 5, offset: 17018},
+						pos: position{line: 573, col: 5, offset: 17028},
 						run: (*parser).callonLetAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 573, col: 5, offset: 17018},
+							pos:   position{line: 573, col: 5, offset: 17028},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 573, col: 8, offset: 17021},
+								pos:  position{line: 573, col: 8, offset: 17031},
 								name: "IdentifierName",
 							},
 						},
@@ -4494,27 +4516,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldProc",
-			pos:  position{line: 577, col: 1, offset: 17151},
+			pos:  position{line: 577, col: 1, offset: 17161},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 5, offset: 17165},
+				pos: position{line: 578, col: 5, offset: 17175},
 				run: (*parser).callonYieldProc1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 5, offset: 17165},
+					pos: position{line: 578, col: 5, offset: 17175},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 578, col: 5, offset: 17165},
+							pos:        position{line: 578, col: 5, offset: 17175},
 							val:        "yield",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 578, col: 13, offset: 17173},
+							pos:  position{line: 578, col: 13, offset: 17183},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 578, col: 15, offset: 17175},
+							pos:   position{line: 578, col: 15, offset: 17185},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 578, col: 21, offset: 17181},
+								pos:  position{line: 578, col: 21, offset: 17191},
 								name: "Exprs",
 							},
 						},
@@ -4524,30 +4546,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 582, col: 1, offset: 17265},
+			pos:  position{line: 582, col: 1, offset: 17275},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 5, offset: 17277},
+				pos: position{line: 583, col: 5, offset: 17287},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 583, col: 5, offset: 17277},
+					pos: position{line: 583, col: 5, offset: 17287},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 5, offset: 17277},
+							pos:  position{line: 583, col: 5, offset: 17287},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 7, offset: 17279},
+							pos:  position{line: 583, col: 7, offset: 17289},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 10, offset: 17282},
+							pos:  position{line: 583, col: 10, offset: 17292},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 12, offset: 17284},
+							pos:   position{line: 583, col: 12, offset: 17294},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 16, offset: 17288},
+								pos:  position{line: 583, col: 16, offset: 17298},
 								name: "Type",
 							},
 						},
@@ -4557,30 +4579,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 585, col: 1, offset: 17313},
+			pos:  position{line: 585, col: 1, offset: 17323},
 			expr: &actionExpr{
-				pos: position{line: 586, col: 5, offset: 17323},
+				pos: position{line: 586, col: 5, offset: 17333},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 586, col: 5, offset: 17323},
+					pos: position{line: 586, col: 5, offset: 17333},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 5, offset: 17323},
+							pos:  position{line: 586, col: 5, offset: 17333},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 7, offset: 17325},
+							pos:  position{line: 586, col: 7, offset: 17335},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 10, offset: 17328},
+							pos:  position{line: 586, col: 10, offset: 17338},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 586, col: 12, offset: 17330},
+							pos:   position{line: 586, col: 12, offset: 17340},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 586, col: 16, offset: 17334},
+								pos:  position{line: 586, col: 16, offset: 17344},
 								name: "Lval",
 							},
 						},
@@ -4590,58 +4612,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 590, col: 1, offset: 17385},
+			pos:  position{line: 590, col: 1, offset: 17395},
 			expr: &ruleRefExpr{
-				pos:  position{line: 590, col: 8, offset: 17392},
+				pos:  position{line: 590, col: 8, offset: 17402},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 592, col: 1, offset: 17403},
+			pos:  position{line: 592, col: 1, offset: 17413},
 			expr: &actionExpr{
-				pos: position{line: 593, col: 5, offset: 17413},
+				pos: position{line: 593, col: 5, offset: 17423},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 593, col: 5, offset: 17413},
+					pos: position{line: 593, col: 5, offset: 17423},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 593, col: 5, offset: 17413},
+							pos:   position{line: 593, col: 5, offset: 17423},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 593, col: 11, offset: 17419},
+								pos:  position{line: 593, col: 11, offset: 17429},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 593, col: 16, offset: 17424},
+							pos:   position{line: 593, col: 16, offset: 17434},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 593, col: 21, offset: 17429},
+								pos: position{line: 593, col: 21, offset: 17439},
 								expr: &actionExpr{
-									pos: position{line: 593, col: 22, offset: 17430},
+									pos: position{line: 593, col: 22, offset: 17440},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 593, col: 22, offset: 17430},
+										pos: position{line: 593, col: 22, offset: 17440},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 593, col: 22, offset: 17430},
+												pos:  position{line: 593, col: 22, offset: 17440},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 593, col: 25, offset: 17433},
+												pos:        position{line: 593, col: 25, offset: 17443},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 593, col: 29, offset: 17437},
+												pos:  position{line: 593, col: 29, offset: 17447},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 593, col: 32, offset: 17440},
+												pos:   position{line: 593, col: 32, offset: 17450},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 593, col: 37, offset: 17445},
+													pos:  position{line: 593, col: 37, offset: 17455},
 													name: "Lval",
 												},
 											},
@@ -4656,52 +4678,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 597, col: 1, offset: 17557},
+			pos:  position{line: 597, col: 1, offset: 17567},
 			expr: &ruleRefExpr{
-				pos:  position{line: 597, col: 13, offset: 17569},
+				pos:  position{line: 597, col: 13, offset: 17579},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 599, col: 1, offset: 17575},
+			pos:  position{line: 599, col: 1, offset: 17585},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 5, offset: 17590},
+				pos: position{line: 600, col: 5, offset: 17600},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 5, offset: 17590},
+					pos: position{line: 600, col: 5, offset: 17600},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 600, col: 5, offset: 17590},
+							pos:   position{line: 600, col: 5, offset: 17600},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 600, col: 11, offset: 17596},
+								pos:  position{line: 600, col: 11, offset: 17606},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 21, offset: 17606},
+							pos:   position{line: 600, col: 21, offset: 17616},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 600, col: 26, offset: 17611},
+								pos: position{line: 600, col: 26, offset: 17621},
 								expr: &seqExpr{
-									pos: position{line: 600, col: 27, offset: 17612},
+									pos: position{line: 600, col: 27, offset: 17622},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 27, offset: 17612},
+											pos:  position{line: 600, col: 27, offset: 17622},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 600, col: 30, offset: 17615},
+											pos:        position{line: 600, col: 30, offset: 17625},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 34, offset: 17619},
+											pos:  position{line: 600, col: 34, offset: 17629},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 37, offset: 17622},
+											pos:  position{line: 600, col: 37, offset: 17632},
 											name: "FieldExpr",
 										},
 									},
@@ -4714,50 +4736,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 610, col: 1, offset: 17821},
+			pos:  position{line: 610, col: 1, offset: 17831},
 			expr: &actionExpr{
-				pos: position{line: 611, col: 5, offset: 17837},
+				pos: position{line: 611, col: 5, offset: 17847},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 611, col: 5, offset: 17837},
+					pos: position{line: 611, col: 5, offset: 17847},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 611, col: 5, offset: 17837},
+							pos:   position{line: 611, col: 5, offset: 17847},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 11, offset: 17843},
+								pos:  position{line: 611, col: 11, offset: 17853},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 22, offset: 17854},
+							pos:   position{line: 611, col: 22, offset: 17864},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 611, col: 27, offset: 17859},
+								pos: position{line: 611, col: 27, offset: 17869},
 								expr: &actionExpr{
-									pos: position{line: 611, col: 28, offset: 17860},
+									pos: position{line: 611, col: 28, offset: 17870},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 611, col: 28, offset: 17860},
+										pos: position{line: 611, col: 28, offset: 17870},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 28, offset: 17860},
+												pos:  position{line: 611, col: 28, offset: 17870},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 611, col: 31, offset: 17863},
+												pos:        position{line: 611, col: 31, offset: 17873},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 35, offset: 17867},
+												pos:  position{line: 611, col: 35, offset: 17877},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 611, col: 38, offset: 17870},
+												pos:   position{line: 611, col: 38, offset: 17880},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 611, col: 40, offset: 17872},
+													pos:  position{line: 611, col: 40, offset: 17882},
 													name: "Assignment",
 												},
 											},
@@ -4772,39 +4794,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 615, col: 1, offset: 17983},
+			pos:  position{line: 615, col: 1, offset: 17993},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 5, offset: 17998},
+				pos: position{line: 616, col: 5, offset: 18008},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 5, offset: 17998},
+					pos: position{line: 616, col: 5, offset: 18008},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 616, col: 5, offset: 17998},
+							pos:   position{line: 616, col: 5, offset: 18008},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 9, offset: 18002},
+								pos:  position{line: 616, col: 9, offset: 18012},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 616, col: 14, offset: 18007},
+							pos:  position{line: 616, col: 14, offset: 18017},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 616, col: 17, offset: 18010},
+							pos:        position{line: 616, col: 17, offset: 18020},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 616, col: 22, offset: 18015},
+							pos:  position{line: 616, col: 22, offset: 18025},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 616, col: 25, offset: 18018},
+							pos:   position{line: 616, col: 25, offset: 18028},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 29, offset: 18022},
+								pos:  position{line: 616, col: 29, offset: 18032},
 								name: "Expr",
 							},
 						},
@@ -4814,71 +4836,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 618, col: 1, offset: 18113},
+			pos:  position{line: 618, col: 1, offset: 18123},
 			expr: &ruleRefExpr{
-				pos:  position{line: 618, col: 8, offset: 18120},
+				pos:  position{line: 618, col: 8, offset: 18130},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 620, col: 1, offset: 18137},
+			pos:  position{line: 620, col: 1, offset: 18147},
 			expr: &choiceExpr{
-				pos: position{line: 621, col: 5, offset: 18157},
+				pos: position{line: 621, col: 5, offset: 18167},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 621, col: 5, offset: 18157},
+						pos: position{line: 621, col: 5, offset: 18167},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 621, col: 5, offset: 18157},
+							pos: position{line: 621, col: 5, offset: 18167},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 621, col: 5, offset: 18157},
+									pos:   position{line: 621, col: 5, offset: 18167},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 15, offset: 18167},
+										pos:  position{line: 621, col: 15, offset: 18177},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 29, offset: 18181},
+									pos:  position{line: 621, col: 29, offset: 18191},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 621, col: 32, offset: 18184},
+									pos:        position{line: 621, col: 32, offset: 18194},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 36, offset: 18188},
+									pos:  position{line: 621, col: 36, offset: 18198},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 621, col: 39, offset: 18191},
+									pos:   position{line: 621, col: 39, offset: 18201},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 50, offset: 18202},
+										pos:  position{line: 621, col: 50, offset: 18212},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 55, offset: 18207},
+									pos:  position{line: 621, col: 55, offset: 18217},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 621, col: 58, offset: 18210},
+									pos:        position{line: 621, col: 58, offset: 18220},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 62, offset: 18214},
+									pos:  position{line: 621, col: 62, offset: 18224},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 621, col: 65, offset: 18217},
+									pos:   position{line: 621, col: 65, offset: 18227},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 76, offset: 18228},
+										pos:  position{line: 621, col: 76, offset: 18238},
 										name: "Expr",
 									},
 								},
@@ -4886,7 +4908,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 5, offset: 18368},
+						pos:  position{line: 624, col: 5, offset: 18378},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4894,53 +4916,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 626, col: 1, offset: 18383},
+			pos:  position{line: 626, col: 1, offset: 18393},
 			expr: &actionExpr{
-				pos: position{line: 627, col: 5, offset: 18401},
+				pos: position{line: 627, col: 5, offset: 18411},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 627, col: 5, offset: 18401},
+					pos: position{line: 627, col: 5, offset: 18411},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 627, col: 5, offset: 18401},
+							pos:   position{line: 627, col: 5, offset: 18411},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 627, col: 11, offset: 18407},
+								pos:  position{line: 627, col: 11, offset: 18417},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 628, col: 5, offset: 18426},
+							pos:   position{line: 628, col: 5, offset: 18436},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 628, col: 10, offset: 18431},
+								pos: position{line: 628, col: 10, offset: 18441},
 								expr: &actionExpr{
-									pos: position{line: 628, col: 11, offset: 18432},
+									pos: position{line: 628, col: 11, offset: 18442},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 628, col: 11, offset: 18432},
+										pos: position{line: 628, col: 11, offset: 18442},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 628, col: 11, offset: 18432},
+												pos:  position{line: 628, col: 11, offset: 18442},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 628, col: 14, offset: 18435},
+												pos:   position{line: 628, col: 14, offset: 18445},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 628, col: 17, offset: 18438},
+													pos:  position{line: 628, col: 17, offset: 18448},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 628, col: 25, offset: 18446},
+												pos:  position{line: 628, col: 25, offset: 18456},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 628, col: 28, offset: 18449},
+												pos:   position{line: 628, col: 28, offset: 18459},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 628, col: 33, offset: 18454},
+													pos:  position{line: 628, col: 33, offset: 18464},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4955,53 +4977,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 632, col: 1, offset: 18572},
+			pos:  position{line: 632, col: 1, offset: 18582},
 			expr: &actionExpr{
-				pos: position{line: 633, col: 5, offset: 18591},
+				pos: position{line: 633, col: 5, offset: 18601},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 633, col: 5, offset: 18591},
+					pos: position{line: 633, col: 5, offset: 18601},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 633, col: 5, offset: 18591},
+							pos:   position{line: 633, col: 5, offset: 18601},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 11, offset: 18597},
+								pos:  position{line: 633, col: 11, offset: 18607},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 5, offset: 18616},
+							pos:   position{line: 634, col: 5, offset: 18626},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 634, col: 10, offset: 18621},
+								pos: position{line: 634, col: 10, offset: 18631},
 								expr: &actionExpr{
-									pos: position{line: 634, col: 11, offset: 18622},
+									pos: position{line: 634, col: 11, offset: 18632},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 634, col: 11, offset: 18622},
+										pos: position{line: 634, col: 11, offset: 18632},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 634, col: 11, offset: 18622},
+												pos:  position{line: 634, col: 11, offset: 18632},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 634, col: 14, offset: 18625},
+												pos:   position{line: 634, col: 14, offset: 18635},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 634, col: 17, offset: 18628},
+													pos:  position{line: 634, col: 17, offset: 18638},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 634, col: 26, offset: 18637},
+												pos:  position{line: 634, col: 26, offset: 18647},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 634, col: 29, offset: 18640},
+												pos:   position{line: 634, col: 29, offset: 18650},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 634, col: 34, offset: 18645},
+													pos:  position{line: 634, col: 34, offset: 18655},
 													name: "ComparisonExpr",
 												},
 											},
@@ -5016,45 +5038,45 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 638, col: 1, offset: 18763},
+			pos:  position{line: 638, col: 1, offset: 18773},
 			expr: &choiceExpr{
-				pos: position{line: 639, col: 5, offset: 18782},
+				pos: position{line: 639, col: 5, offset: 18792},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 639, col: 5, offset: 18782},
+						pos: position{line: 639, col: 5, offset: 18792},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 639, col: 5, offset: 18782},
+							pos: position{line: 639, col: 5, offset: 18792},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 639, col: 5, offset: 18782},
+									pos:   position{line: 639, col: 5, offset: 18792},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 9, offset: 18786},
+										pos:  position{line: 639, col: 9, offset: 18796},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 639, col: 22, offset: 18799},
+									pos:  position{line: 639, col: 22, offset: 18809},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 639, col: 25, offset: 18802},
+									pos:   position{line: 639, col: 25, offset: 18812},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 28, offset: 18805},
+										pos:  position{line: 639, col: 28, offset: 18815},
 										name: "Comparator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 639, col: 39, offset: 18816},
+									pos:  position{line: 639, col: 39, offset: 18826},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 639, col: 42, offset: 18819},
+									pos:   position{line: 639, col: 42, offset: 18829},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 46, offset: 18823},
+										pos:  position{line: 639, col: 46, offset: 18833},
 										name: "AdditiveExpr",
 									},
 								},
@@ -5062,37 +5084,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 642, col: 5, offset: 18947},
+						pos: position{line: 642, col: 5, offset: 18957},
 						run: (*parser).callonComparisonExpr12,
 						expr: &seqExpr{
-							pos: position{line: 642, col: 5, offset: 18947},
+							pos: position{line: 642, col: 5, offset: 18957},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 642, col: 5, offset: 18947},
+									pos:   position{line: 642, col: 5, offset: 18957},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 642, col: 9, offset: 18951},
+										pos:  position{line: 642, col: 9, offset: 18961},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 642, col: 22, offset: 18964},
+									pos:  position{line: 642, col: 22, offset: 18974},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 642, col: 25, offset: 18967},
+									pos:        position{line: 642, col: 25, offset: 18977},
 									val:        "~",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 642, col: 29, offset: 18971},
+									pos:  position{line: 642, col: 29, offset: 18981},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 642, col: 32, offset: 18974},
+									pos:   position{line: 642, col: 32, offset: 18984},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 642, col: 36, offset: 18978},
+										pos:  position{line: 642, col: 36, offset: 18988},
 										name: "Regexp",
 									},
 								},
@@ -5100,7 +5122,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 645, col: 5, offset: 19097},
+						pos:  position{line: 645, col: 5, offset: 19107},
 						name: "AdditiveExpr",
 					},
 				},
@@ -5108,53 +5130,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 647, col: 1, offset: 19111},
+			pos:  position{line: 647, col: 1, offset: 19121},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 5, offset: 19128},
+				pos: position{line: 648, col: 5, offset: 19138},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 648, col: 5, offset: 19128},
+					pos: position{line: 648, col: 5, offset: 19138},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 648, col: 5, offset: 19128},
+							pos:   position{line: 648, col: 5, offset: 19138},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 648, col: 11, offset: 19134},
+								pos:  position{line: 648, col: 11, offset: 19144},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 5, offset: 19157},
+							pos:   position{line: 649, col: 5, offset: 19167},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 649, col: 10, offset: 19162},
+								pos: position{line: 649, col: 10, offset: 19172},
 								expr: &actionExpr{
-									pos: position{line: 649, col: 11, offset: 19163},
+									pos: position{line: 649, col: 11, offset: 19173},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 649, col: 11, offset: 19163},
+										pos: position{line: 649, col: 11, offset: 19173},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 649, col: 11, offset: 19163},
+												pos:  position{line: 649, col: 11, offset: 19173},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 649, col: 14, offset: 19166},
+												pos:   position{line: 649, col: 14, offset: 19176},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 649, col: 17, offset: 19169},
+													pos:  position{line: 649, col: 17, offset: 19179},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 649, col: 34, offset: 19186},
+												pos:  position{line: 649, col: 34, offset: 19196},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 649, col: 37, offset: 19189},
+												pos:   position{line: 649, col: 37, offset: 19199},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 649, col: 42, offset: 19194},
+													pos:  position{line: 649, col: 42, offset: 19204},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5169,20 +5191,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 653, col: 1, offset: 19316},
+			pos:  position{line: 653, col: 1, offset: 19326},
 			expr: &actionExpr{
-				pos: position{line: 653, col: 20, offset: 19335},
+				pos: position{line: 653, col: 20, offset: 19345},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 653, col: 21, offset: 19336},
+					pos: position{line: 653, col: 21, offset: 19346},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 653, col: 21, offset: 19336},
+							pos:        position{line: 653, col: 21, offset: 19346},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 653, col: 27, offset: 19342},
+							pos:        position{line: 653, col: 27, offset: 19352},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5192,53 +5214,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 655, col: 1, offset: 19379},
+			pos:  position{line: 655, col: 1, offset: 19389},
 			expr: &actionExpr{
-				pos: position{line: 656, col: 5, offset: 19402},
+				pos: position{line: 656, col: 5, offset: 19412},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 656, col: 5, offset: 19402},
+					pos: position{line: 656, col: 5, offset: 19412},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 656, col: 5, offset: 19402},
+							pos:   position{line: 656, col: 5, offset: 19412},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 656, col: 11, offset: 19408},
+								pos:  position{line: 656, col: 11, offset: 19418},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 5, offset: 19420},
+							pos:   position{line: 657, col: 5, offset: 19430},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 657, col: 10, offset: 19425},
+								pos: position{line: 657, col: 10, offset: 19435},
 								expr: &actionExpr{
-									pos: position{line: 657, col: 11, offset: 19426},
+									pos: position{line: 657, col: 11, offset: 19436},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 657, col: 11, offset: 19426},
+										pos: position{line: 657, col: 11, offset: 19436},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 657, col: 11, offset: 19426},
+												pos:  position{line: 657, col: 11, offset: 19436},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 657, col: 14, offset: 19429},
+												pos:   position{line: 657, col: 14, offset: 19439},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 657, col: 17, offset: 19432},
+													pos:  position{line: 657, col: 17, offset: 19442},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 657, col: 40, offset: 19455},
+												pos:  position{line: 657, col: 40, offset: 19465},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 657, col: 43, offset: 19458},
+												pos:   position{line: 657, col: 43, offset: 19468},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 657, col: 48, offset: 19463},
+													pos:  position{line: 657, col: 48, offset: 19473},
 													name: "NotExpr",
 												},
 											},
@@ -5253,25 +5275,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 661, col: 1, offset: 19574},
+			pos:  position{line: 661, col: 1, offset: 19584},
 			expr: &actionExpr{
-				pos: position{line: 661, col: 26, offset: 19599},
+				pos: position{line: 661, col: 26, offset: 19609},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 661, col: 27, offset: 19600},
+					pos: position{line: 661, col: 27, offset: 19610},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 661, col: 27, offset: 19600},
+							pos:        position{line: 661, col: 27, offset: 19610},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 661, col: 33, offset: 19606},
+							pos:        position{line: 661, col: 33, offset: 19616},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 661, col: 39, offset: 19612},
+							pos:        position{line: 661, col: 39, offset: 19622},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5281,30 +5303,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 663, col: 1, offset: 19649},
+			pos:  position{line: 663, col: 1, offset: 19659},
 			expr: &choiceExpr{
-				pos: position{line: 664, col: 5, offset: 19661},
+				pos: position{line: 664, col: 5, offset: 19671},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 19661},
+						pos: position{line: 664, col: 5, offset: 19671},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 664, col: 5, offset: 19661},
+							pos: position{line: 664, col: 5, offset: 19671},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 664, col: 5, offset: 19661},
+									pos:        position{line: 664, col: 5, offset: 19671},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 664, col: 9, offset: 19665},
+									pos:  position{line: 664, col: 9, offset: 19675},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 664, col: 12, offset: 19668},
+									pos:   position{line: 664, col: 12, offset: 19678},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 664, col: 14, offset: 19670},
+										pos:  position{line: 664, col: 14, offset: 19680},
 										name: "NotExpr",
 									},
 								},
@@ -5312,7 +5334,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 19779},
+						pos:  position{line: 667, col: 5, offset: 19789},
 						name: "FuncExpr",
 					},
 				},
@@ -5320,31 +5342,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 669, col: 1, offset: 19789},
+			pos:  position{line: 669, col: 1, offset: 19799},
 			expr: &choiceExpr{
-				pos: position{line: 670, col: 5, offset: 19802},
+				pos: position{line: 670, col: 5, offset: 19812},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 670, col: 5, offset: 19802},
+						pos: position{line: 670, col: 5, offset: 19812},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 670, col: 5, offset: 19802},
+							pos: position{line: 670, col: 5, offset: 19812},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 670, col: 5, offset: 19802},
+									pos:   position{line: 670, col: 5, offset: 19812},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 670, col: 11, offset: 19808},
+										pos:  position{line: 670, col: 11, offset: 19818},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 670, col: 16, offset: 19813},
+									pos:   position{line: 670, col: 16, offset: 19823},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 670, col: 21, offset: 19818},
+										pos: position{line: 670, col: 21, offset: 19828},
 										expr: &ruleRefExpr{
-											pos:  position{line: 670, col: 22, offset: 19819},
+											pos:  position{line: 670, col: 22, offset: 19829},
 											name: "Deref",
 										},
 									},
@@ -5353,26 +5375,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 19890},
+						pos: position{line: 673, col: 5, offset: 19900},
 						run: (*parser).callonFuncExpr9,
 						expr: &seqExpr{
-							pos: position{line: 673, col: 5, offset: 19890},
+							pos: position{line: 673, col: 5, offset: 19900},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 673, col: 5, offset: 19890},
+									pos:   position{line: 673, col: 5, offset: 19900},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 673, col: 11, offset: 19896},
+										pos:  position{line: 673, col: 11, offset: 19906},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 673, col: 20, offset: 19905},
+									pos:   position{line: 673, col: 20, offset: 19915},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 673, col: 25, offset: 19910},
+										pos: position{line: 673, col: 25, offset: 19920},
 										expr: &ruleRefExpr{
-											pos:  position{line: 673, col: 26, offset: 19911},
+											pos:  position{line: 673, col: 26, offset: 19921},
 											name: "Deref",
 										},
 									},
@@ -5381,11 +5403,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 676, col: 5, offset: 19982},
+						pos:  position{line: 676, col: 5, offset: 19992},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 5, offset: 19996},
+						pos:  position{line: 677, col: 5, offset: 20006},
 						name: "Primary",
 					},
 				},
@@ -5393,20 +5415,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 679, col: 1, offset: 20005},
+			pos:  position{line: 679, col: 1, offset: 20015},
 			expr: &seqExpr{
-				pos: position{line: 679, col: 13, offset: 20017},
+				pos: position{line: 679, col: 13, offset: 20027},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 679, col: 13, offset: 20017},
+						pos:  position{line: 679, col: 13, offset: 20027},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 679, col: 22, offset: 20026},
+						pos:  position{line: 679, col: 22, offset: 20036},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 679, col: 25, offset: 20029},
+						pos:        position{line: 679, col: 25, offset: 20039},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5415,17 +5437,17 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 681, col: 1, offset: 20034},
+			pos:  position{line: 681, col: 1, offset: 20044},
 			expr: &choiceExpr{
-				pos: position{line: 682, col: 5, offset: 20047},
+				pos: position{line: 682, col: 5, offset: 20057},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 682, col: 5, offset: 20047},
+						pos:        position{line: 682, col: 5, offset: 20057},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 683, col: 5, offset: 20057},
+						pos:        position{line: 683, col: 5, offset: 20067},
 						val:        "select",
 						ignoreCase: false,
 					},
@@ -5434,48 +5456,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 685, col: 1, offset: 20067},
+			pos:  position{line: 685, col: 1, offset: 20077},
 			expr: &actionExpr{
-				pos: position{line: 686, col: 5, offset: 20076},
+				pos: position{line: 686, col: 5, offset: 20086},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 686, col: 5, offset: 20076},
+					pos: position{line: 686, col: 5, offset: 20086},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 686, col: 5, offset: 20076},
+							pos:   position{line: 686, col: 5, offset: 20086},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 686, col: 9, offset: 20080},
+								pos:  position{line: 686, col: 9, offset: 20090},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 686, col: 18, offset: 20089},
+							pos:  position{line: 686, col: 18, offset: 20099},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 686, col: 21, offset: 20092},
+							pos:        position{line: 686, col: 21, offset: 20102},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 686, col: 25, offset: 20096},
+							pos:  position{line: 686, col: 25, offset: 20106},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 686, col: 28, offset: 20099},
+							pos:   position{line: 686, col: 28, offset: 20109},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 686, col: 33, offset: 20104},
+								pos:  position{line: 686, col: 33, offset: 20114},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 686, col: 38, offset: 20109},
+							pos:  position{line: 686, col: 38, offset: 20119},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 686, col: 41, offset: 20112},
+							pos:        position{line: 686, col: 41, offset: 20122},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5485,72 +5507,72 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 690, col: 1, offset: 20209},
+			pos:  position{line: 690, col: 1, offset: 20219},
 			expr: &choiceExpr{
-				pos: position{line: 691, col: 5, offset: 20222},
+				pos: position{line: 691, col: 5, offset: 20232},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 691, col: 5, offset: 20222},
+						pos:  position{line: 691, col: 5, offset: 20232},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 692, col: 5, offset: 20231},
+						pos: position{line: 692, col: 5, offset: 20241},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 692, col: 5, offset: 20231},
+							pos: position{line: 692, col: 5, offset: 20241},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 692, col: 5, offset: 20231},
+									pos: position{line: 692, col: 5, offset: 20241},
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 6, offset: 20232},
+										pos:  position{line: 692, col: 6, offset: 20242},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 692, col: 16, offset: 20242},
+									pos:   position{line: 692, col: 16, offset: 20252},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 19, offset: 20245},
+										pos:  position{line: 692, col: 19, offset: 20255},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 692, col: 34, offset: 20260},
+									pos:  position{line: 692, col: 34, offset: 20270},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 692, col: 37, offset: 20263},
+									pos:        position{line: 692, col: 37, offset: 20273},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 692, col: 41, offset: 20267},
+									pos:  position{line: 692, col: 41, offset: 20277},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 692, col: 44, offset: 20270},
+									pos:   position{line: 692, col: 44, offset: 20280},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 49, offset: 20275},
+										pos:  position{line: 692, col: 49, offset: 20285},
 										name: "OptionalExprs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 692, col: 63, offset: 20289},
+									pos:  position{line: 692, col: 63, offset: 20299},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 692, col: 66, offset: 20292},
+									pos:        position{line: 692, col: 66, offset: 20302},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 692, col: 70, offset: 20296},
+									pos:   position{line: 692, col: 70, offset: 20306},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 692, col: 76, offset: 20302},
+										pos: position{line: 692, col: 76, offset: 20312},
 										expr: &ruleRefExpr{
-											pos:  position{line: 692, col: 76, offset: 20302},
+											pos:  position{line: 692, col: 76, offset: 20312},
 											name: "WhereClause",
 										},
 									},
@@ -5563,48 +5585,48 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 696, col: 1, offset: 20423},
+			pos:  position{line: 696, col: 1, offset: 20433},
 			expr: &choiceExpr{
-				pos: position{line: 697, col: 5, offset: 20432},
+				pos: position{line: 697, col: 5, offset: 20442},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 697, col: 5, offset: 20432},
+						pos: position{line: 697, col: 5, offset: 20442},
 						run: (*parser).callonGrep2,
 						expr: &seqExpr{
-							pos: position{line: 697, col: 5, offset: 20432},
+							pos: position{line: 697, col: 5, offset: 20442},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 697, col: 5, offset: 20432},
+									pos:        position{line: 697, col: 5, offset: 20442},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 697, col: 12, offset: 20439},
+									pos:  position{line: 697, col: 12, offset: 20449},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 697, col: 15, offset: 20442},
+									pos:        position{line: 697, col: 15, offset: 20452},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 697, col: 19, offset: 20446},
+									pos:  position{line: 697, col: 19, offset: 20456},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 697, col: 22, offset: 20449},
+									pos:   position{line: 697, col: 22, offset: 20459},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 697, col: 30, offset: 20457},
+										pos:  position{line: 697, col: 30, offset: 20467},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 697, col: 38, offset: 20465},
+									pos:  position{line: 697, col: 38, offset: 20475},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 697, col: 41, offset: 20468},
+									pos:        position{line: 697, col: 41, offset: 20478},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5612,64 +5634,64 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20623},
+						pos: position{line: 700, col: 5, offset: 20633},
 						run: (*parser).callonGrep12,
 						expr: &seqExpr{
-							pos: position{line: 700, col: 5, offset: 20623},
+							pos: position{line: 700, col: 5, offset: 20633},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 700, col: 5, offset: 20623},
+									pos:        position{line: 700, col: 5, offset: 20633},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 12, offset: 20630},
+									pos:  position{line: 700, col: 12, offset: 20640},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 15, offset: 20633},
+									pos:        position{line: 700, col: 15, offset: 20643},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 19, offset: 20637},
+									pos:  position{line: 700, col: 19, offset: 20647},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 700, col: 22, offset: 20640},
+									pos:   position{line: 700, col: 22, offset: 20650},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 700, col: 30, offset: 20648},
+										pos:  position{line: 700, col: 30, offset: 20658},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 38, offset: 20656},
+									pos:  position{line: 700, col: 38, offset: 20666},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 42, offset: 20660},
+									pos:        position{line: 700, col: 42, offset: 20670},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 46, offset: 20664},
+									pos:  position{line: 700, col: 46, offset: 20674},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 700, col: 49, offset: 20667},
+									pos:   position{line: 700, col: 49, offset: 20677},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 700, col: 54, offset: 20672},
+										pos:  position{line: 700, col: 54, offset: 20682},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 59, offset: 20677},
+									pos:  position{line: 700, col: 59, offset: 20687},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 62, offset: 20680},
+									pos:        position{line: 700, col: 62, offset: 20690},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5681,26 +5703,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 704, col: 1, offset: 20784},
+			pos:  position{line: 704, col: 1, offset: 20794},
 			expr: &choiceExpr{
-				pos: position{line: 705, col: 5, offset: 20796},
+				pos: position{line: 705, col: 5, offset: 20806},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 705, col: 5, offset: 20796},
+						pos:  position{line: 705, col: 5, offset: 20806},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 706, col: 5, offset: 20807},
+						pos:  position{line: 706, col: 5, offset: 20817},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 707, col: 5, offset: 20816},
+						pos: position{line: 707, col: 5, offset: 20826},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 707, col: 5, offset: 20816},
+							pos:   position{line: 707, col: 5, offset: 20826},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 707, col: 7, offset: 20818},
+								pos:  position{line: 707, col: 7, offset: 20828},
 								name: "QuotedString",
 							},
 						},
@@ -5710,19 +5732,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 711, col: 1, offset: 20910},
+			pos:  position{line: 711, col: 1, offset: 20920},
 			expr: &choiceExpr{
-				pos: position{line: 712, col: 5, offset: 20928},
+				pos: position{line: 712, col: 5, offset: 20938},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 712, col: 5, offset: 20928},
+						pos:  position{line: 712, col: 5, offset: 20938},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 20938},
+						pos: position{line: 713, col: 5, offset: 20948},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 713, col: 5, offset: 20938},
+							pos:  position{line: 713, col: 5, offset: 20948},
 							name: "__",
 						},
 					},
@@ -5731,50 +5753,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 715, col: 1, offset: 20974},
+			pos:  position{line: 715, col: 1, offset: 20984},
 			expr: &actionExpr{
-				pos: position{line: 716, col: 5, offset: 20984},
+				pos: position{line: 716, col: 5, offset: 20994},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 716, col: 5, offset: 20984},
+					pos: position{line: 716, col: 5, offset: 20994},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 716, col: 5, offset: 20984},
+							pos:   position{line: 716, col: 5, offset: 20994},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 716, col: 11, offset: 20990},
+								pos:  position{line: 716, col: 11, offset: 21000},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 716, col: 16, offset: 20995},
+							pos:   position{line: 716, col: 16, offset: 21005},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 716, col: 21, offset: 21000},
+								pos: position{line: 716, col: 21, offset: 21010},
 								expr: &actionExpr{
-									pos: position{line: 716, col: 22, offset: 21001},
+									pos: position{line: 716, col: 22, offset: 21011},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 716, col: 22, offset: 21001},
+										pos: position{line: 716, col: 22, offset: 21011},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 716, col: 22, offset: 21001},
+												pos:  position{line: 716, col: 22, offset: 21011},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 716, col: 25, offset: 21004},
+												pos:        position{line: 716, col: 25, offset: 21014},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 716, col: 29, offset: 21008},
+												pos:  position{line: 716, col: 29, offset: 21018},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 716, col: 32, offset: 21011},
+												pos:   position{line: 716, col: 32, offset: 21021},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 716, col: 34, offset: 21013},
+													pos:  position{line: 716, col: 34, offset: 21023},
 													name: "Expr",
 												},
 											},
@@ -5789,35 +5811,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 720, col: 1, offset: 21122},
+			pos:  position{line: 720, col: 1, offset: 21132},
 			expr: &actionExpr{
-				pos: position{line: 721, col: 5, offset: 21136},
+				pos: position{line: 721, col: 5, offset: 21146},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 721, col: 5, offset: 21136},
+					pos: position{line: 721, col: 5, offset: 21146},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 721, col: 5, offset: 21136},
+							pos: position{line: 721, col: 5, offset: 21146},
 							expr: &ruleRefExpr{
-								pos:  position{line: 721, col: 6, offset: 21137},
+								pos:  position{line: 721, col: 6, offset: 21147},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 721, col: 10, offset: 21141},
+							pos:   position{line: 721, col: 10, offset: 21151},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 721, col: 16, offset: 21147},
+								pos:  position{line: 721, col: 16, offset: 21157},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 721, col: 27, offset: 21158},
+							pos:   position{line: 721, col: 27, offset: 21168},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 721, col: 32, offset: 21163},
+								pos: position{line: 721, col: 32, offset: 21173},
 								expr: &ruleRefExpr{
-									pos:  position{line: 721, col: 33, offset: 21164},
+									pos:  position{line: 721, col: 33, offset: 21174},
 									name: "Deref",
 								},
 							},
@@ -5828,52 +5850,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 725, col: 1, offset: 21232},
+			pos:  position{line: 725, col: 1, offset: 21242},
 			expr: &choiceExpr{
-				pos: position{line: 726, col: 5, offset: 21242},
+				pos: position{line: 726, col: 5, offset: 21252},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 726, col: 5, offset: 21242},
+						pos: position{line: 726, col: 5, offset: 21252},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 726, col: 5, offset: 21242},
+							pos: position{line: 726, col: 5, offset: 21252},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 726, col: 5, offset: 21242},
+									pos:        position{line: 726, col: 5, offset: 21252},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 726, col: 9, offset: 21246},
+									pos:   position{line: 726, col: 9, offset: 21256},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 726, col: 14, offset: 21251},
+										pos:  position{line: 726, col: 14, offset: 21261},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 726, col: 27, offset: 21264},
+									pos:  position{line: 726, col: 27, offset: 21274},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 726, col: 30, offset: 21267},
+									pos:        position{line: 726, col: 30, offset: 21277},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 726, col: 34, offset: 21271},
+									pos:  position{line: 726, col: 34, offset: 21281},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 726, col: 37, offset: 21274},
+									pos:   position{line: 726, col: 37, offset: 21284},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 726, col: 40, offset: 21277},
+										pos:  position{line: 726, col: 40, offset: 21287},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 726, col: 53, offset: 21290},
+									pos:        position{line: 726, col: 53, offset: 21300},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5881,39 +5903,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 732, col: 5, offset: 21461},
+						pos: position{line: 732, col: 5, offset: 21471},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 732, col: 5, offset: 21461},
+							pos: position{line: 732, col: 5, offset: 21471},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 732, col: 5, offset: 21461},
+									pos:        position{line: 732, col: 5, offset: 21471},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 732, col: 9, offset: 21465},
+									pos:  position{line: 732, col: 9, offset: 21475},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 732, col: 12, offset: 21468},
+									pos:        position{line: 732, col: 12, offset: 21478},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 732, col: 16, offset: 21472},
+									pos:  position{line: 732, col: 16, offset: 21482},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 732, col: 19, offset: 21475},
+									pos:   position{line: 732, col: 19, offset: 21485},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 732, col: 22, offset: 21478},
+										pos:  position{line: 732, col: 22, offset: 21488},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 732, col: 35, offset: 21491},
+									pos:        position{line: 732, col: 35, offset: 21501},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5921,39 +5943,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 738, col: 5, offset: 21662},
+						pos: position{line: 738, col: 5, offset: 21672},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 738, col: 5, offset: 21662},
+							pos: position{line: 738, col: 5, offset: 21672},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 738, col: 5, offset: 21662},
+									pos:        position{line: 738, col: 5, offset: 21672},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 738, col: 9, offset: 21666},
+									pos:   position{line: 738, col: 9, offset: 21676},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 738, col: 14, offset: 21671},
+										pos:  position{line: 738, col: 14, offset: 21681},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 738, col: 27, offset: 21684},
+									pos:  position{line: 738, col: 27, offset: 21694},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 738, col: 30, offset: 21687},
+									pos:        position{line: 738, col: 30, offset: 21697},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 738, col: 34, offset: 21691},
+									pos:  position{line: 738, col: 34, offset: 21701},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 738, col: 37, offset: 21694},
+									pos:        position{line: 738, col: 37, offset: 21704},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5961,26 +5983,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 744, col: 5, offset: 21867},
+						pos: position{line: 744, col: 5, offset: 21877},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 744, col: 5, offset: 21867},
+							pos: position{line: 744, col: 5, offset: 21877},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 744, col: 5, offset: 21867},
+									pos:        position{line: 744, col: 5, offset: 21877},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 744, col: 9, offset: 21871},
+									pos:   position{line: 744, col: 9, offset: 21881},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 744, col: 14, offset: 21876},
+										pos:  position{line: 744, col: 14, offset: 21886},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 744, col: 19, offset: 21881},
+									pos:        position{line: 744, col: 19, offset: 21891},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5988,21 +6010,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 745, col: 5, offset: 21930},
+						pos: position{line: 745, col: 5, offset: 21940},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 745, col: 5, offset: 21930},
+							pos: position{line: 745, col: 5, offset: 21940},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 745, col: 5, offset: 21930},
+									pos:        position{line: 745, col: 5, offset: 21940},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 745, col: 9, offset: 21934},
+									pos:   position{line: 745, col: 9, offset: 21944},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 745, col: 12, offset: 21937},
+										pos:  position{line: 745, col: 12, offset: 21947},
 										name: "Identifier",
 									},
 								},
@@ -6014,59 +6036,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 747, col: 1, offset: 21988},
+			pos:  position{line: 747, col: 1, offset: 21998},
 			expr: &choiceExpr{
-				pos: position{line: 748, col: 5, offset: 22000},
+				pos: position{line: 748, col: 5, offset: 22010},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 748, col: 5, offset: 22000},
+						pos:  position{line: 748, col: 5, offset: 22010},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 749, col: 5, offset: 22011},
+						pos:  position{line: 749, col: 5, offset: 22021},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 750, col: 5, offset: 22021},
+						pos:  position{line: 750, col: 5, offset: 22031},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 751, col: 5, offset: 22029},
+						pos:  position{line: 751, col: 5, offset: 22039},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 752, col: 5, offset: 22037},
+						pos:  position{line: 752, col: 5, offset: 22047},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 753, col: 5, offset: 22049},
+						pos: position{line: 753, col: 5, offset: 22059},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 753, col: 5, offset: 22049},
+							pos: position{line: 753, col: 5, offset: 22059},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 753, col: 5, offset: 22049},
+									pos:        position{line: 753, col: 5, offset: 22059},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 753, col: 9, offset: 22053},
+									pos:  position{line: 753, col: 9, offset: 22063},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 753, col: 12, offset: 22056},
+									pos:   position{line: 753, col: 12, offset: 22066},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 753, col: 17, offset: 22061},
+										pos:  position{line: 753, col: 17, offset: 22071},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 753, col: 22, offset: 22066},
+									pos:  position{line: 753, col: 22, offset: 22076},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 753, col: 25, offset: 22069},
+									pos:        position{line: 753, col: 25, offset: 22079},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6078,36 +6100,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 755, col: 1, offset: 22095},
+			pos:  position{line: 755, col: 1, offset: 22105},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 22106},
+				pos: position{line: 756, col: 5, offset: 22116},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 756, col: 5, offset: 22106},
+					pos: position{line: 756, col: 5, offset: 22116},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 756, col: 5, offset: 22106},
+							pos:        position{line: 756, col: 5, offset: 22116},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 9, offset: 22110},
+							pos:  position{line: 756, col: 9, offset: 22120},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 12, offset: 22113},
+							pos:   position{line: 756, col: 12, offset: 22123},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 18, offset: 22119},
+								pos:  position{line: 756, col: 18, offset: 22129},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 30, offset: 22131},
+							pos:  position{line: 756, col: 30, offset: 22141},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 756, col: 33, offset: 22134},
+							pos:        position{line: 756, col: 33, offset: 22144},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6117,31 +6139,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 760, col: 1, offset: 22224},
+			pos:  position{line: 760, col: 1, offset: 22234},
 			expr: &choiceExpr{
-				pos: position{line: 761, col: 5, offset: 22240},
+				pos: position{line: 761, col: 5, offset: 22250},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 761, col: 5, offset: 22240},
+						pos: position{line: 761, col: 5, offset: 22250},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 761, col: 5, offset: 22240},
+							pos: position{line: 761, col: 5, offset: 22250},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 761, col: 5, offset: 22240},
+									pos:   position{line: 761, col: 5, offset: 22250},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 761, col: 11, offset: 22246},
+										pos:  position{line: 761, col: 11, offset: 22256},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 761, col: 22, offset: 22257},
+									pos:   position{line: 761, col: 22, offset: 22267},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 761, col: 27, offset: 22262},
+										pos: position{line: 761, col: 27, offset: 22272},
 										expr: &ruleRefExpr{
-											pos:  position{line: 761, col: 27, offset: 22262},
+											pos:  position{line: 761, col: 27, offset: 22272},
 											name: "RecordElemTail",
 										},
 									},
@@ -6150,10 +6172,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 764, col: 5, offset: 22361},
+						pos: position{line: 764, col: 5, offset: 22371},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 764, col: 5, offset: 22361},
+							pos:  position{line: 764, col: 5, offset: 22371},
 							name: "__",
 						},
 					},
@@ -6162,31 +6184,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 766, col: 1, offset: 22397},
+			pos:  position{line: 766, col: 1, offset: 22407},
 			expr: &actionExpr{
-				pos: position{line: 766, col: 18, offset: 22414},
+				pos: position{line: 766, col: 18, offset: 22424},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 766, col: 18, offset: 22414},
+					pos: position{line: 766, col: 18, offset: 22424},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 766, col: 18, offset: 22414},
+							pos:  position{line: 766, col: 18, offset: 22424},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 766, col: 21, offset: 22417},
+							pos:        position{line: 766, col: 21, offset: 22427},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 766, col: 25, offset: 22421},
+							pos:  position{line: 766, col: 25, offset: 22431},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 766, col: 28, offset: 22424},
+							pos:   position{line: 766, col: 28, offset: 22434},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 766, col: 33, offset: 22429},
+								pos:  position{line: 766, col: 33, offset: 22439},
 								name: "RecordElem",
 							},
 						},
@@ -6196,20 +6218,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 768, col: 1, offset: 22462},
+			pos:  position{line: 768, col: 1, offset: 22472},
 			expr: &choiceExpr{
-				pos: position{line: 769, col: 5, offset: 22477},
+				pos: position{line: 769, col: 5, offset: 22487},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 769, col: 5, offset: 22477},
+						pos:  position{line: 769, col: 5, offset: 22487},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 770, col: 5, offset: 22488},
+						pos:  position{line: 770, col: 5, offset: 22498},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 771, col: 5, offset: 22498},
+						pos:  position{line: 771, col: 5, offset: 22508},
 						name: "Identifier",
 					},
 				},
@@ -6217,27 +6239,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 773, col: 1, offset: 22510},
+			pos:  position{line: 773, col: 1, offset: 22520},
 			expr: &actionExpr{
-				pos: position{line: 774, col: 5, offset: 22521},
+				pos: position{line: 774, col: 5, offset: 22531},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 774, col: 5, offset: 22521},
+					pos: position{line: 774, col: 5, offset: 22531},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 774, col: 5, offset: 22521},
+							pos:        position{line: 774, col: 5, offset: 22531},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 774, col: 11, offset: 22527},
+							pos:  position{line: 774, col: 11, offset: 22537},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 774, col: 14, offset: 22530},
+							pos:   position{line: 774, col: 14, offset: 22540},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 774, col: 19, offset: 22535},
+								pos:  position{line: 774, col: 19, offset: 22545},
 								name: "Expr",
 							},
 						},
@@ -6247,39 +6269,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 778, col: 1, offset: 22621},
+			pos:  position{line: 778, col: 1, offset: 22631},
 			expr: &actionExpr{
-				pos: position{line: 779, col: 5, offset: 22631},
+				pos: position{line: 779, col: 5, offset: 22641},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 779, col: 5, offset: 22631},
+					pos: position{line: 779, col: 5, offset: 22641},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 779, col: 5, offset: 22631},
+							pos:   position{line: 779, col: 5, offset: 22641},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 779, col: 10, offset: 22636},
+								pos:  position{line: 779, col: 10, offset: 22646},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 20, offset: 22646},
+							pos:  position{line: 779, col: 20, offset: 22656},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 779, col: 23, offset: 22649},
+							pos:        position{line: 779, col: 23, offset: 22659},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 27, offset: 22653},
+							pos:  position{line: 779, col: 27, offset: 22663},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 779, col: 30, offset: 22656},
+							pos:   position{line: 779, col: 30, offset: 22666},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 779, col: 36, offset: 22662},
+								pos:  position{line: 779, col: 36, offset: 22672},
 								name: "Expr",
 							},
 						},
@@ -6289,36 +6311,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 783, col: 1, offset: 22762},
+			pos:  position{line: 783, col: 1, offset: 22772},
 			expr: &actionExpr{
-				pos: position{line: 784, col: 5, offset: 22772},
+				pos: position{line: 784, col: 5, offset: 22782},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 784, col: 5, offset: 22772},
+					pos: position{line: 784, col: 5, offset: 22782},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 784, col: 5, offset: 22772},
+							pos:        position{line: 784, col: 5, offset: 22782},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 784, col: 9, offset: 22776},
+							pos:  position{line: 784, col: 9, offset: 22786},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 784, col: 12, offset: 22779},
+							pos:   position{line: 784, col: 12, offset: 22789},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 784, col: 18, offset: 22785},
+								pos:  position{line: 784, col: 18, offset: 22795},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 784, col: 32, offset: 22799},
+							pos:  position{line: 784, col: 32, offset: 22809},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 784, col: 35, offset: 22802},
+							pos:        position{line: 784, col: 35, offset: 22812},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6328,36 +6350,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 788, col: 1, offset: 22892},
+			pos:  position{line: 788, col: 1, offset: 22902},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 5, offset: 22900},
+				pos: position{line: 789, col: 5, offset: 22910},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 5, offset: 22900},
+					pos: position{line: 789, col: 5, offset: 22910},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 789, col: 5, offset: 22900},
+							pos:        position{line: 789, col: 5, offset: 22910},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 10, offset: 22905},
+							pos:  position{line: 789, col: 10, offset: 22915},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 13, offset: 22908},
+							pos:   position{line: 789, col: 13, offset: 22918},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 19, offset: 22914},
+								pos:  position{line: 789, col: 19, offset: 22924},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 33, offset: 22928},
+							pos:  position{line: 789, col: 33, offset: 22938},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 789, col: 36, offset: 22931},
+							pos:        position{line: 789, col: 36, offset: 22941},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6367,36 +6389,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 793, col: 1, offset: 23020},
+			pos:  position{line: 793, col: 1, offset: 23030},
 			expr: &actionExpr{
-				pos: position{line: 794, col: 5, offset: 23028},
+				pos: position{line: 794, col: 5, offset: 23038},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 794, col: 5, offset: 23028},
+					pos: position{line: 794, col: 5, offset: 23038},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 794, col: 5, offset: 23028},
+							pos:        position{line: 794, col: 5, offset: 23038},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 794, col: 10, offset: 23033},
+							pos:  position{line: 794, col: 10, offset: 23043},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 794, col: 13, offset: 23036},
+							pos:   position{line: 794, col: 13, offset: 23046},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 794, col: 19, offset: 23042},
+								pos:  position{line: 794, col: 19, offset: 23052},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 794, col: 27, offset: 23050},
+							pos:  position{line: 794, col: 27, offset: 23060},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 794, col: 30, offset: 23053},
+							pos:        position{line: 794, col: 30, offset: 23063},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6406,31 +6428,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 798, col: 1, offset: 23144},
+			pos:  position{line: 798, col: 1, offset: 23154},
 			expr: &choiceExpr{
-				pos: position{line: 799, col: 5, offset: 23156},
+				pos: position{line: 799, col: 5, offset: 23166},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 799, col: 5, offset: 23156},
+						pos: position{line: 799, col: 5, offset: 23166},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 799, col: 5, offset: 23156},
+							pos: position{line: 799, col: 5, offset: 23166},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 799, col: 5, offset: 23156},
+									pos:   position{line: 799, col: 5, offset: 23166},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 799, col: 11, offset: 23162},
+										pos:  position{line: 799, col: 11, offset: 23172},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 799, col: 17, offset: 23168},
+									pos:   position{line: 799, col: 17, offset: 23178},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 799, col: 22, offset: 23173},
+										pos: position{line: 799, col: 22, offset: 23183},
 										expr: &ruleRefExpr{
-											pos:  position{line: 799, col: 22, offset: 23173},
+											pos:  position{line: 799, col: 22, offset: 23183},
 											name: "EntryTail",
 										},
 									},
@@ -6439,10 +6461,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 802, col: 5, offset: 23267},
+						pos: position{line: 802, col: 5, offset: 23277},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 802, col: 5, offset: 23267},
+							pos:  position{line: 802, col: 5, offset: 23277},
 							name: "__",
 						},
 					},
@@ -6451,31 +6473,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 805, col: 1, offset: 23304},
+			pos:  position{line: 805, col: 1, offset: 23314},
 			expr: &actionExpr{
-				pos: position{line: 805, col: 13, offset: 23316},
+				pos: position{line: 805, col: 13, offset: 23326},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 805, col: 13, offset: 23316},
+					pos: position{line: 805, col: 13, offset: 23326},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 13, offset: 23316},
+							pos:  position{line: 805, col: 13, offset: 23326},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 805, col: 16, offset: 23319},
+							pos:        position{line: 805, col: 16, offset: 23329},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 20, offset: 23323},
+							pos:  position{line: 805, col: 20, offset: 23333},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 805, col: 23, offset: 23326},
+							pos:   position{line: 805, col: 23, offset: 23336},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 805, col: 25, offset: 23328},
+								pos:  position{line: 805, col: 25, offset: 23338},
 								name: "Entry",
 							},
 						},
@@ -6485,39 +6507,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 807, col: 1, offset: 23353},
+			pos:  position{line: 807, col: 1, offset: 23363},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 5, offset: 23363},
+				pos: position{line: 808, col: 5, offset: 23373},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 5, offset: 23363},
+					pos: position{line: 808, col: 5, offset: 23373},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 808, col: 5, offset: 23363},
+							pos:   position{line: 808, col: 5, offset: 23373},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 9, offset: 23367},
+								pos:  position{line: 808, col: 9, offset: 23377},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 14, offset: 23372},
+							pos:  position{line: 808, col: 14, offset: 23382},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 808, col: 17, offset: 23375},
+							pos:        position{line: 808, col: 17, offset: 23385},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 21, offset: 23379},
+							pos:  position{line: 808, col: 21, offset: 23389},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 24, offset: 23382},
+							pos:   position{line: 808, col: 24, offset: 23392},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 30, offset: 23388},
+								pos:  position{line: 808, col: 30, offset: 23398},
 								name: "Expr",
 							},
 						},
@@ -6527,92 +6549,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLProc",
-			pos:  position{line: 814, col: 1, offset: 23495},
+			pos:  position{line: 814, col: 1, offset: 23505},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 23507},
+				pos: position{line: 815, col: 5, offset: 23517},
 				run: (*parser).callonSQLProc1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 23507},
+					pos: position{line: 815, col: 5, offset: 23517},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 815, col: 5, offset: 23507},
+							pos:   position{line: 815, col: 5, offset: 23517},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 15, offset: 23517},
+								pos:  position{line: 815, col: 15, offset: 23527},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 816, col: 5, offset: 23531},
+							pos:   position{line: 816, col: 5, offset: 23541},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 816, col: 10, offset: 23536},
+								pos: position{line: 816, col: 10, offset: 23546},
 								expr: &ruleRefExpr{
-									pos:  position{line: 816, col: 10, offset: 23536},
+									pos:  position{line: 816, col: 10, offset: 23546},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 817, col: 5, offset: 23549},
+							pos:   position{line: 817, col: 5, offset: 23559},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 817, col: 11, offset: 23555},
+								pos: position{line: 817, col: 11, offset: 23565},
 								expr: &ruleRefExpr{
-									pos:  position{line: 817, col: 11, offset: 23555},
+									pos:  position{line: 817, col: 11, offset: 23565},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 5, offset: 23569},
+							pos:   position{line: 818, col: 5, offset: 23579},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 818, col: 11, offset: 23575},
+								pos: position{line: 818, col: 11, offset: 23585},
 								expr: &ruleRefExpr{
-									pos:  position{line: 818, col: 11, offset: 23575},
+									pos:  position{line: 818, col: 11, offset: 23585},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 819, col: 5, offset: 23589},
+							pos:   position{line: 819, col: 5, offset: 23599},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 819, col: 13, offset: 23597},
+								pos: position{line: 819, col: 13, offset: 23607},
 								expr: &ruleRefExpr{
-									pos:  position{line: 819, col: 13, offset: 23597},
+									pos:  position{line: 819, col: 13, offset: 23607},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 820, col: 5, offset: 23613},
+							pos:   position{line: 820, col: 5, offset: 23623},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 820, col: 12, offset: 23620},
+								pos: position{line: 820, col: 12, offset: 23630},
 								expr: &ruleRefExpr{
-									pos:  position{line: 820, col: 12, offset: 23620},
+									pos:  position{line: 820, col: 12, offset: 23630},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 5, offset: 23635},
+							pos:   position{line: 821, col: 5, offset: 23645},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 821, col: 13, offset: 23643},
+								pos: position{line: 821, col: 13, offset: 23653},
 								expr: &ruleRefExpr{
-									pos:  position{line: 821, col: 13, offset: 23643},
+									pos:  position{line: 821, col: 13, offset: 23653},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 5, offset: 23659},
+							pos:   position{line: 822, col: 5, offset: 23669},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 822, col: 11, offset: 23665},
+								pos:  position{line: 822, col: 11, offset: 23675},
 								name: "SQLLimit",
 							},
 						},
@@ -6622,26 +6644,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 846, col: 1, offset: 24032},
+			pos:  position{line: 846, col: 1, offset: 24042},
 			expr: &choiceExpr{
-				pos: position{line: 847, col: 5, offset: 24046},
+				pos: position{line: 847, col: 5, offset: 24056},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 847, col: 5, offset: 24046},
+						pos: position{line: 847, col: 5, offset: 24056},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 847, col: 5, offset: 24046},
+							pos: position{line: 847, col: 5, offset: 24056},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 5, offset: 24046},
+									pos:  position{line: 847, col: 5, offset: 24056},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 12, offset: 24053},
+									pos:  position{line: 847, col: 12, offset: 24063},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 847, col: 14, offset: 24055},
+									pos:        position{line: 847, col: 14, offset: 24065},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6649,24 +6671,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 848, col: 5, offset: 24083},
+						pos: position{line: 848, col: 5, offset: 24093},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 848, col: 5, offset: 24083},
+							pos: position{line: 848, col: 5, offset: 24093},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 5, offset: 24083},
+									pos:  position{line: 848, col: 5, offset: 24093},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 12, offset: 24090},
+									pos:  position{line: 848, col: 12, offset: 24100},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 848, col: 14, offset: 24092},
+									pos:   position{line: 848, col: 14, offset: 24102},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 848, col: 26, offset: 24104},
+										pos:  position{line: 848, col: 26, offset: 24114},
 										name: "SQLAssignments",
 									},
 								},
@@ -6678,41 +6700,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 850, col: 1, offset: 24148},
+			pos:  position{line: 850, col: 1, offset: 24158},
 			expr: &choiceExpr{
-				pos: position{line: 851, col: 5, offset: 24166},
+				pos: position{line: 851, col: 5, offset: 24176},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 851, col: 5, offset: 24166},
+						pos: position{line: 851, col: 5, offset: 24176},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 851, col: 5, offset: 24166},
+							pos: position{line: 851, col: 5, offset: 24176},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 851, col: 5, offset: 24166},
+									pos:   position{line: 851, col: 5, offset: 24176},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 851, col: 9, offset: 24170},
+										pos:  position{line: 851, col: 9, offset: 24180},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 851, col: 14, offset: 24175},
+									pos:  position{line: 851, col: 14, offset: 24185},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 851, col: 16, offset: 24177},
+									pos:  position{line: 851, col: 16, offset: 24187},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 851, col: 19, offset: 24180},
+									pos:  position{line: 851, col: 19, offset: 24190},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 851, col: 21, offset: 24182},
+									pos:   position{line: 851, col: 21, offset: 24192},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 851, col: 25, offset: 24186},
+										pos:  position{line: 851, col: 25, offset: 24196},
 										name: "Lval",
 									},
 								},
@@ -6720,13 +6742,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 852, col: 5, offset: 24280},
+						pos: position{line: 852, col: 5, offset: 24290},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 852, col: 5, offset: 24280},
+							pos:   position{line: 852, col: 5, offset: 24290},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 852, col: 10, offset: 24285},
+								pos:  position{line: 852, col: 10, offset: 24295},
 								name: "Expr",
 							},
 						},
@@ -6736,50 +6758,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 854, col: 1, offset: 24377},
+			pos:  position{line: 854, col: 1, offset: 24387},
 			expr: &actionExpr{
-				pos: position{line: 855, col: 5, offset: 24396},
+				pos: position{line: 855, col: 5, offset: 24406},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 855, col: 5, offset: 24396},
+					pos: position{line: 855, col: 5, offset: 24406},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 855, col: 5, offset: 24396},
+							pos:   position{line: 855, col: 5, offset: 24406},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 11, offset: 24402},
+								pos:  position{line: 855, col: 11, offset: 24412},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 25, offset: 24416},
+							pos:   position{line: 855, col: 25, offset: 24426},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 855, col: 30, offset: 24421},
+								pos: position{line: 855, col: 30, offset: 24431},
 								expr: &actionExpr{
-									pos: position{line: 855, col: 31, offset: 24422},
+									pos: position{line: 855, col: 31, offset: 24432},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 855, col: 31, offset: 24422},
+										pos: position{line: 855, col: 31, offset: 24432},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 855, col: 31, offset: 24422},
+												pos:  position{line: 855, col: 31, offset: 24432},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 855, col: 34, offset: 24425},
+												pos:        position{line: 855, col: 34, offset: 24435},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 855, col: 38, offset: 24429},
+												pos:  position{line: 855, col: 38, offset: 24439},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 855, col: 41, offset: 24432},
+												pos:   position{line: 855, col: 41, offset: 24442},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 855, col: 46, offset: 24437},
+													pos:  position{line: 855, col: 46, offset: 24447},
 													name: "SQLAssignment",
 												},
 											},
@@ -6794,43 +6816,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 859, col: 1, offset: 24558},
+			pos:  position{line: 859, col: 1, offset: 24568},
 			expr: &choiceExpr{
-				pos: position{line: 860, col: 5, offset: 24570},
+				pos: position{line: 860, col: 5, offset: 24580},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 860, col: 5, offset: 24570},
+						pos: position{line: 860, col: 5, offset: 24580},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 860, col: 5, offset: 24570},
+							pos: position{line: 860, col: 5, offset: 24580},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 860, col: 5, offset: 24570},
+									pos:  position{line: 860, col: 5, offset: 24580},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 860, col: 7, offset: 24572},
+									pos:  position{line: 860, col: 7, offset: 24582},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 860, col: 12, offset: 24577},
+									pos:  position{line: 860, col: 12, offset: 24587},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 860, col: 14, offset: 24579},
+									pos:   position{line: 860, col: 14, offset: 24589},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 860, col: 20, offset: 24585},
+										pos:  position{line: 860, col: 20, offset: 24595},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 860, col: 29, offset: 24594},
+									pos:   position{line: 860, col: 29, offset: 24604},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 860, col: 35, offset: 24600},
+										pos: position{line: 860, col: 35, offset: 24610},
 										expr: &ruleRefExpr{
-											pos:  position{line: 860, col: 35, offset: 24600},
+											pos:  position{line: 860, col: 35, offset: 24610},
 											name: "SQLAlias",
 										},
 									},
@@ -6839,25 +6861,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 863, col: 5, offset: 24695},
+						pos: position{line: 863, col: 5, offset: 24705},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 863, col: 5, offset: 24695},
+							pos: position{line: 863, col: 5, offset: 24705},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 5, offset: 24695},
+									pos:  position{line: 863, col: 5, offset: 24705},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 7, offset: 24697},
+									pos:  position{line: 863, col: 7, offset: 24707},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 12, offset: 24702},
+									pos:  position{line: 863, col: 12, offset: 24712},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 863, col: 14, offset: 24704},
+									pos:        position{line: 863, col: 14, offset: 24714},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6869,33 +6891,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 865, col: 1, offset: 24729},
+			pos:  position{line: 865, col: 1, offset: 24739},
 			expr: &choiceExpr{
-				pos: position{line: 866, col: 5, offset: 24742},
+				pos: position{line: 866, col: 5, offset: 24752},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 866, col: 5, offset: 24742},
+						pos: position{line: 866, col: 5, offset: 24752},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 866, col: 5, offset: 24742},
+							pos: position{line: 866, col: 5, offset: 24752},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 5, offset: 24742},
+									pos:  position{line: 866, col: 5, offset: 24752},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 7, offset: 24744},
+									pos:  position{line: 866, col: 7, offset: 24754},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 10, offset: 24747},
+									pos:  position{line: 866, col: 10, offset: 24757},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 866, col: 12, offset: 24749},
+									pos:   position{line: 866, col: 12, offset: 24759},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 866, col: 15, offset: 24752},
+										pos:  position{line: 866, col: 15, offset: 24762},
 										name: "Lval",
 									},
 								},
@@ -6903,36 +6925,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 867, col: 5, offset: 24780},
+						pos: position{line: 867, col: 5, offset: 24790},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 867, col: 5, offset: 24780},
+							pos: position{line: 867, col: 5, offset: 24790},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 867, col: 5, offset: 24780},
+									pos:  position{line: 867, col: 5, offset: 24790},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 867, col: 7, offset: 24782},
+									pos: position{line: 867, col: 7, offset: 24792},
 									expr: &seqExpr{
-										pos: position{line: 867, col: 9, offset: 24784},
+										pos: position{line: 867, col: 9, offset: 24794},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 867, col: 9, offset: 24784},
+												pos:  position{line: 867, col: 9, offset: 24794},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 867, col: 27, offset: 24802},
+												pos:  position{line: 867, col: 27, offset: 24812},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 867, col: 30, offset: 24805},
+									pos:   position{line: 867, col: 30, offset: 24815},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 867, col: 33, offset: 24808},
+										pos:  position{line: 867, col: 33, offset: 24818},
 										name: "Lval",
 									},
 								},
@@ -6944,42 +6966,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 869, col: 1, offset: 24833},
+			pos:  position{line: 869, col: 1, offset: 24843},
 			expr: &ruleRefExpr{
-				pos:  position{line: 870, col: 5, offset: 24846},
+				pos:  position{line: 870, col: 5, offset: 24856},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 872, col: 1, offset: 24852},
+			pos:  position{line: 872, col: 1, offset: 24862},
 			expr: &actionExpr{
-				pos: position{line: 873, col: 5, offset: 24865},
+				pos: position{line: 873, col: 5, offset: 24875},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 873, col: 5, offset: 24865},
+					pos: position{line: 873, col: 5, offset: 24875},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 24865},
+							pos:   position{line: 873, col: 5, offset: 24875},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 873, col: 11, offset: 24871},
+								pos:  position{line: 873, col: 11, offset: 24881},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 873, col: 19, offset: 24879},
+							pos:   position{line: 873, col: 19, offset: 24889},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 873, col: 24, offset: 24884},
+								pos: position{line: 873, col: 24, offset: 24894},
 								expr: &actionExpr{
-									pos: position{line: 873, col: 25, offset: 24885},
+									pos: position{line: 873, col: 25, offset: 24895},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 873, col: 25, offset: 24885},
+										pos:   position{line: 873, col: 25, offset: 24895},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 873, col: 30, offset: 24890},
+											pos:  position{line: 873, col: 30, offset: 24900},
 											name: "SQLJoin",
 										},
 									},
@@ -6992,90 +7014,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 877, col: 1, offset: 25005},
+			pos:  position{line: 877, col: 1, offset: 25015},
 			expr: &actionExpr{
-				pos: position{line: 878, col: 5, offset: 25017},
+				pos: position{line: 878, col: 5, offset: 25027},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 878, col: 5, offset: 25017},
+					pos: position{line: 878, col: 5, offset: 25027},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 878, col: 5, offset: 25017},
+							pos:   position{line: 878, col: 5, offset: 25027},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 11, offset: 25023},
+								pos:  position{line: 878, col: 11, offset: 25033},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 24, offset: 25036},
+							pos:  position{line: 878, col: 24, offset: 25046},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 26, offset: 25038},
+							pos:  position{line: 878, col: 26, offset: 25048},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 31, offset: 25043},
+							pos:  position{line: 878, col: 31, offset: 25053},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 33, offset: 25045},
+							pos:   position{line: 878, col: 33, offset: 25055},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 39, offset: 25051},
+								pos:  position{line: 878, col: 39, offset: 25061},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 48, offset: 25060},
+							pos:   position{line: 878, col: 48, offset: 25070},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 878, col: 54, offset: 25066},
+								pos: position{line: 878, col: 54, offset: 25076},
 								expr: &ruleRefExpr{
-									pos:  position{line: 878, col: 54, offset: 25066},
+									pos:  position{line: 878, col: 54, offset: 25076},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 64, offset: 25076},
+							pos:  position{line: 878, col: 64, offset: 25086},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 66, offset: 25078},
+							pos:  position{line: 878, col: 66, offset: 25088},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 69, offset: 25081},
+							pos:  position{line: 878, col: 69, offset: 25091},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 71, offset: 25083},
+							pos:   position{line: 878, col: 71, offset: 25093},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 79, offset: 25091},
+								pos:  position{line: 878, col: 79, offset: 25101},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 87, offset: 25099},
+							pos:  position{line: 878, col: 87, offset: 25109},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 878, col: 90, offset: 25102},
+							pos:        position{line: 878, col: 90, offset: 25112},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 94, offset: 25106},
+							pos:  position{line: 878, col: 94, offset: 25116},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 97, offset: 25109},
+							pos:   position{line: 878, col: 97, offset: 25119},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 106, offset: 25118},
+								pos:  position{line: 878, col: 106, offset: 25128},
 								name: "JoinKey",
 							},
 						},
@@ -7085,40 +7107,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 897, col: 1, offset: 25353},
+			pos:  position{line: 897, col: 1, offset: 25363},
 			expr: &choiceExpr{
-				pos: position{line: 898, col: 5, offset: 25370},
+				pos: position{line: 898, col: 5, offset: 25380},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 898, col: 5, offset: 25370},
+						pos: position{line: 898, col: 5, offset: 25380},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 898, col: 5, offset: 25370},
+							pos: position{line: 898, col: 5, offset: 25380},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 898, col: 5, offset: 25370},
+									pos:  position{line: 898, col: 5, offset: 25380},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 898, col: 7, offset: 25372},
+									pos:   position{line: 898, col: 7, offset: 25382},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 898, col: 14, offset: 25379},
+										pos: position{line: 898, col: 14, offset: 25389},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 14, offset: 25379},
+												pos:  position{line: 898, col: 14, offset: 25389},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 21, offset: 25386},
+												pos:  position{line: 898, col: 21, offset: 25396},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 29, offset: 25394},
+												pos:  position{line: 898, col: 29, offset: 25404},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 36, offset: 25401},
+												pos:  position{line: 898, col: 36, offset: 25411},
 												name: "RIGHT",
 											},
 										},
@@ -7128,10 +7150,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 899, col: 5, offset: 25434},
+						pos: position{line: 899, col: 5, offset: 25444},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 899, col: 5, offset: 25434},
+							pos:        position{line: 899, col: 5, offset: 25444},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7141,30 +7163,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 901, col: 1, offset: 25462},
+			pos:  position{line: 901, col: 1, offset: 25472},
 			expr: &actionExpr{
-				pos: position{line: 902, col: 5, offset: 25475},
+				pos: position{line: 902, col: 5, offset: 25485},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 902, col: 5, offset: 25475},
+					pos: position{line: 902, col: 5, offset: 25485},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 902, col: 5, offset: 25475},
+							pos:  position{line: 902, col: 5, offset: 25485},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 902, col: 7, offset: 25477},
+							pos:  position{line: 902, col: 7, offset: 25487},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 902, col: 13, offset: 25483},
+							pos:  position{line: 902, col: 13, offset: 25493},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 902, col: 15, offset: 25485},
+							pos:   position{line: 902, col: 15, offset: 25495},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 902, col: 20, offset: 25490},
+								pos:  position{line: 902, col: 20, offset: 25500},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7174,38 +7196,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 904, col: 1, offset: 25526},
+			pos:  position{line: 904, col: 1, offset: 25536},
 			expr: &actionExpr{
-				pos: position{line: 905, col: 5, offset: 25541},
+				pos: position{line: 905, col: 5, offset: 25551},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 905, col: 5, offset: 25541},
+					pos: position{line: 905, col: 5, offset: 25551},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 5, offset: 25541},
+							pos:  position{line: 905, col: 5, offset: 25551},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 7, offset: 25543},
+							pos:  position{line: 905, col: 7, offset: 25553},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 13, offset: 25549},
+							pos:  position{line: 905, col: 13, offset: 25559},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 15, offset: 25551},
+							pos:  position{line: 905, col: 15, offset: 25561},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 18, offset: 25554},
+							pos:  position{line: 905, col: 18, offset: 25564},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 905, col: 20, offset: 25556},
+							pos:   position{line: 905, col: 20, offset: 25566},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 905, col: 28, offset: 25564},
+								pos:  position{line: 905, col: 28, offset: 25574},
 								name: "FieldExprs",
 							},
 						},
@@ -7215,30 +7237,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 907, col: 1, offset: 25600},
+			pos:  position{line: 907, col: 1, offset: 25610},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 5, offset: 25614},
+				pos: position{line: 908, col: 5, offset: 25624},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 908, col: 5, offset: 25614},
+					pos: position{line: 908, col: 5, offset: 25624},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 5, offset: 25614},
+							pos:  position{line: 908, col: 5, offset: 25624},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 7, offset: 25616},
+							pos:  position{line: 908, col: 7, offset: 25626},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 14, offset: 25623},
+							pos:  position{line: 908, col: 14, offset: 25633},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 908, col: 16, offset: 25625},
+							pos:   position{line: 908, col: 16, offset: 25635},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 908, col: 21, offset: 25630},
+								pos:  position{line: 908, col: 21, offset: 25640},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7248,46 +7270,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 910, col: 1, offset: 25666},
+			pos:  position{line: 910, col: 1, offset: 25676},
 			expr: &actionExpr{
-				pos: position{line: 911, col: 5, offset: 25681},
+				pos: position{line: 911, col: 5, offset: 25691},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 911, col: 5, offset: 25681},
+					pos: position{line: 911, col: 5, offset: 25691},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 5, offset: 25681},
+							pos:  position{line: 911, col: 5, offset: 25691},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 7, offset: 25683},
+							pos:  position{line: 911, col: 7, offset: 25693},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 13, offset: 25689},
+							pos:  position{line: 911, col: 13, offset: 25699},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 15, offset: 25691},
+							pos:  position{line: 911, col: 15, offset: 25701},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 18, offset: 25694},
+							pos:  position{line: 911, col: 18, offset: 25704},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 911, col: 20, offset: 25696},
+							pos:   position{line: 911, col: 20, offset: 25706},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 911, col: 25, offset: 25701},
+								pos:  position{line: 911, col: 25, offset: 25711},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 911, col: 31, offset: 25707},
+							pos:   position{line: 911, col: 31, offset: 25717},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 911, col: 37, offset: 25713},
+								pos:  position{line: 911, col: 37, offset: 25723},
 								name: "SQLOrder",
 							},
 						},
@@ -7297,32 +7319,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 915, col: 1, offset: 25823},
+			pos:  position{line: 915, col: 1, offset: 25833},
 			expr: &choiceExpr{
-				pos: position{line: 916, col: 5, offset: 25836},
+				pos: position{line: 916, col: 5, offset: 25846},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 916, col: 5, offset: 25836},
+						pos: position{line: 916, col: 5, offset: 25846},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 916, col: 5, offset: 25836},
+							pos: position{line: 916, col: 5, offset: 25846},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 916, col: 5, offset: 25836},
+									pos:  position{line: 916, col: 5, offset: 25846},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 916, col: 7, offset: 25838},
+									pos:   position{line: 916, col: 7, offset: 25848},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 916, col: 12, offset: 25843},
+										pos: position{line: 916, col: 12, offset: 25853},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 12, offset: 25843},
+												pos:  position{line: 916, col: 12, offset: 25853},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 18, offset: 25849},
+												pos:  position{line: 916, col: 18, offset: 25859},
 												name: "DESC",
 											},
 										},
@@ -7332,10 +7354,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 917, col: 5, offset: 25879},
+						pos: position{line: 917, col: 5, offset: 25889},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 917, col: 5, offset: 25879},
+							pos:        position{line: 917, col: 5, offset: 25889},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7345,33 +7367,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 919, col: 1, offset: 25905},
+			pos:  position{line: 919, col: 1, offset: 25915},
 			expr: &choiceExpr{
-				pos: position{line: 920, col: 5, offset: 25918},
+				pos: position{line: 920, col: 5, offset: 25928},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 920, col: 5, offset: 25918},
+						pos: position{line: 920, col: 5, offset: 25928},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 920, col: 5, offset: 25918},
+							pos: position{line: 920, col: 5, offset: 25928},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 920, col: 5, offset: 25918},
+									pos:  position{line: 920, col: 5, offset: 25928},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 920, col: 7, offset: 25920},
+									pos:  position{line: 920, col: 7, offset: 25930},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 920, col: 13, offset: 25926},
+									pos:  position{line: 920, col: 13, offset: 25936},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 920, col: 15, offset: 25928},
+									pos:   position{line: 920, col: 15, offset: 25938},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 920, col: 21, offset: 25934},
+										pos:  position{line: 920, col: 21, offset: 25944},
 										name: "UInt",
 									},
 								},
@@ -7379,10 +7401,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 921, col: 5, offset: 25965},
+						pos: position{line: 921, col: 5, offset: 25975},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 921, col: 5, offset: 25965},
+							pos:        position{line: 921, col: 5, offset: 25975},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7392,12 +7414,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 923, col: 1, offset: 25987},
+			pos:  position{line: 923, col: 1, offset: 25997},
 			expr: &actionExpr{
-				pos: position{line: 923, col: 10, offset: 25996},
+				pos: position{line: 923, col: 10, offset: 26006},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 923, col: 10, offset: 25996},
+					pos:        position{line: 923, col: 10, offset: 26006},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7405,12 +7427,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 924, col: 1, offset: 26031},
+			pos:  position{line: 924, col: 1, offset: 26041},
 			expr: &actionExpr{
-				pos: position{line: 924, col: 6, offset: 26036},
+				pos: position{line: 924, col: 6, offset: 26046},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 924, col: 6, offset: 26036},
+					pos:        position{line: 924, col: 6, offset: 26046},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7418,12 +7440,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 925, col: 1, offset: 26063},
+			pos:  position{line: 925, col: 1, offset: 26073},
 			expr: &actionExpr{
-				pos: position{line: 925, col: 8, offset: 26070},
+				pos: position{line: 925, col: 8, offset: 26080},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 925, col: 8, offset: 26070},
+					pos:        position{line: 925, col: 8, offset: 26080},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7431,12 +7453,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 926, col: 1, offset: 26101},
+			pos:  position{line: 926, col: 1, offset: 26111},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 8, offset: 26108},
+				pos: position{line: 926, col: 8, offset: 26118},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 926, col: 8, offset: 26108},
+					pos:        position{line: 926, col: 8, offset: 26118},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7444,12 +7466,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 927, col: 1, offset: 26139},
+			pos:  position{line: 927, col: 1, offset: 26149},
 			expr: &actionExpr{
-				pos: position{line: 927, col: 9, offset: 26147},
+				pos: position{line: 927, col: 9, offset: 26157},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 927, col: 9, offset: 26147},
+					pos:        position{line: 927, col: 9, offset: 26157},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7457,12 +7479,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 928, col: 1, offset: 26180},
+			pos:  position{line: 928, col: 1, offset: 26190},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 9, offset: 26188},
+				pos: position{line: 928, col: 9, offset: 26198},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 928, col: 9, offset: 26188},
+					pos:        position{line: 928, col: 9, offset: 26198},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7470,12 +7492,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 929, col: 1, offset: 26221},
+			pos:  position{line: 929, col: 1, offset: 26231},
 			expr: &actionExpr{
-				pos: position{line: 929, col: 6, offset: 26226},
+				pos: position{line: 929, col: 6, offset: 26236},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 929, col: 6, offset: 26226},
+					pos:        position{line: 929, col: 6, offset: 26236},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7483,12 +7505,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 930, col: 1, offset: 26253},
+			pos:  position{line: 930, col: 1, offset: 26263},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 10, offset: 26262},
+				pos: position{line: 930, col: 10, offset: 26272},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 930, col: 10, offset: 26262},
+					pos:        position{line: 930, col: 10, offset: 26272},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7496,12 +7518,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 931, col: 1, offset: 26297},
+			pos:  position{line: 931, col: 1, offset: 26307},
 			expr: &actionExpr{
-				pos: position{line: 931, col: 9, offset: 26305},
+				pos: position{line: 931, col: 9, offset: 26315},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 931, col: 9, offset: 26305},
+					pos:        position{line: 931, col: 9, offset: 26315},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7509,12 +7531,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 932, col: 1, offset: 26338},
+			pos:  position{line: 932, col: 1, offset: 26348},
 			expr: &actionExpr{
-				pos: position{line: 932, col: 6, offset: 26343},
+				pos: position{line: 932, col: 6, offset: 26353},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 932, col: 6, offset: 26343},
+					pos:        position{line: 932, col: 6, offset: 26353},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7522,12 +7544,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 933, col: 1, offset: 26370},
+			pos:  position{line: 933, col: 1, offset: 26380},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 9, offset: 26378},
+				pos: position{line: 933, col: 9, offset: 26388},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 933, col: 9, offset: 26378},
+					pos:        position{line: 933, col: 9, offset: 26388},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7535,12 +7557,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 934, col: 1, offset: 26411},
+			pos:  position{line: 934, col: 1, offset: 26421},
 			expr: &actionExpr{
-				pos: position{line: 934, col: 7, offset: 26417},
+				pos: position{line: 934, col: 7, offset: 26427},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 934, col: 7, offset: 26417},
+					pos:        position{line: 934, col: 7, offset: 26427},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7548,12 +7570,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 935, col: 1, offset: 26446},
+			pos:  position{line: 935, col: 1, offset: 26456},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 8, offset: 26453},
+				pos: position{line: 935, col: 8, offset: 26463},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 935, col: 8, offset: 26453},
+					pos:        position{line: 935, col: 8, offset: 26463},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7561,12 +7583,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 936, col: 1, offset: 26484},
+			pos:  position{line: 936, col: 1, offset: 26494},
 			expr: &actionExpr{
-				pos: position{line: 936, col: 8, offset: 26491},
+				pos: position{line: 936, col: 8, offset: 26501},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 936, col: 8, offset: 26491},
+					pos:        position{line: 936, col: 8, offset: 26501},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7574,12 +7596,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 937, col: 1, offset: 26522},
+			pos:  position{line: 937, col: 1, offset: 26532},
 			expr: &actionExpr{
-				pos: position{line: 937, col: 8, offset: 26529},
+				pos: position{line: 937, col: 8, offset: 26539},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 937, col: 8, offset: 26529},
+					pos:        position{line: 937, col: 8, offset: 26539},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7587,12 +7609,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 938, col: 1, offset: 26560},
+			pos:  position{line: 938, col: 1, offset: 26570},
 			expr: &actionExpr{
-				pos: position{line: 938, col: 9, offset: 26568},
+				pos: position{line: 938, col: 9, offset: 26578},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 938, col: 9, offset: 26568},
+					pos:        position{line: 938, col: 9, offset: 26578},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7600,12 +7622,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 939, col: 1, offset: 26601},
+			pos:  position{line: 939, col: 1, offset: 26611},
 			expr: &actionExpr{
-				pos: position{line: 939, col: 9, offset: 26609},
+				pos: position{line: 939, col: 9, offset: 26619},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 939, col: 9, offset: 26609},
+					pos:        position{line: 939, col: 9, offset: 26619},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7613,48 +7635,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 941, col: 1, offset: 26643},
+			pos:  position{line: 941, col: 1, offset: 26653},
 			expr: &choiceExpr{
-				pos: position{line: 942, col: 5, offset: 26665},
+				pos: position{line: 942, col: 5, offset: 26675},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 5, offset: 26665},
+						pos:  position{line: 942, col: 5, offset: 26675},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 14, offset: 26674},
+						pos:  position{line: 942, col: 14, offset: 26684},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 19, offset: 26679},
+						pos:  position{line: 942, col: 19, offset: 26689},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 27, offset: 26687},
+						pos:  position{line: 942, col: 27, offset: 26697},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 34, offset: 26694},
+						pos:  position{line: 942, col: 34, offset: 26704},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 42, offset: 26702},
+						pos:  position{line: 942, col: 42, offset: 26712},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 50, offset: 26710},
+						pos:  position{line: 942, col: 50, offset: 26720},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 59, offset: 26719},
+						pos:  position{line: 942, col: 59, offset: 26729},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 67, offset: 26727},
+						pos:  position{line: 942, col: 67, offset: 26737},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 75, offset: 26735},
+						pos:  position{line: 942, col: 75, offset: 26745},
 						name: "ON",
 					},
 				},
@@ -7662,52 +7684,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 946, col: 1, offset: 26761},
+			pos:  position{line: 946, col: 1, offset: 26771},
 			expr: &choiceExpr{
-				pos: position{line: 947, col: 5, offset: 26773},
+				pos: position{line: 947, col: 5, offset: 26783},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 947, col: 5, offset: 26773},
+						pos:  position{line: 947, col: 5, offset: 26783},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 948, col: 5, offset: 26789},
+						pos:  position{line: 948, col: 5, offset: 26799},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 949, col: 5, offset: 26809},
+						pos:  position{line: 949, col: 5, offset: 26819},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 950, col: 5, offset: 26827},
+						pos:  position{line: 950, col: 5, offset: 26837},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 951, col: 5, offset: 26846},
+						pos:  position{line: 951, col: 5, offset: 26856},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 5, offset: 26863},
+						pos:  position{line: 952, col: 5, offset: 26873},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 953, col: 5, offset: 26876},
+						pos:  position{line: 953, col: 5, offset: 26886},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 954, col: 5, offset: 26885},
+						pos:  position{line: 954, col: 5, offset: 26895},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 955, col: 5, offset: 26902},
+						pos:  position{line: 955, col: 5, offset: 26912},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 956, col: 5, offset: 26921},
+						pos:  position{line: 956, col: 5, offset: 26931},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 5, offset: 26940},
+						pos:  position{line: 957, col: 5, offset: 26950},
 						name: "NullLiteral",
 					},
 				},
@@ -7715,28 +7737,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 959, col: 1, offset: 26953},
+			pos:  position{line: 959, col: 1, offset: 26963},
 			expr: &choiceExpr{
-				pos: position{line: 960, col: 5, offset: 26971},
+				pos: position{line: 960, col: 5, offset: 26981},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 960, col: 5, offset: 26971},
+						pos: position{line: 960, col: 5, offset: 26981},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 960, col: 5, offset: 26971},
+							pos: position{line: 960, col: 5, offset: 26981},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 960, col: 5, offset: 26971},
+									pos:   position{line: 960, col: 5, offset: 26981},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 960, col: 7, offset: 26973},
+										pos:  position{line: 960, col: 7, offset: 26983},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 960, col: 14, offset: 26980},
+									pos: position{line: 960, col: 14, offset: 26990},
 									expr: &ruleRefExpr{
-										pos:  position{line: 960, col: 15, offset: 26981},
+										pos:  position{line: 960, col: 15, offset: 26991},
 										name: "IdentifierRest",
 									},
 								},
@@ -7744,13 +7766,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 963, col: 5, offset: 27096},
+						pos: position{line: 963, col: 5, offset: 27106},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 963, col: 5, offset: 27096},
+							pos:   position{line: 963, col: 5, offset: 27106},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 963, col: 7, offset: 27098},
+								pos:  position{line: 963, col: 7, offset: 27108},
 								name: "IP4Net",
 							},
 						},
@@ -7760,28 +7782,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 967, col: 1, offset: 27202},
+			pos:  position{line: 967, col: 1, offset: 27212},
 			expr: &choiceExpr{
-				pos: position{line: 968, col: 5, offset: 27221},
+				pos: position{line: 968, col: 5, offset: 27231},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 968, col: 5, offset: 27221},
+						pos: position{line: 968, col: 5, offset: 27231},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 968, col: 5, offset: 27221},
+							pos: position{line: 968, col: 5, offset: 27231},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 968, col: 5, offset: 27221},
+									pos:   position{line: 968, col: 5, offset: 27231},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 968, col: 7, offset: 27223},
+										pos:  position{line: 968, col: 7, offset: 27233},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 968, col: 11, offset: 27227},
+									pos: position{line: 968, col: 11, offset: 27237},
 									expr: &ruleRefExpr{
-										pos:  position{line: 968, col: 12, offset: 27228},
+										pos:  position{line: 968, col: 12, offset: 27238},
 										name: "IdentifierRest",
 									},
 								},
@@ -7789,13 +7811,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 971, col: 5, offset: 27342},
+						pos: position{line: 971, col: 5, offset: 27352},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 971, col: 5, offset: 27342},
+							pos:   position{line: 971, col: 5, offset: 27352},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 971, col: 7, offset: 27344},
+								pos:  position{line: 971, col: 7, offset: 27354},
 								name: "IP",
 							},
 						},
@@ -7805,15 +7827,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 975, col: 1, offset: 27443},
+			pos:  position{line: 975, col: 1, offset: 27453},
 			expr: &actionExpr{
-				pos: position{line: 976, col: 5, offset: 27460},
+				pos: position{line: 976, col: 5, offset: 27470},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 976, col: 5, offset: 27460},
+					pos:   position{line: 976, col: 5, offset: 27470},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 976, col: 7, offset: 27462},
+						pos:  position{line: 976, col: 7, offset: 27472},
 						name: "FloatString",
 					},
 				},
@@ -7821,15 +7843,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 980, col: 1, offset: 27575},
+			pos:  position{line: 980, col: 1, offset: 27585},
 			expr: &actionExpr{
-				pos: position{line: 981, col: 5, offset: 27594},
+				pos: position{line: 981, col: 5, offset: 27604},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 981, col: 5, offset: 27594},
+					pos:   position{line: 981, col: 5, offset: 27604},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 981, col: 7, offset: 27596},
+						pos:  position{line: 981, col: 7, offset: 27606},
 						name: "IntString",
 					},
 				},
@@ -7837,24 +7859,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 985, col: 1, offset: 27705},
+			pos:  position{line: 985, col: 1, offset: 27715},
 			expr: &choiceExpr{
-				pos: position{line: 986, col: 5, offset: 27724},
+				pos: position{line: 986, col: 5, offset: 27734},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 986, col: 5, offset: 27724},
+						pos: position{line: 986, col: 5, offset: 27734},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 986, col: 5, offset: 27724},
+							pos:        position{line: 986, col: 5, offset: 27734},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 987, col: 5, offset: 27837},
+						pos: position{line: 987, col: 5, offset: 27847},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 987, col: 5, offset: 27837},
+							pos:        position{line: 987, col: 5, offset: 27847},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7864,12 +7886,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 989, col: 1, offset: 27948},
+			pos:  position{line: 989, col: 1, offset: 27958},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 5, offset: 27964},
+				pos: position{line: 990, col: 5, offset: 27974},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 990, col: 5, offset: 27964},
+					pos:        position{line: 990, col: 5, offset: 27974},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7877,22 +7899,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 992, col: 1, offset: 28070},
+			pos:  position{line: 992, col: 1, offset: 28080},
 			expr: &actionExpr{
-				pos: position{line: 993, col: 5, offset: 28087},
+				pos: position{line: 993, col: 5, offset: 28097},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 993, col: 5, offset: 28087},
+					pos: position{line: 993, col: 5, offset: 28097},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 993, col: 5, offset: 28087},
+							pos:        position{line: 993, col: 5, offset: 28097},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 993, col: 10, offset: 28092},
+							pos: position{line: 993, col: 10, offset: 28102},
 							expr: &ruleRefExpr{
-								pos:  position{line: 993, col: 10, offset: 28092},
+								pos:  position{line: 993, col: 10, offset: 28102},
 								name: "HexDigit",
 							},
 						},
@@ -7902,28 +7924,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 997, col: 1, offset: 28207},
+			pos:  position{line: 997, col: 1, offset: 28217},
 			expr: &actionExpr{
-				pos: position{line: 998, col: 5, offset: 28223},
+				pos: position{line: 998, col: 5, offset: 28233},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 998, col: 5, offset: 28223},
+					pos: position{line: 998, col: 5, offset: 28233},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 998, col: 5, offset: 28223},
+							pos:        position{line: 998, col: 5, offset: 28233},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 998, col: 9, offset: 28227},
+							pos:   position{line: 998, col: 9, offset: 28237},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 998, col: 13, offset: 28231},
+								pos:  position{line: 998, col: 13, offset: 28241},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 998, col: 18, offset: 28236},
+							pos:        position{line: 998, col: 18, offset: 28246},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -7933,31 +7955,31 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1002, col: 1, offset: 28325},
+			pos:  position{line: 1002, col: 1, offset: 28335},
 			expr: &choiceExpr{
-				pos: position{line: 1003, col: 5, offset: 28338},
+				pos: position{line: 1003, col: 5, offset: 28348},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1003, col: 5, offset: 28338},
+						pos: position{line: 1003, col: 5, offset: 28348},
 						run: (*parser).callonCastType2,
 						expr: &seqExpr{
-							pos: position{line: 1003, col: 5, offset: 28338},
+							pos: position{line: 1003, col: 5, offset: 28348},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1003, col: 5, offset: 28338},
+									pos:        position{line: 1003, col: 5, offset: 28348},
 									val:        "<",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1003, col: 9, offset: 28342},
+									pos:   position{line: 1003, col: 9, offset: 28352},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1003, col: 13, offset: 28346},
+										pos:  position{line: 1003, col: 13, offset: 28356},
 										name: "Type",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1003, col: 18, offset: 28351},
+									pos:        position{line: 1003, col: 18, offset: 28361},
 									val:        ">",
 									ignoreCase: false,
 								},
@@ -7965,10 +7987,10 @@ var g = &grammar{
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 1004, col: 5, offset: 28380},
+						pos:   position{line: 1004, col: 5, offset: 28389},
 						label: "typ",
 						expr: &ruleRefExpr{
-							pos:  position{line: 1004, col: 9, offset: 28384},
+							pos:  position{line: 1004, col: 9, offset: 28393},
 							name: "PrimitiveType",
 						},
 					},
@@ -7977,20 +7999,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1006, col: 1, offset: 28399},
+			pos:  position{line: 1006, col: 1, offset: 28408},
 			expr: &choiceExpr{
-				pos: position{line: 1007, col: 5, offset: 28408},
+				pos: position{line: 1007, col: 5, offset: 28417},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 28408},
+						pos:  position{line: 1007, col: 5, offset: 28417},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 28424},
+						pos:  position{line: 1008, col: 5, offset: 28433},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 28442},
+						pos:  position{line: 1009, col: 5, offset: 28451},
 						name: "ComplexType",
 					},
 				},
@@ -7998,28 +8020,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1011, col: 1, offset: 28455},
+			pos:  position{line: 1011, col: 1, offset: 28464},
 			expr: &choiceExpr{
-				pos: position{line: 1012, col: 5, offset: 28473},
+				pos: position{line: 1012, col: 5, offset: 28482},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 28473},
+						pos: position{line: 1012, col: 5, offset: 28482},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1012, col: 5, offset: 28473},
+							pos: position{line: 1012, col: 5, offset: 28482},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1012, col: 5, offset: 28473},
+									pos:   position{line: 1012, col: 5, offset: 28482},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1012, col: 10, offset: 28478},
+										pos:  position{line: 1012, col: 10, offset: 28487},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1012, col: 24, offset: 28492},
+									pos: position{line: 1012, col: 24, offset: 28501},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1012, col: 25, offset: 28493},
+										pos:  position{line: 1012, col: 25, offset: 28502},
 										name: "IdentifierRest",
 									},
 								},
@@ -8027,37 +8049,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1013, col: 5, offset: 28533},
+						pos: position{line: 1013, col: 5, offset: 28542},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1013, col: 5, offset: 28533},
+							pos: position{line: 1013, col: 5, offset: 28542},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1013, col: 5, offset: 28533},
+									pos:   position{line: 1013, col: 5, offset: 28542},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 10, offset: 28538},
+										pos:  position{line: 1013, col: 10, offset: 28547},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 25, offset: 28553},
+									pos:  position{line: 1013, col: 25, offset: 28562},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1013, col: 28, offset: 28556},
+									pos:        position{line: 1013, col: 28, offset: 28565},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 32, offset: 28560},
+									pos:  position{line: 1013, col: 32, offset: 28569},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 35, offset: 28563},
+									pos:   position{line: 1013, col: 35, offset: 28572},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 39, offset: 28567},
+										pos:  position{line: 1013, col: 39, offset: 28576},
 										name: "Type",
 									},
 								},
@@ -8065,42 +8087,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1016, col: 5, offset: 28669},
+						pos: position{line: 1016, col: 5, offset: 28678},
 						run: (*parser).callonAmbiguousType17,
 						expr: &labeledExpr{
-							pos:   position{line: 1016, col: 5, offset: 28669},
+							pos:   position{line: 1016, col: 5, offset: 28678},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1016, col: 10, offset: 28674},
+								pos:  position{line: 1016, col: 10, offset: 28683},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 28776},
+						pos: position{line: 1019, col: 5, offset: 28785},
 						run: (*parser).callonAmbiguousType20,
 						expr: &seqExpr{
-							pos: position{line: 1019, col: 5, offset: 28776},
+							pos: position{line: 1019, col: 5, offset: 28785},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1019, col: 5, offset: 28776},
+									pos:        position{line: 1019, col: 5, offset: 28785},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 9, offset: 28780},
+									pos:  position{line: 1019, col: 9, offset: 28789},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1019, col: 12, offset: 28783},
+									pos:   position{line: 1019, col: 12, offset: 28792},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 14, offset: 28785},
+										pos:  position{line: 1019, col: 14, offset: 28794},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 25, offset: 28796},
+									pos:        position{line: 1019, col: 25, offset: 28805},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8112,15 +8134,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1021, col: 1, offset: 28819},
+			pos:  position{line: 1021, col: 1, offset: 28828},
 			expr: &actionExpr{
-				pos: position{line: 1022, col: 5, offset: 28833},
+				pos: position{line: 1022, col: 5, offset: 28842},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1022, col: 5, offset: 28833},
+					pos:   position{line: 1022, col: 5, offset: 28842},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1022, col: 11, offset: 28839},
+						pos:  position{line: 1022, col: 11, offset: 28848},
 						name: "TypeList",
 					},
 				},
@@ -8128,28 +8150,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1026, col: 1, offset: 28935},
+			pos:  position{line: 1026, col: 1, offset: 28944},
 			expr: &actionExpr{
-				pos: position{line: 1027, col: 5, offset: 28948},
+				pos: position{line: 1027, col: 5, offset: 28957},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1027, col: 5, offset: 28948},
+					pos: position{line: 1027, col: 5, offset: 28957},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1027, col: 5, offset: 28948},
+							pos:   position{line: 1027, col: 5, offset: 28957},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1027, col: 11, offset: 28954},
+								pos:  position{line: 1027, col: 11, offset: 28963},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1027, col: 16, offset: 28959},
+							pos:   position{line: 1027, col: 16, offset: 28968},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1027, col: 21, offset: 28964},
+								pos: position{line: 1027, col: 21, offset: 28973},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1027, col: 21, offset: 28964},
+									pos:  position{line: 1027, col: 21, offset: 28973},
 									name: "TypeListTail",
 								},
 							},
@@ -8160,31 +8182,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1031, col: 1, offset: 29058},
+			pos:  position{line: 1031, col: 1, offset: 29067},
 			expr: &actionExpr{
-				pos: position{line: 1031, col: 16, offset: 29073},
+				pos: position{line: 1031, col: 16, offset: 29082},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1031, col: 16, offset: 29073},
+					pos: position{line: 1031, col: 16, offset: 29082},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1031, col: 16, offset: 29073},
+							pos:  position{line: 1031, col: 16, offset: 29082},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1031, col: 19, offset: 29076},
+							pos:        position{line: 1031, col: 19, offset: 29085},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1031, col: 23, offset: 29080},
+							pos:  position{line: 1031, col: 23, offset: 29089},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1031, col: 26, offset: 29083},
+							pos:   position{line: 1031, col: 26, offset: 29092},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1031, col: 30, offset: 29087},
+								pos:  position{line: 1031, col: 30, offset: 29096},
 								name: "Type",
 							},
 						},
@@ -8194,39 +8216,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1033, col: 1, offset: 29113},
+			pos:  position{line: 1033, col: 1, offset: 29122},
 			expr: &choiceExpr{
-				pos: position{line: 1034, col: 5, offset: 29129},
+				pos: position{line: 1034, col: 5, offset: 29138},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1034, col: 5, offset: 29129},
+						pos: position{line: 1034, col: 5, offset: 29138},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1034, col: 5, offset: 29129},
+							pos: position{line: 1034, col: 5, offset: 29138},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1034, col: 5, offset: 29129},
+									pos:        position{line: 1034, col: 5, offset: 29138},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1034, col: 9, offset: 29133},
+									pos:  position{line: 1034, col: 9, offset: 29142},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1034, col: 12, offset: 29136},
+									pos:   position{line: 1034, col: 12, offset: 29145},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1034, col: 19, offset: 29143},
+										pos:  position{line: 1034, col: 19, offset: 29152},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1034, col: 33, offset: 29157},
+									pos:  position{line: 1034, col: 33, offset: 29166},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1034, col: 36, offset: 29160},
+									pos:        position{line: 1034, col: 36, offset: 29169},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8234,34 +8256,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1037, col: 5, offset: 29255},
+						pos: position{line: 1037, col: 5, offset: 29264},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1037, col: 5, offset: 29255},
+							pos: position{line: 1037, col: 5, offset: 29264},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1037, col: 5, offset: 29255},
+									pos:        position{line: 1037, col: 5, offset: 29264},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 9, offset: 29259},
+									pos:  position{line: 1037, col: 9, offset: 29268},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1037, col: 12, offset: 29262},
+									pos:   position{line: 1037, col: 12, offset: 29271},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1037, col: 16, offset: 29266},
+										pos:  position{line: 1037, col: 16, offset: 29275},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 21, offset: 29271},
+									pos:  position{line: 1037, col: 21, offset: 29280},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1037, col: 24, offset: 29274},
+									pos:        position{line: 1037, col: 24, offset: 29283},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8269,34 +8291,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1040, col: 5, offset: 29363},
+						pos: position{line: 1040, col: 5, offset: 29372},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1040, col: 5, offset: 29363},
+							pos: position{line: 1040, col: 5, offset: 29372},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1040, col: 5, offset: 29363},
+									pos:        position{line: 1040, col: 5, offset: 29372},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1040, col: 10, offset: 29368},
+									pos:  position{line: 1040, col: 10, offset: 29377},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1040, col: 14, offset: 29372},
+									pos:   position{line: 1040, col: 14, offset: 29381},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1040, col: 18, offset: 29376},
+										pos:  position{line: 1040, col: 18, offset: 29385},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1040, col: 23, offset: 29381},
+									pos:  position{line: 1040, col: 23, offset: 29390},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1040, col: 26, offset: 29384},
+									pos:        position{line: 1040, col: 26, offset: 29393},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8304,55 +8326,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 29472},
+						pos: position{line: 1043, col: 5, offset: 29481},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1043, col: 5, offset: 29472},
+							pos: position{line: 1043, col: 5, offset: 29481},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1043, col: 5, offset: 29472},
+									pos:        position{line: 1043, col: 5, offset: 29481},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 10, offset: 29477},
+									pos:  position{line: 1043, col: 10, offset: 29486},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 13, offset: 29480},
+									pos:   position{line: 1043, col: 13, offset: 29489},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 21, offset: 29488},
+										pos:  position{line: 1043, col: 21, offset: 29497},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 26, offset: 29493},
+									pos:  position{line: 1043, col: 26, offset: 29502},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 29, offset: 29496},
+									pos:        position{line: 1043, col: 29, offset: 29505},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 33, offset: 29500},
+									pos:  position{line: 1043, col: 33, offset: 29509},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 36, offset: 29503},
+									pos:   position{line: 1043, col: 36, offset: 29512},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 44, offset: 29511},
+										pos:  position{line: 1043, col: 44, offset: 29520},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 49, offset: 29516},
+									pos:  position{line: 1043, col: 49, offset: 29525},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 52, offset: 29519},
+									pos:        position{line: 1043, col: 52, offset: 29528},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8364,15 +8386,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1047, col: 1, offset: 29633},
+			pos:  position{line: 1047, col: 1, offset: 29642},
 			expr: &actionExpr{
-				pos: position{line: 1048, col: 5, offset: 29653},
+				pos: position{line: 1048, col: 5, offset: 29662},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1048, col: 5, offset: 29653},
+					pos:   position{line: 1048, col: 5, offset: 29662},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1048, col: 7, offset: 29655},
+						pos:  position{line: 1048, col: 7, offset: 29664},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8380,34 +8402,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1055, col: 1, offset: 29871},
+			pos:  position{line: 1055, col: 1, offset: 29880},
 			expr: &choiceExpr{
-				pos: position{line: 1056, col: 5, offset: 29896},
+				pos: position{line: 1056, col: 5, offset: 29905},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1056, col: 5, offset: 29896},
+						pos: position{line: 1056, col: 5, offset: 29905},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1056, col: 5, offset: 29896},
+							pos: position{line: 1056, col: 5, offset: 29905},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1056, col: 5, offset: 29896},
+									pos:        position{line: 1056, col: 5, offset: 29905},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1056, col: 9, offset: 29900},
+									pos:   position{line: 1056, col: 9, offset: 29909},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1056, col: 11, offset: 29902},
+										pos: position{line: 1056, col: 11, offset: 29911},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1056, col: 11, offset: 29902},
+											pos:  position{line: 1056, col: 11, offset: 29911},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1056, col: 37, offset: 29928},
+									pos:        position{line: 1056, col: 37, offset: 29937},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8415,29 +8437,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 29954},
+						pos: position{line: 1057, col: 5, offset: 29963},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 29954},
+							pos: position{line: 1057, col: 5, offset: 29963},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1057, col: 5, offset: 29954},
+									pos:        position{line: 1057, col: 5, offset: 29963},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 9, offset: 29958},
+									pos:   position{line: 1057, col: 9, offset: 29967},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1057, col: 11, offset: 29960},
+										pos: position{line: 1057, col: 11, offset: 29969},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1057, col: 11, offset: 29960},
+											pos:  position{line: 1057, col: 11, offset: 29969},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 37, offset: 29986},
+									pos:        position{line: 1057, col: 37, offset: 29995},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8449,24 +8471,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1059, col: 1, offset: 30009},
+			pos:  position{line: 1059, col: 1, offset: 30018},
 			expr: &choiceExpr{
-				pos: position{line: 1060, col: 5, offset: 30038},
+				pos: position{line: 1060, col: 5, offset: 30047},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1060, col: 5, offset: 30038},
+						pos:  position{line: 1060, col: 5, offset: 30047},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1061, col: 5, offset: 30055},
+						pos: position{line: 1061, col: 5, offset: 30064},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1061, col: 5, offset: 30055},
+							pos:   position{line: 1061, col: 5, offset: 30064},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1061, col: 7, offset: 30057},
+								pos: position{line: 1061, col: 7, offset: 30066},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1061, col: 7, offset: 30057},
+									pos:  position{line: 1061, col: 7, offset: 30066},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8477,26 +8499,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1065, col: 1, offset: 30194},
+			pos:  position{line: 1065, col: 1, offset: 30203},
 			expr: &choiceExpr{
-				pos: position{line: 1066, col: 5, offset: 30223},
+				pos: position{line: 1066, col: 5, offset: 30232},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 30223},
+						pos: position{line: 1066, col: 5, offset: 30232},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1066, col: 5, offset: 30223},
+							pos: position{line: 1066, col: 5, offset: 30232},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1066, col: 5, offset: 30223},
+									pos:        position{line: 1066, col: 5, offset: 30232},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 10, offset: 30228},
+									pos:   position{line: 1066, col: 10, offset: 30237},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1066, col: 12, offset: 30230},
+										pos:        position{line: 1066, col: 12, offset: 30239},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8505,24 +8527,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 30257},
+						pos: position{line: 1067, col: 5, offset: 30266},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1067, col: 5, offset: 30257},
+							pos: position{line: 1067, col: 5, offset: 30266},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1067, col: 5, offset: 30257},
+									pos: position{line: 1067, col: 5, offset: 30266},
 									expr: &litMatcher{
-										pos:        position{line: 1067, col: 8, offset: 30260},
+										pos:        position{line: 1067, col: 8, offset: 30269},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1067, col: 15, offset: 30267},
+									pos:   position{line: 1067, col: 15, offset: 30276},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1067, col: 17, offset: 30269},
+										pos:  position{line: 1067, col: 17, offset: 30278},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8534,24 +8556,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1069, col: 1, offset: 30305},
+			pos:  position{line: 1069, col: 1, offset: 30314},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 5, offset: 30334},
+				pos: position{line: 1070, col: 5, offset: 30343},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1070, col: 5, offset: 30334},
+						pos:  position{line: 1070, col: 5, offset: 30343},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 30351},
+						pos: position{line: 1071, col: 5, offset: 30360},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1071, col: 5, offset: 30351},
+							pos:   position{line: 1071, col: 5, offset: 30360},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1071, col: 7, offset: 30353},
+								pos: position{line: 1071, col: 7, offset: 30362},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1071, col: 7, offset: 30353},
+									pos:  position{line: 1071, col: 7, offset: 30362},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8562,26 +8584,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1075, col: 1, offset: 30490},
+			pos:  position{line: 1075, col: 1, offset: 30499},
 			expr: &choiceExpr{
-				pos: position{line: 1076, col: 5, offset: 30519},
+				pos: position{line: 1076, col: 5, offset: 30528},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1076, col: 5, offset: 30519},
+						pos: position{line: 1076, col: 5, offset: 30528},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1076, col: 5, offset: 30519},
+							pos: position{line: 1076, col: 5, offset: 30528},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1076, col: 5, offset: 30519},
+									pos:        position{line: 1076, col: 5, offset: 30528},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1076, col: 10, offset: 30524},
+									pos:   position{line: 1076, col: 10, offset: 30533},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1076, col: 12, offset: 30526},
+										pos:        position{line: 1076, col: 12, offset: 30535},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8590,24 +8612,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 30553},
+						pos: position{line: 1077, col: 5, offset: 30562},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 30553},
+							pos: position{line: 1077, col: 5, offset: 30562},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1077, col: 5, offset: 30553},
+									pos: position{line: 1077, col: 5, offset: 30562},
 									expr: &litMatcher{
-										pos:        position{line: 1077, col: 8, offset: 30556},
+										pos:        position{line: 1077, col: 8, offset: 30565},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 15, offset: 30563},
+									pos:   position{line: 1077, col: 15, offset: 30572},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 17, offset: 30565},
+										pos:  position{line: 1077, col: 17, offset: 30574},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8619,36 +8641,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1079, col: 1, offset: 30601},
+			pos:  position{line: 1079, col: 1, offset: 30610},
 			expr: &actionExpr{
-				pos: position{line: 1080, col: 5, offset: 30618},
+				pos: position{line: 1080, col: 5, offset: 30627},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1080, col: 5, offset: 30618},
+					pos: position{line: 1080, col: 5, offset: 30627},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1080, col: 5, offset: 30618},
+							pos:        position{line: 1080, col: 5, offset: 30627},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1080, col: 10, offset: 30623},
+							pos:  position{line: 1080, col: 10, offset: 30632},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1080, col: 13, offset: 30626},
+							pos:   position{line: 1080, col: 13, offset: 30635},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1080, col: 15, offset: 30628},
+								pos:  position{line: 1080, col: 15, offset: 30637},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1080, col: 20, offset: 30633},
+							pos:  position{line: 1080, col: 20, offset: 30642},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1080, col: 23, offset: 30636},
+							pos:        position{line: 1080, col: 23, offset: 30645},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8658,105 +8680,105 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1082, col: 1, offset: 30659},
+			pos:  position{line: 1082, col: 1, offset: 30668},
 			expr: &actionExpr{
-				pos: position{line: 1083, col: 5, offset: 30677},
+				pos: position{line: 1083, col: 5, offset: 30686},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1083, col: 9, offset: 30681},
+					pos: position{line: 1083, col: 9, offset: 30690},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1083, col: 9, offset: 30681},
+							pos:        position{line: 1083, col: 9, offset: 30690},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 19, offset: 30691},
+							pos:        position{line: 1083, col: 19, offset: 30700},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 30, offset: 30702},
+							pos:        position{line: 1083, col: 30, offset: 30711},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 41, offset: 30713},
+							pos:        position{line: 1083, col: 41, offset: 30722},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 9, offset: 30730},
+							pos:        position{line: 1084, col: 9, offset: 30739},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 18, offset: 30739},
+							pos:        position{line: 1084, col: 18, offset: 30748},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 28, offset: 30749},
+							pos:        position{line: 1084, col: 28, offset: 30758},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 38, offset: 30759},
+							pos:        position{line: 1084, col: 38, offset: 30768},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1085, col: 9, offset: 30775},
+							pos:        position{line: 1085, col: 9, offset: 30784},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1085, col: 21, offset: 30787},
+							pos:        position{line: 1085, col: 21, offset: 30796},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 9, offset: 30805},
+							pos:        position{line: 1086, col: 9, offset: 30814},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 18, offset: 30814},
+							pos:        position{line: 1086, col: 18, offset: 30823},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1087, col: 9, offset: 30831},
+							pos:        position{line: 1087, col: 9, offset: 30840},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1087, col: 22, offset: 30844},
+							pos:        position{line: 1087, col: 22, offset: 30853},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1088, col: 9, offset: 30859},
+							pos:        position{line: 1088, col: 9, offset: 30868},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1089, col: 9, offset: 30875},
+							pos:        position{line: 1089, col: 9, offset: 30884},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1089, col: 16, offset: 30882},
+							pos:        position{line: 1089, col: 16, offset: 30891},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1090, col: 9, offset: 30896},
+							pos:        position{line: 1090, col: 9, offset: 30905},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1090, col: 18, offset: 30905},
+							pos:        position{line: 1090, col: 18, offset: 30914},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8766,28 +8788,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1094, col: 1, offset: 31021},
+			pos:  position{line: 1094, col: 1, offset: 31030},
 			expr: &actionExpr{
-				pos: position{line: 1095, col: 5, offset: 31039},
+				pos: position{line: 1095, col: 5, offset: 31048},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1095, col: 5, offset: 31039},
+					pos: position{line: 1095, col: 5, offset: 31048},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1095, col: 5, offset: 31039},
+							pos:   position{line: 1095, col: 5, offset: 31048},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1095, col: 11, offset: 31045},
+								pos:  position{line: 1095, col: 11, offset: 31054},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1095, col: 21, offset: 31055},
+							pos:   position{line: 1095, col: 21, offset: 31064},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1095, col: 26, offset: 31060},
+								pos: position{line: 1095, col: 26, offset: 31069},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1095, col: 26, offset: 31060},
+									pos:  position{line: 1095, col: 26, offset: 31069},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -8798,31 +8820,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1099, col: 1, offset: 31159},
+			pos:  position{line: 1099, col: 1, offset: 31168},
 			expr: &actionExpr{
-				pos: position{line: 1099, col: 21, offset: 31179},
+				pos: position{line: 1099, col: 21, offset: 31188},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1099, col: 21, offset: 31179},
+					pos: position{line: 1099, col: 21, offset: 31188},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1099, col: 21, offset: 31179},
+							pos:  position{line: 1099, col: 21, offset: 31188},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1099, col: 24, offset: 31182},
+							pos:        position{line: 1099, col: 24, offset: 31191},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1099, col: 28, offset: 31186},
+							pos:  position{line: 1099, col: 28, offset: 31195},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1099, col: 31, offset: 31189},
+							pos:   position{line: 1099, col: 31, offset: 31198},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1099, col: 35, offset: 31193},
+								pos:  position{line: 1099, col: 35, offset: 31202},
 								name: "TypeField",
 							},
 						},
@@ -8832,39 +8854,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1101, col: 1, offset: 31224},
+			pos:  position{line: 1101, col: 1, offset: 31233},
 			expr: &actionExpr{
-				pos: position{line: 1102, col: 5, offset: 31238},
+				pos: position{line: 1102, col: 5, offset: 31247},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1102, col: 5, offset: 31238},
+					pos: position{line: 1102, col: 5, offset: 31247},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1102, col: 5, offset: 31238},
+							pos:   position{line: 1102, col: 5, offset: 31247},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1102, col: 10, offset: 31243},
+								pos:  position{line: 1102, col: 10, offset: 31252},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1102, col: 20, offset: 31253},
+							pos:  position{line: 1102, col: 20, offset: 31262},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1102, col: 23, offset: 31256},
+							pos:        position{line: 1102, col: 23, offset: 31265},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1102, col: 27, offset: 31260},
+							pos:  position{line: 1102, col: 27, offset: 31269},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1102, col: 30, offset: 31263},
+							pos:   position{line: 1102, col: 30, offset: 31272},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1102, col: 34, offset: 31267},
+								pos:  position{line: 1102, col: 34, offset: 31276},
 								name: "Type",
 							},
 						},
@@ -8874,16 +8896,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1106, col: 1, offset: 31349},
+			pos:  position{line: 1106, col: 1, offset: 31358},
 			expr: &choiceExpr{
-				pos: position{line: 1107, col: 5, offset: 31363},
+				pos: position{line: 1107, col: 5, offset: 31372},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1107, col: 5, offset: 31363},
+						pos:  position{line: 1107, col: 5, offset: 31372},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1108, col: 5, offset: 31382},
+						pos:  position{line: 1108, col: 5, offset: 31391},
 						name: "QuotedString",
 					},
 				},
@@ -8891,32 +8913,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1110, col: 1, offset: 31396},
+			pos:  position{line: 1110, col: 1, offset: 31405},
 			expr: &actionExpr{
-				pos: position{line: 1110, col: 12, offset: 31407},
+				pos: position{line: 1110, col: 12, offset: 31416},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1110, col: 12, offset: 31407},
+					pos: position{line: 1110, col: 12, offset: 31416},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1110, col: 13, offset: 31408},
+							pos: position{line: 1110, col: 13, offset: 31417},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1110, col: 13, offset: 31408},
+									pos:        position{line: 1110, col: 13, offset: 31417},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 21, offset: 31416},
+									pos:        position{line: 1110, col: 21, offset: 31425},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1110, col: 28, offset: 31423},
+							pos: position{line: 1110, col: 28, offset: 31432},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1110, col: 29, offset: 31424},
+								pos:  position{line: 1110, col: 29, offset: 31433},
 								name: "IdentifierRest",
 							},
 						},
@@ -8926,32 +8948,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1111, col: 1, offset: 31461},
+			pos:  position{line: 1111, col: 1, offset: 31470},
 			expr: &actionExpr{
-				pos: position{line: 1111, col: 11, offset: 31471},
+				pos: position{line: 1111, col: 11, offset: 31480},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1111, col: 11, offset: 31471},
+					pos: position{line: 1111, col: 11, offset: 31480},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1111, col: 12, offset: 31472},
+							pos: position{line: 1111, col: 12, offset: 31481},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1111, col: 12, offset: 31472},
+									pos:        position{line: 1111, col: 12, offset: 31481},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 19, offset: 31479},
+									pos:        position{line: 1111, col: 19, offset: 31488},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1111, col: 25, offset: 31485},
+							pos: position{line: 1111, col: 25, offset: 31494},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1111, col: 26, offset: 31486},
+								pos:  position{line: 1111, col: 26, offset: 31495},
 								name: "IdentifierRest",
 							},
 						},
@@ -8961,22 +8983,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1112, col: 1, offset: 31522},
+			pos:  position{line: 1112, col: 1, offset: 31531},
 			expr: &actionExpr{
-				pos: position{line: 1112, col: 11, offset: 31532},
+				pos: position{line: 1112, col: 11, offset: 31541},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1112, col: 11, offset: 31532},
+					pos: position{line: 1112, col: 11, offset: 31541},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1112, col: 11, offset: 31532},
+							pos:        position{line: 1112, col: 11, offset: 31541},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1112, col: 16, offset: 31537},
+							pos: position{line: 1112, col: 16, offset: 31546},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1112, col: 17, offset: 31538},
+								pos:  position{line: 1112, col: 17, offset: 31547},
 								name: "IdentifierRest",
 							},
 						},
@@ -8986,32 +9008,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1113, col: 1, offset: 31574},
+			pos:  position{line: 1113, col: 1, offset: 31583},
 			expr: &actionExpr{
-				pos: position{line: 1113, col: 12, offset: 31585},
+				pos: position{line: 1113, col: 12, offset: 31594},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1113, col: 12, offset: 31585},
+					pos: position{line: 1113, col: 12, offset: 31594},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1113, col: 13, offset: 31586},
+							pos: position{line: 1113, col: 13, offset: 31595},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1113, col: 13, offset: 31586},
+									pos:        position{line: 1113, col: 13, offset: 31595},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1113, col: 21, offset: 31594},
+									pos:        position{line: 1113, col: 21, offset: 31603},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1113, col: 28, offset: 31601},
+							pos: position{line: 1113, col: 28, offset: 31610},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1113, col: 29, offset: 31602},
+								pos:  position{line: 1113, col: 29, offset: 31611},
 								name: "IdentifierRest",
 							},
 						},
@@ -9021,22 +9043,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1114, col: 1, offset: 31639},
+			pos:  position{line: 1114, col: 1, offset: 31648},
 			expr: &actionExpr{
-				pos: position{line: 1114, col: 11, offset: 31649},
+				pos: position{line: 1114, col: 11, offset: 31658},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1114, col: 11, offset: 31649},
+					pos: position{line: 1114, col: 11, offset: 31658},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1114, col: 11, offset: 31649},
+							pos:        position{line: 1114, col: 11, offset: 31658},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1114, col: 16, offset: 31654},
+							pos: position{line: 1114, col: 16, offset: 31663},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1114, col: 17, offset: 31655},
+								pos:  position{line: 1114, col: 17, offset: 31664},
 								name: "IdentifierRest",
 							},
 						},
@@ -9046,9 +9068,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1116, col: 1, offset: 31692},
+			pos:  position{line: 1116, col: 1, offset: 31701},
 			expr: &charClassMatcher{
-				pos:        position{line: 1116, col: 19, offset: 31710},
+				pos:        position{line: 1116, col: 19, offset: 31719},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9058,16 +9080,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1118, col: 1, offset: 31722},
+			pos:  position{line: 1118, col: 1, offset: 31731},
 			expr: &choiceExpr{
-				pos: position{line: 1118, col: 18, offset: 31739},
+				pos: position{line: 1118, col: 18, offset: 31748},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1118, col: 18, offset: 31739},
+						pos:  position{line: 1118, col: 18, offset: 31748},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1118, col: 36, offset: 31757},
+						pos:        position{line: 1118, col: 36, offset: 31766},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9078,15 +9100,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1120, col: 1, offset: 31764},
+			pos:  position{line: 1120, col: 1, offset: 31773},
 			expr: &actionExpr{
-				pos: position{line: 1121, col: 5, offset: 31779},
+				pos: position{line: 1121, col: 5, offset: 31788},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1121, col: 5, offset: 31779},
+					pos:   position{line: 1121, col: 5, offset: 31788},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1121, col: 8, offset: 31782},
+						pos:  position{line: 1121, col: 8, offset: 31791},
 						name: "IdentifierName",
 					},
 				},
@@ -9094,29 +9116,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1123, col: 1, offset: 31863},
+			pos:  position{line: 1123, col: 1, offset: 31872},
 			expr: &choiceExpr{
-				pos: position{line: 1124, col: 5, offset: 31882},
+				pos: position{line: 1124, col: 5, offset: 31891},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1124, col: 5, offset: 31882},
+						pos: position{line: 1124, col: 5, offset: 31891},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1124, col: 5, offset: 31882},
+							pos: position{line: 1124, col: 5, offset: 31891},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1124, col: 5, offset: 31882},
+									pos: position{line: 1124, col: 5, offset: 31891},
 									expr: &seqExpr{
-										pos: position{line: 1124, col: 7, offset: 31884},
+										pos: position{line: 1124, col: 7, offset: 31893},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1124, col: 7, offset: 31884},
+												pos:  position{line: 1124, col: 7, offset: 31893},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1124, col: 15, offset: 31892},
+												pos: position{line: 1124, col: 15, offset: 31901},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1124, col: 16, offset: 31893},
+													pos:  position{line: 1124, col: 16, offset: 31902},
 													name: "IdentifierRest",
 												},
 											},
@@ -9124,13 +9146,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1124, col: 32, offset: 31909},
+									pos:  position{line: 1124, col: 32, offset: 31918},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1124, col: 48, offset: 31925},
+									pos: position{line: 1124, col: 48, offset: 31934},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1124, col: 48, offset: 31925},
+										pos:  position{line: 1124, col: 48, offset: 31934},
 										name: "IdentifierRest",
 									},
 								},
@@ -9138,30 +9160,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1125, col: 5, offset: 31977},
+						pos: position{line: 1125, col: 5, offset: 31986},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1125, col: 5, offset: 31977},
+							pos:        position{line: 1125, col: 5, offset: 31986},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1126, col: 5, offset: 32016},
+						pos: position{line: 1126, col: 5, offset: 32025},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1126, col: 5, offset: 32016},
+							pos: position{line: 1126, col: 5, offset: 32025},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1126, col: 5, offset: 32016},
+									pos:        position{line: 1126, col: 5, offset: 32025},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 10, offset: 32021},
+									pos:   position{line: 1126, col: 10, offset: 32030},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 13, offset: 32024},
+										pos:  position{line: 1126, col: 13, offset: 32033},
 										name: "IDGuard",
 									},
 								},
@@ -9169,39 +9191,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1128, col: 5, offset: 32115},
+						pos: position{line: 1128, col: 5, offset: 32124},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1128, col: 5, offset: 32115},
+							pos:        position{line: 1128, col: 5, offset: 32124},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1129, col: 5, offset: 32157},
+						pos: position{line: 1129, col: 5, offset: 32166},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1129, col: 5, offset: 32157},
+							pos: position{line: 1129, col: 5, offset: 32166},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1129, col: 5, offset: 32157},
+									pos:   position{line: 1129, col: 5, offset: 32166},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1129, col: 8, offset: 32160},
+										pos:  position{line: 1129, col: 8, offset: 32169},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1129, col: 26, offset: 32178},
+									pos: position{line: 1129, col: 26, offset: 32187},
 									expr: &seqExpr{
-										pos: position{line: 1129, col: 28, offset: 32180},
+										pos: position{line: 1129, col: 28, offset: 32189},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1129, col: 28, offset: 32180},
+												pos:  position{line: 1129, col: 28, offset: 32189},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1129, col: 31, offset: 32183},
+												pos:        position{line: 1129, col: 31, offset: 32192},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9216,16 +9238,16 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1131, col: 1, offset: 32208},
+			pos:  position{line: 1131, col: 1, offset: 32217},
 			expr: &choiceExpr{
-				pos: position{line: 1132, col: 5, offset: 32220},
+				pos: position{line: 1132, col: 5, offset: 32229},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 5, offset: 32220},
+						pos:  position{line: 1132, col: 5, offset: 32229},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 5, offset: 32239},
+						pos:  position{line: 1133, col: 5, offset: 32248},
 						name: "NullLiteral",
 					},
 				},
@@ -9233,24 +9255,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1135, col: 1, offset: 32252},
+			pos:  position{line: 1135, col: 1, offset: 32261},
 			expr: &actionExpr{
-				pos: position{line: 1136, col: 5, offset: 32261},
+				pos: position{line: 1136, col: 5, offset: 32270},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1136, col: 5, offset: 32261},
+					pos: position{line: 1136, col: 5, offset: 32270},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1136, col: 5, offset: 32261},
+							pos:  position{line: 1136, col: 5, offset: 32270},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1136, col: 14, offset: 32270},
+							pos:        position{line: 1136, col: 14, offset: 32279},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1136, col: 18, offset: 32274},
+							pos:  position{line: 1136, col: 18, offset: 32283},
 							name: "FullTime",
 						},
 					},
@@ -9259,30 +9281,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1140, col: 1, offset: 32394},
+			pos:  position{line: 1140, col: 1, offset: 32403},
 			expr: &seqExpr{
-				pos: position{line: 1140, col: 12, offset: 32405},
+				pos: position{line: 1140, col: 12, offset: 32414},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1140, col: 12, offset: 32405},
+						pos:  position{line: 1140, col: 12, offset: 32414},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1140, col: 15, offset: 32408},
+						pos:        position{line: 1140, col: 15, offset: 32417},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1140, col: 19, offset: 32412},
+						pos:  position{line: 1140, col: 19, offset: 32421},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1140, col: 22, offset: 32415},
+						pos:        position{line: 1140, col: 22, offset: 32424},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1140, col: 26, offset: 32419},
+						pos:  position{line: 1140, col: 26, offset: 32428},
 						name: "D2",
 					},
 				},
@@ -9290,33 +9312,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1142, col: 1, offset: 32423},
+			pos:  position{line: 1142, col: 1, offset: 32432},
 			expr: &seqExpr{
-				pos: position{line: 1142, col: 6, offset: 32428},
+				pos: position{line: 1142, col: 6, offset: 32437},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1142, col: 6, offset: 32428},
+						pos:        position{line: 1142, col: 6, offset: 32437},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1142, col: 11, offset: 32433},
+						pos:        position{line: 1142, col: 11, offset: 32442},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1142, col: 16, offset: 32438},
+						pos:        position{line: 1142, col: 16, offset: 32447},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1142, col: 21, offset: 32443},
+						pos:        position{line: 1142, col: 21, offset: 32452},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9327,19 +9349,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1143, col: 1, offset: 32449},
+			pos:  position{line: 1143, col: 1, offset: 32458},
 			expr: &seqExpr{
-				pos: position{line: 1143, col: 6, offset: 32454},
+				pos: position{line: 1143, col: 6, offset: 32463},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1143, col: 6, offset: 32454},
+						pos:        position{line: 1143, col: 6, offset: 32463},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1143, col: 11, offset: 32459},
+						pos:        position{line: 1143, col: 11, offset: 32468},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9350,16 +9372,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1145, col: 1, offset: 32466},
+			pos:  position{line: 1145, col: 1, offset: 32475},
 			expr: &seqExpr{
-				pos: position{line: 1145, col: 12, offset: 32477},
+				pos: position{line: 1145, col: 12, offset: 32486},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1145, col: 12, offset: 32477},
+						pos:  position{line: 1145, col: 12, offset: 32486},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1145, col: 24, offset: 32489},
+						pos:  position{line: 1145, col: 24, offset: 32498},
 						name: "TimeOffset",
 					},
 				},
@@ -9367,46 +9389,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1147, col: 1, offset: 32501},
+			pos:  position{line: 1147, col: 1, offset: 32510},
 			expr: &seqExpr{
-				pos: position{line: 1147, col: 15, offset: 32515},
+				pos: position{line: 1147, col: 15, offset: 32524},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1147, col: 15, offset: 32515},
+						pos:  position{line: 1147, col: 15, offset: 32524},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1147, col: 18, offset: 32518},
+						pos:        position{line: 1147, col: 18, offset: 32527},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1147, col: 22, offset: 32522},
+						pos:  position{line: 1147, col: 22, offset: 32531},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1147, col: 25, offset: 32525},
+						pos:        position{line: 1147, col: 25, offset: 32534},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1147, col: 29, offset: 32529},
+						pos:  position{line: 1147, col: 29, offset: 32538},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1147, col: 32, offset: 32532},
+						pos: position{line: 1147, col: 32, offset: 32541},
 						expr: &seqExpr{
-							pos: position{line: 1147, col: 33, offset: 32533},
+							pos: position{line: 1147, col: 33, offset: 32542},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1147, col: 33, offset: 32533},
+									pos:        position{line: 1147, col: 33, offset: 32542},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1147, col: 37, offset: 32537},
+									pos: position{line: 1147, col: 37, offset: 32546},
 									expr: &charClassMatcher{
-										pos:        position{line: 1147, col: 37, offset: 32537},
+										pos:        position{line: 1147, col: 37, offset: 32546},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9421,60 +9443,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1149, col: 1, offset: 32547},
+			pos:  position{line: 1149, col: 1, offset: 32556},
 			expr: &choiceExpr{
-				pos: position{line: 1150, col: 5, offset: 32562},
+				pos: position{line: 1150, col: 5, offset: 32571},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1150, col: 5, offset: 32562},
+						pos:        position{line: 1150, col: 5, offset: 32571},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1151, col: 5, offset: 32570},
+						pos: position{line: 1151, col: 5, offset: 32579},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1151, col: 6, offset: 32571},
+								pos: position{line: 1151, col: 6, offset: 32580},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1151, col: 6, offset: 32571},
+										pos:        position{line: 1151, col: 6, offset: 32580},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1151, col: 12, offset: 32577},
+										pos:        position{line: 1151, col: 12, offset: 32586},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1151, col: 17, offset: 32582},
+								pos:  position{line: 1151, col: 17, offset: 32591},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1151, col: 20, offset: 32585},
+								pos:        position{line: 1151, col: 20, offset: 32594},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1151, col: 24, offset: 32589},
+								pos:  position{line: 1151, col: 24, offset: 32598},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1151, col: 27, offset: 32592},
+								pos: position{line: 1151, col: 27, offset: 32601},
 								expr: &seqExpr{
-									pos: position{line: 1151, col: 28, offset: 32593},
+									pos: position{line: 1151, col: 28, offset: 32602},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1151, col: 28, offset: 32593},
+											pos:        position{line: 1151, col: 28, offset: 32602},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1151, col: 32, offset: 32597},
+											pos: position{line: 1151, col: 32, offset: 32606},
 											expr: &charClassMatcher{
-												pos:        position{line: 1151, col: 32, offset: 32597},
+												pos:        position{line: 1151, col: 32, offset: 32606},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9491,32 +9513,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1153, col: 1, offset: 32607},
+			pos:  position{line: 1153, col: 1, offset: 32616},
 			expr: &actionExpr{
-				pos: position{line: 1154, col: 5, offset: 32620},
+				pos: position{line: 1154, col: 5, offset: 32629},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1154, col: 5, offset: 32620},
+					pos: position{line: 1154, col: 5, offset: 32629},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1154, col: 5, offset: 32620},
+							pos: position{line: 1154, col: 5, offset: 32629},
 							expr: &litMatcher{
-								pos:        position{line: 1154, col: 5, offset: 32620},
+								pos:        position{line: 1154, col: 5, offset: 32629},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1154, col: 10, offset: 32625},
+							pos: position{line: 1154, col: 10, offset: 32634},
 							expr: &seqExpr{
-								pos: position{line: 1154, col: 11, offset: 32626},
+								pos: position{line: 1154, col: 11, offset: 32635},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1154, col: 11, offset: 32626},
+										pos:  position{line: 1154, col: 11, offset: 32635},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1154, col: 19, offset: 32634},
+										pos:  position{line: 1154, col: 19, offset: 32643},
 										name: "TimeUnit",
 									},
 								},
@@ -9528,26 +9550,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1158, col: 1, offset: 32760},
+			pos:  position{line: 1158, col: 1, offset: 32769},
 			expr: &seqExpr{
-				pos: position{line: 1158, col: 11, offset: 32770},
+				pos: position{line: 1158, col: 11, offset: 32779},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1158, col: 11, offset: 32770},
+						pos:  position{line: 1158, col: 11, offset: 32779},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1158, col: 16, offset: 32775},
+						pos: position{line: 1158, col: 16, offset: 32784},
 						expr: &seqExpr{
-							pos: position{line: 1158, col: 17, offset: 32776},
+							pos: position{line: 1158, col: 17, offset: 32785},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1158, col: 17, offset: 32776},
+									pos:        position{line: 1158, col: 17, offset: 32785},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1158, col: 21, offset: 32780},
+									pos:  position{line: 1158, col: 21, offset: 32789},
 									name: "UInt",
 								},
 							},
@@ -9558,52 +9580,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1160, col: 1, offset: 32788},
+			pos:  position{line: 1160, col: 1, offset: 32797},
 			expr: &choiceExpr{
-				pos: position{line: 1161, col: 5, offset: 32801},
+				pos: position{line: 1161, col: 5, offset: 32810},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1161, col: 5, offset: 32801},
+						pos:        position{line: 1161, col: 5, offset: 32810},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1162, col: 5, offset: 32810},
+						pos:        position{line: 1162, col: 5, offset: 32819},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1163, col: 5, offset: 32819},
+						pos:        position{line: 1163, col: 5, offset: 32828},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1164, col: 5, offset: 32828},
+						pos:        position{line: 1164, col: 5, offset: 32837},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1165, col: 5, offset: 32836},
+						pos:        position{line: 1165, col: 5, offset: 32845},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1166, col: 5, offset: 32844},
+						pos:        position{line: 1166, col: 5, offset: 32853},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1167, col: 5, offset: 32852},
+						pos:        position{line: 1167, col: 5, offset: 32861},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1168, col: 5, offset: 32860},
+						pos:        position{line: 1168, col: 5, offset: 32869},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1169, col: 5, offset: 32868},
+						pos:        position{line: 1169, col: 5, offset: 32877},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9612,42 +9634,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1171, col: 1, offset: 32873},
+			pos:  position{line: 1171, col: 1, offset: 32882},
 			expr: &actionExpr{
-				pos: position{line: 1172, col: 5, offset: 32880},
+				pos: position{line: 1172, col: 5, offset: 32889},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1172, col: 5, offset: 32880},
+					pos: position{line: 1172, col: 5, offset: 32889},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1172, col: 5, offset: 32880},
+							pos:  position{line: 1172, col: 5, offset: 32889},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1172, col: 10, offset: 32885},
+							pos:        position{line: 1172, col: 10, offset: 32894},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1172, col: 14, offset: 32889},
+							pos:  position{line: 1172, col: 14, offset: 32898},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1172, col: 19, offset: 32894},
+							pos:        position{line: 1172, col: 19, offset: 32903},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1172, col: 23, offset: 32898},
+							pos:  position{line: 1172, col: 23, offset: 32907},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1172, col: 28, offset: 32903},
+							pos:        position{line: 1172, col: 28, offset: 32912},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1172, col: 32, offset: 32907},
+							pos:  position{line: 1172, col: 32, offset: 32916},
 							name: "UInt",
 						},
 					},
@@ -9656,42 +9678,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1174, col: 1, offset: 32944},
+			pos:  position{line: 1174, col: 1, offset: 32953},
 			expr: &actionExpr{
-				pos: position{line: 1175, col: 5, offset: 32952},
+				pos: position{line: 1175, col: 5, offset: 32961},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1175, col: 5, offset: 32952},
+					pos: position{line: 1175, col: 5, offset: 32961},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1175, col: 5, offset: 32952},
+							pos: position{line: 1175, col: 5, offset: 32961},
 							expr: &seqExpr{
-								pos: position{line: 1175, col: 8, offset: 32955},
+								pos: position{line: 1175, col: 8, offset: 32964},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1175, col: 8, offset: 32955},
+										pos:  position{line: 1175, col: 8, offset: 32964},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1175, col: 12, offset: 32959},
+										pos:        position{line: 1175, col: 12, offset: 32968},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1175, col: 16, offset: 32963},
+										pos:  position{line: 1175, col: 16, offset: 32972},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1175, col: 20, offset: 32967},
+										pos: position{line: 1175, col: 20, offset: 32976},
 										expr: &choiceExpr{
-											pos: position{line: 1175, col: 22, offset: 32969},
+											pos: position{line: 1175, col: 22, offset: 32978},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1175, col: 22, offset: 32969},
+													pos:  position{line: 1175, col: 22, offset: 32978},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1175, col: 33, offset: 32980},
+													pos:        position{line: 1175, col: 33, offset: 32989},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9702,10 +9724,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1175, col: 39, offset: 32986},
+							pos:   position{line: 1175, col: 39, offset: 32995},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1175, col: 41, offset: 32988},
+								pos:  position{line: 1175, col: 41, offset: 32997},
 								name: "IP6Variations",
 							},
 						},
@@ -9715,32 +9737,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1179, col: 1, offset: 33152},
+			pos:  position{line: 1179, col: 1, offset: 33161},
 			expr: &choiceExpr{
-				pos: position{line: 1180, col: 5, offset: 33170},
+				pos: position{line: 1180, col: 5, offset: 33179},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1180, col: 5, offset: 33170},
+						pos: position{line: 1180, col: 5, offset: 33179},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1180, col: 5, offset: 33170},
+							pos: position{line: 1180, col: 5, offset: 33179},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1180, col: 5, offset: 33170},
+									pos:   position{line: 1180, col: 5, offset: 33179},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1180, col: 7, offset: 33172},
+										pos: position{line: 1180, col: 7, offset: 33181},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1180, col: 7, offset: 33172},
+											pos:  position{line: 1180, col: 7, offset: 33181},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1180, col: 17, offset: 33182},
+									pos:   position{line: 1180, col: 17, offset: 33191},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1180, col: 19, offset: 33184},
+										pos:  position{line: 1180, col: 19, offset: 33193},
 										name: "IP6Tail",
 									},
 								},
@@ -9748,51 +9770,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1183, col: 5, offset: 33248},
+						pos: position{line: 1183, col: 5, offset: 33257},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1183, col: 5, offset: 33248},
+							pos: position{line: 1183, col: 5, offset: 33257},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1183, col: 5, offset: 33248},
+									pos:   position{line: 1183, col: 5, offset: 33257},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1183, col: 7, offset: 33250},
+										pos:  position{line: 1183, col: 7, offset: 33259},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1183, col: 11, offset: 33254},
+									pos:   position{line: 1183, col: 11, offset: 33263},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1183, col: 13, offset: 33256},
+										pos: position{line: 1183, col: 13, offset: 33265},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1183, col: 13, offset: 33256},
+											pos:  position{line: 1183, col: 13, offset: 33265},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1183, col: 23, offset: 33266},
+									pos:        position{line: 1183, col: 23, offset: 33275},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1183, col: 28, offset: 33271},
+									pos:   position{line: 1183, col: 28, offset: 33280},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1183, col: 30, offset: 33273},
+										pos: position{line: 1183, col: 30, offset: 33282},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1183, col: 30, offset: 33273},
+											pos:  position{line: 1183, col: 30, offset: 33282},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1183, col: 40, offset: 33283},
+									pos:   position{line: 1183, col: 40, offset: 33292},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1183, col: 42, offset: 33285},
+										pos:  position{line: 1183, col: 42, offset: 33294},
 										name: "IP6Tail",
 									},
 								},
@@ -9800,32 +9822,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1186, col: 5, offset: 33384},
+						pos: position{line: 1186, col: 5, offset: 33393},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1186, col: 5, offset: 33384},
+							pos: position{line: 1186, col: 5, offset: 33393},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1186, col: 5, offset: 33384},
+									pos:        position{line: 1186, col: 5, offset: 33393},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1186, col: 10, offset: 33389},
+									pos:   position{line: 1186, col: 10, offset: 33398},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1186, col: 12, offset: 33391},
+										pos: position{line: 1186, col: 12, offset: 33400},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1186, col: 12, offset: 33391},
+											pos:  position{line: 1186, col: 12, offset: 33400},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1186, col: 22, offset: 33401},
+									pos:   position{line: 1186, col: 22, offset: 33410},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1186, col: 24, offset: 33403},
+										pos:  position{line: 1186, col: 24, offset: 33412},
 										name: "IP6Tail",
 									},
 								},
@@ -9833,32 +9855,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1189, col: 5, offset: 33474},
+						pos: position{line: 1189, col: 5, offset: 33483},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1189, col: 5, offset: 33474},
+							pos: position{line: 1189, col: 5, offset: 33483},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1189, col: 5, offset: 33474},
+									pos:   position{line: 1189, col: 5, offset: 33483},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1189, col: 7, offset: 33476},
+										pos:  position{line: 1189, col: 7, offset: 33485},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1189, col: 11, offset: 33480},
+									pos:   position{line: 1189, col: 11, offset: 33489},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1189, col: 13, offset: 33482},
+										pos: position{line: 1189, col: 13, offset: 33491},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1189, col: 13, offset: 33482},
+											pos:  position{line: 1189, col: 13, offset: 33491},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1189, col: 23, offset: 33492},
+									pos:        position{line: 1189, col: 23, offset: 33501},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -9866,10 +9888,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1192, col: 5, offset: 33560},
+						pos: position{line: 1192, col: 5, offset: 33569},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1192, col: 5, offset: 33560},
+							pos:        position{line: 1192, col: 5, offset: 33569},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -9879,16 +9901,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1196, col: 1, offset: 33597},
+			pos:  position{line: 1196, col: 1, offset: 33606},
 			expr: &choiceExpr{
-				pos: position{line: 1197, col: 5, offset: 33609},
+				pos: position{line: 1197, col: 5, offset: 33618},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1197, col: 5, offset: 33609},
+						pos:  position{line: 1197, col: 5, offset: 33618},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1198, col: 5, offset: 33616},
+						pos:  position{line: 1198, col: 5, offset: 33625},
 						name: "Hex",
 					},
 				},
@@ -9896,23 +9918,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1200, col: 1, offset: 33621},
+			pos:  position{line: 1200, col: 1, offset: 33630},
 			expr: &actionExpr{
-				pos: position{line: 1200, col: 12, offset: 33632},
+				pos: position{line: 1200, col: 12, offset: 33641},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1200, col: 12, offset: 33632},
+					pos: position{line: 1200, col: 12, offset: 33641},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1200, col: 12, offset: 33632},
+							pos:        position{line: 1200, col: 12, offset: 33641},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1200, col: 16, offset: 33636},
+							pos:   position{line: 1200, col: 16, offset: 33645},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1200, col: 18, offset: 33638},
+								pos:  position{line: 1200, col: 18, offset: 33647},
 								name: "Hex",
 							},
 						},
@@ -9922,23 +9944,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1202, col: 1, offset: 33676},
+			pos:  position{line: 1202, col: 1, offset: 33685},
 			expr: &actionExpr{
-				pos: position{line: 1202, col: 12, offset: 33687},
+				pos: position{line: 1202, col: 12, offset: 33696},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1202, col: 12, offset: 33687},
+					pos: position{line: 1202, col: 12, offset: 33696},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1202, col: 12, offset: 33687},
+							pos:   position{line: 1202, col: 12, offset: 33696},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1202, col: 14, offset: 33689},
+								pos:  position{line: 1202, col: 14, offset: 33698},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1202, col: 18, offset: 33693},
+							pos:        position{line: 1202, col: 18, offset: 33702},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -9948,31 +9970,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1204, col: 1, offset: 33731},
+			pos:  position{line: 1204, col: 1, offset: 33740},
 			expr: &actionExpr{
-				pos: position{line: 1205, col: 5, offset: 33742},
+				pos: position{line: 1205, col: 5, offset: 33751},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1205, col: 5, offset: 33742},
+					pos: position{line: 1205, col: 5, offset: 33751},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1205, col: 5, offset: 33742},
+							pos:   position{line: 1205, col: 5, offset: 33751},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1205, col: 7, offset: 33744},
+								pos:  position{line: 1205, col: 7, offset: 33753},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1205, col: 10, offset: 33747},
+							pos:        position{line: 1205, col: 10, offset: 33756},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1205, col: 14, offset: 33751},
+							pos:   position{line: 1205, col: 14, offset: 33760},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1205, col: 16, offset: 33753},
+								pos:  position{line: 1205, col: 16, offset: 33762},
 								name: "UInt",
 							},
 						},
@@ -9982,31 +10004,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1209, col: 1, offset: 33826},
+			pos:  position{line: 1209, col: 1, offset: 33835},
 			expr: &actionExpr{
-				pos: position{line: 1210, col: 5, offset: 33837},
+				pos: position{line: 1210, col: 5, offset: 33846},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1210, col: 5, offset: 33837},
+					pos: position{line: 1210, col: 5, offset: 33846},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1210, col: 5, offset: 33837},
+							pos:   position{line: 1210, col: 5, offset: 33846},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1210, col: 7, offset: 33839},
+								pos:  position{line: 1210, col: 7, offset: 33848},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1210, col: 11, offset: 33843},
+							pos:        position{line: 1210, col: 11, offset: 33852},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1210, col: 15, offset: 33847},
+							pos:   position{line: 1210, col: 15, offset: 33856},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1210, col: 17, offset: 33849},
+								pos:  position{line: 1210, col: 17, offset: 33858},
 								name: "UInt",
 							},
 						},
@@ -10016,15 +10038,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1214, col: 1, offset: 33912},
+			pos:  position{line: 1214, col: 1, offset: 33921},
 			expr: &actionExpr{
-				pos: position{line: 1215, col: 4, offset: 33920},
+				pos: position{line: 1215, col: 4, offset: 33929},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1215, col: 4, offset: 33920},
+					pos:   position{line: 1215, col: 4, offset: 33929},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1215, col: 6, offset: 33922},
+						pos:  position{line: 1215, col: 6, offset: 33931},
 						name: "UIntString",
 					},
 				},
@@ -10032,16 +10054,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1217, col: 1, offset: 33962},
+			pos:  position{line: 1217, col: 1, offset: 33971},
 			expr: &choiceExpr{
-				pos: position{line: 1218, col: 5, offset: 33976},
+				pos: position{line: 1218, col: 5, offset: 33985},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1218, col: 5, offset: 33976},
+						pos:  position{line: 1218, col: 5, offset: 33985},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 5, offset: 33991},
+						pos:  position{line: 1219, col: 5, offset: 34000},
 						name: "MinusIntString",
 					},
 				},
@@ -10049,14 +10071,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1221, col: 1, offset: 34007},
+			pos:  position{line: 1221, col: 1, offset: 34016},
 			expr: &actionExpr{
-				pos: position{line: 1221, col: 14, offset: 34020},
+				pos: position{line: 1221, col: 14, offset: 34029},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1221, col: 14, offset: 34020},
+					pos: position{line: 1221, col: 14, offset: 34029},
 					expr: &charClassMatcher{
-						pos:        position{line: 1221, col: 14, offset: 34020},
+						pos:        position{line: 1221, col: 14, offset: 34029},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10067,20 +10089,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1223, col: 1, offset: 34059},
+			pos:  position{line: 1223, col: 1, offset: 34068},
 			expr: &actionExpr{
-				pos: position{line: 1224, col: 5, offset: 34078},
+				pos: position{line: 1224, col: 5, offset: 34087},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1224, col: 5, offset: 34078},
+					pos: position{line: 1224, col: 5, offset: 34087},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1224, col: 5, offset: 34078},
+							pos:        position{line: 1224, col: 5, offset: 34087},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1224, col: 9, offset: 34082},
+							pos:  position{line: 1224, col: 9, offset: 34091},
 							name: "UIntString",
 						},
 					},
@@ -10089,28 +10111,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1226, col: 1, offset: 34125},
+			pos:  position{line: 1226, col: 1, offset: 34134},
 			expr: &choiceExpr{
-				pos: position{line: 1227, col: 5, offset: 34141},
+				pos: position{line: 1227, col: 5, offset: 34150},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1227, col: 5, offset: 34141},
+						pos: position{line: 1227, col: 5, offset: 34150},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1227, col: 5, offset: 34141},
+							pos: position{line: 1227, col: 5, offset: 34150},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1227, col: 5, offset: 34141},
+									pos: position{line: 1227, col: 5, offset: 34150},
 									expr: &litMatcher{
-										pos:        position{line: 1227, col: 5, offset: 34141},
+										pos:        position{line: 1227, col: 5, offset: 34150},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1227, col: 10, offset: 34146},
+									pos: position{line: 1227, col: 10, offset: 34155},
 									expr: &charClassMatcher{
-										pos:        position{line: 1227, col: 10, offset: 34146},
+										pos:        position{line: 1227, col: 10, offset: 34155},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10118,14 +10140,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1227, col: 17, offset: 34153},
+									pos:        position{line: 1227, col: 17, offset: 34162},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1227, col: 21, offset: 34157},
+									pos: position{line: 1227, col: 21, offset: 34166},
 									expr: &charClassMatcher{
-										pos:        position{line: 1227, col: 21, offset: 34157},
+										pos:        position{line: 1227, col: 21, offset: 34166},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10133,9 +10155,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1227, col: 28, offset: 34164},
+									pos: position{line: 1227, col: 28, offset: 34173},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1227, col: 28, offset: 34164},
+										pos:  position{line: 1227, col: 28, offset: 34173},
 										name: "ExponentPart",
 									},
 								},
@@ -10143,28 +10165,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1230, col: 5, offset: 34223},
+						pos: position{line: 1230, col: 5, offset: 34232},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1230, col: 5, offset: 34223},
+							pos: position{line: 1230, col: 5, offset: 34232},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1230, col: 5, offset: 34223},
+									pos: position{line: 1230, col: 5, offset: 34232},
 									expr: &litMatcher{
-										pos:        position{line: 1230, col: 5, offset: 34223},
+										pos:        position{line: 1230, col: 5, offset: 34232},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1230, col: 10, offset: 34228},
+									pos:        position{line: 1230, col: 10, offset: 34237},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1230, col: 14, offset: 34232},
+									pos: position{line: 1230, col: 14, offset: 34241},
 									expr: &charClassMatcher{
-										pos:        position{line: 1230, col: 14, offset: 34232},
+										pos:        position{line: 1230, col: 14, offset: 34241},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10172,9 +10194,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1230, col: 21, offset: 34239},
+									pos: position{line: 1230, col: 21, offset: 34248},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1230, col: 21, offset: 34239},
+										pos:  position{line: 1230, col: 21, offset: 34248},
 										name: "ExponentPart",
 									},
 								},
@@ -10186,19 +10208,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1234, col: 1, offset: 34295},
+			pos:  position{line: 1234, col: 1, offset: 34304},
 			expr: &seqExpr{
-				pos: position{line: 1234, col: 16, offset: 34310},
+				pos: position{line: 1234, col: 16, offset: 34319},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1234, col: 16, offset: 34310},
+						pos:        position{line: 1234, col: 16, offset: 34319},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1234, col: 21, offset: 34315},
+						pos: position{line: 1234, col: 21, offset: 34324},
 						expr: &charClassMatcher{
-							pos:        position{line: 1234, col: 21, offset: 34315},
+							pos:        position{line: 1234, col: 21, offset: 34324},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10206,7 +10228,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1234, col: 27, offset: 34321},
+						pos:  position{line: 1234, col: 27, offset: 34330},
 						name: "UIntString",
 					},
 				},
@@ -10214,14 +10236,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1236, col: 1, offset: 34333},
+			pos:  position{line: 1236, col: 1, offset: 34342},
 			expr: &actionExpr{
-				pos: position{line: 1236, col: 7, offset: 34339},
+				pos: position{line: 1236, col: 7, offset: 34348},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1236, col: 7, offset: 34339},
+					pos: position{line: 1236, col: 7, offset: 34348},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1236, col: 7, offset: 34339},
+						pos:  position{line: 1236, col: 7, offset: 34348},
 						name: "HexDigit",
 					},
 				},
@@ -10229,9 +10251,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1238, col: 1, offset: 34381},
+			pos:  position{line: 1238, col: 1, offset: 34390},
 			expr: &charClassMatcher{
-				pos:        position{line: 1238, col: 12, offset: 34392},
+				pos:        position{line: 1238, col: 12, offset: 34401},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10240,34 +10262,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1240, col: 1, offset: 34405},
+			pos:  position{line: 1240, col: 1, offset: 34414},
 			expr: &choiceExpr{
-				pos: position{line: 1241, col: 5, offset: 34422},
+				pos: position{line: 1241, col: 5, offset: 34431},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1241, col: 5, offset: 34422},
+						pos: position{line: 1241, col: 5, offset: 34431},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1241, col: 5, offset: 34422},
+							pos: position{line: 1241, col: 5, offset: 34431},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1241, col: 5, offset: 34422},
+									pos:        position{line: 1241, col: 5, offset: 34431},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1241, col: 9, offset: 34426},
+									pos:   position{line: 1241, col: 9, offset: 34435},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1241, col: 11, offset: 34428},
+										pos: position{line: 1241, col: 11, offset: 34437},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1241, col: 11, offset: 34428},
+											pos:  position{line: 1241, col: 11, offset: 34437},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1241, col: 29, offset: 34446},
+									pos:        position{line: 1241, col: 29, offset: 34455},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10275,29 +10297,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1242, col: 5, offset: 34483},
+						pos: position{line: 1242, col: 5, offset: 34492},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1242, col: 5, offset: 34483},
+							pos: position{line: 1242, col: 5, offset: 34492},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1242, col: 5, offset: 34483},
+									pos:        position{line: 1242, col: 5, offset: 34492},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1242, col: 9, offset: 34487},
+									pos:   position{line: 1242, col: 9, offset: 34496},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1242, col: 11, offset: 34489},
+										pos: position{line: 1242, col: 11, offset: 34498},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1242, col: 11, offset: 34489},
+											pos:  position{line: 1242, col: 11, offset: 34498},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1242, col: 29, offset: 34507},
+									pos:        position{line: 1242, col: 29, offset: 34516},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10309,55 +10331,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1244, col: 1, offset: 34541},
+			pos:  position{line: 1244, col: 1, offset: 34550},
 			expr: &choiceExpr{
-				pos: position{line: 1245, col: 5, offset: 34562},
+				pos: position{line: 1245, col: 5, offset: 34571},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1245, col: 5, offset: 34562},
+						pos: position{line: 1245, col: 5, offset: 34571},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1245, col: 5, offset: 34562},
+							pos: position{line: 1245, col: 5, offset: 34571},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1245, col: 5, offset: 34562},
+									pos: position{line: 1245, col: 5, offset: 34571},
 									expr: &choiceExpr{
-										pos: position{line: 1245, col: 7, offset: 34564},
+										pos: position{line: 1245, col: 7, offset: 34573},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1245, col: 7, offset: 34564},
+												pos:        position{line: 1245, col: 7, offset: 34573},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1245, col: 13, offset: 34570},
+												pos:  position{line: 1245, col: 13, offset: 34579},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1245, col: 26, offset: 34583,
+									line: 1245, col: 26, offset: 34592,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1246, col: 5, offset: 34620},
+						pos: position{line: 1246, col: 5, offset: 34629},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1246, col: 5, offset: 34620},
+							pos: position{line: 1246, col: 5, offset: 34629},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1246, col: 5, offset: 34620},
+									pos:        position{line: 1246, col: 5, offset: 34629},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1246, col: 10, offset: 34625},
+									pos:   position{line: 1246, col: 10, offset: 34634},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1246, col: 12, offset: 34627},
+										pos:  position{line: 1246, col: 12, offset: 34636},
 										name: "EscapeSequence",
 									},
 								},
@@ -10369,28 +10391,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1248, col: 1, offset: 34661},
+			pos:  position{line: 1248, col: 1, offset: 34670},
 			expr: &actionExpr{
-				pos: position{line: 1249, col: 5, offset: 34673},
+				pos: position{line: 1249, col: 5, offset: 34682},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1249, col: 5, offset: 34673},
+					pos: position{line: 1249, col: 5, offset: 34682},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1249, col: 5, offset: 34673},
+							pos:   position{line: 1249, col: 5, offset: 34682},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1249, col: 10, offset: 34678},
+								pos:  position{line: 1249, col: 10, offset: 34687},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1249, col: 23, offset: 34691},
+							pos:   position{line: 1249, col: 23, offset: 34700},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1249, col: 28, offset: 34696},
+								pos: position{line: 1249, col: 28, offset: 34705},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1249, col: 28, offset: 34696},
+									pos:  position{line: 1249, col: 28, offset: 34705},
 									name: "KeyWordRest",
 								},
 							},
@@ -10401,16 +10423,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1251, col: 1, offset: 34758},
+			pos:  position{line: 1251, col: 1, offset: 34767},
 			expr: &choiceExpr{
-				pos: position{line: 1252, col: 5, offset: 34775},
+				pos: position{line: 1252, col: 5, offset: 34784},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1252, col: 5, offset: 34775},
+						pos:  position{line: 1252, col: 5, offset: 34784},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 5, offset: 34792},
+						pos:  position{line: 1253, col: 5, offset: 34801},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10418,12 +10440,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1255, col: 1, offset: 34804},
+			pos:  position{line: 1255, col: 1, offset: 34813},
 			expr: &actionExpr{
-				pos: position{line: 1255, col: 16, offset: 34819},
+				pos: position{line: 1255, col: 16, offset: 34828},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1255, col: 16, offset: 34819},
+					pos:        position{line: 1255, col: 16, offset: 34828},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10434,16 +10456,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1257, col: 1, offset: 34868},
+			pos:  position{line: 1257, col: 1, offset: 34877},
 			expr: &choiceExpr{
-				pos: position{line: 1258, col: 5, offset: 34884},
+				pos: position{line: 1258, col: 5, offset: 34893},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1258, col: 5, offset: 34884},
+						pos:  position{line: 1258, col: 5, offset: 34893},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1259, col: 5, offset: 34901},
+						pos:        position{line: 1259, col: 5, offset: 34910},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10454,30 +10476,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1261, col: 1, offset: 34908},
+			pos:  position{line: 1261, col: 1, offset: 34917},
 			expr: &actionExpr{
-				pos: position{line: 1261, col: 14, offset: 34921},
+				pos: position{line: 1261, col: 14, offset: 34930},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1261, col: 14, offset: 34921},
+					pos: position{line: 1261, col: 14, offset: 34930},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1261, col: 14, offset: 34921},
+							pos:        position{line: 1261, col: 14, offset: 34930},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1261, col: 19, offset: 34926},
+							pos:   position{line: 1261, col: 19, offset: 34935},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1261, col: 22, offset: 34929},
+								pos: position{line: 1261, col: 22, offset: 34938},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1261, col: 22, offset: 34929},
+										pos:  position{line: 1261, col: 22, offset: 34938},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1261, col: 38, offset: 34945},
+										pos:  position{line: 1261, col: 38, offset: 34954},
 										name: "EscapeSequence",
 									},
 								},
@@ -10489,42 +10511,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1263, col: 1, offset: 34981},
+			pos:  position{line: 1263, col: 1, offset: 34990},
 			expr: &actionExpr{
-				pos: position{line: 1264, col: 5, offset: 34997},
+				pos: position{line: 1264, col: 5, offset: 35006},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1264, col: 5, offset: 34997},
+					pos: position{line: 1264, col: 5, offset: 35006},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1264, col: 5, offset: 34997},
+							pos: position{line: 1264, col: 5, offset: 35006},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1264, col: 6, offset: 34998},
+								pos:  position{line: 1264, col: 6, offset: 35007},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1264, col: 22, offset: 35014},
+							pos: position{line: 1264, col: 22, offset: 35023},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1264, col: 23, offset: 35015},
+								pos:  position{line: 1264, col: 23, offset: 35024},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1264, col: 35, offset: 35027},
+							pos:   position{line: 1264, col: 35, offset: 35036},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1264, col: 40, offset: 35032},
+								pos:  position{line: 1264, col: 40, offset: 35041},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1264, col: 50, offset: 35042},
+							pos:   position{line: 1264, col: 50, offset: 35051},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1264, col: 55, offset: 35047},
+								pos: position{line: 1264, col: 55, offset: 35056},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1264, col: 55, offset: 35047},
+									pos:  position{line: 1264, col: 55, offset: 35056},
 									name: "GlobRest",
 								},
 							},
@@ -10535,20 +10557,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1268, col: 1, offset: 35116},
+			pos:  position{line: 1268, col: 1, offset: 35125},
 			expr: &seqExpr{
-				pos: position{line: 1268, col: 19, offset: 35134},
+				pos: position{line: 1268, col: 19, offset: 35143},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1268, col: 19, offset: 35134},
+						pos: position{line: 1268, col: 19, offset: 35143},
 						expr: &litMatcher{
-							pos:        position{line: 1268, col: 19, offset: 35134},
+							pos:        position{line: 1268, col: 19, offset: 35143},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1268, col: 24, offset: 35139},
+						pos:  position{line: 1268, col: 24, offset: 35148},
 						name: "KeyWordStart",
 					},
 				},
@@ -10556,19 +10578,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1269, col: 1, offset: 35152},
+			pos:  position{line: 1269, col: 1, offset: 35161},
 			expr: &seqExpr{
-				pos: position{line: 1269, col: 15, offset: 35166},
+				pos: position{line: 1269, col: 15, offset: 35175},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1269, col: 15, offset: 35166},
+						pos: position{line: 1269, col: 15, offset: 35175},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1269, col: 15, offset: 35166},
+							pos:  position{line: 1269, col: 15, offset: 35175},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1269, col: 28, offset: 35179},
+						pos:        position{line: 1269, col: 28, offset: 35188},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10577,23 +10599,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1271, col: 1, offset: 35184},
+			pos:  position{line: 1271, col: 1, offset: 35193},
 			expr: &choiceExpr{
-				pos: position{line: 1272, col: 5, offset: 35198},
+				pos: position{line: 1272, col: 5, offset: 35207},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1272, col: 5, offset: 35198},
+						pos:  position{line: 1272, col: 5, offset: 35207},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 35215},
+						pos:  position{line: 1273, col: 5, offset: 35224},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1274, col: 5, offset: 35227},
+						pos: position{line: 1274, col: 5, offset: 35236},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1274, col: 5, offset: 35227},
+							pos:        position{line: 1274, col: 5, offset: 35236},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10603,16 +10625,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1276, col: 1, offset: 35251},
+			pos:  position{line: 1276, col: 1, offset: 35260},
 			expr: &choiceExpr{
-				pos: position{line: 1277, col: 5, offset: 35264},
+				pos: position{line: 1277, col: 5, offset: 35273},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1277, col: 5, offset: 35264},
+						pos:  position{line: 1277, col: 5, offset: 35273},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1278, col: 5, offset: 35278},
+						pos:        position{line: 1278, col: 5, offset: 35287},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10623,30 +10645,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1280, col: 1, offset: 35285},
+			pos:  position{line: 1280, col: 1, offset: 35294},
 			expr: &actionExpr{
-				pos: position{line: 1280, col: 11, offset: 35295},
+				pos: position{line: 1280, col: 11, offset: 35304},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1280, col: 11, offset: 35295},
+					pos: position{line: 1280, col: 11, offset: 35304},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1280, col: 11, offset: 35295},
+							pos:        position{line: 1280, col: 11, offset: 35304},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1280, col: 16, offset: 35300},
+							pos:   position{line: 1280, col: 16, offset: 35309},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1280, col: 19, offset: 35303},
+								pos: position{line: 1280, col: 19, offset: 35312},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1280, col: 19, offset: 35303},
+										pos:  position{line: 1280, col: 19, offset: 35312},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1280, col: 32, offset: 35316},
+										pos:  position{line: 1280, col: 32, offset: 35325},
 										name: "EscapeSequence",
 									},
 								},
@@ -10658,30 +10680,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1282, col: 1, offset: 35352},
+			pos:  position{line: 1282, col: 1, offset: 35361},
 			expr: &choiceExpr{
-				pos: position{line: 1283, col: 5, offset: 35367},
+				pos: position{line: 1283, col: 5, offset: 35376},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1283, col: 5, offset: 35367},
+						pos: position{line: 1283, col: 5, offset: 35376},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1283, col: 5, offset: 35367},
+							pos:        position{line: 1283, col: 5, offset: 35376},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1284, col: 5, offset: 35395},
+						pos: position{line: 1284, col: 5, offset: 35404},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1284, col: 5, offset: 35395},
+							pos:        position{line: 1284, col: 5, offset: 35404},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1285, col: 5, offset: 35425},
+						pos:        position{line: 1285, col: 5, offset: 35434},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10692,55 +10714,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1288, col: 1, offset: 35432},
+			pos:  position{line: 1288, col: 1, offset: 35441},
 			expr: &choiceExpr{
-				pos: position{line: 1289, col: 5, offset: 35453},
+				pos: position{line: 1289, col: 5, offset: 35462},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1289, col: 5, offset: 35453},
+						pos: position{line: 1289, col: 5, offset: 35462},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1289, col: 5, offset: 35453},
+							pos: position{line: 1289, col: 5, offset: 35462},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1289, col: 5, offset: 35453},
+									pos: position{line: 1289, col: 5, offset: 35462},
 									expr: &choiceExpr{
-										pos: position{line: 1289, col: 7, offset: 35455},
+										pos: position{line: 1289, col: 7, offset: 35464},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1289, col: 7, offset: 35455},
+												pos:        position{line: 1289, col: 7, offset: 35464},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1289, col: 13, offset: 35461},
+												pos:  position{line: 1289, col: 13, offset: 35470},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1289, col: 26, offset: 35474,
+									line: 1289, col: 26, offset: 35483,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 35511},
+						pos: position{line: 1290, col: 5, offset: 35520},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1290, col: 5, offset: 35511},
+							pos: position{line: 1290, col: 5, offset: 35520},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1290, col: 5, offset: 35511},
+									pos:        position{line: 1290, col: 5, offset: 35520},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1290, col: 10, offset: 35516},
+									pos:   position{line: 1290, col: 10, offset: 35525},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1290, col: 12, offset: 35518},
+										pos:  position{line: 1290, col: 12, offset: 35527},
 										name: "EscapeSequence",
 									},
 								},
@@ -10752,16 +10774,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1292, col: 1, offset: 35552},
+			pos:  position{line: 1292, col: 1, offset: 35561},
 			expr: &choiceExpr{
-				pos: position{line: 1293, col: 5, offset: 35571},
+				pos: position{line: 1293, col: 5, offset: 35580},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1293, col: 5, offset: 35571},
+						pos:  position{line: 1293, col: 5, offset: 35580},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1294, col: 5, offset: 35592},
+						pos:  position{line: 1294, col: 5, offset: 35601},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10769,79 +10791,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1296, col: 1, offset: 35607},
+			pos:  position{line: 1296, col: 1, offset: 35616},
 			expr: &choiceExpr{
-				pos: position{line: 1297, col: 5, offset: 35628},
+				pos: position{line: 1297, col: 5, offset: 35637},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1297, col: 5, offset: 35628},
+						pos:        position{line: 1297, col: 5, offset: 35637},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1298, col: 5, offset: 35636},
+						pos: position{line: 1298, col: 5, offset: 35645},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1298, col: 5, offset: 35636},
+							pos:        position{line: 1298, col: 5, offset: 35645},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1299, col: 5, offset: 35676},
+						pos:        position{line: 1299, col: 5, offset: 35685},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1300, col: 5, offset: 35685},
+						pos: position{line: 1300, col: 5, offset: 35694},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1300, col: 5, offset: 35685},
+							pos:        position{line: 1300, col: 5, offset: 35694},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1301, col: 5, offset: 35714},
+						pos: position{line: 1301, col: 5, offset: 35723},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1301, col: 5, offset: 35714},
+							pos:        position{line: 1301, col: 5, offset: 35723},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1302, col: 5, offset: 35743},
+						pos: position{line: 1302, col: 5, offset: 35752},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1302, col: 5, offset: 35743},
+							pos:        position{line: 1302, col: 5, offset: 35752},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1303, col: 5, offset: 35772},
+						pos: position{line: 1303, col: 5, offset: 35781},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1303, col: 5, offset: 35772},
+							pos:        position{line: 1303, col: 5, offset: 35781},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1304, col: 5, offset: 35801},
+						pos: position{line: 1304, col: 5, offset: 35810},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1304, col: 5, offset: 35801},
+							pos:        position{line: 1304, col: 5, offset: 35810},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1305, col: 5, offset: 35830},
+						pos: position{line: 1305, col: 5, offset: 35839},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1305, col: 5, offset: 35830},
+							pos:        position{line: 1305, col: 5, offset: 35839},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -10851,30 +10873,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1307, col: 1, offset: 35856},
+			pos:  position{line: 1307, col: 1, offset: 35865},
 			expr: &choiceExpr{
-				pos: position{line: 1308, col: 5, offset: 35874},
+				pos: position{line: 1308, col: 5, offset: 35883},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1308, col: 5, offset: 35874},
+						pos: position{line: 1308, col: 5, offset: 35883},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1308, col: 5, offset: 35874},
+							pos:        position{line: 1308, col: 5, offset: 35883},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 35902},
+						pos: position{line: 1309, col: 5, offset: 35911},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1309, col: 5, offset: 35902},
+							pos:        position{line: 1309, col: 5, offset: 35911},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1310, col: 5, offset: 35930},
+						pos:        position{line: 1310, col: 5, offset: 35939},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10885,41 +10907,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1312, col: 1, offset: 35936},
+			pos:  position{line: 1312, col: 1, offset: 35945},
 			expr: &choiceExpr{
-				pos: position{line: 1313, col: 5, offset: 35954},
+				pos: position{line: 1313, col: 5, offset: 35963},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 35954},
+						pos: position{line: 1313, col: 5, offset: 35963},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1313, col: 5, offset: 35954},
+							pos: position{line: 1313, col: 5, offset: 35963},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1313, col: 5, offset: 35954},
+									pos:        position{line: 1313, col: 5, offset: 35963},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1313, col: 9, offset: 35958},
+									pos:   position{line: 1313, col: 9, offset: 35967},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1313, col: 16, offset: 35965},
+										pos: position{line: 1313, col: 16, offset: 35974},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1313, col: 16, offset: 35965},
+												pos:  position{line: 1313, col: 16, offset: 35974},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1313, col: 25, offset: 35974},
+												pos:  position{line: 1313, col: 25, offset: 35983},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1313, col: 34, offset: 35983},
+												pos:  position{line: 1313, col: 34, offset: 35992},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1313, col: 43, offset: 35992},
+												pos:  position{line: 1313, col: 43, offset: 36001},
 												name: "HexDigit",
 											},
 										},
@@ -10929,63 +10951,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 36055},
+						pos: position{line: 1316, col: 5, offset: 36064},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 5, offset: 36055},
+							pos: position{line: 1316, col: 5, offset: 36064},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1316, col: 5, offset: 36055},
+									pos:        position{line: 1316, col: 5, offset: 36064},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1316, col: 9, offset: 36059},
+									pos:        position{line: 1316, col: 9, offset: 36068},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1316, col: 13, offset: 36063},
+									pos:   position{line: 1316, col: 13, offset: 36072},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1316, col: 20, offset: 36070},
+										pos: position{line: 1316, col: 20, offset: 36079},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1316, col: 20, offset: 36070},
+												pos:  position{line: 1316, col: 20, offset: 36079},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1316, col: 29, offset: 36079},
+												pos: position{line: 1316, col: 29, offset: 36088},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1316, col: 29, offset: 36079},
+													pos:  position{line: 1316, col: 29, offset: 36088},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1316, col: 39, offset: 36089},
+												pos: position{line: 1316, col: 39, offset: 36098},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1316, col: 39, offset: 36089},
+													pos:  position{line: 1316, col: 39, offset: 36098},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1316, col: 49, offset: 36099},
+												pos: position{line: 1316, col: 49, offset: 36108},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1316, col: 49, offset: 36099},
+													pos:  position{line: 1316, col: 49, offset: 36108},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1316, col: 59, offset: 36109},
+												pos: position{line: 1316, col: 59, offset: 36118},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1316, col: 59, offset: 36109},
+													pos:  position{line: 1316, col: 59, offset: 36118},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1316, col: 69, offset: 36119},
+												pos: position{line: 1316, col: 69, offset: 36128},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1316, col: 69, offset: 36119},
+													pos:  position{line: 1316, col: 69, offset: 36128},
 													name: "HexDigit",
 												},
 											},
@@ -10993,7 +11015,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1316, col: 80, offset: 36130},
+									pos:        position{line: 1316, col: 80, offset: 36139},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11005,35 +11027,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1320, col: 1, offset: 36184},
+			pos:  position{line: 1320, col: 1, offset: 36193},
 			expr: &actionExpr{
-				pos: position{line: 1321, col: 5, offset: 36202},
+				pos: position{line: 1321, col: 5, offset: 36211},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1321, col: 5, offset: 36202},
+					pos: position{line: 1321, col: 5, offset: 36211},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1321, col: 5, offset: 36202},
+							pos:        position{line: 1321, col: 5, offset: 36211},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1321, col: 9, offset: 36206},
+							pos:   position{line: 1321, col: 9, offset: 36215},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1321, col: 14, offset: 36211},
+								pos:  position{line: 1321, col: 14, offset: 36220},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1321, col: 25, offset: 36222},
+							pos:        position{line: 1321, col: 25, offset: 36231},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1321, col: 29, offset: 36226},
+							pos: position{line: 1321, col: 29, offset: 36235},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1321, col: 30, offset: 36227},
+								pos:  position{line: 1321, col: 30, offset: 36236},
 								name: "KeyWordStart",
 							},
 						},
@@ -11043,32 +11065,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1323, col: 1, offset: 36262},
+			pos:  position{line: 1323, col: 1, offset: 36271},
 			expr: &actionExpr{
-				pos: position{line: 1324, col: 5, offset: 36277},
+				pos: position{line: 1324, col: 5, offset: 36286},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1324, col: 5, offset: 36277},
+					pos: position{line: 1324, col: 5, offset: 36286},
 					expr: &choiceExpr{
-						pos: position{line: 1324, col: 6, offset: 36278},
+						pos: position{line: 1324, col: 6, offset: 36287},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1324, col: 6, offset: 36278},
+								pos:        position{line: 1324, col: 6, offset: 36287},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1324, col: 15, offset: 36287},
+								pos: position{line: 1324, col: 15, offset: 36296},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1324, col: 15, offset: 36287},
+										pos:        position{line: 1324, col: 15, offset: 36296},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1324, col: 20, offset: 36292,
+										line: 1324, col: 20, offset: 36301,
 									},
 								},
 							},
@@ -11079,9 +11101,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1326, col: 1, offset: 36328},
+			pos:  position{line: 1326, col: 1, offset: 36337},
 			expr: &charClassMatcher{
-				pos:        position{line: 1327, col: 5, offset: 36344},
+				pos:        position{line: 1327, col: 5, offset: 36353},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11091,42 +11113,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1329, col: 1, offset: 36359},
+			pos:  position{line: 1329, col: 1, offset: 36368},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1329, col: 6, offset: 36364},
+				pos: position{line: 1329, col: 6, offset: 36373},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1329, col: 6, offset: 36364},
+					pos:  position{line: 1329, col: 6, offset: 36373},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1331, col: 1, offset: 36375},
+			pos:  position{line: 1331, col: 1, offset: 36384},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1331, col: 6, offset: 36380},
+				pos: position{line: 1331, col: 6, offset: 36389},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1331, col: 6, offset: 36380},
+					pos:  position{line: 1331, col: 6, offset: 36389},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1333, col: 1, offset: 36391},
+			pos:  position{line: 1333, col: 1, offset: 36400},
 			expr: &choiceExpr{
-				pos: position{line: 1334, col: 5, offset: 36404},
+				pos: position{line: 1334, col: 5, offset: 36413},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1334, col: 5, offset: 36404},
+						pos:  position{line: 1334, col: 5, offset: 36413},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1335, col: 5, offset: 36419},
+						pos:  position{line: 1335, col: 5, offset: 36428},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1336, col: 5, offset: 36438},
+						pos:  position{line: 1336, col: 5, offset: 36447},
 						name: "Comment",
 					},
 				},
@@ -11134,45 +11156,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1338, col: 1, offset: 36447},
+			pos:  position{line: 1338, col: 1, offset: 36456},
 			expr: &anyMatcher{
-				line: 1339, col: 5, offset: 36467,
+				line: 1339, col: 5, offset: 36476,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1341, col: 1, offset: 36470},
+			pos:         position{line: 1341, col: 1, offset: 36479},
 			expr: &choiceExpr{
-				pos: position{line: 1342, col: 5, offset: 36498},
+				pos: position{line: 1342, col: 5, offset: 36507},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1342, col: 5, offset: 36498},
+						pos:        position{line: 1342, col: 5, offset: 36507},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1343, col: 5, offset: 36507},
+						pos:        position{line: 1343, col: 5, offset: 36516},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1344, col: 5, offset: 36516},
+						pos:        position{line: 1344, col: 5, offset: 36525},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1345, col: 5, offset: 36525},
+						pos:        position{line: 1345, col: 5, offset: 36534},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1346, col: 5, offset: 36533},
+						pos:        position{line: 1346, col: 5, offset: 36542},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1347, col: 5, offset: 36546},
+						pos:        position{line: 1347, col: 5, offset: 36555},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11181,9 +11203,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1349, col: 1, offset: 36556},
+			pos:  position{line: 1349, col: 1, offset: 36565},
 			expr: &charClassMatcher{
-				pos:        position{line: 1350, col: 5, offset: 36575},
+				pos:        position{line: 1350, col: 5, offset: 36584},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11193,45 +11215,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1356, col: 1, offset: 36905},
+			pos:         position{line: 1356, col: 1, offset: 36914},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1359, col: 5, offset: 36976},
+				pos:  position{line: 1359, col: 5, offset: 36985},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1361, col: 1, offset: 36995},
+			pos:  position{line: 1361, col: 1, offset: 37004},
 			expr: &seqExpr{
-				pos: position{line: 1362, col: 5, offset: 37016},
+				pos: position{line: 1362, col: 5, offset: 37025},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1362, col: 5, offset: 37016},
+						pos:        position{line: 1362, col: 5, offset: 37025},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1362, col: 10, offset: 37021},
+						pos: position{line: 1362, col: 10, offset: 37030},
 						expr: &seqExpr{
-							pos: position{line: 1362, col: 11, offset: 37022},
+							pos: position{line: 1362, col: 11, offset: 37031},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1362, col: 11, offset: 37022},
+									pos: position{line: 1362, col: 11, offset: 37031},
 									expr: &litMatcher{
-										pos:        position{line: 1362, col: 12, offset: 37023},
+										pos:        position{line: 1362, col: 12, offset: 37032},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1362, col: 17, offset: 37028},
+									pos:  position{line: 1362, col: 17, offset: 37037},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1362, col: 35, offset: 37046},
+						pos:        position{line: 1362, col: 35, offset: 37055},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11240,29 +11262,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1364, col: 1, offset: 37052},
+			pos:  position{line: 1364, col: 1, offset: 37061},
 			expr: &seqExpr{
-				pos: position{line: 1365, col: 5, offset: 37074},
+				pos: position{line: 1365, col: 5, offset: 37083},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1365, col: 5, offset: 37074},
+						pos:        position{line: 1365, col: 5, offset: 37083},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1365, col: 10, offset: 37079},
+						pos: position{line: 1365, col: 10, offset: 37088},
 						expr: &seqExpr{
-							pos: position{line: 1365, col: 11, offset: 37080},
+							pos: position{line: 1365, col: 11, offset: 37089},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1365, col: 11, offset: 37080},
+									pos: position{line: 1365, col: 11, offset: 37089},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1365, col: 12, offset: 37081},
+										pos:  position{line: 1365, col: 12, offset: 37090},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 27, offset: 37096},
+									pos:  position{line: 1365, col: 27, offset: 37105},
 									name: "SourceCharacter",
 								},
 							},
@@ -11273,19 +11295,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1367, col: 1, offset: 37115},
+			pos:  position{line: 1367, col: 1, offset: 37124},
 			expr: &seqExpr{
-				pos: position{line: 1367, col: 7, offset: 37121},
+				pos: position{line: 1367, col: 7, offset: 37130},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1367, col: 7, offset: 37121},
+						pos: position{line: 1367, col: 7, offset: 37130},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1367, col: 7, offset: 37121},
+							pos:  position{line: 1367, col: 7, offset: 37130},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1367, col: 19, offset: 37133},
+						pos:  position{line: 1367, col: 19, offset: 37142},
 						name: "LineTerminator",
 					},
 				},
@@ -11293,16 +11315,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1369, col: 1, offset: 37149},
+			pos:  position{line: 1369, col: 1, offset: 37158},
 			expr: &choiceExpr{
-				pos: position{line: 1369, col: 7, offset: 37155},
+				pos: position{line: 1369, col: 7, offset: 37164},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1369, col: 7, offset: 37155},
+						pos:  position{line: 1369, col: 7, offset: 37164},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1369, col: 11, offset: 37159},
+						pos:  position{line: 1369, col: 11, offset: 37168},
 						name: "EOF",
 					},
 				},
@@ -11310,11 +11332,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1371, col: 1, offset: 37164},
+			pos:  position{line: 1371, col: 1, offset: 37173},
 			expr: &notExpr{
-				pos: position{line: 1371, col: 7, offset: 37170},
+				pos: position{line: 1371, col: 7, offset: 37179},
 				expr: &anyMatcher{
-					line: 1371, col: 8, offset: 37171,
+					line: 1371, col: 8, offset: 37180,
 				},
 			},
 		},

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -4546,7 +4546,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseShapeProc() {
-    var s0, s1;
+    var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 5) === peg$c167) {
@@ -4557,10 +4557,48 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c168); }
     }
     if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c169();
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s5 = peg$c16;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        }
+        if (s5 !== peg$FAILED) {
+          s4 = [s4, s5];
+          s3 = s4;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c169();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
-    s0 = s1;
 
     return s0;
   }

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -379,7 +379,7 @@ FuseProc
     }
 
 ShapeProc
-  = "shape" {
+  = "shape" !(__ "(") {
       RETURN(MAP("kind": "Shape"))
     }
 
@@ -994,7 +994,7 @@ TypeLiteral
     }
 
 CastType
-  = "<" typ:Type ">" { RETURN(typ) } 
+  = "<" typ:Type ">" { RETURN(typ) }
   / typ:PrimitiveType
 
 Type

--- a/compiler/parser/ztests/shape.yaml
+++ b/compiler/parser/ztests/shape.yaml
@@ -1,0 +1,7 @@
+zed: shape(this,<{s:string}>)
+
+input: |
+  {s:1}
+
+output: |
+  {s:"1"}


### PR DESCRIPTION
This commit fixes a parser problem where the implied-yield shape
function would result in a parser error because the PEG grammer
matched operator "shape" then ran into the open paren.