### PR TITLE
add calculator-style usage for zq

### DIFF
--- a/cli/queryflags/flags.go
+++ b/cli/queryflags/flags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/zed/compiler"
 	"github.com/brimdata/zed/compiler/ast"
 	"github.com/brimdata/zed/zbuf"
+	"github.com/brimdata/zed/zfmt"
 	"github.com/brimdata/zed/zson"
 )
 
@@ -24,22 +25,41 @@ func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	fs.Var(&f.Includes, "I", "source file containing Zed query text (may be used multiple times)")
 }
 
-func (f *Flags) ParseSourcesAndInputs(paths []string) ([]string, ast.Proc, error) {
+func (f *Flags) ParseSourcesAndInputs(paths []string) ([]string, ast.Proc, bool, error) {
 	var src string
 	if len(paths) != 0 && !cli.FileExists(paths[0]) && !isURLWithKnownScheme(paths[0], "http", "https", "s3") {
-		if len(paths) == 1 {
-			// We don't interpret the first arg as a query if there
-			// are no additional args.
-			return nil, nil, fmt.Errorf("no such file: %s", paths[0])
-		}
 		src = paths[0]
 		paths = paths[1:]
+		if len(paths) == 0 {
+			query, err := compiler.ParseProc(src, f.Includes...)
+			if err != nil || !isYield(query) {
+				// We don't interpret the first arg as a query if there
+				// are no additional args, unless the additional arg
+				// could be compiled and looks like a yield optionally
+				// followed by other pipeline ops.
+				return nil, nil, false, fmt.Errorf("no such file: %s", src)
+			}
+			return paths, query, true, nil
+		}
 	}
 	query, err := compiler.ParseProc(src, f.Includes...)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
-	return paths, query, nil
+	return paths, query, false, nil
+}
+
+func isYield(op ast.Proc) bool {
+	if seq, ok := op.(*ast.Sequential); ok && len(seq.Procs) >= 1 {
+		op := seq.Procs[0]
+		if _, ok := op.(*ast.Yield); ok {
+			return true
+		}
+		if e, ok := op.(*ast.OpExpr); ok {
+			return !zfmt.IsSearch(e.Expr) && !zfmt.IsBool(e.Expr)
+		}
+	}
+	return false
 }
 
 func isURLWithKnownScheme(path string, schemes ...string) bool {

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -439,9 +439,9 @@ func (c *canon) proc(p ast.Proc) {
 		c.next()
 		var which string
 		e := p.Expr
-		if isSearch(e) {
+		if IsSearch(e) {
 			which = "search "
-		} else if isBool(e) {
+		} else if IsBool(e) {
 			which = "where "
 		} else {
 			which = "yield "
@@ -539,12 +539,12 @@ func isAggFunc(e ast.Expr) *ast.Summarize {
 	}
 }
 
-func isBool(e ast.Expr) bool {
+func IsBool(e ast.Expr) bool {
 	switch e := e.(type) {
 	case *astzed.Primitive:
 		return e.Type == "bool"
 	case *ast.UnaryExpr:
-		return isBool(e.Operand)
+		return IsBool(e.Operand)
 	case *ast.BinaryExpr:
 		switch e.Op {
 		case "and", "or", "in", "==", "!=", "<", "<=", ">", ">=":
@@ -553,7 +553,7 @@ func isBool(e ast.Expr) bool {
 			return false
 		}
 	case *ast.Conditional:
-		return isBool(e.Then) && isBool(e.Else)
+		return IsBool(e.Then) && IsBool(e.Else)
 	case *ast.Call:
 		return function.HasBoolResult(e.Name)
 	case *ast.Cast:
@@ -568,19 +568,19 @@ func isBool(e ast.Expr) bool {
 	}
 }
 
-func isSearch(e ast.Expr) bool {
+func IsSearch(e ast.Expr) bool {
 	switch e := e.(type) {
 	case *ast.Regexp, *ast.Glob, *ast.Term:
 		return true
 	case *ast.BinaryExpr:
 		switch e.Op {
 		case "and", "or":
-			return isSearch(e.LHS) || isSearch(e.RHS)
+			return IsSearch(e.LHS) || IsSearch(e.RHS)
 		default:
 			return false
 		}
 	case *ast.UnaryExpr:
-		return isSearch(e.Operand)
+		return IsSearch(e.Operand)
 	default:
 		return false
 	}


### PR DESCRIPTION
This commit changes the zq command parser to accept a single
argument that consists of a yield operator (or implied yield)
followed by optional pipelines operators so that the common
pattern of running 'echo null | zq "..." -' can be replaced simply
with 'zq "..."'.  e.g., zq '1+1' prints out 2.