### PR TITLE
simplify sample operator output

### DIFF
--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -482,13 +482,11 @@ function peg$parse(input, options) {
                 
             "limit": 0},
               
-            {"kind": "Cut",
+            {"kind": "Yield",
+                
+            "exprs": [
                   
-            "args": [{"kind": "Assignment",
-                                      
-            "lhs": null,
-                                      
-            "rhs": {"kind": "ID", "name": "sample"}}]}]}
+            {"kind": "ID", "name": "sample"}]}]}
           
           },
       peg$c189 = function(a) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -3163,15 +3163,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 420, col: 1, offset: 12654},
+			pos:  position{line: 418, col: 1, offset: 12532},
 			expr: &actionExpr{
-				pos: position{line: 421, col: 5, offset: 12671},
+				pos: position{line: 419, col: 5, offset: 12549},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 421, col: 5, offset: 12671},
+					pos:   position{line: 419, col: 5, offset: 12549},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 421, col: 7, offset: 12673},
+						pos:  position{line: 419, col: 7, offset: 12551},
 						name: "Assignments",
 					},
 				},
@@ -3179,25 +3179,25 @@ var g = &grammar{
 		},
 		{
 			name: "SampleExpr",
-			pos:  position{line: 425, col: 1, offset: 12773},
+			pos:  position{line: 423, col: 1, offset: 12651},
 			expr: &choiceExpr{
-				pos: position{line: 426, col: 5, offset: 12788},
+				pos: position{line: 424, col: 5, offset: 12666},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 426, col: 5, offset: 12788},
+						pos: position{line: 424, col: 5, offset: 12666},
 						run: (*parser).callonSampleExpr2,
 						expr: &seqExpr{
-							pos: position{line: 426, col: 5, offset: 12788},
+							pos: position{line: 424, col: 5, offset: 12666},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 426, col: 5, offset: 12788},
+									pos:  position{line: 424, col: 5, offset: 12666},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 426, col: 7, offset: 12790},
+									pos:   position{line: 424, col: 7, offset: 12668},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 426, col: 12, offset: 12795},
+										pos:  position{line: 424, col: 12, offset: 12673},
 										name: "Lval",
 									},
 								},
@@ -3205,10 +3205,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 427, col: 5, offset: 12824},
+						pos: position{line: 425, col: 5, offset: 12702},
 						run: (*parser).callonSampleExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 427, col: 5, offset: 12824},
+							pos:        position{line: 425, col: 5, offset: 12702},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3218,15 +3218,15 @@ var g = &grammar{
 		},
 		{
 			name: "FromProc",
-			pos:  position{line: 429, col: 1, offset: 12895},
+			pos:  position{line: 427, col: 1, offset: 12773},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 12908},
+				pos: position{line: 428, col: 5, offset: 12786},
 				run: (*parser).callonFromProc1,
 				expr: &labeledExpr{
-					pos:   position{line: 430, col: 5, offset: 12908},
+					pos:   position{line: 428, col: 5, offset: 12786},
 					label: "source",
 					expr: &ruleRefExpr{
-						pos:  position{line: 430, col: 12, offset: 12915},
+						pos:  position{line: 428, col: 12, offset: 12793},
 						name: "FromAny",
 					},
 				},
@@ -3234,20 +3234,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromAny",
-			pos:  position{line: 434, col: 1, offset: 13071},
+			pos:  position{line: 432, col: 1, offset: 12949},
 			expr: &choiceExpr{
-				pos: position{line: 435, col: 5, offset: 13083},
+				pos: position{line: 433, col: 5, offset: 12961},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 435, col: 5, offset: 13083},
+						pos:  position{line: 433, col: 5, offset: 12961},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 436, col: 5, offset: 13092},
+						pos:  position{line: 434, col: 5, offset: 12970},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 437, col: 5, offset: 13100},
+						pos:  position{line: 435, col: 5, offset: 12978},
 						name: "From",
 					},
 				},
@@ -3255,48 +3255,48 @@ var g = &grammar{
 		},
 		{
 			name: "File",
-			pos:  position{line: 439, col: 1, offset: 13106},
+			pos:  position{line: 437, col: 1, offset: 12984},
 			expr: &actionExpr{
-				pos: position{line: 440, col: 5, offset: 13115},
+				pos: position{line: 438, col: 5, offset: 12993},
 				run: (*parser).callonFile1,
 				expr: &seqExpr{
-					pos: position{line: 440, col: 5, offset: 13115},
+					pos: position{line: 438, col: 5, offset: 12993},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 440, col: 5, offset: 13115},
+							pos:        position{line: 438, col: 5, offset: 12993},
 							val:        "file",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 440, col: 12, offset: 13122},
+							pos:  position{line: 438, col: 12, offset: 13000},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 14, offset: 13124},
+							pos:   position{line: 438, col: 14, offset: 13002},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 440, col: 19, offset: 13129},
+								pos:  position{line: 438, col: 19, offset: 13007},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 24, offset: 13134},
+							pos:   position{line: 438, col: 24, offset: 13012},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 440, col: 31, offset: 13141},
+								pos: position{line: 438, col: 31, offset: 13019},
 								expr: &ruleRefExpr{
-									pos:  position{line: 440, col: 31, offset: 13141},
+									pos:  position{line: 438, col: 31, offset: 13019},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 42, offset: 13152},
+							pos:   position{line: 438, col: 42, offset: 13030},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 440, col: 49, offset: 13159},
+								pos: position{line: 438, col: 49, offset: 13037},
 								expr: &ruleRefExpr{
-									pos:  position{line: 440, col: 49, offset: 13159},
+									pos:  position{line: 438, col: 49, offset: 13037},
 									name: "LayoutArg",
 								},
 							},
@@ -3307,27 +3307,27 @@ var g = &grammar{
 		},
 		{
 			name: "From",
-			pos:  position{line: 444, col: 1, offset: 13288},
+			pos:  position{line: 442, col: 1, offset: 13166},
 			expr: &actionExpr{
-				pos: position{line: 445, col: 5, offset: 13297},
+				pos: position{line: 443, col: 5, offset: 13175},
 				run: (*parser).callonFrom1,
 				expr: &seqExpr{
-					pos: position{line: 445, col: 5, offset: 13297},
+					pos: position{line: 443, col: 5, offset: 13175},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 445, col: 5, offset: 13297},
+							pos:        position{line: 443, col: 5, offset: 13175},
 							val:        "from",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 445, col: 12, offset: 13304},
+							pos:  position{line: 443, col: 12, offset: 13182},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 14, offset: 13306},
+							pos:   position{line: 443, col: 14, offset: 13184},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 19, offset: 13311},
+								pos:  position{line: 443, col: 19, offset: 13189},
 								name: "PoolBody",
 							},
 						},
@@ -3337,27 +3337,27 @@ var g = &grammar{
 		},
 		{
 			name: "Pool",
-			pos:  position{line: 447, col: 1, offset: 13342},
+			pos:  position{line: 445, col: 1, offset: 13220},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 5, offset: 13351},
+				pos: position{line: 446, col: 5, offset: 13229},
 				run: (*parser).callonPool1,
 				expr: &seqExpr{
-					pos: position{line: 448, col: 5, offset: 13351},
+					pos: position{line: 446, col: 5, offset: 13229},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 448, col: 5, offset: 13351},
+							pos:        position{line: 446, col: 5, offset: 13229},
 							val:        "pool",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 448, col: 12, offset: 13358},
+							pos:  position{line: 446, col: 12, offset: 13236},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 448, col: 14, offset: 13360},
+							pos:   position{line: 446, col: 14, offset: 13238},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 448, col: 19, offset: 13365},
+								pos:  position{line: 446, col: 19, offset: 13243},
 								name: "PoolBody",
 							},
 						},
@@ -3367,50 +3367,50 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBody",
-			pos:  position{line: 450, col: 1, offset: 13396},
+			pos:  position{line: 448, col: 1, offset: 13274},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 13409},
+				pos: position{line: 449, col: 5, offset: 13287},
 				run: (*parser).callonPoolBody1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 13409},
+					pos: position{line: 449, col: 5, offset: 13287},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 13409},
+							pos:   position{line: 449, col: 5, offset: 13287},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 10, offset: 13414},
+								pos:  position{line: 449, col: 10, offset: 13292},
 								name: "PoolSpec",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 19, offset: 13423},
+							pos:   position{line: 449, col: 19, offset: 13301},
 							label: "at",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 22, offset: 13426},
+								pos: position{line: 449, col: 22, offset: 13304},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 22, offset: 13426},
+									pos:  position{line: 449, col: 22, offset: 13304},
 									name: "PoolAt",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 30, offset: 13434},
+							pos:   position{line: 449, col: 30, offset: 13312},
 							label: "over",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 35, offset: 13439},
+								pos: position{line: 449, col: 35, offset: 13317},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 35, offset: 13439},
+									pos:  position{line: 449, col: 35, offset: 13317},
 									name: "PoolRange",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 46, offset: 13450},
+							pos:   position{line: 449, col: 46, offset: 13328},
 							label: "order",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 52, offset: 13456},
+								pos: position{line: 449, col: 52, offset: 13334},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 52, offset: 13456},
+									pos:  position{line: 449, col: 52, offset: 13334},
 									name: "OrderArg",
 								},
 							},
@@ -3421,48 +3421,48 @@ var g = &grammar{
 		},
 		{
 			name: "Get",
-			pos:  position{line: 455, col: 1, offset: 13592},
+			pos:  position{line: 453, col: 1, offset: 13470},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 5, offset: 13600},
+				pos: position{line: 454, col: 5, offset: 13478},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 456, col: 5, offset: 13600},
+					pos: position{line: 454, col: 5, offset: 13478},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 456, col: 5, offset: 13600},
+							pos:        position{line: 454, col: 5, offset: 13478},
 							val:        "get",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 456, col: 11, offset: 13606},
+							pos:  position{line: 454, col: 11, offset: 13484},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 13, offset: 13608},
+							pos:   position{line: 454, col: 13, offset: 13486},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 456, col: 17, offset: 13612},
+								pos:  position{line: 454, col: 17, offset: 13490},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 21, offset: 13616},
+							pos:   position{line: 454, col: 21, offset: 13494},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 456, col: 28, offset: 13623},
+								pos: position{line: 454, col: 28, offset: 13501},
 								expr: &ruleRefExpr{
-									pos:  position{line: 456, col: 28, offset: 13623},
+									pos:  position{line: 454, col: 28, offset: 13501},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 39, offset: 13634},
+							pos:   position{line: 454, col: 39, offset: 13512},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 456, col: 46, offset: 13641},
+								pos: position{line: 454, col: 46, offset: 13519},
 								expr: &ruleRefExpr{
-									pos:  position{line: 456, col: 46, offset: 13641},
+									pos:  position{line: 454, col: 46, offset: 13519},
 									name: "LayoutArg",
 								},
 							},
@@ -3473,30 +3473,30 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 460, col: 1, offset: 13767},
+			pos:  position{line: 458, col: 1, offset: 13645},
 			expr: &actionExpr{
-				pos: position{line: 460, col: 7, offset: 13773},
+				pos: position{line: 458, col: 7, offset: 13651},
 				run: (*parser).callonURL1,
 				expr: &seqExpr{
-					pos: position{line: 460, col: 7, offset: 13773},
+					pos: position{line: 458, col: 7, offset: 13651},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 460, col: 8, offset: 13774},
+							pos: position{line: 458, col: 8, offset: 13652},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 460, col: 8, offset: 13774},
+									pos:        position{line: 458, col: 8, offset: 13652},
 									val:        "http:",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 460, col: 18, offset: 13784},
+									pos:        position{line: 458, col: 18, offset: 13662},
 									val:        "https:",
 									ignoreCase: false,
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 460, col: 28, offset: 13794},
+							pos:  position{line: 458, col: 28, offset: 13672},
 							name: "Path",
 						},
 					},
@@ -3505,29 +3505,29 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 462, col: 1, offset: 13831},
+			pos:  position{line: 460, col: 1, offset: 13709},
 			expr: &choiceExpr{
-				pos: position{line: 463, col: 5, offset: 13840},
+				pos: position{line: 461, col: 5, offset: 13718},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 463, col: 5, offset: 13840},
+						pos: position{line: 461, col: 5, offset: 13718},
 						run: (*parser).callonPath2,
 						expr: &labeledExpr{
-							pos:   position{line: 463, col: 5, offset: 13840},
+							pos:   position{line: 461, col: 5, offset: 13718},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 463, col: 7, offset: 13842},
+								pos:  position{line: 461, col: 7, offset: 13720},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 464, col: 5, offset: 13877},
+						pos: position{line: 462, col: 5, offset: 13755},
 						run: (*parser).callonPath5,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 464, col: 5, offset: 13877},
+							pos: position{line: 462, col: 5, offset: 13755},
 							expr: &charClassMatcher{
-								pos:        position{line: 464, col: 5, offset: 13877},
+								pos:        position{line: 462, col: 5, offset: 13755},
 								val:        "[0-9a-zA-Z!@$%^&*()_=<>,./?:[\\]{}~|+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '(', ')', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '|', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -3541,31 +3541,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 467, col: 1, offset: 13982},
+			pos:  position{line: 465, col: 1, offset: 13860},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 5, offset: 13993},
+				pos: position{line: 466, col: 5, offset: 13871},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 468, col: 5, offset: 13993},
+					pos: position{line: 466, col: 5, offset: 13871},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 5, offset: 13993},
+							pos:  position{line: 466, col: 5, offset: 13871},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 468, col: 7, offset: 13995},
+							pos:        position{line: 466, col: 7, offset: 13873},
 							val:        "at",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 12, offset: 14000},
+							pos:  position{line: 466, col: 12, offset: 13878},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 14, offset: 14002},
+							pos:   position{line: 466, col: 14, offset: 13880},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 17, offset: 14005},
+								pos:  position{line: 466, col: 17, offset: 13883},
 								name: "KSUID",
 							},
 						},
@@ -3575,14 +3575,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 471, col: 1, offset: 14071},
+			pos:  position{line: 469, col: 1, offset: 13949},
 			expr: &actionExpr{
-				pos: position{line: 471, col: 9, offset: 14079},
+				pos: position{line: 469, col: 9, offset: 13957},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 471, col: 9, offset: 14079},
+					pos: position{line: 469, col: 9, offset: 13957},
 					expr: &charClassMatcher{
-						pos:        position{line: 471, col: 10, offset: 14080},
+						pos:        position{line: 469, col: 10, offset: 13958},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -3593,52 +3593,52 @@ var g = &grammar{
 		},
 		{
 			name: "PoolRange",
-			pos:  position{line: 473, col: 1, offset: 14126},
+			pos:  position{line: 471, col: 1, offset: 14004},
 			expr: &actionExpr{
-				pos: position{line: 474, col: 5, offset: 14140},
+				pos: position{line: 472, col: 5, offset: 14018},
 				run: (*parser).callonPoolRange1,
 				expr: &seqExpr{
-					pos: position{line: 474, col: 5, offset: 14140},
+					pos: position{line: 472, col: 5, offset: 14018},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 5, offset: 14140},
+							pos:  position{line: 472, col: 5, offset: 14018},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 7, offset: 14142},
+							pos:        position{line: 472, col: 7, offset: 14020},
 							val:        "range",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 15, offset: 14150},
+							pos:  position{line: 472, col: 15, offset: 14028},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 17, offset: 14152},
+							pos:   position{line: 472, col: 17, offset: 14030},
 							label: "lower",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 23, offset: 14158},
+								pos:  position{line: 472, col: 23, offset: 14036},
 								name: "Literal",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 31, offset: 14166},
+							pos:  position{line: 472, col: 31, offset: 14044},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 33, offset: 14168},
+							pos:        position{line: 472, col: 33, offset: 14046},
 							val:        "to",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 38, offset: 14173},
+							pos:  position{line: 472, col: 38, offset: 14051},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 40, offset: 14175},
+							pos:   position{line: 472, col: 40, offset: 14053},
 							label: "upper",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 46, offset: 14181},
+								pos:  position{line: 472, col: 46, offset: 14059},
 								name: "Literal",
 							},
 						},
@@ -3648,42 +3648,42 @@ var g = &grammar{
 		},
 		{
 			name: "PoolSpec",
-			pos:  position{line: 478, col: 1, offset: 14286},
+			pos:  position{line: 476, col: 1, offset: 14164},
 			expr: &choiceExpr{
-				pos: position{line: 479, col: 5, offset: 14299},
+				pos: position{line: 477, col: 5, offset: 14177},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 479, col: 5, offset: 14299},
+						pos: position{line: 477, col: 5, offset: 14177},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 479, col: 5, offset: 14299},
+							pos: position{line: 477, col: 5, offset: 14177},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 479, col: 5, offset: 14299},
+									pos:   position{line: 477, col: 5, offset: 14177},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 10, offset: 14304},
+										pos:  position{line: 477, col: 10, offset: 14182},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 19, offset: 14313},
+									pos:   position{line: 477, col: 19, offset: 14191},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 479, col: 26, offset: 14320},
+										pos: position{line: 477, col: 26, offset: 14198},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 26, offset: 14320},
+											pos:  position{line: 477, col: 26, offset: 14198},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 38, offset: 14332},
+									pos:   position{line: 477, col: 38, offset: 14210},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 479, col: 43, offset: 14337},
+										pos: position{line: 477, col: 43, offset: 14215},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 43, offset: 14337},
+											pos:  position{line: 477, col: 43, offset: 14215},
 											name: "PoolMeta",
 										},
 									},
@@ -3692,13 +3692,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 14446},
+						pos: position{line: 480, col: 5, offset: 14324},
 						run: (*parser).callonPoolSpec12,
 						expr: &labeledExpr{
-							pos:   position{line: 482, col: 5, offset: 14446},
+							pos:   position{line: 480, col: 5, offset: 14324},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 482, col: 10, offset: 14451},
+								pos:  position{line: 480, col: 10, offset: 14329},
 								name: "PoolMeta",
 							},
 						},
@@ -3708,23 +3708,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 486, col: 1, offset: 14552},
+			pos:  position{line: 484, col: 1, offset: 14430},
 			expr: &actionExpr{
-				pos: position{line: 487, col: 5, offset: 14567},
+				pos: position{line: 485, col: 5, offset: 14445},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 487, col: 5, offset: 14567},
+					pos: position{line: 485, col: 5, offset: 14445},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 487, col: 5, offset: 14567},
+							pos:        position{line: 485, col: 5, offset: 14445},
 							val:        "@",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 487, col: 9, offset: 14571},
+							pos:   position{line: 485, col: 9, offset: 14449},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 487, col: 16, offset: 14578},
+								pos:  position{line: 485, col: 16, offset: 14456},
 								name: "PoolName",
 							},
 						},
@@ -3734,23 +3734,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 489, col: 1, offset: 14611},
+			pos:  position{line: 487, col: 1, offset: 14489},
 			expr: &actionExpr{
-				pos: position{line: 490, col: 5, offset: 14624},
+				pos: position{line: 488, col: 5, offset: 14502},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 490, col: 5, offset: 14624},
+					pos: position{line: 488, col: 5, offset: 14502},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 490, col: 5, offset: 14624},
+							pos:        position{line: 488, col: 5, offset: 14502},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 490, col: 9, offset: 14628},
+							pos:   position{line: 488, col: 9, offset: 14506},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 490, col: 14, offset: 14633},
+								pos:  position{line: 488, col: 14, offset: 14511},
 								name: "PoolIdentifier",
 							},
 						},
@@ -3760,20 +3760,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 492, col: 1, offset: 14670},
+			pos:  position{line: 490, col: 1, offset: 14548},
 			expr: &choiceExpr{
-				pos: position{line: 493, col: 5, offset: 14683},
+				pos: position{line: 491, col: 5, offset: 14561},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 493, col: 5, offset: 14683},
+						pos:  position{line: 491, col: 5, offset: 14561},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 494, col: 5, offset: 14702},
+						pos:  position{line: 492, col: 5, offset: 14580},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 495, col: 5, offset: 14712},
+						pos:  position{line: 493, col: 5, offset: 14590},
 						name: "QuotedString",
 					},
 				},
@@ -3781,38 +3781,38 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 497, col: 1, offset: 14726},
+			pos:  position{line: 495, col: 1, offset: 14604},
 			expr: &actionExpr{
-				pos: position{line: 498, col: 5, offset: 14745},
+				pos: position{line: 496, col: 5, offset: 14623},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 498, col: 5, offset: 14745},
+					pos: position{line: 496, col: 5, offset: 14623},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 498, col: 6, offset: 14746},
+							pos: position{line: 496, col: 6, offset: 14624},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 498, col: 6, offset: 14746},
+									pos:  position{line: 496, col: 6, offset: 14624},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 498, col: 24, offset: 14764},
+									pos:        position{line: 496, col: 24, offset: 14642},
 									val:        ".",
 									ignoreCase: false,
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 498, col: 29, offset: 14769},
+							pos: position{line: 496, col: 29, offset: 14647},
 							expr: &choiceExpr{
-								pos: position{line: 498, col: 30, offset: 14770},
+								pos: position{line: 496, col: 30, offset: 14648},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 498, col: 30, offset: 14770},
+										pos:  position{line: 496, col: 30, offset: 14648},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 498, col: 47, offset: 14787},
+										pos:        position{line: 496, col: 47, offset: 14665},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -3825,39 +3825,39 @@ var g = &grammar{
 		},
 		{
 			name: "LayoutArg",
-			pos:  position{line: 500, col: 1, offset: 14826},
+			pos:  position{line: 498, col: 1, offset: 14704},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 14840},
+				pos: position{line: 499, col: 5, offset: 14718},
 				run: (*parser).callonLayoutArg1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 14840},
+					pos: position{line: 499, col: 5, offset: 14718},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 5, offset: 14840},
+							pos:  position{line: 499, col: 5, offset: 14718},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 7, offset: 14842},
+							pos:        position{line: 499, col: 7, offset: 14720},
 							val:        "order",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 15, offset: 14850},
+							pos:  position{line: 499, col: 15, offset: 14728},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 17, offset: 14852},
+							pos:   position{line: 499, col: 17, offset: 14730},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 22, offset: 14857},
+								pos:  position{line: 499, col: 22, offset: 14735},
 								name: "FieldExprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 33, offset: 14868},
+							pos:   position{line: 499, col: 33, offset: 14746},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 39, offset: 14874},
+								pos:  position{line: 499, col: 39, offset: 14752},
 								name: "OrderSuffix",
 							},
 						},
@@ -3867,31 +3867,31 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 505, col: 1, offset: 14984},
+			pos:  position{line: 503, col: 1, offset: 14862},
 			expr: &actionExpr{
-				pos: position{line: 506, col: 5, offset: 14998},
+				pos: position{line: 504, col: 5, offset: 14876},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 506, col: 5, offset: 14998},
+					pos: position{line: 504, col: 5, offset: 14876},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 5, offset: 14998},
+							pos:  position{line: 504, col: 5, offset: 14876},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 506, col: 7, offset: 15000},
+							pos:        position{line: 504, col: 7, offset: 14878},
 							val:        "format",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 16, offset: 15009},
+							pos:  position{line: 504, col: 16, offset: 14887},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 506, col: 18, offset: 15011},
+							pos:   position{line: 504, col: 18, offset: 14889},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 506, col: 22, offset: 15015},
+								pos:  position{line: 504, col: 22, offset: 14893},
 								name: "IdentifierName",
 							},
 						},
@@ -3901,33 +3901,33 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 508, col: 1, offset: 15051},
+			pos:  position{line: 506, col: 1, offset: 14929},
 			expr: &choiceExpr{
-				pos: position{line: 509, col: 5, offset: 15067},
+				pos: position{line: 507, col: 5, offset: 14945},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 509, col: 5, offset: 15067},
+						pos: position{line: 507, col: 5, offset: 14945},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 509, col: 5, offset: 15067},
+							pos:        position{line: 507, col: 5, offset: 14945},
 							val:        ":asc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 15101},
+						pos: position{line: 508, col: 5, offset: 14979},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 510, col: 5, offset: 15101},
+							pos:        position{line: 508, col: 5, offset: 14979},
 							val:        ":desc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 511, col: 5, offset: 15137},
+						pos: position{line: 509, col: 5, offset: 15015},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 511, col: 5, offset: 15137},
+							pos:        position{line: 509, col: 5, offset: 15015},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3937,31 +3937,31 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 513, col: 1, offset: 15163},
+			pos:  position{line: 511, col: 1, offset: 15041},
 			expr: &choiceExpr{
-				pos: position{line: 514, col: 5, offset: 15176},
+				pos: position{line: 512, col: 5, offset: 15054},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 15176},
+						pos: position{line: 512, col: 5, offset: 15054},
 						run: (*parser).callonOrderArg2,
 						expr: &seqExpr{
-							pos: position{line: 514, col: 5, offset: 15176},
+							pos: position{line: 512, col: 5, offset: 15054},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 5, offset: 15176},
+									pos:  position{line: 512, col: 5, offset: 15054},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 7, offset: 15178},
+									pos:        position{line: 512, col: 7, offset: 15056},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 15, offset: 15186},
+									pos:  position{line: 512, col: 15, offset: 15064},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 17, offset: 15188},
+									pos:        position{line: 512, col: 17, offset: 15066},
 									val:        "asc",
 									ignoreCase: false,
 								},
@@ -3969,26 +3969,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 515, col: 5, offset: 15221},
+						pos: position{line: 513, col: 5, offset: 15099},
 						run: (*parser).callonOrderArg8,
 						expr: &seqExpr{
-							pos: position{line: 515, col: 5, offset: 15221},
+							pos: position{line: 513, col: 5, offset: 15099},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 515, col: 5, offset: 15221},
+									pos:  position{line: 513, col: 5, offset: 15099},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 515, col: 7, offset: 15223},
+									pos:        position{line: 513, col: 7, offset: 15101},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 515, col: 15, offset: 15231},
+									pos:  position{line: 513, col: 15, offset: 15109},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 515, col: 17, offset: 15233},
+									pos:        position{line: 513, col: 17, offset: 15111},
 									val:        "desc",
 									ignoreCase: false,
 								},
@@ -4000,12 +4000,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassProc",
-			pos:  position{line: 517, col: 1, offset: 15265},
+			pos:  position{line: 515, col: 1, offset: 15143},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 5, offset: 15278},
+				pos: position{line: 516, col: 5, offset: 15156},
 				run: (*parser).callonPassProc1,
 				expr: &litMatcher{
-					pos:        position{line: 518, col: 5, offset: 15278},
+					pos:        position{line: 516, col: 5, offset: 15156},
 					val:        "pass",
 					ignoreCase: false,
 				},
@@ -4013,45 +4013,45 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeProc",
-			pos:  position{line: 524, col: 1, offset: 15472},
+			pos:  position{line: 522, col: 1, offset: 15350},
 			expr: &actionExpr{
-				pos: position{line: 525, col: 5, offset: 15488},
+				pos: position{line: 523, col: 5, offset: 15366},
 				run: (*parser).callonExplodeProc1,
 				expr: &seqExpr{
-					pos: position{line: 525, col: 5, offset: 15488},
+					pos: position{line: 523, col: 5, offset: 15366},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 525, col: 5, offset: 15488},
+							pos:        position{line: 523, col: 5, offset: 15366},
 							val:        "explode",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 525, col: 15, offset: 15498},
+							pos:  position{line: 523, col: 15, offset: 15376},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 17, offset: 15500},
+							pos:   position{line: 523, col: 17, offset: 15378},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 22, offset: 15505},
+								pos:  position{line: 523, col: 22, offset: 15383},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 28, offset: 15511},
+							pos:   position{line: 523, col: 28, offset: 15389},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 32, offset: 15515},
+								pos:  position{line: 523, col: 32, offset: 15393},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 40, offset: 15523},
+							pos:   position{line: 523, col: 40, offset: 15401},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 525, col: 43, offset: 15526},
+								pos: position{line: 523, col: 43, offset: 15404},
 								expr: &ruleRefExpr{
-									pos:  position{line: 525, col: 43, offset: 15526},
+									pos:  position{line: 523, col: 43, offset: 15404},
 									name: "AsArg",
 								},
 							},
@@ -4062,27 +4062,27 @@ var g = &grammar{
 		},
 		{
 			name: "MergeProc",
-			pos:  position{line: 529, col: 1, offset: 15638},
+			pos:  position{line: 527, col: 1, offset: 15516},
 			expr: &actionExpr{
-				pos: position{line: 530, col: 5, offset: 15652},
+				pos: position{line: 528, col: 5, offset: 15530},
 				run: (*parser).callonMergeProc1,
 				expr: &seqExpr{
-					pos: position{line: 530, col: 5, offset: 15652},
+					pos: position{line: 528, col: 5, offset: 15530},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 530, col: 5, offset: 15652},
+							pos:        position{line: 528, col: 5, offset: 15530},
 							val:        "merge",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 530, col: 13, offset: 15660},
+							pos:  position{line: 528, col: 13, offset: 15538},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 15, offset: 15662},
+							pos:   position{line: 528, col: 15, offset: 15540},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 21, offset: 15668},
+								pos:  position{line: 528, col: 21, offset: 15546},
 								name: "Expr",
 							},
 						},
@@ -4092,42 +4092,42 @@ var g = &grammar{
 		},
 		{
 			name: "OverProc",
-			pos:  position{line: 534, col: 1, offset: 15751},
+			pos:  position{line: 532, col: 1, offset: 15629},
 			expr: &choiceExpr{
-				pos: position{line: 535, col: 5, offset: 15764},
+				pos: position{line: 533, col: 5, offset: 15642},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 535, col: 5, offset: 15764},
+						pos: position{line: 533, col: 5, offset: 15642},
 						run: (*parser).callonOverProc2,
 						expr: &labeledExpr{
-							pos:   position{line: 535, col: 5, offset: 15764},
+							pos:   position{line: 533, col: 5, offset: 15642},
 							label: "over",
 							expr: &ruleRefExpr{
-								pos:  position{line: 535, col: 10, offset: 15769},
+								pos:  position{line: 533, col: 10, offset: 15647},
 								name: "ScopedOver",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 15874},
+						pos: position{line: 536, col: 5, offset: 15752},
 						run: (*parser).callonOverProc5,
 						expr: &seqExpr{
-							pos: position{line: 538, col: 5, offset: 15874},
+							pos: position{line: 536, col: 5, offset: 15752},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 538, col: 5, offset: 15874},
+									pos:        position{line: 536, col: 5, offset: 15752},
 									val:        "over",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 538, col: 12, offset: 15881},
+									pos:  position{line: 536, col: 12, offset: 15759},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 538, col: 14, offset: 15883},
+									pos:   position{line: 536, col: 14, offset: 15761},
 									label: "exprs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 538, col: 20, offset: 15889},
+										pos:  position{line: 536, col: 20, offset: 15767},
 										name: "Exprs",
 									},
 								},
@@ -4139,47 +4139,47 @@ var g = &grammar{
 		},
 		{
 			name: "ScopedOver",
-			pos:  position{line: 542, col: 1, offset: 15997},
+			pos:  position{line: 540, col: 1, offset: 15875},
 			expr: &actionExpr{
-				pos: position{line: 543, col: 5, offset: 16012},
+				pos: position{line: 541, col: 5, offset: 15890},
 				run: (*parser).callonScopedOver1,
 				expr: &seqExpr{
-					pos: position{line: 543, col: 5, offset: 16012},
+					pos: position{line: 541, col: 5, offset: 15890},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 543, col: 5, offset: 16012},
+							pos:        position{line: 541, col: 5, offset: 15890},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 12, offset: 16019},
+							pos:  position{line: 541, col: 12, offset: 15897},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 543, col: 14, offset: 16021},
+							pos:   position{line: 541, col: 14, offset: 15899},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 20, offset: 16027},
+								pos:  position{line: 541, col: 20, offset: 15905},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 543, col: 26, offset: 16033},
+							pos:   position{line: 541, col: 26, offset: 15911},
 							label: "as",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 29, offset: 16036},
+								pos:  position{line: 541, col: 29, offset: 15914},
 								name: "As",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 32, offset: 16039},
+							pos:  position{line: 541, col: 32, offset: 15917},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 543, col: 35, offset: 16042},
+							pos:   position{line: 541, col: 35, offset: 15920},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 41, offset: 16048},
+								pos:  position{line: 541, col: 41, offset: 15926},
 								name: "Scope",
 							},
 						},
@@ -4189,60 +4189,60 @@ var g = &grammar{
 		},
 		{
 			name: "OverWith",
-			pos:  position{line: 547, col: 1, offset: 16158},
+			pos:  position{line: 545, col: 1, offset: 16036},
 			expr: &actionExpr{
-				pos: position{line: 548, col: 5, offset: 16171},
+				pos: position{line: 546, col: 5, offset: 16049},
 				run: (*parser).callonOverWith1,
 				expr: &seqExpr{
-					pos: position{line: 548, col: 5, offset: 16171},
+					pos: position{line: 546, col: 5, offset: 16049},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 548, col: 5, offset: 16171},
+							pos:        position{line: 546, col: 5, offset: 16049},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 548, col: 12, offset: 16178},
+							pos:  position{line: 546, col: 12, offset: 16056},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 548, col: 14, offset: 16180},
+							pos:   position{line: 546, col: 14, offset: 16058},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 20, offset: 16186},
+								pos:  position{line: 546, col: 20, offset: 16064},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 548, col: 26, offset: 16192},
+							pos:  position{line: 546, col: 26, offset: 16070},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 548, col: 28, offset: 16194},
+							pos:        position{line: 546, col: 28, offset: 16072},
 							val:        "with",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 548, col: 35, offset: 16201},
+							pos:  position{line: 546, col: 35, offset: 16079},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 548, col: 37, offset: 16203},
+							pos:   position{line: 546, col: 37, offset: 16081},
 							label: "locals",
 							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 44, offset: 16210},
+								pos:  position{line: 546, col: 44, offset: 16088},
 								name: "LetAssignments",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 548, col: 59, offset: 16225},
+							pos:  position{line: 546, col: 59, offset: 16103},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 548, col: 62, offset: 16228},
+							pos:   position{line: 546, col: 62, offset: 16106},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 68, offset: 16234},
+								pos:  position{line: 546, col: 68, offset: 16112},
 								name: "Scope",
 							},
 						},
@@ -4252,34 +4252,34 @@ var g = &grammar{
 		},
 		{
 			name: "As",
-			pos:  position{line: 552, col: 1, offset: 16406},
+			pos:  position{line: 550, col: 1, offset: 16284},
 			expr: &choiceExpr{
-				pos: position{line: 553, col: 5, offset: 16413},
+				pos: position{line: 551, col: 5, offset: 16291},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 553, col: 5, offset: 16413},
+						pos: position{line: 551, col: 5, offset: 16291},
 						run: (*parser).callonAs2,
 						expr: &seqExpr{
-							pos: position{line: 553, col: 5, offset: 16413},
+							pos: position{line: 551, col: 5, offset: 16291},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 5, offset: 16413},
+									pos:  position{line: 551, col: 5, offset: 16291},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 553, col: 7, offset: 16415},
+									pos:        position{line: 551, col: 7, offset: 16293},
 									val:        "as",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 12, offset: 16420},
+									pos:  position{line: 551, col: 12, offset: 16298},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 553, col: 14, offset: 16422},
+									pos:   position{line: 551, col: 14, offset: 16300},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 553, col: 17, offset: 16425},
+										pos:  position{line: 551, col: 17, offset: 16303},
 										name: "IdentifierName",
 									},
 								},
@@ -4287,10 +4287,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 16463},
+						pos: position{line: 552, col: 5, offset: 16341},
 						run: (*parser).callonAs9,
 						expr: &litMatcher{
-							pos:        position{line: 554, col: 5, offset: 16463},
+							pos:        position{line: 552, col: 5, offset: 16341},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4300,42 +4300,42 @@ var g = &grammar{
 		},
 		{
 			name: "LetProc",
-			pos:  position{line: 556, col: 1, offset: 16486},
+			pos:  position{line: 554, col: 1, offset: 16364},
 			expr: &choiceExpr{
-				pos: position{line: 557, col: 5, offset: 16498},
+				pos: position{line: 555, col: 5, offset: 16376},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 557, col: 5, offset: 16498},
+						pos: position{line: 555, col: 5, offset: 16376},
 						run: (*parser).callonLetProc2,
 						expr: &seqExpr{
-							pos: position{line: 557, col: 5, offset: 16498},
+							pos: position{line: 555, col: 5, offset: 16376},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 557, col: 5, offset: 16498},
+									pos:        position{line: 555, col: 5, offset: 16376},
 									val:        "let",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 557, col: 11, offset: 16504},
+									pos:  position{line: 555, col: 11, offset: 16382},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 557, col: 13, offset: 16506},
+									pos:   position{line: 555, col: 13, offset: 16384},
 									label: "locals",
 									expr: &ruleRefExpr{
-										pos:  position{line: 557, col: 20, offset: 16513},
+										pos:  position{line: 555, col: 20, offset: 16391},
 										name: "LetAssignments",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 557, col: 35, offset: 16528},
+									pos:  position{line: 555, col: 35, offset: 16406},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 557, col: 38, offset: 16531},
+									pos:   position{line: 555, col: 38, offset: 16409},
 									label: "over",
 									expr: &ruleRefExpr{
-										pos:  position{line: 557, col: 43, offset: 16536},
+										pos:  position{line: 555, col: 43, offset: 16414},
 										name: "ScopedOver",
 									},
 								},
@@ -4343,7 +4343,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 560, col: 5, offset: 16644},
+						pos:  position{line: 558, col: 5, offset: 16522},
 						name: "OverWith",
 					},
 				},
@@ -4351,45 +4351,45 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 562, col: 1, offset: 16654},
+			pos:  position{line: 560, col: 1, offset: 16532},
 			expr: &actionExpr{
-				pos: position{line: 562, col: 9, offset: 16662},
+				pos: position{line: 560, col: 9, offset: 16540},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 562, col: 9, offset: 16662},
+					pos: position{line: 560, col: 9, offset: 16540},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 562, col: 9, offset: 16662},
+							pos:        position{line: 560, col: 9, offset: 16540},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 14, offset: 16667},
+							pos:  position{line: 560, col: 14, offset: 16545},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 562, col: 17, offset: 16670},
+							pos:        position{line: 560, col: 17, offset: 16548},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 21, offset: 16674},
+							pos:  position{line: 560, col: 21, offset: 16552},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 562, col: 24, offset: 16677},
+							pos:   position{line: 560, col: 24, offset: 16555},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 28, offset: 16681},
+								pos:  position{line: 560, col: 28, offset: 16559},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 39, offset: 16692},
+							pos:  position{line: 560, col: 39, offset: 16570},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 562, col: 42, offset: 16695},
+							pos:        position{line: 560, col: 42, offset: 16573},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4399,50 +4399,50 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignments",
-			pos:  position{line: 564, col: 1, offset: 16720},
+			pos:  position{line: 562, col: 1, offset: 16598},
 			expr: &actionExpr{
-				pos: position{line: 565, col: 5, offset: 16739},
+				pos: position{line: 563, col: 5, offset: 16617},
 				run: (*parser).callonLetAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 565, col: 5, offset: 16739},
+					pos: position{line: 563, col: 5, offset: 16617},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 565, col: 5, offset: 16739},
+							pos:   position{line: 563, col: 5, offset: 16617},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 565, col: 11, offset: 16745},
+								pos:  position{line: 563, col: 11, offset: 16623},
 								name: "LetAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 565, col: 25, offset: 16759},
+							pos:   position{line: 563, col: 25, offset: 16637},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 565, col: 30, offset: 16764},
+								pos: position{line: 563, col: 30, offset: 16642},
 								expr: &actionExpr{
-									pos: position{line: 565, col: 31, offset: 16765},
+									pos: position{line: 563, col: 31, offset: 16643},
 									run: (*parser).callonLetAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 565, col: 31, offset: 16765},
+										pos: position{line: 563, col: 31, offset: 16643},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 565, col: 31, offset: 16765},
+												pos:  position{line: 563, col: 31, offset: 16643},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 565, col: 34, offset: 16768},
+												pos:        position{line: 563, col: 34, offset: 16646},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 565, col: 38, offset: 16772},
+												pos:  position{line: 563, col: 38, offset: 16650},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 565, col: 41, offset: 16775},
+												pos:   position{line: 563, col: 41, offset: 16653},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 565, col: 43, offset: 16777},
+													pos:  position{line: 563, col: 43, offset: 16655},
 													name: "LetAssignment",
 												},
 											},
@@ -4457,42 +4457,42 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignment",
-			pos:  position{line: 569, col: 1, offset: 16895},
+			pos:  position{line: 567, col: 1, offset: 16773},
 			expr: &choiceExpr{
-				pos: position{line: 570, col: 5, offset: 16913},
+				pos: position{line: 568, col: 5, offset: 16791},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 570, col: 5, offset: 16913},
+						pos: position{line: 568, col: 5, offset: 16791},
 						run: (*parser).callonLetAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 570, col: 5, offset: 16913},
+							pos: position{line: 568, col: 5, offset: 16791},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 570, col: 5, offset: 16913},
+									pos:   position{line: 568, col: 5, offset: 16791},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 570, col: 8, offset: 16916},
+										pos:  position{line: 568, col: 8, offset: 16794},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 23, offset: 16931},
+									pos:  position{line: 568, col: 23, offset: 16809},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 570, col: 26, offset: 16934},
+									pos:        position{line: 568, col: 26, offset: 16812},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 30, offset: 16938},
+									pos:  position{line: 568, col: 30, offset: 16816},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 570, col: 33, offset: 16941},
+									pos:   position{line: 568, col: 33, offset: 16819},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 570, col: 38, offset: 16946},
+										pos:  position{line: 568, col: 38, offset: 16824},
 										name: "Expr",
 									},
 								},
@@ -4500,13 +4500,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 573, col: 5, offset: 17028},
+						pos: position{line: 571, col: 5, offset: 16906},
 						run: (*parser).callonLetAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 573, col: 5, offset: 17028},
+							pos:   position{line: 571, col: 5, offset: 16906},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 573, col: 8, offset: 17031},
+								pos:  position{line: 571, col: 8, offset: 16909},
 								name: "IdentifierName",
 							},
 						},
@@ -4516,27 +4516,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldProc",
-			pos:  position{line: 577, col: 1, offset: 17161},
+			pos:  position{line: 575, col: 1, offset: 17039},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 5, offset: 17175},
+				pos: position{line: 576, col: 5, offset: 17053},
 				run: (*parser).callonYieldProc1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 5, offset: 17175},
+					pos: position{line: 576, col: 5, offset: 17053},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 578, col: 5, offset: 17175},
+							pos:        position{line: 576, col: 5, offset: 17053},
 							val:        "yield",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 578, col: 13, offset: 17183},
+							pos:  position{line: 576, col: 13, offset: 17061},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 578, col: 15, offset: 17185},
+							pos:   position{line: 576, col: 15, offset: 17063},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 578, col: 21, offset: 17191},
+								pos:  position{line: 576, col: 21, offset: 17069},
 								name: "Exprs",
 							},
 						},
@@ -4546,30 +4546,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 582, col: 1, offset: 17275},
+			pos:  position{line: 580, col: 1, offset: 17153},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 5, offset: 17287},
+				pos: position{line: 581, col: 5, offset: 17165},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 583, col: 5, offset: 17287},
+					pos: position{line: 581, col: 5, offset: 17165},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 5, offset: 17287},
+							pos:  position{line: 581, col: 5, offset: 17165},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 7, offset: 17289},
+							pos:  position{line: 581, col: 7, offset: 17167},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 10, offset: 17292},
+							pos:  position{line: 581, col: 10, offset: 17170},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 12, offset: 17294},
+							pos:   position{line: 581, col: 12, offset: 17172},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 16, offset: 17298},
+								pos:  position{line: 581, col: 16, offset: 17176},
 								name: "Type",
 							},
 						},
@@ -4579,30 +4579,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 585, col: 1, offset: 17323},
+			pos:  position{line: 583, col: 1, offset: 17201},
 			expr: &actionExpr{
-				pos: position{line: 586, col: 5, offset: 17333},
+				pos: position{line: 584, col: 5, offset: 17211},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 586, col: 5, offset: 17333},
+					pos: position{line: 584, col: 5, offset: 17211},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 5, offset: 17333},
+							pos:  position{line: 584, col: 5, offset: 17211},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 7, offset: 17335},
+							pos:  position{line: 584, col: 7, offset: 17213},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 10, offset: 17338},
+							pos:  position{line: 584, col: 10, offset: 17216},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 586, col: 12, offset: 17340},
+							pos:   position{line: 584, col: 12, offset: 17218},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 586, col: 16, offset: 17344},
+								pos:  position{line: 584, col: 16, offset: 17222},
 								name: "Lval",
 							},
 						},
@@ -4612,58 +4612,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 590, col: 1, offset: 17395},
+			pos:  position{line: 588, col: 1, offset: 17273},
 			expr: &ruleRefExpr{
-				pos:  position{line: 590, col: 8, offset: 17402},
+				pos:  position{line: 588, col: 8, offset: 17280},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 592, col: 1, offset: 17413},
+			pos:  position{line: 590, col: 1, offset: 17291},
 			expr: &actionExpr{
-				pos: position{line: 593, col: 5, offset: 17423},
+				pos: position{line: 591, col: 5, offset: 17301},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 593, col: 5, offset: 17423},
+					pos: position{line: 591, col: 5, offset: 17301},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 593, col: 5, offset: 17423},
+							pos:   position{line: 591, col: 5, offset: 17301},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 593, col: 11, offset: 17429},
+								pos:  position{line: 591, col: 11, offset: 17307},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 593, col: 16, offset: 17434},
+							pos:   position{line: 591, col: 16, offset: 17312},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 593, col: 21, offset: 17439},
+								pos: position{line: 591, col: 21, offset: 17317},
 								expr: &actionExpr{
-									pos: position{line: 593, col: 22, offset: 17440},
+									pos: position{line: 591, col: 22, offset: 17318},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 593, col: 22, offset: 17440},
+										pos: position{line: 591, col: 22, offset: 17318},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 593, col: 22, offset: 17440},
+												pos:  position{line: 591, col: 22, offset: 17318},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 593, col: 25, offset: 17443},
+												pos:        position{line: 591, col: 25, offset: 17321},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 593, col: 29, offset: 17447},
+												pos:  position{line: 591, col: 29, offset: 17325},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 593, col: 32, offset: 17450},
+												pos:   position{line: 591, col: 32, offset: 17328},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 593, col: 37, offset: 17455},
+													pos:  position{line: 591, col: 37, offset: 17333},
 													name: "Lval",
 												},
 											},
@@ -4678,52 +4678,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 597, col: 1, offset: 17567},
+			pos:  position{line: 595, col: 1, offset: 17445},
 			expr: &ruleRefExpr{
-				pos:  position{line: 597, col: 13, offset: 17579},
+				pos:  position{line: 595, col: 13, offset: 17457},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 599, col: 1, offset: 17585},
+			pos:  position{line: 597, col: 1, offset: 17463},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 5, offset: 17600},
+				pos: position{line: 598, col: 5, offset: 17478},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 5, offset: 17600},
+					pos: position{line: 598, col: 5, offset: 17478},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 600, col: 5, offset: 17600},
+							pos:   position{line: 598, col: 5, offset: 17478},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 600, col: 11, offset: 17606},
+								pos:  position{line: 598, col: 11, offset: 17484},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 21, offset: 17616},
+							pos:   position{line: 598, col: 21, offset: 17494},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 600, col: 26, offset: 17621},
+								pos: position{line: 598, col: 26, offset: 17499},
 								expr: &seqExpr{
-									pos: position{line: 600, col: 27, offset: 17622},
+									pos: position{line: 598, col: 27, offset: 17500},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 27, offset: 17622},
+											pos:  position{line: 598, col: 27, offset: 17500},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 600, col: 30, offset: 17625},
+											pos:        position{line: 598, col: 30, offset: 17503},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 34, offset: 17629},
+											pos:  position{line: 598, col: 34, offset: 17507},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 37, offset: 17632},
+											pos:  position{line: 598, col: 37, offset: 17510},
 											name: "FieldExpr",
 										},
 									},
@@ -4736,50 +4736,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 610, col: 1, offset: 17831},
+			pos:  position{line: 608, col: 1, offset: 17709},
 			expr: &actionExpr{
-				pos: position{line: 611, col: 5, offset: 17847},
+				pos: position{line: 609, col: 5, offset: 17725},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 611, col: 5, offset: 17847},
+					pos: position{line: 609, col: 5, offset: 17725},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 611, col: 5, offset: 17847},
+							pos:   position{line: 609, col: 5, offset: 17725},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 11, offset: 17853},
+								pos:  position{line: 609, col: 11, offset: 17731},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 22, offset: 17864},
+							pos:   position{line: 609, col: 22, offset: 17742},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 611, col: 27, offset: 17869},
+								pos: position{line: 609, col: 27, offset: 17747},
 								expr: &actionExpr{
-									pos: position{line: 611, col: 28, offset: 17870},
+									pos: position{line: 609, col: 28, offset: 17748},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 611, col: 28, offset: 17870},
+										pos: position{line: 609, col: 28, offset: 17748},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 28, offset: 17870},
+												pos:  position{line: 609, col: 28, offset: 17748},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 611, col: 31, offset: 17873},
+												pos:        position{line: 609, col: 31, offset: 17751},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 35, offset: 17877},
+												pos:  position{line: 609, col: 35, offset: 17755},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 611, col: 38, offset: 17880},
+												pos:   position{line: 609, col: 38, offset: 17758},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 611, col: 40, offset: 17882},
+													pos:  position{line: 609, col: 40, offset: 17760},
 													name: "Assignment",
 												},
 											},
@@ -4794,39 +4794,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 615, col: 1, offset: 17993},
+			pos:  position{line: 613, col: 1, offset: 17871},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 5, offset: 18008},
+				pos: position{line: 614, col: 5, offset: 17886},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 5, offset: 18008},
+					pos: position{line: 614, col: 5, offset: 17886},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 616, col: 5, offset: 18008},
+							pos:   position{line: 614, col: 5, offset: 17886},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 9, offset: 18012},
+								pos:  position{line: 614, col: 9, offset: 17890},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 616, col: 14, offset: 18017},
+							pos:  position{line: 614, col: 14, offset: 17895},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 616, col: 17, offset: 18020},
+							pos:        position{line: 614, col: 17, offset: 17898},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 616, col: 22, offset: 18025},
+							pos:  position{line: 614, col: 22, offset: 17903},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 616, col: 25, offset: 18028},
+							pos:   position{line: 614, col: 25, offset: 17906},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 29, offset: 18032},
+								pos:  position{line: 614, col: 29, offset: 17910},
 								name: "Expr",
 							},
 						},
@@ -4836,71 +4836,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 618, col: 1, offset: 18123},
+			pos:  position{line: 616, col: 1, offset: 18001},
 			expr: &ruleRefExpr{
-				pos:  position{line: 618, col: 8, offset: 18130},
+				pos:  position{line: 616, col: 8, offset: 18008},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 620, col: 1, offset: 18147},
+			pos:  position{line: 618, col: 1, offset: 18025},
 			expr: &choiceExpr{
-				pos: position{line: 621, col: 5, offset: 18167},
+				pos: position{line: 619, col: 5, offset: 18045},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 621, col: 5, offset: 18167},
+						pos: position{line: 619, col: 5, offset: 18045},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 621, col: 5, offset: 18167},
+							pos: position{line: 619, col: 5, offset: 18045},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 621, col: 5, offset: 18167},
+									pos:   position{line: 619, col: 5, offset: 18045},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 15, offset: 18177},
+										pos:  position{line: 619, col: 15, offset: 18055},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 29, offset: 18191},
+									pos:  position{line: 619, col: 29, offset: 18069},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 621, col: 32, offset: 18194},
+									pos:        position{line: 619, col: 32, offset: 18072},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 36, offset: 18198},
+									pos:  position{line: 619, col: 36, offset: 18076},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 621, col: 39, offset: 18201},
+									pos:   position{line: 619, col: 39, offset: 18079},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 50, offset: 18212},
+										pos:  position{line: 619, col: 50, offset: 18090},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 55, offset: 18217},
+									pos:  position{line: 619, col: 55, offset: 18095},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 621, col: 58, offset: 18220},
+									pos:        position{line: 619, col: 58, offset: 18098},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 62, offset: 18224},
+									pos:  position{line: 619, col: 62, offset: 18102},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 621, col: 65, offset: 18227},
+									pos:   position{line: 619, col: 65, offset: 18105},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 76, offset: 18238},
+										pos:  position{line: 619, col: 76, offset: 18116},
 										name: "Expr",
 									},
 								},
@@ -4908,7 +4908,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 5, offset: 18378},
+						pos:  position{line: 622, col: 5, offset: 18256},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4916,53 +4916,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 626, col: 1, offset: 18393},
+			pos:  position{line: 624, col: 1, offset: 18271},
 			expr: &actionExpr{
-				pos: position{line: 627, col: 5, offset: 18411},
+				pos: position{line: 625, col: 5, offset: 18289},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 627, col: 5, offset: 18411},
+					pos: position{line: 625, col: 5, offset: 18289},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 627, col: 5, offset: 18411},
+							pos:   position{line: 625, col: 5, offset: 18289},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 627, col: 11, offset: 18417},
+								pos:  position{line: 625, col: 11, offset: 18295},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 628, col: 5, offset: 18436},
+							pos:   position{line: 626, col: 5, offset: 18314},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 628, col: 10, offset: 18441},
+								pos: position{line: 626, col: 10, offset: 18319},
 								expr: &actionExpr{
-									pos: position{line: 628, col: 11, offset: 18442},
+									pos: position{line: 626, col: 11, offset: 18320},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 628, col: 11, offset: 18442},
+										pos: position{line: 626, col: 11, offset: 18320},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 628, col: 11, offset: 18442},
+												pos:  position{line: 626, col: 11, offset: 18320},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 628, col: 14, offset: 18445},
+												pos:   position{line: 626, col: 14, offset: 18323},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 628, col: 17, offset: 18448},
+													pos:  position{line: 626, col: 17, offset: 18326},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 628, col: 25, offset: 18456},
+												pos:  position{line: 626, col: 25, offset: 18334},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 628, col: 28, offset: 18459},
+												pos:   position{line: 626, col: 28, offset: 18337},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 628, col: 33, offset: 18464},
+													pos:  position{line: 626, col: 33, offset: 18342},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4977,53 +4977,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 632, col: 1, offset: 18582},
+			pos:  position{line: 630, col: 1, offset: 18460},
 			expr: &actionExpr{
-				pos: position{line: 633, col: 5, offset: 18601},
+				pos: position{line: 631, col: 5, offset: 18479},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 633, col: 5, offset: 18601},
+					pos: position{line: 631, col: 5, offset: 18479},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 633, col: 5, offset: 18601},
+							pos:   position{line: 631, col: 5, offset: 18479},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 11, offset: 18607},
+								pos:  position{line: 631, col: 11, offset: 18485},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 5, offset: 18626},
+							pos:   position{line: 632, col: 5, offset: 18504},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 634, col: 10, offset: 18631},
+								pos: position{line: 632, col: 10, offset: 18509},
 								expr: &actionExpr{
-									pos: position{line: 634, col: 11, offset: 18632},
+									pos: position{line: 632, col: 11, offset: 18510},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 634, col: 11, offset: 18632},
+										pos: position{line: 632, col: 11, offset: 18510},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 634, col: 11, offset: 18632},
+												pos:  position{line: 632, col: 11, offset: 18510},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 634, col: 14, offset: 18635},
+												pos:   position{line: 632, col: 14, offset: 18513},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 634, col: 17, offset: 18638},
+													pos:  position{line: 632, col: 17, offset: 18516},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 634, col: 26, offset: 18647},
+												pos:  position{line: 632, col: 26, offset: 18525},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 634, col: 29, offset: 18650},
+												pos:   position{line: 632, col: 29, offset: 18528},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 634, col: 34, offset: 18655},
+													pos:  position{line: 632, col: 34, offset: 18533},
 													name: "ComparisonExpr",
 												},
 											},
@@ -5038,45 +5038,45 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 638, col: 1, offset: 18773},
+			pos:  position{line: 636, col: 1, offset: 18651},
 			expr: &choiceExpr{
-				pos: position{line: 639, col: 5, offset: 18792},
+				pos: position{line: 637, col: 5, offset: 18670},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 639, col: 5, offset: 18792},
+						pos: position{line: 637, col: 5, offset: 18670},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 639, col: 5, offset: 18792},
+							pos: position{line: 637, col: 5, offset: 18670},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 639, col: 5, offset: 18792},
+									pos:   position{line: 637, col: 5, offset: 18670},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 9, offset: 18796},
+										pos:  position{line: 637, col: 9, offset: 18674},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 639, col: 22, offset: 18809},
+									pos:  position{line: 637, col: 22, offset: 18687},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 639, col: 25, offset: 18812},
+									pos:   position{line: 637, col: 25, offset: 18690},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 28, offset: 18815},
+										pos:  position{line: 637, col: 28, offset: 18693},
 										name: "Comparator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 639, col: 39, offset: 18826},
+									pos:  position{line: 637, col: 39, offset: 18704},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 639, col: 42, offset: 18829},
+									pos:   position{line: 637, col: 42, offset: 18707},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 46, offset: 18833},
+										pos:  position{line: 637, col: 46, offset: 18711},
 										name: "AdditiveExpr",
 									},
 								},
@@ -5084,37 +5084,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 642, col: 5, offset: 18957},
+						pos: position{line: 640, col: 5, offset: 18835},
 						run: (*parser).callonComparisonExpr12,
 						expr: &seqExpr{
-							pos: position{line: 642, col: 5, offset: 18957},
+							pos: position{line: 640, col: 5, offset: 18835},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 642, col: 5, offset: 18957},
+									pos:   position{line: 640, col: 5, offset: 18835},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 642, col: 9, offset: 18961},
+										pos:  position{line: 640, col: 9, offset: 18839},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 642, col: 22, offset: 18974},
+									pos:  position{line: 640, col: 22, offset: 18852},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 642, col: 25, offset: 18977},
+									pos:        position{line: 640, col: 25, offset: 18855},
 									val:        "~",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 642, col: 29, offset: 18981},
+									pos:  position{line: 640, col: 29, offset: 18859},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 642, col: 32, offset: 18984},
+									pos:   position{line: 640, col: 32, offset: 18862},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 642, col: 36, offset: 18988},
+										pos:  position{line: 640, col: 36, offset: 18866},
 										name: "Regexp",
 									},
 								},
@@ -5122,7 +5122,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 645, col: 5, offset: 19107},
+						pos:  position{line: 643, col: 5, offset: 18985},
 						name: "AdditiveExpr",
 					},
 				},
@@ -5130,53 +5130,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 647, col: 1, offset: 19121},
+			pos:  position{line: 645, col: 1, offset: 18999},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 5, offset: 19138},
+				pos: position{line: 646, col: 5, offset: 19016},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 648, col: 5, offset: 19138},
+					pos: position{line: 646, col: 5, offset: 19016},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 648, col: 5, offset: 19138},
+							pos:   position{line: 646, col: 5, offset: 19016},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 648, col: 11, offset: 19144},
+								pos:  position{line: 646, col: 11, offset: 19022},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 5, offset: 19167},
+							pos:   position{line: 647, col: 5, offset: 19045},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 649, col: 10, offset: 19172},
+								pos: position{line: 647, col: 10, offset: 19050},
 								expr: &actionExpr{
-									pos: position{line: 649, col: 11, offset: 19173},
+									pos: position{line: 647, col: 11, offset: 19051},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 649, col: 11, offset: 19173},
+										pos: position{line: 647, col: 11, offset: 19051},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 649, col: 11, offset: 19173},
+												pos:  position{line: 647, col: 11, offset: 19051},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 649, col: 14, offset: 19176},
+												pos:   position{line: 647, col: 14, offset: 19054},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 649, col: 17, offset: 19179},
+													pos:  position{line: 647, col: 17, offset: 19057},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 649, col: 34, offset: 19196},
+												pos:  position{line: 647, col: 34, offset: 19074},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 649, col: 37, offset: 19199},
+												pos:   position{line: 647, col: 37, offset: 19077},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 649, col: 42, offset: 19204},
+													pos:  position{line: 647, col: 42, offset: 19082},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5191,20 +5191,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 653, col: 1, offset: 19326},
+			pos:  position{line: 651, col: 1, offset: 19204},
 			expr: &actionExpr{
-				pos: position{line: 653, col: 20, offset: 19345},
+				pos: position{line: 651, col: 20, offset: 19223},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 653, col: 21, offset: 19346},
+					pos: position{line: 651, col: 21, offset: 19224},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 653, col: 21, offset: 19346},
+							pos:        position{line: 651, col: 21, offset: 19224},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 653, col: 27, offset: 19352},
+							pos:        position{line: 651, col: 27, offset: 19230},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5214,53 +5214,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 655, col: 1, offset: 19389},
+			pos:  position{line: 653, col: 1, offset: 19267},
 			expr: &actionExpr{
-				pos: position{line: 656, col: 5, offset: 19412},
+				pos: position{line: 654, col: 5, offset: 19290},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 656, col: 5, offset: 19412},
+					pos: position{line: 654, col: 5, offset: 19290},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 656, col: 5, offset: 19412},
+							pos:   position{line: 654, col: 5, offset: 19290},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 656, col: 11, offset: 19418},
+								pos:  position{line: 654, col: 11, offset: 19296},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 5, offset: 19430},
+							pos:   position{line: 655, col: 5, offset: 19308},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 657, col: 10, offset: 19435},
+								pos: position{line: 655, col: 10, offset: 19313},
 								expr: &actionExpr{
-									pos: position{line: 657, col: 11, offset: 19436},
+									pos: position{line: 655, col: 11, offset: 19314},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 657, col: 11, offset: 19436},
+										pos: position{line: 655, col: 11, offset: 19314},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 657, col: 11, offset: 19436},
+												pos:  position{line: 655, col: 11, offset: 19314},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 657, col: 14, offset: 19439},
+												pos:   position{line: 655, col: 14, offset: 19317},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 657, col: 17, offset: 19442},
+													pos:  position{line: 655, col: 17, offset: 19320},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 657, col: 40, offset: 19465},
+												pos:  position{line: 655, col: 40, offset: 19343},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 657, col: 43, offset: 19468},
+												pos:   position{line: 655, col: 43, offset: 19346},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 657, col: 48, offset: 19473},
+													pos:  position{line: 655, col: 48, offset: 19351},
 													name: "NotExpr",
 												},
 											},
@@ -5275,25 +5275,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 661, col: 1, offset: 19584},
+			pos:  position{line: 659, col: 1, offset: 19462},
 			expr: &actionExpr{
-				pos: position{line: 661, col: 26, offset: 19609},
+				pos: position{line: 659, col: 26, offset: 19487},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 661, col: 27, offset: 19610},
+					pos: position{line: 659, col: 27, offset: 19488},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 661, col: 27, offset: 19610},
+							pos:        position{line: 659, col: 27, offset: 19488},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 661, col: 33, offset: 19616},
+							pos:        position{line: 659, col: 33, offset: 19494},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 661, col: 39, offset: 19622},
+							pos:        position{line: 659, col: 39, offset: 19500},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5303,30 +5303,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 663, col: 1, offset: 19659},
+			pos:  position{line: 661, col: 1, offset: 19537},
 			expr: &choiceExpr{
-				pos: position{line: 664, col: 5, offset: 19671},
+				pos: position{line: 662, col: 5, offset: 19549},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 19671},
+						pos: position{line: 662, col: 5, offset: 19549},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 664, col: 5, offset: 19671},
+							pos: position{line: 662, col: 5, offset: 19549},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 664, col: 5, offset: 19671},
+									pos:        position{line: 662, col: 5, offset: 19549},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 664, col: 9, offset: 19675},
+									pos:  position{line: 662, col: 9, offset: 19553},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 664, col: 12, offset: 19678},
+									pos:   position{line: 662, col: 12, offset: 19556},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 664, col: 14, offset: 19680},
+										pos:  position{line: 662, col: 14, offset: 19558},
 										name: "NotExpr",
 									},
 								},
@@ -5334,7 +5334,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 19789},
+						pos:  position{line: 665, col: 5, offset: 19667},
 						name: "FuncExpr",
 					},
 				},
@@ -5342,31 +5342,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 669, col: 1, offset: 19799},
+			pos:  position{line: 667, col: 1, offset: 19677},
 			expr: &choiceExpr{
-				pos: position{line: 670, col: 5, offset: 19812},
+				pos: position{line: 668, col: 5, offset: 19690},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 670, col: 5, offset: 19812},
+						pos: position{line: 668, col: 5, offset: 19690},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 670, col: 5, offset: 19812},
+							pos: position{line: 668, col: 5, offset: 19690},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 670, col: 5, offset: 19812},
+									pos:   position{line: 668, col: 5, offset: 19690},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 670, col: 11, offset: 19818},
+										pos:  position{line: 668, col: 11, offset: 19696},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 670, col: 16, offset: 19823},
+									pos:   position{line: 668, col: 16, offset: 19701},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 670, col: 21, offset: 19828},
+										pos: position{line: 668, col: 21, offset: 19706},
 										expr: &ruleRefExpr{
-											pos:  position{line: 670, col: 22, offset: 19829},
+											pos:  position{line: 668, col: 22, offset: 19707},
 											name: "Deref",
 										},
 									},
@@ -5375,26 +5375,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 19900},
+						pos: position{line: 671, col: 5, offset: 19778},
 						run: (*parser).callonFuncExpr9,
 						expr: &seqExpr{
-							pos: position{line: 673, col: 5, offset: 19900},
+							pos: position{line: 671, col: 5, offset: 19778},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 673, col: 5, offset: 19900},
+									pos:   position{line: 671, col: 5, offset: 19778},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 673, col: 11, offset: 19906},
+										pos:  position{line: 671, col: 11, offset: 19784},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 673, col: 20, offset: 19915},
+									pos:   position{line: 671, col: 20, offset: 19793},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 673, col: 25, offset: 19920},
+										pos: position{line: 671, col: 25, offset: 19798},
 										expr: &ruleRefExpr{
-											pos:  position{line: 673, col: 26, offset: 19921},
+											pos:  position{line: 671, col: 26, offset: 19799},
 											name: "Deref",
 										},
 									},
@@ -5403,11 +5403,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 676, col: 5, offset: 19992},
+						pos:  position{line: 674, col: 5, offset: 19870},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 5, offset: 20006},
+						pos:  position{line: 675, col: 5, offset: 19884},
 						name: "Primary",
 					},
 				},
@@ -5415,20 +5415,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 679, col: 1, offset: 20015},
+			pos:  position{line: 677, col: 1, offset: 19893},
 			expr: &seqExpr{
-				pos: position{line: 679, col: 13, offset: 20027},
+				pos: position{line: 677, col: 13, offset: 19905},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 679, col: 13, offset: 20027},
+						pos:  position{line: 677, col: 13, offset: 19905},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 679, col: 22, offset: 20036},
+						pos:  position{line: 677, col: 22, offset: 19914},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 679, col: 25, offset: 20039},
+						pos:        position{line: 677, col: 25, offset: 19917},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5437,17 +5437,17 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 681, col: 1, offset: 20044},
+			pos:  position{line: 679, col: 1, offset: 19922},
 			expr: &choiceExpr{
-				pos: position{line: 682, col: 5, offset: 20057},
+				pos: position{line: 680, col: 5, offset: 19935},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 682, col: 5, offset: 20057},
+						pos:        position{line: 680, col: 5, offset: 19935},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 683, col: 5, offset: 20067},
+						pos:        position{line: 681, col: 5, offset: 19945},
 						val:        "select",
 						ignoreCase: false,
 					},
@@ -5456,48 +5456,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 685, col: 1, offset: 20077},
+			pos:  position{line: 683, col: 1, offset: 19955},
 			expr: &actionExpr{
-				pos: position{line: 686, col: 5, offset: 20086},
+				pos: position{line: 684, col: 5, offset: 19964},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 686, col: 5, offset: 20086},
+					pos: position{line: 684, col: 5, offset: 19964},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 686, col: 5, offset: 20086},
+							pos:   position{line: 684, col: 5, offset: 19964},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 686, col: 9, offset: 20090},
+								pos:  position{line: 684, col: 9, offset: 19968},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 686, col: 18, offset: 20099},
+							pos:  position{line: 684, col: 18, offset: 19977},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 686, col: 21, offset: 20102},
+							pos:        position{line: 684, col: 21, offset: 19980},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 686, col: 25, offset: 20106},
+							pos:  position{line: 684, col: 25, offset: 19984},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 686, col: 28, offset: 20109},
+							pos:   position{line: 684, col: 28, offset: 19987},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 686, col: 33, offset: 20114},
+								pos:  position{line: 684, col: 33, offset: 19992},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 686, col: 38, offset: 20119},
+							pos:  position{line: 684, col: 38, offset: 19997},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 686, col: 41, offset: 20122},
+							pos:        position{line: 684, col: 41, offset: 20000},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5507,72 +5507,72 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 690, col: 1, offset: 20219},
+			pos:  position{line: 688, col: 1, offset: 20097},
 			expr: &choiceExpr{
-				pos: position{line: 691, col: 5, offset: 20232},
+				pos: position{line: 689, col: 5, offset: 20110},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 691, col: 5, offset: 20232},
+						pos:  position{line: 689, col: 5, offset: 20110},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 692, col: 5, offset: 20241},
+						pos: position{line: 690, col: 5, offset: 20119},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 692, col: 5, offset: 20241},
+							pos: position{line: 690, col: 5, offset: 20119},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 692, col: 5, offset: 20241},
+									pos: position{line: 690, col: 5, offset: 20119},
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 6, offset: 20242},
+										pos:  position{line: 690, col: 6, offset: 20120},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 692, col: 16, offset: 20252},
+									pos:   position{line: 690, col: 16, offset: 20130},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 19, offset: 20255},
+										pos:  position{line: 690, col: 19, offset: 20133},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 692, col: 34, offset: 20270},
+									pos:  position{line: 690, col: 34, offset: 20148},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 692, col: 37, offset: 20273},
+									pos:        position{line: 690, col: 37, offset: 20151},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 692, col: 41, offset: 20277},
+									pos:  position{line: 690, col: 41, offset: 20155},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 692, col: 44, offset: 20280},
+									pos:   position{line: 690, col: 44, offset: 20158},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 49, offset: 20285},
+										pos:  position{line: 690, col: 49, offset: 20163},
 										name: "OptionalExprs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 692, col: 63, offset: 20299},
+									pos:  position{line: 690, col: 63, offset: 20177},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 692, col: 66, offset: 20302},
+									pos:        position{line: 690, col: 66, offset: 20180},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 692, col: 70, offset: 20306},
+									pos:   position{line: 690, col: 70, offset: 20184},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 692, col: 76, offset: 20312},
+										pos: position{line: 690, col: 76, offset: 20190},
 										expr: &ruleRefExpr{
-											pos:  position{line: 692, col: 76, offset: 20312},
+											pos:  position{line: 690, col: 76, offset: 20190},
 											name: "WhereClause",
 										},
 									},
@@ -5585,48 +5585,48 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 696, col: 1, offset: 20433},
+			pos:  position{line: 694, col: 1, offset: 20311},
 			expr: &choiceExpr{
-				pos: position{line: 697, col: 5, offset: 20442},
+				pos: position{line: 695, col: 5, offset: 20320},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 697, col: 5, offset: 20442},
+						pos: position{line: 695, col: 5, offset: 20320},
 						run: (*parser).callonGrep2,
 						expr: &seqExpr{
-							pos: position{line: 697, col: 5, offset: 20442},
+							pos: position{line: 695, col: 5, offset: 20320},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 697, col: 5, offset: 20442},
+									pos:        position{line: 695, col: 5, offset: 20320},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 697, col: 12, offset: 20449},
+									pos:  position{line: 695, col: 12, offset: 20327},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 697, col: 15, offset: 20452},
+									pos:        position{line: 695, col: 15, offset: 20330},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 697, col: 19, offset: 20456},
+									pos:  position{line: 695, col: 19, offset: 20334},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 697, col: 22, offset: 20459},
+									pos:   position{line: 695, col: 22, offset: 20337},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 697, col: 30, offset: 20467},
+										pos:  position{line: 695, col: 30, offset: 20345},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 697, col: 38, offset: 20475},
+									pos:  position{line: 695, col: 38, offset: 20353},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 697, col: 41, offset: 20478},
+									pos:        position{line: 695, col: 41, offset: 20356},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5634,64 +5634,64 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20633},
+						pos: position{line: 698, col: 5, offset: 20511},
 						run: (*parser).callonGrep12,
 						expr: &seqExpr{
-							pos: position{line: 700, col: 5, offset: 20633},
+							pos: position{line: 698, col: 5, offset: 20511},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 700, col: 5, offset: 20633},
+									pos:        position{line: 698, col: 5, offset: 20511},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 12, offset: 20640},
+									pos:  position{line: 698, col: 12, offset: 20518},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 15, offset: 20643},
+									pos:        position{line: 698, col: 15, offset: 20521},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 19, offset: 20647},
+									pos:  position{line: 698, col: 19, offset: 20525},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 700, col: 22, offset: 20650},
+									pos:   position{line: 698, col: 22, offset: 20528},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 700, col: 30, offset: 20658},
+										pos:  position{line: 698, col: 30, offset: 20536},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 38, offset: 20666},
+									pos:  position{line: 698, col: 38, offset: 20544},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 42, offset: 20670},
+									pos:        position{line: 698, col: 42, offset: 20548},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 46, offset: 20674},
+									pos:  position{line: 698, col: 46, offset: 20552},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 700, col: 49, offset: 20677},
+									pos:   position{line: 698, col: 49, offset: 20555},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 700, col: 54, offset: 20682},
+										pos:  position{line: 698, col: 54, offset: 20560},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 59, offset: 20687},
+									pos:  position{line: 698, col: 59, offset: 20565},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 62, offset: 20690},
+									pos:        position{line: 698, col: 62, offset: 20568},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5703,26 +5703,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 704, col: 1, offset: 20794},
+			pos:  position{line: 702, col: 1, offset: 20672},
 			expr: &choiceExpr{
-				pos: position{line: 705, col: 5, offset: 20806},
+				pos: position{line: 703, col: 5, offset: 20684},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 705, col: 5, offset: 20806},
+						pos:  position{line: 703, col: 5, offset: 20684},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 706, col: 5, offset: 20817},
+						pos:  position{line: 704, col: 5, offset: 20695},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 707, col: 5, offset: 20826},
+						pos: position{line: 705, col: 5, offset: 20704},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 707, col: 5, offset: 20826},
+							pos:   position{line: 705, col: 5, offset: 20704},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 707, col: 7, offset: 20828},
+								pos:  position{line: 705, col: 7, offset: 20706},
 								name: "QuotedString",
 							},
 						},
@@ -5732,19 +5732,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 711, col: 1, offset: 20920},
+			pos:  position{line: 709, col: 1, offset: 20798},
 			expr: &choiceExpr{
-				pos: position{line: 712, col: 5, offset: 20938},
+				pos: position{line: 710, col: 5, offset: 20816},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 712, col: 5, offset: 20938},
+						pos:  position{line: 710, col: 5, offset: 20816},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 20948},
+						pos: position{line: 711, col: 5, offset: 20826},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 713, col: 5, offset: 20948},
+							pos:  position{line: 711, col: 5, offset: 20826},
 							name: "__",
 						},
 					},
@@ -5753,50 +5753,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 715, col: 1, offset: 20984},
+			pos:  position{line: 713, col: 1, offset: 20862},
 			expr: &actionExpr{
-				pos: position{line: 716, col: 5, offset: 20994},
+				pos: position{line: 714, col: 5, offset: 20872},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 716, col: 5, offset: 20994},
+					pos: position{line: 714, col: 5, offset: 20872},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 716, col: 5, offset: 20994},
+							pos:   position{line: 714, col: 5, offset: 20872},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 716, col: 11, offset: 21000},
+								pos:  position{line: 714, col: 11, offset: 20878},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 716, col: 16, offset: 21005},
+							pos:   position{line: 714, col: 16, offset: 20883},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 716, col: 21, offset: 21010},
+								pos: position{line: 714, col: 21, offset: 20888},
 								expr: &actionExpr{
-									pos: position{line: 716, col: 22, offset: 21011},
+									pos: position{line: 714, col: 22, offset: 20889},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 716, col: 22, offset: 21011},
+										pos: position{line: 714, col: 22, offset: 20889},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 716, col: 22, offset: 21011},
+												pos:  position{line: 714, col: 22, offset: 20889},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 716, col: 25, offset: 21014},
+												pos:        position{line: 714, col: 25, offset: 20892},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 716, col: 29, offset: 21018},
+												pos:  position{line: 714, col: 29, offset: 20896},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 716, col: 32, offset: 21021},
+												pos:   position{line: 714, col: 32, offset: 20899},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 716, col: 34, offset: 21023},
+													pos:  position{line: 714, col: 34, offset: 20901},
 													name: "Expr",
 												},
 											},
@@ -5811,35 +5811,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 720, col: 1, offset: 21132},
+			pos:  position{line: 718, col: 1, offset: 21010},
 			expr: &actionExpr{
-				pos: position{line: 721, col: 5, offset: 21146},
+				pos: position{line: 719, col: 5, offset: 21024},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 721, col: 5, offset: 21146},
+					pos: position{line: 719, col: 5, offset: 21024},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 721, col: 5, offset: 21146},
+							pos: position{line: 719, col: 5, offset: 21024},
 							expr: &ruleRefExpr{
-								pos:  position{line: 721, col: 6, offset: 21147},
+								pos:  position{line: 719, col: 6, offset: 21025},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 721, col: 10, offset: 21151},
+							pos:   position{line: 719, col: 10, offset: 21029},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 721, col: 16, offset: 21157},
+								pos:  position{line: 719, col: 16, offset: 21035},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 721, col: 27, offset: 21168},
+							pos:   position{line: 719, col: 27, offset: 21046},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 721, col: 32, offset: 21173},
+								pos: position{line: 719, col: 32, offset: 21051},
 								expr: &ruleRefExpr{
-									pos:  position{line: 721, col: 33, offset: 21174},
+									pos:  position{line: 719, col: 33, offset: 21052},
 									name: "Deref",
 								},
 							},
@@ -5850,52 +5850,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 725, col: 1, offset: 21242},
+			pos:  position{line: 723, col: 1, offset: 21120},
 			expr: &choiceExpr{
-				pos: position{line: 726, col: 5, offset: 21252},
+				pos: position{line: 724, col: 5, offset: 21130},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 726, col: 5, offset: 21252},
+						pos: position{line: 724, col: 5, offset: 21130},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 726, col: 5, offset: 21252},
+							pos: position{line: 724, col: 5, offset: 21130},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 726, col: 5, offset: 21252},
+									pos:        position{line: 724, col: 5, offset: 21130},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 726, col: 9, offset: 21256},
+									pos:   position{line: 724, col: 9, offset: 21134},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 726, col: 14, offset: 21261},
+										pos:  position{line: 724, col: 14, offset: 21139},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 726, col: 27, offset: 21274},
+									pos:  position{line: 724, col: 27, offset: 21152},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 726, col: 30, offset: 21277},
+									pos:        position{line: 724, col: 30, offset: 21155},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 726, col: 34, offset: 21281},
+									pos:  position{line: 724, col: 34, offset: 21159},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 726, col: 37, offset: 21284},
+									pos:   position{line: 724, col: 37, offset: 21162},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 726, col: 40, offset: 21287},
+										pos:  position{line: 724, col: 40, offset: 21165},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 726, col: 53, offset: 21300},
+									pos:        position{line: 724, col: 53, offset: 21178},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5903,39 +5903,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 732, col: 5, offset: 21471},
+						pos: position{line: 730, col: 5, offset: 21349},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 732, col: 5, offset: 21471},
+							pos: position{line: 730, col: 5, offset: 21349},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 732, col: 5, offset: 21471},
+									pos:        position{line: 730, col: 5, offset: 21349},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 732, col: 9, offset: 21475},
+									pos:  position{line: 730, col: 9, offset: 21353},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 732, col: 12, offset: 21478},
+									pos:        position{line: 730, col: 12, offset: 21356},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 732, col: 16, offset: 21482},
+									pos:  position{line: 730, col: 16, offset: 21360},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 732, col: 19, offset: 21485},
+									pos:   position{line: 730, col: 19, offset: 21363},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 732, col: 22, offset: 21488},
+										pos:  position{line: 730, col: 22, offset: 21366},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 732, col: 35, offset: 21501},
+									pos:        position{line: 730, col: 35, offset: 21379},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5943,39 +5943,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 738, col: 5, offset: 21672},
+						pos: position{line: 736, col: 5, offset: 21550},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 738, col: 5, offset: 21672},
+							pos: position{line: 736, col: 5, offset: 21550},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 738, col: 5, offset: 21672},
+									pos:        position{line: 736, col: 5, offset: 21550},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 738, col: 9, offset: 21676},
+									pos:   position{line: 736, col: 9, offset: 21554},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 738, col: 14, offset: 21681},
+										pos:  position{line: 736, col: 14, offset: 21559},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 738, col: 27, offset: 21694},
+									pos:  position{line: 736, col: 27, offset: 21572},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 738, col: 30, offset: 21697},
+									pos:        position{line: 736, col: 30, offset: 21575},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 738, col: 34, offset: 21701},
+									pos:  position{line: 736, col: 34, offset: 21579},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 738, col: 37, offset: 21704},
+									pos:        position{line: 736, col: 37, offset: 21582},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5983,26 +5983,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 744, col: 5, offset: 21877},
+						pos: position{line: 742, col: 5, offset: 21755},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 744, col: 5, offset: 21877},
+							pos: position{line: 742, col: 5, offset: 21755},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 744, col: 5, offset: 21877},
+									pos:        position{line: 742, col: 5, offset: 21755},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 744, col: 9, offset: 21881},
+									pos:   position{line: 742, col: 9, offset: 21759},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 744, col: 14, offset: 21886},
+										pos:  position{line: 742, col: 14, offset: 21764},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 744, col: 19, offset: 21891},
+									pos:        position{line: 742, col: 19, offset: 21769},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6010,21 +6010,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 745, col: 5, offset: 21940},
+						pos: position{line: 743, col: 5, offset: 21818},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 745, col: 5, offset: 21940},
+							pos: position{line: 743, col: 5, offset: 21818},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 745, col: 5, offset: 21940},
+									pos:        position{line: 743, col: 5, offset: 21818},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 745, col: 9, offset: 21944},
+									pos:   position{line: 743, col: 9, offset: 21822},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 745, col: 12, offset: 21947},
+										pos:  position{line: 743, col: 12, offset: 21825},
 										name: "Identifier",
 									},
 								},
@@ -6036,59 +6036,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 747, col: 1, offset: 21998},
+			pos:  position{line: 745, col: 1, offset: 21876},
 			expr: &choiceExpr{
-				pos: position{line: 748, col: 5, offset: 22010},
+				pos: position{line: 746, col: 5, offset: 21888},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 748, col: 5, offset: 22010},
+						pos:  position{line: 746, col: 5, offset: 21888},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 749, col: 5, offset: 22021},
+						pos:  position{line: 747, col: 5, offset: 21899},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 750, col: 5, offset: 22031},
+						pos:  position{line: 748, col: 5, offset: 21909},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 751, col: 5, offset: 22039},
+						pos:  position{line: 749, col: 5, offset: 21917},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 752, col: 5, offset: 22047},
+						pos:  position{line: 750, col: 5, offset: 21925},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 753, col: 5, offset: 22059},
+						pos: position{line: 751, col: 5, offset: 21937},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 753, col: 5, offset: 22059},
+							pos: position{line: 751, col: 5, offset: 21937},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 753, col: 5, offset: 22059},
+									pos:        position{line: 751, col: 5, offset: 21937},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 753, col: 9, offset: 22063},
+									pos:  position{line: 751, col: 9, offset: 21941},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 753, col: 12, offset: 22066},
+									pos:   position{line: 751, col: 12, offset: 21944},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 753, col: 17, offset: 22071},
+										pos:  position{line: 751, col: 17, offset: 21949},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 753, col: 22, offset: 22076},
+									pos:  position{line: 751, col: 22, offset: 21954},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 753, col: 25, offset: 22079},
+									pos:        position{line: 751, col: 25, offset: 21957},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6100,36 +6100,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 755, col: 1, offset: 22105},
+			pos:  position{line: 753, col: 1, offset: 21983},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 22116},
+				pos: position{line: 754, col: 5, offset: 21994},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 756, col: 5, offset: 22116},
+					pos: position{line: 754, col: 5, offset: 21994},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 756, col: 5, offset: 22116},
+							pos:        position{line: 754, col: 5, offset: 21994},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 9, offset: 22120},
+							pos:  position{line: 754, col: 9, offset: 21998},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 12, offset: 22123},
+							pos:   position{line: 754, col: 12, offset: 22001},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 18, offset: 22129},
+								pos:  position{line: 754, col: 18, offset: 22007},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 30, offset: 22141},
+							pos:  position{line: 754, col: 30, offset: 22019},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 756, col: 33, offset: 22144},
+							pos:        position{line: 754, col: 33, offset: 22022},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6139,31 +6139,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 760, col: 1, offset: 22234},
+			pos:  position{line: 758, col: 1, offset: 22112},
 			expr: &choiceExpr{
-				pos: position{line: 761, col: 5, offset: 22250},
+				pos: position{line: 759, col: 5, offset: 22128},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 761, col: 5, offset: 22250},
+						pos: position{line: 759, col: 5, offset: 22128},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 761, col: 5, offset: 22250},
+							pos: position{line: 759, col: 5, offset: 22128},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 761, col: 5, offset: 22250},
+									pos:   position{line: 759, col: 5, offset: 22128},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 761, col: 11, offset: 22256},
+										pos:  position{line: 759, col: 11, offset: 22134},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 761, col: 22, offset: 22267},
+									pos:   position{line: 759, col: 22, offset: 22145},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 761, col: 27, offset: 22272},
+										pos: position{line: 759, col: 27, offset: 22150},
 										expr: &ruleRefExpr{
-											pos:  position{line: 761, col: 27, offset: 22272},
+											pos:  position{line: 759, col: 27, offset: 22150},
 											name: "RecordElemTail",
 										},
 									},
@@ -6172,10 +6172,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 764, col: 5, offset: 22371},
+						pos: position{line: 762, col: 5, offset: 22249},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 764, col: 5, offset: 22371},
+							pos:  position{line: 762, col: 5, offset: 22249},
 							name: "__",
 						},
 					},
@@ -6184,31 +6184,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 766, col: 1, offset: 22407},
+			pos:  position{line: 764, col: 1, offset: 22285},
 			expr: &actionExpr{
-				pos: position{line: 766, col: 18, offset: 22424},
+				pos: position{line: 764, col: 18, offset: 22302},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 766, col: 18, offset: 22424},
+					pos: position{line: 764, col: 18, offset: 22302},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 766, col: 18, offset: 22424},
+							pos:  position{line: 764, col: 18, offset: 22302},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 766, col: 21, offset: 22427},
+							pos:        position{line: 764, col: 21, offset: 22305},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 766, col: 25, offset: 22431},
+							pos:  position{line: 764, col: 25, offset: 22309},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 766, col: 28, offset: 22434},
+							pos:   position{line: 764, col: 28, offset: 22312},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 766, col: 33, offset: 22439},
+								pos:  position{line: 764, col: 33, offset: 22317},
 								name: "RecordElem",
 							},
 						},
@@ -6218,20 +6218,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 768, col: 1, offset: 22472},
+			pos:  position{line: 766, col: 1, offset: 22350},
 			expr: &choiceExpr{
-				pos: position{line: 769, col: 5, offset: 22487},
+				pos: position{line: 767, col: 5, offset: 22365},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 769, col: 5, offset: 22487},
+						pos:  position{line: 767, col: 5, offset: 22365},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 770, col: 5, offset: 22498},
+						pos:  position{line: 768, col: 5, offset: 22376},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 771, col: 5, offset: 22508},
+						pos:  position{line: 769, col: 5, offset: 22386},
 						name: "Identifier",
 					},
 				},
@@ -6239,27 +6239,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 773, col: 1, offset: 22520},
+			pos:  position{line: 771, col: 1, offset: 22398},
 			expr: &actionExpr{
-				pos: position{line: 774, col: 5, offset: 22531},
+				pos: position{line: 772, col: 5, offset: 22409},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 774, col: 5, offset: 22531},
+					pos: position{line: 772, col: 5, offset: 22409},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 774, col: 5, offset: 22531},
+							pos:        position{line: 772, col: 5, offset: 22409},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 774, col: 11, offset: 22537},
+							pos:  position{line: 772, col: 11, offset: 22415},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 774, col: 14, offset: 22540},
+							pos:   position{line: 772, col: 14, offset: 22418},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 774, col: 19, offset: 22545},
+								pos:  position{line: 772, col: 19, offset: 22423},
 								name: "Expr",
 							},
 						},
@@ -6269,39 +6269,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 778, col: 1, offset: 22631},
+			pos:  position{line: 776, col: 1, offset: 22509},
 			expr: &actionExpr{
-				pos: position{line: 779, col: 5, offset: 22641},
+				pos: position{line: 777, col: 5, offset: 22519},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 779, col: 5, offset: 22641},
+					pos: position{line: 777, col: 5, offset: 22519},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 779, col: 5, offset: 22641},
+							pos:   position{line: 777, col: 5, offset: 22519},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 779, col: 10, offset: 22646},
+								pos:  position{line: 777, col: 10, offset: 22524},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 20, offset: 22656},
+							pos:  position{line: 777, col: 20, offset: 22534},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 779, col: 23, offset: 22659},
+							pos:        position{line: 777, col: 23, offset: 22537},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 27, offset: 22663},
+							pos:  position{line: 777, col: 27, offset: 22541},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 779, col: 30, offset: 22666},
+							pos:   position{line: 777, col: 30, offset: 22544},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 779, col: 36, offset: 22672},
+								pos:  position{line: 777, col: 36, offset: 22550},
 								name: "Expr",
 							},
 						},
@@ -6311,36 +6311,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 783, col: 1, offset: 22772},
+			pos:  position{line: 781, col: 1, offset: 22650},
 			expr: &actionExpr{
-				pos: position{line: 784, col: 5, offset: 22782},
+				pos: position{line: 782, col: 5, offset: 22660},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 784, col: 5, offset: 22782},
+					pos: position{line: 782, col: 5, offset: 22660},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 784, col: 5, offset: 22782},
+							pos:        position{line: 782, col: 5, offset: 22660},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 784, col: 9, offset: 22786},
+							pos:  position{line: 782, col: 9, offset: 22664},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 784, col: 12, offset: 22789},
+							pos:   position{line: 782, col: 12, offset: 22667},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 784, col: 18, offset: 22795},
+								pos:  position{line: 782, col: 18, offset: 22673},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 784, col: 32, offset: 22809},
+							pos:  position{line: 782, col: 32, offset: 22687},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 784, col: 35, offset: 22812},
+							pos:        position{line: 782, col: 35, offset: 22690},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6350,36 +6350,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 788, col: 1, offset: 22902},
+			pos:  position{line: 786, col: 1, offset: 22780},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 5, offset: 22910},
+				pos: position{line: 787, col: 5, offset: 22788},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 5, offset: 22910},
+					pos: position{line: 787, col: 5, offset: 22788},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 789, col: 5, offset: 22910},
+							pos:        position{line: 787, col: 5, offset: 22788},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 10, offset: 22915},
+							pos:  position{line: 787, col: 10, offset: 22793},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 13, offset: 22918},
+							pos:   position{line: 787, col: 13, offset: 22796},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 19, offset: 22924},
+								pos:  position{line: 787, col: 19, offset: 22802},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 33, offset: 22938},
+							pos:  position{line: 787, col: 33, offset: 22816},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 789, col: 36, offset: 22941},
+							pos:        position{line: 787, col: 36, offset: 22819},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6389,36 +6389,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 793, col: 1, offset: 23030},
+			pos:  position{line: 791, col: 1, offset: 22908},
 			expr: &actionExpr{
-				pos: position{line: 794, col: 5, offset: 23038},
+				pos: position{line: 792, col: 5, offset: 22916},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 794, col: 5, offset: 23038},
+					pos: position{line: 792, col: 5, offset: 22916},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 794, col: 5, offset: 23038},
+							pos:        position{line: 792, col: 5, offset: 22916},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 794, col: 10, offset: 23043},
+							pos:  position{line: 792, col: 10, offset: 22921},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 794, col: 13, offset: 23046},
+							pos:   position{line: 792, col: 13, offset: 22924},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 794, col: 19, offset: 23052},
+								pos:  position{line: 792, col: 19, offset: 22930},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 794, col: 27, offset: 23060},
+							pos:  position{line: 792, col: 27, offset: 22938},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 794, col: 30, offset: 23063},
+							pos:        position{line: 792, col: 30, offset: 22941},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6428,31 +6428,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 798, col: 1, offset: 23154},
+			pos:  position{line: 796, col: 1, offset: 23032},
 			expr: &choiceExpr{
-				pos: position{line: 799, col: 5, offset: 23166},
+				pos: position{line: 797, col: 5, offset: 23044},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 799, col: 5, offset: 23166},
+						pos: position{line: 797, col: 5, offset: 23044},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 799, col: 5, offset: 23166},
+							pos: position{line: 797, col: 5, offset: 23044},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 799, col: 5, offset: 23166},
+									pos:   position{line: 797, col: 5, offset: 23044},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 799, col: 11, offset: 23172},
+										pos:  position{line: 797, col: 11, offset: 23050},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 799, col: 17, offset: 23178},
+									pos:   position{line: 797, col: 17, offset: 23056},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 799, col: 22, offset: 23183},
+										pos: position{line: 797, col: 22, offset: 23061},
 										expr: &ruleRefExpr{
-											pos:  position{line: 799, col: 22, offset: 23183},
+											pos:  position{line: 797, col: 22, offset: 23061},
 											name: "EntryTail",
 										},
 									},
@@ -6461,10 +6461,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 802, col: 5, offset: 23277},
+						pos: position{line: 800, col: 5, offset: 23155},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 802, col: 5, offset: 23277},
+							pos:  position{line: 800, col: 5, offset: 23155},
 							name: "__",
 						},
 					},
@@ -6473,31 +6473,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 805, col: 1, offset: 23314},
+			pos:  position{line: 803, col: 1, offset: 23192},
 			expr: &actionExpr{
-				pos: position{line: 805, col: 13, offset: 23326},
+				pos: position{line: 803, col: 13, offset: 23204},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 805, col: 13, offset: 23326},
+					pos: position{line: 803, col: 13, offset: 23204},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 13, offset: 23326},
+							pos:  position{line: 803, col: 13, offset: 23204},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 805, col: 16, offset: 23329},
+							pos:        position{line: 803, col: 16, offset: 23207},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 20, offset: 23333},
+							pos:  position{line: 803, col: 20, offset: 23211},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 805, col: 23, offset: 23336},
+							pos:   position{line: 803, col: 23, offset: 23214},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 805, col: 25, offset: 23338},
+								pos:  position{line: 803, col: 25, offset: 23216},
 								name: "Entry",
 							},
 						},
@@ -6507,39 +6507,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 807, col: 1, offset: 23363},
+			pos:  position{line: 805, col: 1, offset: 23241},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 5, offset: 23373},
+				pos: position{line: 806, col: 5, offset: 23251},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 5, offset: 23373},
+					pos: position{line: 806, col: 5, offset: 23251},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 808, col: 5, offset: 23373},
+							pos:   position{line: 806, col: 5, offset: 23251},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 9, offset: 23377},
+								pos:  position{line: 806, col: 9, offset: 23255},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 14, offset: 23382},
+							pos:  position{line: 806, col: 14, offset: 23260},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 808, col: 17, offset: 23385},
+							pos:        position{line: 806, col: 17, offset: 23263},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 21, offset: 23389},
+							pos:  position{line: 806, col: 21, offset: 23267},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 24, offset: 23392},
+							pos:   position{line: 806, col: 24, offset: 23270},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 30, offset: 23398},
+								pos:  position{line: 806, col: 30, offset: 23276},
 								name: "Expr",
 							},
 						},
@@ -6549,92 +6549,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLProc",
-			pos:  position{line: 814, col: 1, offset: 23505},
+			pos:  position{line: 812, col: 1, offset: 23383},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 23517},
+				pos: position{line: 813, col: 5, offset: 23395},
 				run: (*parser).callonSQLProc1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 23517},
+					pos: position{line: 813, col: 5, offset: 23395},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 815, col: 5, offset: 23517},
+							pos:   position{line: 813, col: 5, offset: 23395},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 15, offset: 23527},
+								pos:  position{line: 813, col: 15, offset: 23405},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 816, col: 5, offset: 23541},
+							pos:   position{line: 814, col: 5, offset: 23419},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 816, col: 10, offset: 23546},
+								pos: position{line: 814, col: 10, offset: 23424},
 								expr: &ruleRefExpr{
-									pos:  position{line: 816, col: 10, offset: 23546},
+									pos:  position{line: 814, col: 10, offset: 23424},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 817, col: 5, offset: 23559},
+							pos:   position{line: 815, col: 5, offset: 23437},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 817, col: 11, offset: 23565},
+								pos: position{line: 815, col: 11, offset: 23443},
 								expr: &ruleRefExpr{
-									pos:  position{line: 817, col: 11, offset: 23565},
+									pos:  position{line: 815, col: 11, offset: 23443},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 5, offset: 23579},
+							pos:   position{line: 816, col: 5, offset: 23457},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 818, col: 11, offset: 23585},
+								pos: position{line: 816, col: 11, offset: 23463},
 								expr: &ruleRefExpr{
-									pos:  position{line: 818, col: 11, offset: 23585},
+									pos:  position{line: 816, col: 11, offset: 23463},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 819, col: 5, offset: 23599},
+							pos:   position{line: 817, col: 5, offset: 23477},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 819, col: 13, offset: 23607},
+								pos: position{line: 817, col: 13, offset: 23485},
 								expr: &ruleRefExpr{
-									pos:  position{line: 819, col: 13, offset: 23607},
+									pos:  position{line: 817, col: 13, offset: 23485},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 820, col: 5, offset: 23623},
+							pos:   position{line: 818, col: 5, offset: 23501},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 820, col: 12, offset: 23630},
+								pos: position{line: 818, col: 12, offset: 23508},
 								expr: &ruleRefExpr{
-									pos:  position{line: 820, col: 12, offset: 23630},
+									pos:  position{line: 818, col: 12, offset: 23508},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 5, offset: 23645},
+							pos:   position{line: 819, col: 5, offset: 23523},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 821, col: 13, offset: 23653},
+								pos: position{line: 819, col: 13, offset: 23531},
 								expr: &ruleRefExpr{
-									pos:  position{line: 821, col: 13, offset: 23653},
+									pos:  position{line: 819, col: 13, offset: 23531},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 5, offset: 23669},
+							pos:   position{line: 820, col: 5, offset: 23547},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 822, col: 11, offset: 23675},
+								pos:  position{line: 820, col: 11, offset: 23553},
 								name: "SQLLimit",
 							},
 						},
@@ -6644,26 +6644,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 846, col: 1, offset: 24042},
+			pos:  position{line: 844, col: 1, offset: 23920},
 			expr: &choiceExpr{
-				pos: position{line: 847, col: 5, offset: 24056},
+				pos: position{line: 845, col: 5, offset: 23934},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 847, col: 5, offset: 24056},
+						pos: position{line: 845, col: 5, offset: 23934},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 847, col: 5, offset: 24056},
+							pos: position{line: 845, col: 5, offset: 23934},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 5, offset: 24056},
+									pos:  position{line: 845, col: 5, offset: 23934},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 12, offset: 24063},
+									pos:  position{line: 845, col: 12, offset: 23941},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 847, col: 14, offset: 24065},
+									pos:        position{line: 845, col: 14, offset: 23943},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6671,24 +6671,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 848, col: 5, offset: 24093},
+						pos: position{line: 846, col: 5, offset: 23971},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 848, col: 5, offset: 24093},
+							pos: position{line: 846, col: 5, offset: 23971},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 5, offset: 24093},
+									pos:  position{line: 846, col: 5, offset: 23971},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 12, offset: 24100},
+									pos:  position{line: 846, col: 12, offset: 23978},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 848, col: 14, offset: 24102},
+									pos:   position{line: 846, col: 14, offset: 23980},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 848, col: 26, offset: 24114},
+										pos:  position{line: 846, col: 26, offset: 23992},
 										name: "SQLAssignments",
 									},
 								},
@@ -6700,41 +6700,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 850, col: 1, offset: 24158},
+			pos:  position{line: 848, col: 1, offset: 24036},
 			expr: &choiceExpr{
-				pos: position{line: 851, col: 5, offset: 24176},
+				pos: position{line: 849, col: 5, offset: 24054},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 851, col: 5, offset: 24176},
+						pos: position{line: 849, col: 5, offset: 24054},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 851, col: 5, offset: 24176},
+							pos: position{line: 849, col: 5, offset: 24054},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 851, col: 5, offset: 24176},
+									pos:   position{line: 849, col: 5, offset: 24054},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 851, col: 9, offset: 24180},
+										pos:  position{line: 849, col: 9, offset: 24058},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 851, col: 14, offset: 24185},
+									pos:  position{line: 849, col: 14, offset: 24063},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 851, col: 16, offset: 24187},
+									pos:  position{line: 849, col: 16, offset: 24065},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 851, col: 19, offset: 24190},
+									pos:  position{line: 849, col: 19, offset: 24068},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 851, col: 21, offset: 24192},
+									pos:   position{line: 849, col: 21, offset: 24070},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 851, col: 25, offset: 24196},
+										pos:  position{line: 849, col: 25, offset: 24074},
 										name: "Lval",
 									},
 								},
@@ -6742,13 +6742,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 852, col: 5, offset: 24290},
+						pos: position{line: 850, col: 5, offset: 24168},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 852, col: 5, offset: 24290},
+							pos:   position{line: 850, col: 5, offset: 24168},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 852, col: 10, offset: 24295},
+								pos:  position{line: 850, col: 10, offset: 24173},
 								name: "Expr",
 							},
 						},
@@ -6758,50 +6758,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 854, col: 1, offset: 24387},
+			pos:  position{line: 852, col: 1, offset: 24265},
 			expr: &actionExpr{
-				pos: position{line: 855, col: 5, offset: 24406},
+				pos: position{line: 853, col: 5, offset: 24284},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 855, col: 5, offset: 24406},
+					pos: position{line: 853, col: 5, offset: 24284},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 855, col: 5, offset: 24406},
+							pos:   position{line: 853, col: 5, offset: 24284},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 11, offset: 24412},
+								pos:  position{line: 853, col: 11, offset: 24290},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 25, offset: 24426},
+							pos:   position{line: 853, col: 25, offset: 24304},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 855, col: 30, offset: 24431},
+								pos: position{line: 853, col: 30, offset: 24309},
 								expr: &actionExpr{
-									pos: position{line: 855, col: 31, offset: 24432},
+									pos: position{line: 853, col: 31, offset: 24310},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 855, col: 31, offset: 24432},
+										pos: position{line: 853, col: 31, offset: 24310},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 855, col: 31, offset: 24432},
+												pos:  position{line: 853, col: 31, offset: 24310},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 855, col: 34, offset: 24435},
+												pos:        position{line: 853, col: 34, offset: 24313},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 855, col: 38, offset: 24439},
+												pos:  position{line: 853, col: 38, offset: 24317},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 855, col: 41, offset: 24442},
+												pos:   position{line: 853, col: 41, offset: 24320},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 855, col: 46, offset: 24447},
+													pos:  position{line: 853, col: 46, offset: 24325},
 													name: "SQLAssignment",
 												},
 											},
@@ -6816,43 +6816,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 859, col: 1, offset: 24568},
+			pos:  position{line: 857, col: 1, offset: 24446},
 			expr: &choiceExpr{
-				pos: position{line: 860, col: 5, offset: 24580},
+				pos: position{line: 858, col: 5, offset: 24458},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 860, col: 5, offset: 24580},
+						pos: position{line: 858, col: 5, offset: 24458},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 860, col: 5, offset: 24580},
+							pos: position{line: 858, col: 5, offset: 24458},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 860, col: 5, offset: 24580},
+									pos:  position{line: 858, col: 5, offset: 24458},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 860, col: 7, offset: 24582},
+									pos:  position{line: 858, col: 7, offset: 24460},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 860, col: 12, offset: 24587},
+									pos:  position{line: 858, col: 12, offset: 24465},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 860, col: 14, offset: 24589},
+									pos:   position{line: 858, col: 14, offset: 24467},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 860, col: 20, offset: 24595},
+										pos:  position{line: 858, col: 20, offset: 24473},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 860, col: 29, offset: 24604},
+									pos:   position{line: 858, col: 29, offset: 24482},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 860, col: 35, offset: 24610},
+										pos: position{line: 858, col: 35, offset: 24488},
 										expr: &ruleRefExpr{
-											pos:  position{line: 860, col: 35, offset: 24610},
+											pos:  position{line: 858, col: 35, offset: 24488},
 											name: "SQLAlias",
 										},
 									},
@@ -6861,25 +6861,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 863, col: 5, offset: 24705},
+						pos: position{line: 861, col: 5, offset: 24583},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 863, col: 5, offset: 24705},
+							pos: position{line: 861, col: 5, offset: 24583},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 5, offset: 24705},
+									pos:  position{line: 861, col: 5, offset: 24583},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 7, offset: 24707},
+									pos:  position{line: 861, col: 7, offset: 24585},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 863, col: 12, offset: 24712},
+									pos:  position{line: 861, col: 12, offset: 24590},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 863, col: 14, offset: 24714},
+									pos:        position{line: 861, col: 14, offset: 24592},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6891,33 +6891,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 865, col: 1, offset: 24739},
+			pos:  position{line: 863, col: 1, offset: 24617},
 			expr: &choiceExpr{
-				pos: position{line: 866, col: 5, offset: 24752},
+				pos: position{line: 864, col: 5, offset: 24630},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 866, col: 5, offset: 24752},
+						pos: position{line: 864, col: 5, offset: 24630},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 866, col: 5, offset: 24752},
+							pos: position{line: 864, col: 5, offset: 24630},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 5, offset: 24752},
+									pos:  position{line: 864, col: 5, offset: 24630},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 7, offset: 24754},
+									pos:  position{line: 864, col: 7, offset: 24632},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 10, offset: 24757},
+									pos:  position{line: 864, col: 10, offset: 24635},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 866, col: 12, offset: 24759},
+									pos:   position{line: 864, col: 12, offset: 24637},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 866, col: 15, offset: 24762},
+										pos:  position{line: 864, col: 15, offset: 24640},
 										name: "Lval",
 									},
 								},
@@ -6925,36 +6925,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 867, col: 5, offset: 24790},
+						pos: position{line: 865, col: 5, offset: 24668},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 867, col: 5, offset: 24790},
+							pos: position{line: 865, col: 5, offset: 24668},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 867, col: 5, offset: 24790},
+									pos:  position{line: 865, col: 5, offset: 24668},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 867, col: 7, offset: 24792},
+									pos: position{line: 865, col: 7, offset: 24670},
 									expr: &seqExpr{
-										pos: position{line: 867, col: 9, offset: 24794},
+										pos: position{line: 865, col: 9, offset: 24672},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 867, col: 9, offset: 24794},
+												pos:  position{line: 865, col: 9, offset: 24672},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 867, col: 27, offset: 24812},
+												pos:  position{line: 865, col: 27, offset: 24690},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 867, col: 30, offset: 24815},
+									pos:   position{line: 865, col: 30, offset: 24693},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 867, col: 33, offset: 24818},
+										pos:  position{line: 865, col: 33, offset: 24696},
 										name: "Lval",
 									},
 								},
@@ -6966,42 +6966,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 869, col: 1, offset: 24843},
+			pos:  position{line: 867, col: 1, offset: 24721},
 			expr: &ruleRefExpr{
-				pos:  position{line: 870, col: 5, offset: 24856},
+				pos:  position{line: 868, col: 5, offset: 24734},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 872, col: 1, offset: 24862},
+			pos:  position{line: 870, col: 1, offset: 24740},
 			expr: &actionExpr{
-				pos: position{line: 873, col: 5, offset: 24875},
+				pos: position{line: 871, col: 5, offset: 24753},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 873, col: 5, offset: 24875},
+					pos: position{line: 871, col: 5, offset: 24753},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 24875},
+							pos:   position{line: 871, col: 5, offset: 24753},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 873, col: 11, offset: 24881},
+								pos:  position{line: 871, col: 11, offset: 24759},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 873, col: 19, offset: 24889},
+							pos:   position{line: 871, col: 19, offset: 24767},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 873, col: 24, offset: 24894},
+								pos: position{line: 871, col: 24, offset: 24772},
 								expr: &actionExpr{
-									pos: position{line: 873, col: 25, offset: 24895},
+									pos: position{line: 871, col: 25, offset: 24773},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 873, col: 25, offset: 24895},
+										pos:   position{line: 871, col: 25, offset: 24773},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 873, col: 30, offset: 24900},
+											pos:  position{line: 871, col: 30, offset: 24778},
 											name: "SQLJoin",
 										},
 									},
@@ -7014,90 +7014,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 877, col: 1, offset: 25015},
+			pos:  position{line: 875, col: 1, offset: 24893},
 			expr: &actionExpr{
-				pos: position{line: 878, col: 5, offset: 25027},
+				pos: position{line: 876, col: 5, offset: 24905},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 878, col: 5, offset: 25027},
+					pos: position{line: 876, col: 5, offset: 24905},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 878, col: 5, offset: 25027},
+							pos:   position{line: 876, col: 5, offset: 24905},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 11, offset: 25033},
+								pos:  position{line: 876, col: 11, offset: 24911},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 24, offset: 25046},
+							pos:  position{line: 876, col: 24, offset: 24924},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 26, offset: 25048},
+							pos:  position{line: 876, col: 26, offset: 24926},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 31, offset: 25053},
+							pos:  position{line: 876, col: 31, offset: 24931},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 33, offset: 25055},
+							pos:   position{line: 876, col: 33, offset: 24933},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 39, offset: 25061},
+								pos:  position{line: 876, col: 39, offset: 24939},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 48, offset: 25070},
+							pos:   position{line: 876, col: 48, offset: 24948},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 878, col: 54, offset: 25076},
+								pos: position{line: 876, col: 54, offset: 24954},
 								expr: &ruleRefExpr{
-									pos:  position{line: 878, col: 54, offset: 25076},
+									pos:  position{line: 876, col: 54, offset: 24954},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 64, offset: 25086},
+							pos:  position{line: 876, col: 64, offset: 24964},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 66, offset: 25088},
+							pos:  position{line: 876, col: 66, offset: 24966},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 69, offset: 25091},
+							pos:  position{line: 876, col: 69, offset: 24969},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 71, offset: 25093},
+							pos:   position{line: 876, col: 71, offset: 24971},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 79, offset: 25101},
+								pos:  position{line: 876, col: 79, offset: 24979},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 87, offset: 25109},
+							pos:  position{line: 876, col: 87, offset: 24987},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 878, col: 90, offset: 25112},
+							pos:        position{line: 876, col: 90, offset: 24990},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 94, offset: 25116},
+							pos:  position{line: 876, col: 94, offset: 24994},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 97, offset: 25119},
+							pos:   position{line: 876, col: 97, offset: 24997},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 106, offset: 25128},
+								pos:  position{line: 876, col: 106, offset: 25006},
 								name: "JoinKey",
 							},
 						},
@@ -7107,40 +7107,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 897, col: 1, offset: 25363},
+			pos:  position{line: 895, col: 1, offset: 25241},
 			expr: &choiceExpr{
-				pos: position{line: 898, col: 5, offset: 25380},
+				pos: position{line: 896, col: 5, offset: 25258},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 898, col: 5, offset: 25380},
+						pos: position{line: 896, col: 5, offset: 25258},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 898, col: 5, offset: 25380},
+							pos: position{line: 896, col: 5, offset: 25258},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 898, col: 5, offset: 25380},
+									pos:  position{line: 896, col: 5, offset: 25258},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 898, col: 7, offset: 25382},
+									pos:   position{line: 896, col: 7, offset: 25260},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 898, col: 14, offset: 25389},
+										pos: position{line: 896, col: 14, offset: 25267},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 14, offset: 25389},
+												pos:  position{line: 896, col: 14, offset: 25267},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 21, offset: 25396},
+												pos:  position{line: 896, col: 21, offset: 25274},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 29, offset: 25404},
+												pos:  position{line: 896, col: 29, offset: 25282},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 36, offset: 25411},
+												pos:  position{line: 896, col: 36, offset: 25289},
 												name: "RIGHT",
 											},
 										},
@@ -7150,10 +7150,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 899, col: 5, offset: 25444},
+						pos: position{line: 897, col: 5, offset: 25322},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 899, col: 5, offset: 25444},
+							pos:        position{line: 897, col: 5, offset: 25322},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7163,30 +7163,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 901, col: 1, offset: 25472},
+			pos:  position{line: 899, col: 1, offset: 25350},
 			expr: &actionExpr{
-				pos: position{line: 902, col: 5, offset: 25485},
+				pos: position{line: 900, col: 5, offset: 25363},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 902, col: 5, offset: 25485},
+					pos: position{line: 900, col: 5, offset: 25363},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 902, col: 5, offset: 25485},
+							pos:  position{line: 900, col: 5, offset: 25363},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 902, col: 7, offset: 25487},
+							pos:  position{line: 900, col: 7, offset: 25365},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 902, col: 13, offset: 25493},
+							pos:  position{line: 900, col: 13, offset: 25371},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 902, col: 15, offset: 25495},
+							pos:   position{line: 900, col: 15, offset: 25373},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 902, col: 20, offset: 25500},
+								pos:  position{line: 900, col: 20, offset: 25378},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7196,38 +7196,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 904, col: 1, offset: 25536},
+			pos:  position{line: 902, col: 1, offset: 25414},
 			expr: &actionExpr{
-				pos: position{line: 905, col: 5, offset: 25551},
+				pos: position{line: 903, col: 5, offset: 25429},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 905, col: 5, offset: 25551},
+					pos: position{line: 903, col: 5, offset: 25429},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 5, offset: 25551},
+							pos:  position{line: 903, col: 5, offset: 25429},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 7, offset: 25553},
+							pos:  position{line: 903, col: 7, offset: 25431},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 13, offset: 25559},
+							pos:  position{line: 903, col: 13, offset: 25437},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 15, offset: 25561},
+							pos:  position{line: 903, col: 15, offset: 25439},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 18, offset: 25564},
+							pos:  position{line: 903, col: 18, offset: 25442},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 905, col: 20, offset: 25566},
+							pos:   position{line: 903, col: 20, offset: 25444},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 905, col: 28, offset: 25574},
+								pos:  position{line: 903, col: 28, offset: 25452},
 								name: "FieldExprs",
 							},
 						},
@@ -7237,30 +7237,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 907, col: 1, offset: 25610},
+			pos:  position{line: 905, col: 1, offset: 25488},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 5, offset: 25624},
+				pos: position{line: 906, col: 5, offset: 25502},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 908, col: 5, offset: 25624},
+					pos: position{line: 906, col: 5, offset: 25502},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 5, offset: 25624},
+							pos:  position{line: 906, col: 5, offset: 25502},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 7, offset: 25626},
+							pos:  position{line: 906, col: 7, offset: 25504},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 14, offset: 25633},
+							pos:  position{line: 906, col: 14, offset: 25511},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 908, col: 16, offset: 25635},
+							pos:   position{line: 906, col: 16, offset: 25513},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 908, col: 21, offset: 25640},
+								pos:  position{line: 906, col: 21, offset: 25518},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7270,46 +7270,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 910, col: 1, offset: 25676},
+			pos:  position{line: 908, col: 1, offset: 25554},
 			expr: &actionExpr{
-				pos: position{line: 911, col: 5, offset: 25691},
+				pos: position{line: 909, col: 5, offset: 25569},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 911, col: 5, offset: 25691},
+					pos: position{line: 909, col: 5, offset: 25569},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 5, offset: 25691},
+							pos:  position{line: 909, col: 5, offset: 25569},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 7, offset: 25693},
+							pos:  position{line: 909, col: 7, offset: 25571},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 13, offset: 25699},
+							pos:  position{line: 909, col: 13, offset: 25577},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 15, offset: 25701},
+							pos:  position{line: 909, col: 15, offset: 25579},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 911, col: 18, offset: 25704},
+							pos:  position{line: 909, col: 18, offset: 25582},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 911, col: 20, offset: 25706},
+							pos:   position{line: 909, col: 20, offset: 25584},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 911, col: 25, offset: 25711},
+								pos:  position{line: 909, col: 25, offset: 25589},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 911, col: 31, offset: 25717},
+							pos:   position{line: 909, col: 31, offset: 25595},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 911, col: 37, offset: 25723},
+								pos:  position{line: 909, col: 37, offset: 25601},
 								name: "SQLOrder",
 							},
 						},
@@ -7319,32 +7319,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 915, col: 1, offset: 25833},
+			pos:  position{line: 913, col: 1, offset: 25711},
 			expr: &choiceExpr{
-				pos: position{line: 916, col: 5, offset: 25846},
+				pos: position{line: 914, col: 5, offset: 25724},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 916, col: 5, offset: 25846},
+						pos: position{line: 914, col: 5, offset: 25724},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 916, col: 5, offset: 25846},
+							pos: position{line: 914, col: 5, offset: 25724},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 916, col: 5, offset: 25846},
+									pos:  position{line: 914, col: 5, offset: 25724},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 916, col: 7, offset: 25848},
+									pos:   position{line: 914, col: 7, offset: 25726},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 916, col: 12, offset: 25853},
+										pos: position{line: 914, col: 12, offset: 25731},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 12, offset: 25853},
+												pos:  position{line: 914, col: 12, offset: 25731},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 18, offset: 25859},
+												pos:  position{line: 914, col: 18, offset: 25737},
 												name: "DESC",
 											},
 										},
@@ -7354,10 +7354,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 917, col: 5, offset: 25889},
+						pos: position{line: 915, col: 5, offset: 25767},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 917, col: 5, offset: 25889},
+							pos:        position{line: 915, col: 5, offset: 25767},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7367,33 +7367,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 919, col: 1, offset: 25915},
+			pos:  position{line: 917, col: 1, offset: 25793},
 			expr: &choiceExpr{
-				pos: position{line: 920, col: 5, offset: 25928},
+				pos: position{line: 918, col: 5, offset: 25806},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 920, col: 5, offset: 25928},
+						pos: position{line: 918, col: 5, offset: 25806},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 920, col: 5, offset: 25928},
+							pos: position{line: 918, col: 5, offset: 25806},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 920, col: 5, offset: 25928},
+									pos:  position{line: 918, col: 5, offset: 25806},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 920, col: 7, offset: 25930},
+									pos:  position{line: 918, col: 7, offset: 25808},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 920, col: 13, offset: 25936},
+									pos:  position{line: 918, col: 13, offset: 25814},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 920, col: 15, offset: 25938},
+									pos:   position{line: 918, col: 15, offset: 25816},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 920, col: 21, offset: 25944},
+										pos:  position{line: 918, col: 21, offset: 25822},
 										name: "UInt",
 									},
 								},
@@ -7401,10 +7401,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 921, col: 5, offset: 25975},
+						pos: position{line: 919, col: 5, offset: 25853},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 921, col: 5, offset: 25975},
+							pos:        position{line: 919, col: 5, offset: 25853},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7414,12 +7414,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 923, col: 1, offset: 25997},
+			pos:  position{line: 921, col: 1, offset: 25875},
 			expr: &actionExpr{
-				pos: position{line: 923, col: 10, offset: 26006},
+				pos: position{line: 921, col: 10, offset: 25884},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 923, col: 10, offset: 26006},
+					pos:        position{line: 921, col: 10, offset: 25884},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7427,12 +7427,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 924, col: 1, offset: 26041},
+			pos:  position{line: 922, col: 1, offset: 25919},
 			expr: &actionExpr{
-				pos: position{line: 924, col: 6, offset: 26046},
+				pos: position{line: 922, col: 6, offset: 25924},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 924, col: 6, offset: 26046},
+					pos:        position{line: 922, col: 6, offset: 25924},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7440,12 +7440,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 925, col: 1, offset: 26073},
+			pos:  position{line: 923, col: 1, offset: 25951},
 			expr: &actionExpr{
-				pos: position{line: 925, col: 8, offset: 26080},
+				pos: position{line: 923, col: 8, offset: 25958},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 925, col: 8, offset: 26080},
+					pos:        position{line: 923, col: 8, offset: 25958},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7453,12 +7453,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 926, col: 1, offset: 26111},
+			pos:  position{line: 924, col: 1, offset: 25989},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 8, offset: 26118},
+				pos: position{line: 924, col: 8, offset: 25996},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 926, col: 8, offset: 26118},
+					pos:        position{line: 924, col: 8, offset: 25996},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7466,12 +7466,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 927, col: 1, offset: 26149},
+			pos:  position{line: 925, col: 1, offset: 26027},
 			expr: &actionExpr{
-				pos: position{line: 927, col: 9, offset: 26157},
+				pos: position{line: 925, col: 9, offset: 26035},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 927, col: 9, offset: 26157},
+					pos:        position{line: 925, col: 9, offset: 26035},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7479,12 +7479,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 928, col: 1, offset: 26190},
+			pos:  position{line: 926, col: 1, offset: 26068},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 9, offset: 26198},
+				pos: position{line: 926, col: 9, offset: 26076},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 928, col: 9, offset: 26198},
+					pos:        position{line: 926, col: 9, offset: 26076},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7492,12 +7492,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 929, col: 1, offset: 26231},
+			pos:  position{line: 927, col: 1, offset: 26109},
 			expr: &actionExpr{
-				pos: position{line: 929, col: 6, offset: 26236},
+				pos: position{line: 927, col: 6, offset: 26114},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 929, col: 6, offset: 26236},
+					pos:        position{line: 927, col: 6, offset: 26114},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7505,12 +7505,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 930, col: 1, offset: 26263},
+			pos:  position{line: 928, col: 1, offset: 26141},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 10, offset: 26272},
+				pos: position{line: 928, col: 10, offset: 26150},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 930, col: 10, offset: 26272},
+					pos:        position{line: 928, col: 10, offset: 26150},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7518,12 +7518,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 931, col: 1, offset: 26307},
+			pos:  position{line: 929, col: 1, offset: 26185},
 			expr: &actionExpr{
-				pos: position{line: 931, col: 9, offset: 26315},
+				pos: position{line: 929, col: 9, offset: 26193},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 931, col: 9, offset: 26315},
+					pos:        position{line: 929, col: 9, offset: 26193},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7531,12 +7531,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 932, col: 1, offset: 26348},
+			pos:  position{line: 930, col: 1, offset: 26226},
 			expr: &actionExpr{
-				pos: position{line: 932, col: 6, offset: 26353},
+				pos: position{line: 930, col: 6, offset: 26231},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 932, col: 6, offset: 26353},
+					pos:        position{line: 930, col: 6, offset: 26231},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7544,12 +7544,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 933, col: 1, offset: 26380},
+			pos:  position{line: 931, col: 1, offset: 26258},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 9, offset: 26388},
+				pos: position{line: 931, col: 9, offset: 26266},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 933, col: 9, offset: 26388},
+					pos:        position{line: 931, col: 9, offset: 26266},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7557,12 +7557,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 934, col: 1, offset: 26421},
+			pos:  position{line: 932, col: 1, offset: 26299},
 			expr: &actionExpr{
-				pos: position{line: 934, col: 7, offset: 26427},
+				pos: position{line: 932, col: 7, offset: 26305},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 934, col: 7, offset: 26427},
+					pos:        position{line: 932, col: 7, offset: 26305},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7570,12 +7570,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 935, col: 1, offset: 26456},
+			pos:  position{line: 933, col: 1, offset: 26334},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 8, offset: 26463},
+				pos: position{line: 933, col: 8, offset: 26341},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 935, col: 8, offset: 26463},
+					pos:        position{line: 933, col: 8, offset: 26341},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7583,12 +7583,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 936, col: 1, offset: 26494},
+			pos:  position{line: 934, col: 1, offset: 26372},
 			expr: &actionExpr{
-				pos: position{line: 936, col: 8, offset: 26501},
+				pos: position{line: 934, col: 8, offset: 26379},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 936, col: 8, offset: 26501},
+					pos:        position{line: 934, col: 8, offset: 26379},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7596,12 +7596,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 937, col: 1, offset: 26532},
+			pos:  position{line: 935, col: 1, offset: 26410},
 			expr: &actionExpr{
-				pos: position{line: 937, col: 8, offset: 26539},
+				pos: position{line: 935, col: 8, offset: 26417},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 937, col: 8, offset: 26539},
+					pos:        position{line: 935, col: 8, offset: 26417},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7609,12 +7609,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 938, col: 1, offset: 26570},
+			pos:  position{line: 936, col: 1, offset: 26448},
 			expr: &actionExpr{
-				pos: position{line: 938, col: 9, offset: 26578},
+				pos: position{line: 936, col: 9, offset: 26456},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 938, col: 9, offset: 26578},
+					pos:        position{line: 936, col: 9, offset: 26456},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7622,12 +7622,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 939, col: 1, offset: 26611},
+			pos:  position{line: 937, col: 1, offset: 26489},
 			expr: &actionExpr{
-				pos: position{line: 939, col: 9, offset: 26619},
+				pos: position{line: 937, col: 9, offset: 26497},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 939, col: 9, offset: 26619},
+					pos:        position{line: 937, col: 9, offset: 26497},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7635,48 +7635,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 941, col: 1, offset: 26653},
+			pos:  position{line: 939, col: 1, offset: 26531},
 			expr: &choiceExpr{
-				pos: position{line: 942, col: 5, offset: 26675},
+				pos: position{line: 940, col: 5, offset: 26553},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 5, offset: 26675},
+						pos:  position{line: 940, col: 5, offset: 26553},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 14, offset: 26684},
+						pos:  position{line: 940, col: 14, offset: 26562},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 19, offset: 26689},
+						pos:  position{line: 940, col: 19, offset: 26567},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 27, offset: 26697},
+						pos:  position{line: 940, col: 27, offset: 26575},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 34, offset: 26704},
+						pos:  position{line: 940, col: 34, offset: 26582},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 42, offset: 26712},
+						pos:  position{line: 940, col: 42, offset: 26590},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 50, offset: 26720},
+						pos:  position{line: 940, col: 50, offset: 26598},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 59, offset: 26729},
+						pos:  position{line: 940, col: 59, offset: 26607},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 67, offset: 26737},
+						pos:  position{line: 940, col: 67, offset: 26615},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 75, offset: 26745},
+						pos:  position{line: 940, col: 75, offset: 26623},
 						name: "ON",
 					},
 				},
@@ -7684,52 +7684,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 946, col: 1, offset: 26771},
+			pos:  position{line: 944, col: 1, offset: 26649},
 			expr: &choiceExpr{
-				pos: position{line: 947, col: 5, offset: 26783},
+				pos: position{line: 945, col: 5, offset: 26661},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 947, col: 5, offset: 26783},
+						pos:  position{line: 945, col: 5, offset: 26661},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 948, col: 5, offset: 26799},
+						pos:  position{line: 946, col: 5, offset: 26677},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 949, col: 5, offset: 26819},
+						pos:  position{line: 947, col: 5, offset: 26697},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 950, col: 5, offset: 26837},
+						pos:  position{line: 948, col: 5, offset: 26715},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 951, col: 5, offset: 26856},
+						pos:  position{line: 949, col: 5, offset: 26734},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 5, offset: 26873},
+						pos:  position{line: 950, col: 5, offset: 26751},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 953, col: 5, offset: 26886},
+						pos:  position{line: 951, col: 5, offset: 26764},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 954, col: 5, offset: 26895},
+						pos:  position{line: 952, col: 5, offset: 26773},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 955, col: 5, offset: 26912},
+						pos:  position{line: 953, col: 5, offset: 26790},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 956, col: 5, offset: 26931},
+						pos:  position{line: 954, col: 5, offset: 26809},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 5, offset: 26950},
+						pos:  position{line: 955, col: 5, offset: 26828},
 						name: "NullLiteral",
 					},
 				},
@@ -7737,28 +7737,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 959, col: 1, offset: 26963},
+			pos:  position{line: 957, col: 1, offset: 26841},
 			expr: &choiceExpr{
-				pos: position{line: 960, col: 5, offset: 26981},
+				pos: position{line: 958, col: 5, offset: 26859},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 960, col: 5, offset: 26981},
+						pos: position{line: 958, col: 5, offset: 26859},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 960, col: 5, offset: 26981},
+							pos: position{line: 958, col: 5, offset: 26859},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 960, col: 5, offset: 26981},
+									pos:   position{line: 958, col: 5, offset: 26859},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 960, col: 7, offset: 26983},
+										pos:  position{line: 958, col: 7, offset: 26861},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 960, col: 14, offset: 26990},
+									pos: position{line: 958, col: 14, offset: 26868},
 									expr: &ruleRefExpr{
-										pos:  position{line: 960, col: 15, offset: 26991},
+										pos:  position{line: 958, col: 15, offset: 26869},
 										name: "IdentifierRest",
 									},
 								},
@@ -7766,13 +7766,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 963, col: 5, offset: 27106},
+						pos: position{line: 961, col: 5, offset: 26984},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 963, col: 5, offset: 27106},
+							pos:   position{line: 961, col: 5, offset: 26984},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 963, col: 7, offset: 27108},
+								pos:  position{line: 961, col: 7, offset: 26986},
 								name: "IP4Net",
 							},
 						},
@@ -7782,28 +7782,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 967, col: 1, offset: 27212},
+			pos:  position{line: 965, col: 1, offset: 27090},
 			expr: &choiceExpr{
-				pos: position{line: 968, col: 5, offset: 27231},
+				pos: position{line: 966, col: 5, offset: 27109},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 968, col: 5, offset: 27231},
+						pos: position{line: 966, col: 5, offset: 27109},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 968, col: 5, offset: 27231},
+							pos: position{line: 966, col: 5, offset: 27109},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 968, col: 5, offset: 27231},
+									pos:   position{line: 966, col: 5, offset: 27109},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 968, col: 7, offset: 27233},
+										pos:  position{line: 966, col: 7, offset: 27111},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 968, col: 11, offset: 27237},
+									pos: position{line: 966, col: 11, offset: 27115},
 									expr: &ruleRefExpr{
-										pos:  position{line: 968, col: 12, offset: 27238},
+										pos:  position{line: 966, col: 12, offset: 27116},
 										name: "IdentifierRest",
 									},
 								},
@@ -7811,13 +7811,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 971, col: 5, offset: 27352},
+						pos: position{line: 969, col: 5, offset: 27230},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 971, col: 5, offset: 27352},
+							pos:   position{line: 969, col: 5, offset: 27230},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 971, col: 7, offset: 27354},
+								pos:  position{line: 969, col: 7, offset: 27232},
 								name: "IP",
 							},
 						},
@@ -7827,15 +7827,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 975, col: 1, offset: 27453},
+			pos:  position{line: 973, col: 1, offset: 27331},
 			expr: &actionExpr{
-				pos: position{line: 976, col: 5, offset: 27470},
+				pos: position{line: 974, col: 5, offset: 27348},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 976, col: 5, offset: 27470},
+					pos:   position{line: 974, col: 5, offset: 27348},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 976, col: 7, offset: 27472},
+						pos:  position{line: 974, col: 7, offset: 27350},
 						name: "FloatString",
 					},
 				},
@@ -7843,15 +7843,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 980, col: 1, offset: 27585},
+			pos:  position{line: 978, col: 1, offset: 27463},
 			expr: &actionExpr{
-				pos: position{line: 981, col: 5, offset: 27604},
+				pos: position{line: 979, col: 5, offset: 27482},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 981, col: 5, offset: 27604},
+					pos:   position{line: 979, col: 5, offset: 27482},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 981, col: 7, offset: 27606},
+						pos:  position{line: 979, col: 7, offset: 27484},
 						name: "IntString",
 					},
 				},
@@ -7859,24 +7859,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 985, col: 1, offset: 27715},
+			pos:  position{line: 983, col: 1, offset: 27593},
 			expr: &choiceExpr{
-				pos: position{line: 986, col: 5, offset: 27734},
+				pos: position{line: 984, col: 5, offset: 27612},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 986, col: 5, offset: 27734},
+						pos: position{line: 984, col: 5, offset: 27612},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 986, col: 5, offset: 27734},
+							pos:        position{line: 984, col: 5, offset: 27612},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 987, col: 5, offset: 27847},
+						pos: position{line: 985, col: 5, offset: 27725},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 987, col: 5, offset: 27847},
+							pos:        position{line: 985, col: 5, offset: 27725},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7886,12 +7886,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 989, col: 1, offset: 27958},
+			pos:  position{line: 987, col: 1, offset: 27836},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 5, offset: 27974},
+				pos: position{line: 988, col: 5, offset: 27852},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 990, col: 5, offset: 27974},
+					pos:        position{line: 988, col: 5, offset: 27852},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7899,22 +7899,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 992, col: 1, offset: 28080},
+			pos:  position{line: 990, col: 1, offset: 27958},
 			expr: &actionExpr{
-				pos: position{line: 993, col: 5, offset: 28097},
+				pos: position{line: 991, col: 5, offset: 27975},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 993, col: 5, offset: 28097},
+					pos: position{line: 991, col: 5, offset: 27975},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 993, col: 5, offset: 28097},
+							pos:        position{line: 991, col: 5, offset: 27975},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 993, col: 10, offset: 28102},
+							pos: position{line: 991, col: 10, offset: 27980},
 							expr: &ruleRefExpr{
-								pos:  position{line: 993, col: 10, offset: 28102},
+								pos:  position{line: 991, col: 10, offset: 27980},
 								name: "HexDigit",
 							},
 						},
@@ -7924,28 +7924,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 997, col: 1, offset: 28217},
+			pos:  position{line: 995, col: 1, offset: 28095},
 			expr: &actionExpr{
-				pos: position{line: 998, col: 5, offset: 28233},
+				pos: position{line: 996, col: 5, offset: 28111},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 998, col: 5, offset: 28233},
+					pos: position{line: 996, col: 5, offset: 28111},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 998, col: 5, offset: 28233},
+							pos:        position{line: 996, col: 5, offset: 28111},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 998, col: 9, offset: 28237},
+							pos:   position{line: 996, col: 9, offset: 28115},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 998, col: 13, offset: 28241},
+								pos:  position{line: 996, col: 13, offset: 28119},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 998, col: 18, offset: 28246},
+							pos:        position{line: 996, col: 18, offset: 28124},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -7955,31 +7955,31 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1002, col: 1, offset: 28335},
+			pos:  position{line: 1000, col: 1, offset: 28213},
 			expr: &choiceExpr{
-				pos: position{line: 1003, col: 5, offset: 28348},
+				pos: position{line: 1001, col: 5, offset: 28226},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1003, col: 5, offset: 28348},
+						pos: position{line: 1001, col: 5, offset: 28226},
 						run: (*parser).callonCastType2,
 						expr: &seqExpr{
-							pos: position{line: 1003, col: 5, offset: 28348},
+							pos: position{line: 1001, col: 5, offset: 28226},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1003, col: 5, offset: 28348},
+									pos:        position{line: 1001, col: 5, offset: 28226},
 									val:        "<",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1003, col: 9, offset: 28352},
+									pos:   position{line: 1001, col: 9, offset: 28230},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1003, col: 13, offset: 28356},
+										pos:  position{line: 1001, col: 13, offset: 28234},
 										name: "Type",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1003, col: 18, offset: 28361},
+									pos:        position{line: 1001, col: 18, offset: 28239},
 									val:        ">",
 									ignoreCase: false,
 								},
@@ -7987,10 +7987,10 @@ var g = &grammar{
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 1004, col: 5, offset: 28389},
+						pos:   position{line: 1002, col: 5, offset: 28267},
 						label: "typ",
 						expr: &ruleRefExpr{
-							pos:  position{line: 1004, col: 9, offset: 28393},
+							pos:  position{line: 1002, col: 9, offset: 28271},
 							name: "PrimitiveType",
 						},
 					},
@@ -7999,20 +7999,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1006, col: 1, offset: 28408},
+			pos:  position{line: 1004, col: 1, offset: 28286},
 			expr: &choiceExpr{
-				pos: position{line: 1007, col: 5, offset: 28417},
+				pos: position{line: 1005, col: 5, offset: 28295},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 28417},
+						pos:  position{line: 1005, col: 5, offset: 28295},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 28433},
+						pos:  position{line: 1006, col: 5, offset: 28311},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 28451},
+						pos:  position{line: 1007, col: 5, offset: 28329},
 						name: "ComplexType",
 					},
 				},
@@ -8020,28 +8020,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1011, col: 1, offset: 28464},
+			pos:  position{line: 1009, col: 1, offset: 28342},
 			expr: &choiceExpr{
-				pos: position{line: 1012, col: 5, offset: 28482},
+				pos: position{line: 1010, col: 5, offset: 28360},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 28482},
+						pos: position{line: 1010, col: 5, offset: 28360},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1012, col: 5, offset: 28482},
+							pos: position{line: 1010, col: 5, offset: 28360},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1012, col: 5, offset: 28482},
+									pos:   position{line: 1010, col: 5, offset: 28360},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1012, col: 10, offset: 28487},
+										pos:  position{line: 1010, col: 10, offset: 28365},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1012, col: 24, offset: 28501},
+									pos: position{line: 1010, col: 24, offset: 28379},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1012, col: 25, offset: 28502},
+										pos:  position{line: 1010, col: 25, offset: 28380},
 										name: "IdentifierRest",
 									},
 								},
@@ -8049,37 +8049,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1013, col: 5, offset: 28542},
+						pos: position{line: 1011, col: 5, offset: 28420},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1013, col: 5, offset: 28542},
+							pos: position{line: 1011, col: 5, offset: 28420},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1013, col: 5, offset: 28542},
+									pos:   position{line: 1011, col: 5, offset: 28420},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 10, offset: 28547},
+										pos:  position{line: 1011, col: 10, offset: 28425},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 25, offset: 28562},
+									pos:  position{line: 1011, col: 25, offset: 28440},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1013, col: 28, offset: 28565},
+									pos:        position{line: 1011, col: 28, offset: 28443},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 32, offset: 28569},
+									pos:  position{line: 1011, col: 32, offset: 28447},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 35, offset: 28572},
+									pos:   position{line: 1011, col: 35, offset: 28450},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 39, offset: 28576},
+										pos:  position{line: 1011, col: 39, offset: 28454},
 										name: "Type",
 									},
 								},
@@ -8087,42 +8087,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1016, col: 5, offset: 28678},
+						pos: position{line: 1014, col: 5, offset: 28556},
 						run: (*parser).callonAmbiguousType17,
 						expr: &labeledExpr{
-							pos:   position{line: 1016, col: 5, offset: 28678},
+							pos:   position{line: 1014, col: 5, offset: 28556},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1016, col: 10, offset: 28683},
+								pos:  position{line: 1014, col: 10, offset: 28561},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 28785},
+						pos: position{line: 1017, col: 5, offset: 28663},
 						run: (*parser).callonAmbiguousType20,
 						expr: &seqExpr{
-							pos: position{line: 1019, col: 5, offset: 28785},
+							pos: position{line: 1017, col: 5, offset: 28663},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1019, col: 5, offset: 28785},
+									pos:        position{line: 1017, col: 5, offset: 28663},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 9, offset: 28789},
+									pos:  position{line: 1017, col: 9, offset: 28667},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1019, col: 12, offset: 28792},
+									pos:   position{line: 1017, col: 12, offset: 28670},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 14, offset: 28794},
+										pos:  position{line: 1017, col: 14, offset: 28672},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 25, offset: 28805},
+									pos:        position{line: 1017, col: 25, offset: 28683},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8134,15 +8134,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1021, col: 1, offset: 28828},
+			pos:  position{line: 1019, col: 1, offset: 28706},
 			expr: &actionExpr{
-				pos: position{line: 1022, col: 5, offset: 28842},
+				pos: position{line: 1020, col: 5, offset: 28720},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1022, col: 5, offset: 28842},
+					pos:   position{line: 1020, col: 5, offset: 28720},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1022, col: 11, offset: 28848},
+						pos:  position{line: 1020, col: 11, offset: 28726},
 						name: "TypeList",
 					},
 				},
@@ -8150,28 +8150,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1026, col: 1, offset: 28944},
+			pos:  position{line: 1024, col: 1, offset: 28822},
 			expr: &actionExpr{
-				pos: position{line: 1027, col: 5, offset: 28957},
+				pos: position{line: 1025, col: 5, offset: 28835},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1027, col: 5, offset: 28957},
+					pos: position{line: 1025, col: 5, offset: 28835},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1027, col: 5, offset: 28957},
+							pos:   position{line: 1025, col: 5, offset: 28835},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1027, col: 11, offset: 28963},
+								pos:  position{line: 1025, col: 11, offset: 28841},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1027, col: 16, offset: 28968},
+							pos:   position{line: 1025, col: 16, offset: 28846},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1027, col: 21, offset: 28973},
+								pos: position{line: 1025, col: 21, offset: 28851},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1027, col: 21, offset: 28973},
+									pos:  position{line: 1025, col: 21, offset: 28851},
 									name: "TypeListTail",
 								},
 							},
@@ -8182,31 +8182,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1031, col: 1, offset: 29067},
+			pos:  position{line: 1029, col: 1, offset: 28945},
 			expr: &actionExpr{
-				pos: position{line: 1031, col: 16, offset: 29082},
+				pos: position{line: 1029, col: 16, offset: 28960},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1031, col: 16, offset: 29082},
+					pos: position{line: 1029, col: 16, offset: 28960},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1031, col: 16, offset: 29082},
+							pos:  position{line: 1029, col: 16, offset: 28960},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1031, col: 19, offset: 29085},
+							pos:        position{line: 1029, col: 19, offset: 28963},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1031, col: 23, offset: 29089},
+							pos:  position{line: 1029, col: 23, offset: 28967},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1031, col: 26, offset: 29092},
+							pos:   position{line: 1029, col: 26, offset: 28970},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1031, col: 30, offset: 29096},
+								pos:  position{line: 1029, col: 30, offset: 28974},
 								name: "Type",
 							},
 						},
@@ -8216,39 +8216,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1033, col: 1, offset: 29122},
+			pos:  position{line: 1031, col: 1, offset: 29000},
 			expr: &choiceExpr{
-				pos: position{line: 1034, col: 5, offset: 29138},
+				pos: position{line: 1032, col: 5, offset: 29016},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1034, col: 5, offset: 29138},
+						pos: position{line: 1032, col: 5, offset: 29016},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1034, col: 5, offset: 29138},
+							pos: position{line: 1032, col: 5, offset: 29016},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1034, col: 5, offset: 29138},
+									pos:        position{line: 1032, col: 5, offset: 29016},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1034, col: 9, offset: 29142},
+									pos:  position{line: 1032, col: 9, offset: 29020},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1034, col: 12, offset: 29145},
+									pos:   position{line: 1032, col: 12, offset: 29023},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1034, col: 19, offset: 29152},
+										pos:  position{line: 1032, col: 19, offset: 29030},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1034, col: 33, offset: 29166},
+									pos:  position{line: 1032, col: 33, offset: 29044},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1034, col: 36, offset: 29169},
+									pos:        position{line: 1032, col: 36, offset: 29047},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8256,34 +8256,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1037, col: 5, offset: 29264},
+						pos: position{line: 1035, col: 5, offset: 29142},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1037, col: 5, offset: 29264},
+							pos: position{line: 1035, col: 5, offset: 29142},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1037, col: 5, offset: 29264},
+									pos:        position{line: 1035, col: 5, offset: 29142},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 9, offset: 29268},
+									pos:  position{line: 1035, col: 9, offset: 29146},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1037, col: 12, offset: 29271},
+									pos:   position{line: 1035, col: 12, offset: 29149},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1037, col: 16, offset: 29275},
+										pos:  position{line: 1035, col: 16, offset: 29153},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 21, offset: 29280},
+									pos:  position{line: 1035, col: 21, offset: 29158},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1037, col: 24, offset: 29283},
+									pos:        position{line: 1035, col: 24, offset: 29161},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8291,34 +8291,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1040, col: 5, offset: 29372},
+						pos: position{line: 1038, col: 5, offset: 29250},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1040, col: 5, offset: 29372},
+							pos: position{line: 1038, col: 5, offset: 29250},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1040, col: 5, offset: 29372},
+									pos:        position{line: 1038, col: 5, offset: 29250},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1040, col: 10, offset: 29377},
+									pos:  position{line: 1038, col: 10, offset: 29255},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1040, col: 14, offset: 29381},
+									pos:   position{line: 1038, col: 14, offset: 29259},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1040, col: 18, offset: 29385},
+										pos:  position{line: 1038, col: 18, offset: 29263},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1040, col: 23, offset: 29390},
+									pos:  position{line: 1038, col: 23, offset: 29268},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1040, col: 26, offset: 29393},
+									pos:        position{line: 1038, col: 26, offset: 29271},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8326,55 +8326,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 29481},
+						pos: position{line: 1041, col: 5, offset: 29359},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1043, col: 5, offset: 29481},
+							pos: position{line: 1041, col: 5, offset: 29359},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1043, col: 5, offset: 29481},
+									pos:        position{line: 1041, col: 5, offset: 29359},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 10, offset: 29486},
+									pos:  position{line: 1041, col: 10, offset: 29364},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 13, offset: 29489},
+									pos:   position{line: 1041, col: 13, offset: 29367},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 21, offset: 29497},
+										pos:  position{line: 1041, col: 21, offset: 29375},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 26, offset: 29502},
+									pos:  position{line: 1041, col: 26, offset: 29380},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 29, offset: 29505},
+									pos:        position{line: 1041, col: 29, offset: 29383},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 33, offset: 29509},
+									pos:  position{line: 1041, col: 33, offset: 29387},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 36, offset: 29512},
+									pos:   position{line: 1041, col: 36, offset: 29390},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 44, offset: 29520},
+										pos:  position{line: 1041, col: 44, offset: 29398},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 49, offset: 29525},
+									pos:  position{line: 1041, col: 49, offset: 29403},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 52, offset: 29528},
+									pos:        position{line: 1041, col: 52, offset: 29406},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8386,15 +8386,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1047, col: 1, offset: 29642},
+			pos:  position{line: 1045, col: 1, offset: 29520},
 			expr: &actionExpr{
-				pos: position{line: 1048, col: 5, offset: 29662},
+				pos: position{line: 1046, col: 5, offset: 29540},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1048, col: 5, offset: 29662},
+					pos:   position{line: 1046, col: 5, offset: 29540},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1048, col: 7, offset: 29664},
+						pos:  position{line: 1046, col: 7, offset: 29542},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8402,34 +8402,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1055, col: 1, offset: 29880},
+			pos:  position{line: 1053, col: 1, offset: 29758},
 			expr: &choiceExpr{
-				pos: position{line: 1056, col: 5, offset: 29905},
+				pos: position{line: 1054, col: 5, offset: 29783},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1056, col: 5, offset: 29905},
+						pos: position{line: 1054, col: 5, offset: 29783},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1056, col: 5, offset: 29905},
+							pos: position{line: 1054, col: 5, offset: 29783},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1056, col: 5, offset: 29905},
+									pos:        position{line: 1054, col: 5, offset: 29783},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1056, col: 9, offset: 29909},
+									pos:   position{line: 1054, col: 9, offset: 29787},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1056, col: 11, offset: 29911},
+										pos: position{line: 1054, col: 11, offset: 29789},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1056, col: 11, offset: 29911},
+											pos:  position{line: 1054, col: 11, offset: 29789},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1056, col: 37, offset: 29937},
+									pos:        position{line: 1054, col: 37, offset: 29815},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8437,29 +8437,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 29963},
+						pos: position{line: 1055, col: 5, offset: 29841},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 29963},
+							pos: position{line: 1055, col: 5, offset: 29841},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1057, col: 5, offset: 29963},
+									pos:        position{line: 1055, col: 5, offset: 29841},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 9, offset: 29967},
+									pos:   position{line: 1055, col: 9, offset: 29845},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1057, col: 11, offset: 29969},
+										pos: position{line: 1055, col: 11, offset: 29847},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1057, col: 11, offset: 29969},
+											pos:  position{line: 1055, col: 11, offset: 29847},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 37, offset: 29995},
+									pos:        position{line: 1055, col: 37, offset: 29873},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8471,24 +8471,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1059, col: 1, offset: 30018},
+			pos:  position{line: 1057, col: 1, offset: 29896},
 			expr: &choiceExpr{
-				pos: position{line: 1060, col: 5, offset: 30047},
+				pos: position{line: 1058, col: 5, offset: 29925},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1060, col: 5, offset: 30047},
+						pos:  position{line: 1058, col: 5, offset: 29925},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1061, col: 5, offset: 30064},
+						pos: position{line: 1059, col: 5, offset: 29942},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1061, col: 5, offset: 30064},
+							pos:   position{line: 1059, col: 5, offset: 29942},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1061, col: 7, offset: 30066},
+								pos: position{line: 1059, col: 7, offset: 29944},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1061, col: 7, offset: 30066},
+									pos:  position{line: 1059, col: 7, offset: 29944},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8499,26 +8499,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1065, col: 1, offset: 30203},
+			pos:  position{line: 1063, col: 1, offset: 30081},
 			expr: &choiceExpr{
-				pos: position{line: 1066, col: 5, offset: 30232},
+				pos: position{line: 1064, col: 5, offset: 30110},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 30232},
+						pos: position{line: 1064, col: 5, offset: 30110},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1066, col: 5, offset: 30232},
+							pos: position{line: 1064, col: 5, offset: 30110},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1066, col: 5, offset: 30232},
+									pos:        position{line: 1064, col: 5, offset: 30110},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 10, offset: 30237},
+									pos:   position{line: 1064, col: 10, offset: 30115},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1066, col: 12, offset: 30239},
+										pos:        position{line: 1064, col: 12, offset: 30117},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8527,24 +8527,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 30266},
+						pos: position{line: 1065, col: 5, offset: 30144},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1067, col: 5, offset: 30266},
+							pos: position{line: 1065, col: 5, offset: 30144},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1067, col: 5, offset: 30266},
+									pos: position{line: 1065, col: 5, offset: 30144},
 									expr: &litMatcher{
-										pos:        position{line: 1067, col: 8, offset: 30269},
+										pos:        position{line: 1065, col: 8, offset: 30147},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1067, col: 15, offset: 30276},
+									pos:   position{line: 1065, col: 15, offset: 30154},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1067, col: 17, offset: 30278},
+										pos:  position{line: 1065, col: 17, offset: 30156},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8556,24 +8556,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1069, col: 1, offset: 30314},
+			pos:  position{line: 1067, col: 1, offset: 30192},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 5, offset: 30343},
+				pos: position{line: 1068, col: 5, offset: 30221},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1070, col: 5, offset: 30343},
+						pos:  position{line: 1068, col: 5, offset: 30221},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 30360},
+						pos: position{line: 1069, col: 5, offset: 30238},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1071, col: 5, offset: 30360},
+							pos:   position{line: 1069, col: 5, offset: 30238},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1071, col: 7, offset: 30362},
+								pos: position{line: 1069, col: 7, offset: 30240},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1071, col: 7, offset: 30362},
+									pos:  position{line: 1069, col: 7, offset: 30240},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8584,26 +8584,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1075, col: 1, offset: 30499},
+			pos:  position{line: 1073, col: 1, offset: 30377},
 			expr: &choiceExpr{
-				pos: position{line: 1076, col: 5, offset: 30528},
+				pos: position{line: 1074, col: 5, offset: 30406},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1076, col: 5, offset: 30528},
+						pos: position{line: 1074, col: 5, offset: 30406},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1076, col: 5, offset: 30528},
+							pos: position{line: 1074, col: 5, offset: 30406},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1076, col: 5, offset: 30528},
+									pos:        position{line: 1074, col: 5, offset: 30406},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1076, col: 10, offset: 30533},
+									pos:   position{line: 1074, col: 10, offset: 30411},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1076, col: 12, offset: 30535},
+										pos:        position{line: 1074, col: 12, offset: 30413},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8612,24 +8612,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 30562},
+						pos: position{line: 1075, col: 5, offset: 30440},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 30562},
+							pos: position{line: 1075, col: 5, offset: 30440},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1077, col: 5, offset: 30562},
+									pos: position{line: 1075, col: 5, offset: 30440},
 									expr: &litMatcher{
-										pos:        position{line: 1077, col: 8, offset: 30565},
+										pos:        position{line: 1075, col: 8, offset: 30443},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 15, offset: 30572},
+									pos:   position{line: 1075, col: 15, offset: 30450},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 17, offset: 30574},
+										pos:  position{line: 1075, col: 17, offset: 30452},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8641,36 +8641,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1079, col: 1, offset: 30610},
+			pos:  position{line: 1077, col: 1, offset: 30488},
 			expr: &actionExpr{
-				pos: position{line: 1080, col: 5, offset: 30627},
+				pos: position{line: 1078, col: 5, offset: 30505},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1080, col: 5, offset: 30627},
+					pos: position{line: 1078, col: 5, offset: 30505},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1080, col: 5, offset: 30627},
+							pos:        position{line: 1078, col: 5, offset: 30505},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1080, col: 10, offset: 30632},
+							pos:  position{line: 1078, col: 10, offset: 30510},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1080, col: 13, offset: 30635},
+							pos:   position{line: 1078, col: 13, offset: 30513},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1080, col: 15, offset: 30637},
+								pos:  position{line: 1078, col: 15, offset: 30515},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1080, col: 20, offset: 30642},
+							pos:  position{line: 1078, col: 20, offset: 30520},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1080, col: 23, offset: 30645},
+							pos:        position{line: 1078, col: 23, offset: 30523},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8680,105 +8680,105 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1082, col: 1, offset: 30668},
+			pos:  position{line: 1080, col: 1, offset: 30546},
 			expr: &actionExpr{
-				pos: position{line: 1083, col: 5, offset: 30686},
+				pos: position{line: 1081, col: 5, offset: 30564},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1083, col: 9, offset: 30690},
+					pos: position{line: 1081, col: 9, offset: 30568},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1083, col: 9, offset: 30690},
+							pos:        position{line: 1081, col: 9, offset: 30568},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 19, offset: 30700},
+							pos:        position{line: 1081, col: 19, offset: 30578},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 30, offset: 30711},
+							pos:        position{line: 1081, col: 30, offset: 30589},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 41, offset: 30722},
+							pos:        position{line: 1081, col: 41, offset: 30600},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 9, offset: 30739},
+							pos:        position{line: 1082, col: 9, offset: 30617},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 18, offset: 30748},
+							pos:        position{line: 1082, col: 18, offset: 30626},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 28, offset: 30758},
+							pos:        position{line: 1082, col: 28, offset: 30636},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 38, offset: 30768},
+							pos:        position{line: 1082, col: 38, offset: 30646},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1085, col: 9, offset: 30784},
+							pos:        position{line: 1083, col: 9, offset: 30662},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1085, col: 21, offset: 30796},
+							pos:        position{line: 1083, col: 21, offset: 30674},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 9, offset: 30814},
+							pos:        position{line: 1084, col: 9, offset: 30692},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 18, offset: 30823},
+							pos:        position{line: 1084, col: 18, offset: 30701},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1087, col: 9, offset: 30840},
+							pos:        position{line: 1085, col: 9, offset: 30718},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1087, col: 22, offset: 30853},
+							pos:        position{line: 1085, col: 22, offset: 30731},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1088, col: 9, offset: 30868},
+							pos:        position{line: 1086, col: 9, offset: 30746},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1089, col: 9, offset: 30884},
+							pos:        position{line: 1087, col: 9, offset: 30762},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1089, col: 16, offset: 30891},
+							pos:        position{line: 1087, col: 16, offset: 30769},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1090, col: 9, offset: 30905},
+							pos:        position{line: 1088, col: 9, offset: 30783},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1090, col: 18, offset: 30914},
+							pos:        position{line: 1088, col: 18, offset: 30792},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8788,31 +8788,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1094, col: 1, offset: 31030},
+			pos:  position{line: 1092, col: 1, offset: 30908},
 			expr: &choiceExpr{
-				pos: position{line: 1095, col: 5, offset: 31048},
+				pos: position{line: 1093, col: 5, offset: 30926},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1095, col: 5, offset: 31048},
+						pos: position{line: 1093, col: 5, offset: 30926},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1095, col: 5, offset: 31048},
+							pos: position{line: 1093, col: 5, offset: 30926},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1095, col: 5, offset: 31048},
+									pos:   position{line: 1093, col: 5, offset: 30926},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1095, col: 11, offset: 31054},
+										pos:  position{line: 1093, col: 11, offset: 30932},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1095, col: 21, offset: 31064},
+									pos:   position{line: 1093, col: 21, offset: 30942},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1095, col: 26, offset: 31069},
+										pos: position{line: 1093, col: 26, offset: 30947},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1095, col: 26, offset: 31069},
+											pos:  position{line: 1093, col: 26, offset: 30947},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -8821,10 +8821,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1098, col: 5, offset: 31171},
+						pos: position{line: 1096, col: 5, offset: 31049},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1098, col: 5, offset: 31171},
+							pos:        position{line: 1096, col: 5, offset: 31049},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8834,31 +8834,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1100, col: 1, offset: 31195},
+			pos:  position{line: 1098, col: 1, offset: 31073},
 			expr: &actionExpr{
-				pos: position{line: 1100, col: 21, offset: 31215},
+				pos: position{line: 1098, col: 21, offset: 31093},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1100, col: 21, offset: 31215},
+					pos: position{line: 1098, col: 21, offset: 31093},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1100, col: 21, offset: 31215},
+							pos:  position{line: 1098, col: 21, offset: 31093},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 24, offset: 31218},
+							pos:        position{line: 1098, col: 24, offset: 31096},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1100, col: 28, offset: 31222},
+							pos:  position{line: 1098, col: 28, offset: 31100},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1100, col: 31, offset: 31225},
+							pos:   position{line: 1098, col: 31, offset: 31103},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1100, col: 35, offset: 31229},
+								pos:  position{line: 1098, col: 35, offset: 31107},
 								name: "TypeField",
 							},
 						},
@@ -8868,39 +8868,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1102, col: 1, offset: 31260},
+			pos:  position{line: 1100, col: 1, offset: 31138},
 			expr: &actionExpr{
-				pos: position{line: 1103, col: 5, offset: 31274},
+				pos: position{line: 1101, col: 5, offset: 31152},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1103, col: 5, offset: 31274},
+					pos: position{line: 1101, col: 5, offset: 31152},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1103, col: 5, offset: 31274},
+							pos:   position{line: 1101, col: 5, offset: 31152},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1103, col: 10, offset: 31279},
+								pos:  position{line: 1101, col: 10, offset: 31157},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 20, offset: 31289},
+							pos:  position{line: 1101, col: 20, offset: 31167},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 23, offset: 31292},
+							pos:        position{line: 1101, col: 23, offset: 31170},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 27, offset: 31296},
+							pos:  position{line: 1101, col: 27, offset: 31174},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1103, col: 30, offset: 31299},
+							pos:   position{line: 1101, col: 30, offset: 31177},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1103, col: 34, offset: 31303},
+								pos:  position{line: 1101, col: 34, offset: 31181},
 								name: "Type",
 							},
 						},
@@ -8910,16 +8910,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1107, col: 1, offset: 31385},
+			pos:  position{line: 1105, col: 1, offset: 31263},
 			expr: &choiceExpr{
-				pos: position{line: 1108, col: 5, offset: 31399},
+				pos: position{line: 1106, col: 5, offset: 31277},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1108, col: 5, offset: 31399},
+						pos:  position{line: 1106, col: 5, offset: 31277},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1109, col: 5, offset: 31418},
+						pos:  position{line: 1107, col: 5, offset: 31296},
 						name: "QuotedString",
 					},
 				},
@@ -8927,32 +8927,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1111, col: 1, offset: 31432},
+			pos:  position{line: 1109, col: 1, offset: 31310},
 			expr: &actionExpr{
-				pos: position{line: 1111, col: 12, offset: 31443},
+				pos: position{line: 1109, col: 12, offset: 31321},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1111, col: 12, offset: 31443},
+					pos: position{line: 1109, col: 12, offset: 31321},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1111, col: 13, offset: 31444},
+							pos: position{line: 1109, col: 13, offset: 31322},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1111, col: 13, offset: 31444},
+									pos:        position{line: 1109, col: 13, offset: 31322},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 21, offset: 31452},
+									pos:        position{line: 1109, col: 21, offset: 31330},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1111, col: 28, offset: 31459},
+							pos: position{line: 1109, col: 28, offset: 31337},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1111, col: 29, offset: 31460},
+								pos:  position{line: 1109, col: 29, offset: 31338},
 								name: "IdentifierRest",
 							},
 						},
@@ -8962,32 +8962,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1112, col: 1, offset: 31497},
+			pos:  position{line: 1110, col: 1, offset: 31375},
 			expr: &actionExpr{
-				pos: position{line: 1112, col: 11, offset: 31507},
+				pos: position{line: 1110, col: 11, offset: 31385},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1112, col: 11, offset: 31507},
+					pos: position{line: 1110, col: 11, offset: 31385},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1112, col: 12, offset: 31508},
+							pos: position{line: 1110, col: 12, offset: 31386},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1112, col: 12, offset: 31508},
+									pos:        position{line: 1110, col: 12, offset: 31386},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1112, col: 19, offset: 31515},
+									pos:        position{line: 1110, col: 19, offset: 31393},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1112, col: 25, offset: 31521},
+							pos: position{line: 1110, col: 25, offset: 31399},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1112, col: 26, offset: 31522},
+								pos:  position{line: 1110, col: 26, offset: 31400},
 								name: "IdentifierRest",
 							},
 						},
@@ -8997,22 +8997,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1113, col: 1, offset: 31558},
+			pos:  position{line: 1111, col: 1, offset: 31436},
 			expr: &actionExpr{
-				pos: position{line: 1113, col: 11, offset: 31568},
+				pos: position{line: 1111, col: 11, offset: 31446},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1113, col: 11, offset: 31568},
+					pos: position{line: 1111, col: 11, offset: 31446},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1113, col: 11, offset: 31568},
+							pos:        position{line: 1111, col: 11, offset: 31446},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1113, col: 16, offset: 31573},
+							pos: position{line: 1111, col: 16, offset: 31451},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1113, col: 17, offset: 31574},
+								pos:  position{line: 1111, col: 17, offset: 31452},
 								name: "IdentifierRest",
 							},
 						},
@@ -9022,32 +9022,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1114, col: 1, offset: 31610},
+			pos:  position{line: 1112, col: 1, offset: 31488},
 			expr: &actionExpr{
-				pos: position{line: 1114, col: 12, offset: 31621},
+				pos: position{line: 1112, col: 12, offset: 31499},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1114, col: 12, offset: 31621},
+					pos: position{line: 1112, col: 12, offset: 31499},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1114, col: 13, offset: 31622},
+							pos: position{line: 1112, col: 13, offset: 31500},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1114, col: 13, offset: 31622},
+									pos:        position{line: 1112, col: 13, offset: 31500},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 21, offset: 31630},
+									pos:        position{line: 1112, col: 21, offset: 31508},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1114, col: 28, offset: 31637},
+							pos: position{line: 1112, col: 28, offset: 31515},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1114, col: 29, offset: 31638},
+								pos:  position{line: 1112, col: 29, offset: 31516},
 								name: "IdentifierRest",
 							},
 						},
@@ -9057,22 +9057,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1115, col: 1, offset: 31675},
+			pos:  position{line: 1113, col: 1, offset: 31553},
 			expr: &actionExpr{
-				pos: position{line: 1115, col: 11, offset: 31685},
+				pos: position{line: 1113, col: 11, offset: 31563},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1115, col: 11, offset: 31685},
+					pos: position{line: 1113, col: 11, offset: 31563},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1115, col: 11, offset: 31685},
+							pos:        position{line: 1113, col: 11, offset: 31563},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1115, col: 16, offset: 31690},
+							pos: position{line: 1113, col: 16, offset: 31568},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1115, col: 17, offset: 31691},
+								pos:  position{line: 1113, col: 17, offset: 31569},
 								name: "IdentifierRest",
 							},
 						},
@@ -9082,9 +9082,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1117, col: 1, offset: 31728},
+			pos:  position{line: 1115, col: 1, offset: 31606},
 			expr: &charClassMatcher{
-				pos:        position{line: 1117, col: 19, offset: 31746},
+				pos:        position{line: 1115, col: 19, offset: 31624},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9094,16 +9094,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1119, col: 1, offset: 31758},
+			pos:  position{line: 1117, col: 1, offset: 31636},
 			expr: &choiceExpr{
-				pos: position{line: 1119, col: 18, offset: 31775},
+				pos: position{line: 1117, col: 18, offset: 31653},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1119, col: 18, offset: 31775},
+						pos:  position{line: 1117, col: 18, offset: 31653},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1119, col: 36, offset: 31793},
+						pos:        position{line: 1117, col: 36, offset: 31671},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9114,15 +9114,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1121, col: 1, offset: 31800},
+			pos:  position{line: 1119, col: 1, offset: 31678},
 			expr: &actionExpr{
-				pos: position{line: 1122, col: 5, offset: 31815},
+				pos: position{line: 1120, col: 5, offset: 31693},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1122, col: 5, offset: 31815},
+					pos:   position{line: 1120, col: 5, offset: 31693},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1122, col: 8, offset: 31818},
+						pos:  position{line: 1120, col: 8, offset: 31696},
 						name: "IdentifierName",
 					},
 				},
@@ -9130,29 +9130,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1124, col: 1, offset: 31899},
+			pos:  position{line: 1122, col: 1, offset: 31777},
 			expr: &choiceExpr{
-				pos: position{line: 1125, col: 5, offset: 31918},
+				pos: position{line: 1123, col: 5, offset: 31796},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1125, col: 5, offset: 31918},
+						pos: position{line: 1123, col: 5, offset: 31796},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1125, col: 5, offset: 31918},
+							pos: position{line: 1123, col: 5, offset: 31796},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1125, col: 5, offset: 31918},
+									pos: position{line: 1123, col: 5, offset: 31796},
 									expr: &seqExpr{
-										pos: position{line: 1125, col: 7, offset: 31920},
+										pos: position{line: 1123, col: 7, offset: 31798},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1125, col: 7, offset: 31920},
+												pos:  position{line: 1123, col: 7, offset: 31798},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1125, col: 15, offset: 31928},
+												pos: position{line: 1123, col: 15, offset: 31806},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1125, col: 16, offset: 31929},
+													pos:  position{line: 1123, col: 16, offset: 31807},
 													name: "IdentifierRest",
 												},
 											},
@@ -9160,13 +9160,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 32, offset: 31945},
+									pos:  position{line: 1123, col: 32, offset: 31823},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1125, col: 48, offset: 31961},
+									pos: position{line: 1123, col: 48, offset: 31839},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1125, col: 48, offset: 31961},
+										pos:  position{line: 1123, col: 48, offset: 31839},
 										name: "IdentifierRest",
 									},
 								},
@@ -9174,30 +9174,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1126, col: 5, offset: 32013},
+						pos: position{line: 1124, col: 5, offset: 31891},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1126, col: 5, offset: 32013},
+							pos:        position{line: 1124, col: 5, offset: 31891},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1127, col: 5, offset: 32052},
+						pos: position{line: 1125, col: 5, offset: 31930},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1127, col: 5, offset: 32052},
+							pos: position{line: 1125, col: 5, offset: 31930},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1127, col: 5, offset: 32052},
+									pos:        position{line: 1125, col: 5, offset: 31930},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1127, col: 10, offset: 32057},
+									pos:   position{line: 1125, col: 10, offset: 31935},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1127, col: 13, offset: 32060},
+										pos:  position{line: 1125, col: 13, offset: 31938},
 										name: "IDGuard",
 									},
 								},
@@ -9205,39 +9205,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1129, col: 5, offset: 32151},
+						pos: position{line: 1127, col: 5, offset: 32029},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1129, col: 5, offset: 32151},
+							pos:        position{line: 1127, col: 5, offset: 32029},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1130, col: 5, offset: 32193},
+						pos: position{line: 1128, col: 5, offset: 32071},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1130, col: 5, offset: 32193},
+							pos: position{line: 1128, col: 5, offset: 32071},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1130, col: 5, offset: 32193},
+									pos:   position{line: 1128, col: 5, offset: 32071},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1130, col: 8, offset: 32196},
+										pos:  position{line: 1128, col: 8, offset: 32074},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1130, col: 26, offset: 32214},
+									pos: position{line: 1128, col: 26, offset: 32092},
 									expr: &seqExpr{
-										pos: position{line: 1130, col: 28, offset: 32216},
+										pos: position{line: 1128, col: 28, offset: 32094},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1130, col: 28, offset: 32216},
+												pos:  position{line: 1128, col: 28, offset: 32094},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1130, col: 31, offset: 32219},
+												pos:        position{line: 1128, col: 31, offset: 32097},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9252,16 +9252,16 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1132, col: 1, offset: 32244},
+			pos:  position{line: 1130, col: 1, offset: 32122},
 			expr: &choiceExpr{
-				pos: position{line: 1133, col: 5, offset: 32256},
+				pos: position{line: 1131, col: 5, offset: 32134},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 5, offset: 32256},
+						pos:  position{line: 1131, col: 5, offset: 32134},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 5, offset: 32275},
+						pos:  position{line: 1132, col: 5, offset: 32153},
 						name: "NullLiteral",
 					},
 				},
@@ -9269,24 +9269,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1136, col: 1, offset: 32288},
+			pos:  position{line: 1134, col: 1, offset: 32166},
 			expr: &actionExpr{
-				pos: position{line: 1137, col: 5, offset: 32297},
+				pos: position{line: 1135, col: 5, offset: 32175},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1137, col: 5, offset: 32297},
+					pos: position{line: 1135, col: 5, offset: 32175},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1137, col: 5, offset: 32297},
+							pos:  position{line: 1135, col: 5, offset: 32175},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1137, col: 14, offset: 32306},
+							pos:        position{line: 1135, col: 14, offset: 32184},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1137, col: 18, offset: 32310},
+							pos:  position{line: 1135, col: 18, offset: 32188},
 							name: "FullTime",
 						},
 					},
@@ -9295,30 +9295,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1141, col: 1, offset: 32430},
+			pos:  position{line: 1139, col: 1, offset: 32308},
 			expr: &seqExpr{
-				pos: position{line: 1141, col: 12, offset: 32441},
+				pos: position{line: 1139, col: 12, offset: 32319},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1141, col: 12, offset: 32441},
+						pos:  position{line: 1139, col: 12, offset: 32319},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1141, col: 15, offset: 32444},
+						pos:        position{line: 1139, col: 15, offset: 32322},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1141, col: 19, offset: 32448},
+						pos:  position{line: 1139, col: 19, offset: 32326},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1141, col: 22, offset: 32451},
+						pos:        position{line: 1139, col: 22, offset: 32329},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1141, col: 26, offset: 32455},
+						pos:  position{line: 1139, col: 26, offset: 32333},
 						name: "D2",
 					},
 				},
@@ -9326,33 +9326,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1143, col: 1, offset: 32459},
+			pos:  position{line: 1141, col: 1, offset: 32337},
 			expr: &seqExpr{
-				pos: position{line: 1143, col: 6, offset: 32464},
+				pos: position{line: 1141, col: 6, offset: 32342},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1143, col: 6, offset: 32464},
+						pos:        position{line: 1141, col: 6, offset: 32342},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1143, col: 11, offset: 32469},
+						pos:        position{line: 1141, col: 11, offset: 32347},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1143, col: 16, offset: 32474},
+						pos:        position{line: 1141, col: 16, offset: 32352},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1143, col: 21, offset: 32479},
+						pos:        position{line: 1141, col: 21, offset: 32357},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9363,19 +9363,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1144, col: 1, offset: 32485},
+			pos:  position{line: 1142, col: 1, offset: 32363},
 			expr: &seqExpr{
-				pos: position{line: 1144, col: 6, offset: 32490},
+				pos: position{line: 1142, col: 6, offset: 32368},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1144, col: 6, offset: 32490},
+						pos:        position{line: 1142, col: 6, offset: 32368},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1144, col: 11, offset: 32495},
+						pos:        position{line: 1142, col: 11, offset: 32373},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9386,16 +9386,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1146, col: 1, offset: 32502},
+			pos:  position{line: 1144, col: 1, offset: 32380},
 			expr: &seqExpr{
-				pos: position{line: 1146, col: 12, offset: 32513},
+				pos: position{line: 1144, col: 12, offset: 32391},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1146, col: 12, offset: 32513},
+						pos:  position{line: 1144, col: 12, offset: 32391},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1146, col: 24, offset: 32525},
+						pos:  position{line: 1144, col: 24, offset: 32403},
 						name: "TimeOffset",
 					},
 				},
@@ -9403,46 +9403,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1148, col: 1, offset: 32537},
+			pos:  position{line: 1146, col: 1, offset: 32415},
 			expr: &seqExpr{
-				pos: position{line: 1148, col: 15, offset: 32551},
+				pos: position{line: 1146, col: 15, offset: 32429},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1148, col: 15, offset: 32551},
+						pos:  position{line: 1146, col: 15, offset: 32429},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1148, col: 18, offset: 32554},
+						pos:        position{line: 1146, col: 18, offset: 32432},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1148, col: 22, offset: 32558},
+						pos:  position{line: 1146, col: 22, offset: 32436},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1148, col: 25, offset: 32561},
+						pos:        position{line: 1146, col: 25, offset: 32439},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1148, col: 29, offset: 32565},
+						pos:  position{line: 1146, col: 29, offset: 32443},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1148, col: 32, offset: 32568},
+						pos: position{line: 1146, col: 32, offset: 32446},
 						expr: &seqExpr{
-							pos: position{line: 1148, col: 33, offset: 32569},
+							pos: position{line: 1146, col: 33, offset: 32447},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1148, col: 33, offset: 32569},
+									pos:        position{line: 1146, col: 33, offset: 32447},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1148, col: 37, offset: 32573},
+									pos: position{line: 1146, col: 37, offset: 32451},
 									expr: &charClassMatcher{
-										pos:        position{line: 1148, col: 37, offset: 32573},
+										pos:        position{line: 1146, col: 37, offset: 32451},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9457,60 +9457,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1150, col: 1, offset: 32583},
+			pos:  position{line: 1148, col: 1, offset: 32461},
 			expr: &choiceExpr{
-				pos: position{line: 1151, col: 5, offset: 32598},
+				pos: position{line: 1149, col: 5, offset: 32476},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1151, col: 5, offset: 32598},
+						pos:        position{line: 1149, col: 5, offset: 32476},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1152, col: 5, offset: 32606},
+						pos: position{line: 1150, col: 5, offset: 32484},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1152, col: 6, offset: 32607},
+								pos: position{line: 1150, col: 6, offset: 32485},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1152, col: 6, offset: 32607},
+										pos:        position{line: 1150, col: 6, offset: 32485},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1152, col: 12, offset: 32613},
+										pos:        position{line: 1150, col: 12, offset: 32491},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1152, col: 17, offset: 32618},
+								pos:  position{line: 1150, col: 17, offset: 32496},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1152, col: 20, offset: 32621},
+								pos:        position{line: 1150, col: 20, offset: 32499},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1152, col: 24, offset: 32625},
+								pos:  position{line: 1150, col: 24, offset: 32503},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1152, col: 27, offset: 32628},
+								pos: position{line: 1150, col: 27, offset: 32506},
 								expr: &seqExpr{
-									pos: position{line: 1152, col: 28, offset: 32629},
+									pos: position{line: 1150, col: 28, offset: 32507},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1152, col: 28, offset: 32629},
+											pos:        position{line: 1150, col: 28, offset: 32507},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1152, col: 32, offset: 32633},
+											pos: position{line: 1150, col: 32, offset: 32511},
 											expr: &charClassMatcher{
-												pos:        position{line: 1152, col: 32, offset: 32633},
+												pos:        position{line: 1150, col: 32, offset: 32511},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9527,32 +9527,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1154, col: 1, offset: 32643},
+			pos:  position{line: 1152, col: 1, offset: 32521},
 			expr: &actionExpr{
-				pos: position{line: 1155, col: 5, offset: 32656},
+				pos: position{line: 1153, col: 5, offset: 32534},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1155, col: 5, offset: 32656},
+					pos: position{line: 1153, col: 5, offset: 32534},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1155, col: 5, offset: 32656},
+							pos: position{line: 1153, col: 5, offset: 32534},
 							expr: &litMatcher{
-								pos:        position{line: 1155, col: 5, offset: 32656},
+								pos:        position{line: 1153, col: 5, offset: 32534},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1155, col: 10, offset: 32661},
+							pos: position{line: 1153, col: 10, offset: 32539},
 							expr: &seqExpr{
-								pos: position{line: 1155, col: 11, offset: 32662},
+								pos: position{line: 1153, col: 11, offset: 32540},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1155, col: 11, offset: 32662},
+										pos:  position{line: 1153, col: 11, offset: 32540},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1155, col: 19, offset: 32670},
+										pos:  position{line: 1153, col: 19, offset: 32548},
 										name: "TimeUnit",
 									},
 								},
@@ -9564,26 +9564,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1159, col: 1, offset: 32796},
+			pos:  position{line: 1157, col: 1, offset: 32674},
 			expr: &seqExpr{
-				pos: position{line: 1159, col: 11, offset: 32806},
+				pos: position{line: 1157, col: 11, offset: 32684},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1159, col: 11, offset: 32806},
+						pos:  position{line: 1157, col: 11, offset: 32684},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1159, col: 16, offset: 32811},
+						pos: position{line: 1157, col: 16, offset: 32689},
 						expr: &seqExpr{
-							pos: position{line: 1159, col: 17, offset: 32812},
+							pos: position{line: 1157, col: 17, offset: 32690},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1159, col: 17, offset: 32812},
+									pos:        position{line: 1157, col: 17, offset: 32690},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1159, col: 21, offset: 32816},
+									pos:  position{line: 1157, col: 21, offset: 32694},
 									name: "UInt",
 								},
 							},
@@ -9594,52 +9594,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1161, col: 1, offset: 32824},
+			pos:  position{line: 1159, col: 1, offset: 32702},
 			expr: &choiceExpr{
-				pos: position{line: 1162, col: 5, offset: 32837},
+				pos: position{line: 1160, col: 5, offset: 32715},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1162, col: 5, offset: 32837},
+						pos:        position{line: 1160, col: 5, offset: 32715},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1163, col: 5, offset: 32846},
+						pos:        position{line: 1161, col: 5, offset: 32724},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1164, col: 5, offset: 32855},
+						pos:        position{line: 1162, col: 5, offset: 32733},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1165, col: 5, offset: 32864},
+						pos:        position{line: 1163, col: 5, offset: 32742},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1166, col: 5, offset: 32872},
+						pos:        position{line: 1164, col: 5, offset: 32750},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1167, col: 5, offset: 32880},
+						pos:        position{line: 1165, col: 5, offset: 32758},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1168, col: 5, offset: 32888},
+						pos:        position{line: 1166, col: 5, offset: 32766},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1169, col: 5, offset: 32896},
+						pos:        position{line: 1167, col: 5, offset: 32774},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1170, col: 5, offset: 32904},
+						pos:        position{line: 1168, col: 5, offset: 32782},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9648,42 +9648,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1172, col: 1, offset: 32909},
+			pos:  position{line: 1170, col: 1, offset: 32787},
 			expr: &actionExpr{
-				pos: position{line: 1173, col: 5, offset: 32916},
+				pos: position{line: 1171, col: 5, offset: 32794},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1173, col: 5, offset: 32916},
+					pos: position{line: 1171, col: 5, offset: 32794},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1173, col: 5, offset: 32916},
+							pos:  position{line: 1171, col: 5, offset: 32794},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1173, col: 10, offset: 32921},
+							pos:        position{line: 1171, col: 10, offset: 32799},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1173, col: 14, offset: 32925},
+							pos:  position{line: 1171, col: 14, offset: 32803},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1173, col: 19, offset: 32930},
+							pos:        position{line: 1171, col: 19, offset: 32808},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1173, col: 23, offset: 32934},
+							pos:  position{line: 1171, col: 23, offset: 32812},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1173, col: 28, offset: 32939},
+							pos:        position{line: 1171, col: 28, offset: 32817},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1173, col: 32, offset: 32943},
+							pos:  position{line: 1171, col: 32, offset: 32821},
 							name: "UInt",
 						},
 					},
@@ -9692,42 +9692,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1175, col: 1, offset: 32980},
+			pos:  position{line: 1173, col: 1, offset: 32858},
 			expr: &actionExpr{
-				pos: position{line: 1176, col: 5, offset: 32988},
+				pos: position{line: 1174, col: 5, offset: 32866},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1176, col: 5, offset: 32988},
+					pos: position{line: 1174, col: 5, offset: 32866},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1176, col: 5, offset: 32988},
+							pos: position{line: 1174, col: 5, offset: 32866},
 							expr: &seqExpr{
-								pos: position{line: 1176, col: 8, offset: 32991},
+								pos: position{line: 1174, col: 8, offset: 32869},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1176, col: 8, offset: 32991},
+										pos:  position{line: 1174, col: 8, offset: 32869},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1176, col: 12, offset: 32995},
+										pos:        position{line: 1174, col: 12, offset: 32873},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1176, col: 16, offset: 32999},
+										pos:  position{line: 1174, col: 16, offset: 32877},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1176, col: 20, offset: 33003},
+										pos: position{line: 1174, col: 20, offset: 32881},
 										expr: &choiceExpr{
-											pos: position{line: 1176, col: 22, offset: 33005},
+											pos: position{line: 1174, col: 22, offset: 32883},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1176, col: 22, offset: 33005},
+													pos:  position{line: 1174, col: 22, offset: 32883},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1176, col: 33, offset: 33016},
+													pos:        position{line: 1174, col: 33, offset: 32894},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9738,10 +9738,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1176, col: 39, offset: 33022},
+							pos:   position{line: 1174, col: 39, offset: 32900},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1176, col: 41, offset: 33024},
+								pos:  position{line: 1174, col: 41, offset: 32902},
 								name: "IP6Variations",
 							},
 						},
@@ -9751,32 +9751,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1180, col: 1, offset: 33188},
+			pos:  position{line: 1178, col: 1, offset: 33066},
 			expr: &choiceExpr{
-				pos: position{line: 1181, col: 5, offset: 33206},
+				pos: position{line: 1179, col: 5, offset: 33084},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1181, col: 5, offset: 33206},
+						pos: position{line: 1179, col: 5, offset: 33084},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1181, col: 5, offset: 33206},
+							pos: position{line: 1179, col: 5, offset: 33084},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1181, col: 5, offset: 33206},
+									pos:   position{line: 1179, col: 5, offset: 33084},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1181, col: 7, offset: 33208},
+										pos: position{line: 1179, col: 7, offset: 33086},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1181, col: 7, offset: 33208},
+											pos:  position{line: 1179, col: 7, offset: 33086},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 17, offset: 33218},
+									pos:   position{line: 1179, col: 17, offset: 33096},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1181, col: 19, offset: 33220},
+										pos:  position{line: 1179, col: 19, offset: 33098},
 										name: "IP6Tail",
 									},
 								},
@@ -9784,51 +9784,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1184, col: 5, offset: 33284},
+						pos: position{line: 1182, col: 5, offset: 33162},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1184, col: 5, offset: 33284},
+							pos: position{line: 1182, col: 5, offset: 33162},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1184, col: 5, offset: 33284},
+									pos:   position{line: 1182, col: 5, offset: 33162},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1184, col: 7, offset: 33286},
+										pos:  position{line: 1182, col: 7, offset: 33164},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1184, col: 11, offset: 33290},
+									pos:   position{line: 1182, col: 11, offset: 33168},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1184, col: 13, offset: 33292},
+										pos: position{line: 1182, col: 13, offset: 33170},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1184, col: 13, offset: 33292},
+											pos:  position{line: 1182, col: 13, offset: 33170},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1184, col: 23, offset: 33302},
+									pos:        position{line: 1182, col: 23, offset: 33180},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1184, col: 28, offset: 33307},
+									pos:   position{line: 1182, col: 28, offset: 33185},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1184, col: 30, offset: 33309},
+										pos: position{line: 1182, col: 30, offset: 33187},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1184, col: 30, offset: 33309},
+											pos:  position{line: 1182, col: 30, offset: 33187},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1184, col: 40, offset: 33319},
+									pos:   position{line: 1182, col: 40, offset: 33197},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1184, col: 42, offset: 33321},
+										pos:  position{line: 1182, col: 42, offset: 33199},
 										name: "IP6Tail",
 									},
 								},
@@ -9836,32 +9836,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1187, col: 5, offset: 33420},
+						pos: position{line: 1185, col: 5, offset: 33298},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1187, col: 5, offset: 33420},
+							pos: position{line: 1185, col: 5, offset: 33298},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1187, col: 5, offset: 33420},
+									pos:        position{line: 1185, col: 5, offset: 33298},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1187, col: 10, offset: 33425},
+									pos:   position{line: 1185, col: 10, offset: 33303},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1187, col: 12, offset: 33427},
+										pos: position{line: 1185, col: 12, offset: 33305},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1187, col: 12, offset: 33427},
+											pos:  position{line: 1185, col: 12, offset: 33305},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1187, col: 22, offset: 33437},
+									pos:   position{line: 1185, col: 22, offset: 33315},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1187, col: 24, offset: 33439},
+										pos:  position{line: 1185, col: 24, offset: 33317},
 										name: "IP6Tail",
 									},
 								},
@@ -9869,32 +9869,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1190, col: 5, offset: 33510},
+						pos: position{line: 1188, col: 5, offset: 33388},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1190, col: 5, offset: 33510},
+							pos: position{line: 1188, col: 5, offset: 33388},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1190, col: 5, offset: 33510},
+									pos:   position{line: 1188, col: 5, offset: 33388},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1190, col: 7, offset: 33512},
+										pos:  position{line: 1188, col: 7, offset: 33390},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1190, col: 11, offset: 33516},
+									pos:   position{line: 1188, col: 11, offset: 33394},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1190, col: 13, offset: 33518},
+										pos: position{line: 1188, col: 13, offset: 33396},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1190, col: 13, offset: 33518},
+											pos:  position{line: 1188, col: 13, offset: 33396},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1190, col: 23, offset: 33528},
+									pos:        position{line: 1188, col: 23, offset: 33406},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -9902,10 +9902,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1193, col: 5, offset: 33596},
+						pos: position{line: 1191, col: 5, offset: 33474},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1193, col: 5, offset: 33596},
+							pos:        position{line: 1191, col: 5, offset: 33474},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -9915,16 +9915,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1197, col: 1, offset: 33633},
+			pos:  position{line: 1195, col: 1, offset: 33511},
 			expr: &choiceExpr{
-				pos: position{line: 1198, col: 5, offset: 33645},
+				pos: position{line: 1196, col: 5, offset: 33523},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1198, col: 5, offset: 33645},
+						pos:  position{line: 1196, col: 5, offset: 33523},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1199, col: 5, offset: 33652},
+						pos:  position{line: 1197, col: 5, offset: 33530},
 						name: "Hex",
 					},
 				},
@@ -9932,23 +9932,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1201, col: 1, offset: 33657},
+			pos:  position{line: 1199, col: 1, offset: 33535},
 			expr: &actionExpr{
-				pos: position{line: 1201, col: 12, offset: 33668},
+				pos: position{line: 1199, col: 12, offset: 33546},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1201, col: 12, offset: 33668},
+					pos: position{line: 1199, col: 12, offset: 33546},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1201, col: 12, offset: 33668},
+							pos:        position{line: 1199, col: 12, offset: 33546},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1201, col: 16, offset: 33672},
+							pos:   position{line: 1199, col: 16, offset: 33550},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1201, col: 18, offset: 33674},
+								pos:  position{line: 1199, col: 18, offset: 33552},
 								name: "Hex",
 							},
 						},
@@ -9958,23 +9958,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1203, col: 1, offset: 33712},
+			pos:  position{line: 1201, col: 1, offset: 33590},
 			expr: &actionExpr{
-				pos: position{line: 1203, col: 12, offset: 33723},
+				pos: position{line: 1201, col: 12, offset: 33601},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1203, col: 12, offset: 33723},
+					pos: position{line: 1201, col: 12, offset: 33601},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1203, col: 12, offset: 33723},
+							pos:   position{line: 1201, col: 12, offset: 33601},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1203, col: 14, offset: 33725},
+								pos:  position{line: 1201, col: 14, offset: 33603},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1203, col: 18, offset: 33729},
+							pos:        position{line: 1201, col: 18, offset: 33607},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -9984,31 +9984,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1205, col: 1, offset: 33767},
+			pos:  position{line: 1203, col: 1, offset: 33645},
 			expr: &actionExpr{
-				pos: position{line: 1206, col: 5, offset: 33778},
+				pos: position{line: 1204, col: 5, offset: 33656},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1206, col: 5, offset: 33778},
+					pos: position{line: 1204, col: 5, offset: 33656},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1206, col: 5, offset: 33778},
+							pos:   position{line: 1204, col: 5, offset: 33656},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1206, col: 7, offset: 33780},
+								pos:  position{line: 1204, col: 7, offset: 33658},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1206, col: 10, offset: 33783},
+							pos:        position{line: 1204, col: 10, offset: 33661},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1206, col: 14, offset: 33787},
+							pos:   position{line: 1204, col: 14, offset: 33665},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1206, col: 16, offset: 33789},
+								pos:  position{line: 1204, col: 16, offset: 33667},
 								name: "UInt",
 							},
 						},
@@ -10018,31 +10018,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1210, col: 1, offset: 33862},
+			pos:  position{line: 1208, col: 1, offset: 33740},
 			expr: &actionExpr{
-				pos: position{line: 1211, col: 5, offset: 33873},
+				pos: position{line: 1209, col: 5, offset: 33751},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1211, col: 5, offset: 33873},
+					pos: position{line: 1209, col: 5, offset: 33751},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1211, col: 5, offset: 33873},
+							pos:   position{line: 1209, col: 5, offset: 33751},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1211, col: 7, offset: 33875},
+								pos:  position{line: 1209, col: 7, offset: 33753},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1211, col: 11, offset: 33879},
+							pos:        position{line: 1209, col: 11, offset: 33757},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1211, col: 15, offset: 33883},
+							pos:   position{line: 1209, col: 15, offset: 33761},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1211, col: 17, offset: 33885},
+								pos:  position{line: 1209, col: 17, offset: 33763},
 								name: "UInt",
 							},
 						},
@@ -10052,15 +10052,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1215, col: 1, offset: 33948},
+			pos:  position{line: 1213, col: 1, offset: 33826},
 			expr: &actionExpr{
-				pos: position{line: 1216, col: 4, offset: 33956},
+				pos: position{line: 1214, col: 4, offset: 33834},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1216, col: 4, offset: 33956},
+					pos:   position{line: 1214, col: 4, offset: 33834},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1216, col: 6, offset: 33958},
+						pos:  position{line: 1214, col: 6, offset: 33836},
 						name: "UIntString",
 					},
 				},
@@ -10068,16 +10068,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1218, col: 1, offset: 33998},
+			pos:  position{line: 1216, col: 1, offset: 33876},
 			expr: &choiceExpr{
-				pos: position{line: 1219, col: 5, offset: 34012},
+				pos: position{line: 1217, col: 5, offset: 33890},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 5, offset: 34012},
+						pos:  position{line: 1217, col: 5, offset: 33890},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 5, offset: 34027},
+						pos:  position{line: 1218, col: 5, offset: 33905},
 						name: "MinusIntString",
 					},
 				},
@@ -10085,14 +10085,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1222, col: 1, offset: 34043},
+			pos:  position{line: 1220, col: 1, offset: 33921},
 			expr: &actionExpr{
-				pos: position{line: 1222, col: 14, offset: 34056},
+				pos: position{line: 1220, col: 14, offset: 33934},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1222, col: 14, offset: 34056},
+					pos: position{line: 1220, col: 14, offset: 33934},
 					expr: &charClassMatcher{
-						pos:        position{line: 1222, col: 14, offset: 34056},
+						pos:        position{line: 1220, col: 14, offset: 33934},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10103,20 +10103,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1224, col: 1, offset: 34095},
+			pos:  position{line: 1222, col: 1, offset: 33973},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 34114},
+				pos: position{line: 1223, col: 5, offset: 33992},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 34114},
+					pos: position{line: 1223, col: 5, offset: 33992},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1225, col: 5, offset: 34114},
+							pos:        position{line: 1223, col: 5, offset: 33992},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 9, offset: 34118},
+							pos:  position{line: 1223, col: 9, offset: 33996},
 							name: "UIntString",
 						},
 					},
@@ -10125,28 +10125,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1227, col: 1, offset: 34161},
+			pos:  position{line: 1225, col: 1, offset: 34039},
 			expr: &choiceExpr{
-				pos: position{line: 1228, col: 5, offset: 34177},
+				pos: position{line: 1226, col: 5, offset: 34055},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1228, col: 5, offset: 34177},
+						pos: position{line: 1226, col: 5, offset: 34055},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1228, col: 5, offset: 34177},
+							pos: position{line: 1226, col: 5, offset: 34055},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1228, col: 5, offset: 34177},
+									pos: position{line: 1226, col: 5, offset: 34055},
 									expr: &litMatcher{
-										pos:        position{line: 1228, col: 5, offset: 34177},
+										pos:        position{line: 1226, col: 5, offset: 34055},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1228, col: 10, offset: 34182},
+									pos: position{line: 1226, col: 10, offset: 34060},
 									expr: &charClassMatcher{
-										pos:        position{line: 1228, col: 10, offset: 34182},
+										pos:        position{line: 1226, col: 10, offset: 34060},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10154,14 +10154,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1228, col: 17, offset: 34189},
+									pos:        position{line: 1226, col: 17, offset: 34067},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1228, col: 21, offset: 34193},
+									pos: position{line: 1226, col: 21, offset: 34071},
 									expr: &charClassMatcher{
-										pos:        position{line: 1228, col: 21, offset: 34193},
+										pos:        position{line: 1226, col: 21, offset: 34071},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10169,9 +10169,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1228, col: 28, offset: 34200},
+									pos: position{line: 1226, col: 28, offset: 34078},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1228, col: 28, offset: 34200},
+										pos:  position{line: 1226, col: 28, offset: 34078},
 										name: "ExponentPart",
 									},
 								},
@@ -10179,28 +10179,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1231, col: 5, offset: 34259},
+						pos: position{line: 1229, col: 5, offset: 34137},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1231, col: 5, offset: 34259},
+							pos: position{line: 1229, col: 5, offset: 34137},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1231, col: 5, offset: 34259},
+									pos: position{line: 1229, col: 5, offset: 34137},
 									expr: &litMatcher{
-										pos:        position{line: 1231, col: 5, offset: 34259},
+										pos:        position{line: 1229, col: 5, offset: 34137},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1231, col: 10, offset: 34264},
+									pos:        position{line: 1229, col: 10, offset: 34142},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1231, col: 14, offset: 34268},
+									pos: position{line: 1229, col: 14, offset: 34146},
 									expr: &charClassMatcher{
-										pos:        position{line: 1231, col: 14, offset: 34268},
+										pos:        position{line: 1229, col: 14, offset: 34146},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10208,9 +10208,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1231, col: 21, offset: 34275},
+									pos: position{line: 1229, col: 21, offset: 34153},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1231, col: 21, offset: 34275},
+										pos:  position{line: 1229, col: 21, offset: 34153},
 										name: "ExponentPart",
 									},
 								},
@@ -10222,19 +10222,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1235, col: 1, offset: 34331},
+			pos:  position{line: 1233, col: 1, offset: 34209},
 			expr: &seqExpr{
-				pos: position{line: 1235, col: 16, offset: 34346},
+				pos: position{line: 1233, col: 16, offset: 34224},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1235, col: 16, offset: 34346},
+						pos:        position{line: 1233, col: 16, offset: 34224},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1235, col: 21, offset: 34351},
+						pos: position{line: 1233, col: 21, offset: 34229},
 						expr: &charClassMatcher{
-							pos:        position{line: 1235, col: 21, offset: 34351},
+							pos:        position{line: 1233, col: 21, offset: 34229},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10242,7 +10242,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1235, col: 27, offset: 34357},
+						pos:  position{line: 1233, col: 27, offset: 34235},
 						name: "UIntString",
 					},
 				},
@@ -10250,14 +10250,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1237, col: 1, offset: 34369},
+			pos:  position{line: 1235, col: 1, offset: 34247},
 			expr: &actionExpr{
-				pos: position{line: 1237, col: 7, offset: 34375},
+				pos: position{line: 1235, col: 7, offset: 34253},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1237, col: 7, offset: 34375},
+					pos: position{line: 1235, col: 7, offset: 34253},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1237, col: 7, offset: 34375},
+						pos:  position{line: 1235, col: 7, offset: 34253},
 						name: "HexDigit",
 					},
 				},
@@ -10265,9 +10265,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1239, col: 1, offset: 34417},
+			pos:  position{line: 1237, col: 1, offset: 34295},
 			expr: &charClassMatcher{
-				pos:        position{line: 1239, col: 12, offset: 34428},
+				pos:        position{line: 1237, col: 12, offset: 34306},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10276,34 +10276,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1241, col: 1, offset: 34441},
+			pos:  position{line: 1239, col: 1, offset: 34319},
 			expr: &choiceExpr{
-				pos: position{line: 1242, col: 5, offset: 34458},
+				pos: position{line: 1240, col: 5, offset: 34336},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1242, col: 5, offset: 34458},
+						pos: position{line: 1240, col: 5, offset: 34336},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1242, col: 5, offset: 34458},
+							pos: position{line: 1240, col: 5, offset: 34336},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1242, col: 5, offset: 34458},
+									pos:        position{line: 1240, col: 5, offset: 34336},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1242, col: 9, offset: 34462},
+									pos:   position{line: 1240, col: 9, offset: 34340},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1242, col: 11, offset: 34464},
+										pos: position{line: 1240, col: 11, offset: 34342},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1242, col: 11, offset: 34464},
+											pos:  position{line: 1240, col: 11, offset: 34342},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1242, col: 29, offset: 34482},
+									pos:        position{line: 1240, col: 29, offset: 34360},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10311,29 +10311,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1243, col: 5, offset: 34519},
+						pos: position{line: 1241, col: 5, offset: 34397},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1243, col: 5, offset: 34519},
+							pos: position{line: 1241, col: 5, offset: 34397},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1243, col: 5, offset: 34519},
+									pos:        position{line: 1241, col: 5, offset: 34397},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1243, col: 9, offset: 34523},
+									pos:   position{line: 1241, col: 9, offset: 34401},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1243, col: 11, offset: 34525},
+										pos: position{line: 1241, col: 11, offset: 34403},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1243, col: 11, offset: 34525},
+											pos:  position{line: 1241, col: 11, offset: 34403},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1243, col: 29, offset: 34543},
+									pos:        position{line: 1241, col: 29, offset: 34421},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10345,55 +10345,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1245, col: 1, offset: 34577},
+			pos:  position{line: 1243, col: 1, offset: 34455},
 			expr: &choiceExpr{
-				pos: position{line: 1246, col: 5, offset: 34598},
+				pos: position{line: 1244, col: 5, offset: 34476},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1246, col: 5, offset: 34598},
+						pos: position{line: 1244, col: 5, offset: 34476},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1246, col: 5, offset: 34598},
+							pos: position{line: 1244, col: 5, offset: 34476},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1246, col: 5, offset: 34598},
+									pos: position{line: 1244, col: 5, offset: 34476},
 									expr: &choiceExpr{
-										pos: position{line: 1246, col: 7, offset: 34600},
+										pos: position{line: 1244, col: 7, offset: 34478},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1246, col: 7, offset: 34600},
+												pos:        position{line: 1244, col: 7, offset: 34478},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1246, col: 13, offset: 34606},
+												pos:  position{line: 1244, col: 13, offset: 34484},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1246, col: 26, offset: 34619,
+									line: 1244, col: 26, offset: 34497,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1247, col: 5, offset: 34656},
+						pos: position{line: 1245, col: 5, offset: 34534},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1247, col: 5, offset: 34656},
+							pos: position{line: 1245, col: 5, offset: 34534},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1247, col: 5, offset: 34656},
+									pos:        position{line: 1245, col: 5, offset: 34534},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1247, col: 10, offset: 34661},
+									pos:   position{line: 1245, col: 10, offset: 34539},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1247, col: 12, offset: 34663},
+										pos:  position{line: 1245, col: 12, offset: 34541},
 										name: "EscapeSequence",
 									},
 								},
@@ -10405,28 +10405,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1249, col: 1, offset: 34697},
+			pos:  position{line: 1247, col: 1, offset: 34575},
 			expr: &actionExpr{
-				pos: position{line: 1250, col: 5, offset: 34709},
+				pos: position{line: 1248, col: 5, offset: 34587},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1250, col: 5, offset: 34709},
+					pos: position{line: 1248, col: 5, offset: 34587},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1250, col: 5, offset: 34709},
+							pos:   position{line: 1248, col: 5, offset: 34587},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1250, col: 10, offset: 34714},
+								pos:  position{line: 1248, col: 10, offset: 34592},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1250, col: 23, offset: 34727},
+							pos:   position{line: 1248, col: 23, offset: 34605},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1250, col: 28, offset: 34732},
+								pos: position{line: 1248, col: 28, offset: 34610},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1250, col: 28, offset: 34732},
+									pos:  position{line: 1248, col: 28, offset: 34610},
 									name: "KeyWordRest",
 								},
 							},
@@ -10437,16 +10437,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1252, col: 1, offset: 34794},
+			pos:  position{line: 1250, col: 1, offset: 34672},
 			expr: &choiceExpr{
-				pos: position{line: 1253, col: 5, offset: 34811},
+				pos: position{line: 1251, col: 5, offset: 34689},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 5, offset: 34811},
+						pos:  position{line: 1251, col: 5, offset: 34689},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1254, col: 5, offset: 34828},
+						pos:  position{line: 1252, col: 5, offset: 34706},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10454,12 +10454,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1256, col: 1, offset: 34840},
+			pos:  position{line: 1254, col: 1, offset: 34718},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 16, offset: 34855},
+				pos: position{line: 1254, col: 16, offset: 34733},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1256, col: 16, offset: 34855},
+					pos:        position{line: 1254, col: 16, offset: 34733},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10470,16 +10470,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1258, col: 1, offset: 34904},
+			pos:  position{line: 1256, col: 1, offset: 34782},
 			expr: &choiceExpr{
-				pos: position{line: 1259, col: 5, offset: 34920},
+				pos: position{line: 1257, col: 5, offset: 34798},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 5, offset: 34920},
+						pos:  position{line: 1257, col: 5, offset: 34798},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1260, col: 5, offset: 34937},
+						pos:        position{line: 1258, col: 5, offset: 34815},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10490,30 +10490,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1262, col: 1, offset: 34944},
+			pos:  position{line: 1260, col: 1, offset: 34822},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 14, offset: 34957},
+				pos: position{line: 1260, col: 14, offset: 34835},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1262, col: 14, offset: 34957},
+					pos: position{line: 1260, col: 14, offset: 34835},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1262, col: 14, offset: 34957},
+							pos:        position{line: 1260, col: 14, offset: 34835},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1262, col: 19, offset: 34962},
+							pos:   position{line: 1260, col: 19, offset: 34840},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1262, col: 22, offset: 34965},
+								pos: position{line: 1260, col: 22, offset: 34843},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1262, col: 22, offset: 34965},
+										pos:  position{line: 1260, col: 22, offset: 34843},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1262, col: 38, offset: 34981},
+										pos:  position{line: 1260, col: 38, offset: 34859},
 										name: "EscapeSequence",
 									},
 								},
@@ -10525,42 +10525,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1264, col: 1, offset: 35017},
+			pos:  position{line: 1262, col: 1, offset: 34895},
 			expr: &actionExpr{
-				pos: position{line: 1265, col: 5, offset: 35033},
+				pos: position{line: 1263, col: 5, offset: 34911},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1265, col: 5, offset: 35033},
+					pos: position{line: 1263, col: 5, offset: 34911},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1265, col: 5, offset: 35033},
+							pos: position{line: 1263, col: 5, offset: 34911},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1265, col: 6, offset: 35034},
+								pos:  position{line: 1263, col: 6, offset: 34912},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1265, col: 22, offset: 35050},
+							pos: position{line: 1263, col: 22, offset: 34928},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1265, col: 23, offset: 35051},
+								pos:  position{line: 1263, col: 23, offset: 34929},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1265, col: 35, offset: 35063},
+							pos:   position{line: 1263, col: 35, offset: 34941},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1265, col: 40, offset: 35068},
+								pos:  position{line: 1263, col: 40, offset: 34946},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1265, col: 50, offset: 35078},
+							pos:   position{line: 1263, col: 50, offset: 34956},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1265, col: 55, offset: 35083},
+								pos: position{line: 1263, col: 55, offset: 34961},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1265, col: 55, offset: 35083},
+									pos:  position{line: 1263, col: 55, offset: 34961},
 									name: "GlobRest",
 								},
 							},
@@ -10571,20 +10571,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1269, col: 1, offset: 35152},
+			pos:  position{line: 1267, col: 1, offset: 35030},
 			expr: &seqExpr{
-				pos: position{line: 1269, col: 19, offset: 35170},
+				pos: position{line: 1267, col: 19, offset: 35048},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1269, col: 19, offset: 35170},
+						pos: position{line: 1267, col: 19, offset: 35048},
 						expr: &litMatcher{
-							pos:        position{line: 1269, col: 19, offset: 35170},
+							pos:        position{line: 1267, col: 19, offset: 35048},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1269, col: 24, offset: 35175},
+						pos:  position{line: 1267, col: 24, offset: 35053},
 						name: "KeyWordStart",
 					},
 				},
@@ -10592,19 +10592,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1270, col: 1, offset: 35188},
+			pos:  position{line: 1268, col: 1, offset: 35066},
 			expr: &seqExpr{
-				pos: position{line: 1270, col: 15, offset: 35202},
+				pos: position{line: 1268, col: 15, offset: 35080},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1270, col: 15, offset: 35202},
+						pos: position{line: 1268, col: 15, offset: 35080},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1270, col: 15, offset: 35202},
+							pos:  position{line: 1268, col: 15, offset: 35080},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1270, col: 28, offset: 35215},
+						pos:        position{line: 1268, col: 28, offset: 35093},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10613,23 +10613,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1272, col: 1, offset: 35220},
+			pos:  position{line: 1270, col: 1, offset: 35098},
 			expr: &choiceExpr{
-				pos: position{line: 1273, col: 5, offset: 35234},
+				pos: position{line: 1271, col: 5, offset: 35112},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 35234},
+						pos:  position{line: 1271, col: 5, offset: 35112},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1274, col: 5, offset: 35251},
+						pos:  position{line: 1272, col: 5, offset: 35129},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1275, col: 5, offset: 35263},
+						pos: position{line: 1273, col: 5, offset: 35141},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1275, col: 5, offset: 35263},
+							pos:        position{line: 1273, col: 5, offset: 35141},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10639,16 +10639,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1277, col: 1, offset: 35287},
+			pos:  position{line: 1275, col: 1, offset: 35165},
 			expr: &choiceExpr{
-				pos: position{line: 1278, col: 5, offset: 35300},
+				pos: position{line: 1276, col: 5, offset: 35178},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 35300},
+						pos:  position{line: 1276, col: 5, offset: 35178},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1279, col: 5, offset: 35314},
+						pos:        position{line: 1277, col: 5, offset: 35192},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10659,30 +10659,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1281, col: 1, offset: 35321},
+			pos:  position{line: 1279, col: 1, offset: 35199},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 11, offset: 35331},
+				pos: position{line: 1279, col: 11, offset: 35209},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1281, col: 11, offset: 35331},
+					pos: position{line: 1279, col: 11, offset: 35209},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1281, col: 11, offset: 35331},
+							pos:        position{line: 1279, col: 11, offset: 35209},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1281, col: 16, offset: 35336},
+							pos:   position{line: 1279, col: 16, offset: 35214},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1281, col: 19, offset: 35339},
+								pos: position{line: 1279, col: 19, offset: 35217},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1281, col: 19, offset: 35339},
+										pos:  position{line: 1279, col: 19, offset: 35217},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1281, col: 32, offset: 35352},
+										pos:  position{line: 1279, col: 32, offset: 35230},
 										name: "EscapeSequence",
 									},
 								},
@@ -10694,30 +10694,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1283, col: 1, offset: 35388},
+			pos:  position{line: 1281, col: 1, offset: 35266},
 			expr: &choiceExpr{
-				pos: position{line: 1284, col: 5, offset: 35403},
+				pos: position{line: 1282, col: 5, offset: 35281},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1284, col: 5, offset: 35403},
+						pos: position{line: 1282, col: 5, offset: 35281},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1284, col: 5, offset: 35403},
+							pos:        position{line: 1282, col: 5, offset: 35281},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1285, col: 5, offset: 35431},
+						pos: position{line: 1283, col: 5, offset: 35309},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1285, col: 5, offset: 35431},
+							pos:        position{line: 1283, col: 5, offset: 35309},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1286, col: 5, offset: 35461},
+						pos:        position{line: 1284, col: 5, offset: 35339},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10728,55 +10728,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1289, col: 1, offset: 35468},
+			pos:  position{line: 1287, col: 1, offset: 35346},
 			expr: &choiceExpr{
-				pos: position{line: 1290, col: 5, offset: 35489},
+				pos: position{line: 1288, col: 5, offset: 35367},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 35489},
+						pos: position{line: 1288, col: 5, offset: 35367},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1290, col: 5, offset: 35489},
+							pos: position{line: 1288, col: 5, offset: 35367},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1290, col: 5, offset: 35489},
+									pos: position{line: 1288, col: 5, offset: 35367},
 									expr: &choiceExpr{
-										pos: position{line: 1290, col: 7, offset: 35491},
+										pos: position{line: 1288, col: 7, offset: 35369},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1290, col: 7, offset: 35491},
+												pos:        position{line: 1288, col: 7, offset: 35369},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1290, col: 13, offset: 35497},
+												pos:  position{line: 1288, col: 13, offset: 35375},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1290, col: 26, offset: 35510,
+									line: 1288, col: 26, offset: 35388,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1291, col: 5, offset: 35547},
+						pos: position{line: 1289, col: 5, offset: 35425},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1291, col: 5, offset: 35547},
+							pos: position{line: 1289, col: 5, offset: 35425},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1291, col: 5, offset: 35547},
+									pos:        position{line: 1289, col: 5, offset: 35425},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1291, col: 10, offset: 35552},
+									pos:   position{line: 1289, col: 10, offset: 35430},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1291, col: 12, offset: 35554},
+										pos:  position{line: 1289, col: 12, offset: 35432},
 										name: "EscapeSequence",
 									},
 								},
@@ -10788,16 +10788,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1293, col: 1, offset: 35588},
+			pos:  position{line: 1291, col: 1, offset: 35466},
 			expr: &choiceExpr{
-				pos: position{line: 1294, col: 5, offset: 35607},
+				pos: position{line: 1292, col: 5, offset: 35485},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1294, col: 5, offset: 35607},
+						pos:  position{line: 1292, col: 5, offset: 35485},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1295, col: 5, offset: 35628},
+						pos:  position{line: 1293, col: 5, offset: 35506},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10805,79 +10805,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1297, col: 1, offset: 35643},
+			pos:  position{line: 1295, col: 1, offset: 35521},
 			expr: &choiceExpr{
-				pos: position{line: 1298, col: 5, offset: 35664},
+				pos: position{line: 1296, col: 5, offset: 35542},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1298, col: 5, offset: 35664},
+						pos:        position{line: 1296, col: 5, offset: 35542},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1299, col: 5, offset: 35672},
+						pos: position{line: 1297, col: 5, offset: 35550},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1299, col: 5, offset: 35672},
+							pos:        position{line: 1297, col: 5, offset: 35550},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1300, col: 5, offset: 35712},
+						pos:        position{line: 1298, col: 5, offset: 35590},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1301, col: 5, offset: 35721},
+						pos: position{line: 1299, col: 5, offset: 35599},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1301, col: 5, offset: 35721},
+							pos:        position{line: 1299, col: 5, offset: 35599},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1302, col: 5, offset: 35750},
+						pos: position{line: 1300, col: 5, offset: 35628},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1302, col: 5, offset: 35750},
+							pos:        position{line: 1300, col: 5, offset: 35628},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1303, col: 5, offset: 35779},
+						pos: position{line: 1301, col: 5, offset: 35657},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1303, col: 5, offset: 35779},
+							pos:        position{line: 1301, col: 5, offset: 35657},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1304, col: 5, offset: 35808},
+						pos: position{line: 1302, col: 5, offset: 35686},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1304, col: 5, offset: 35808},
+							pos:        position{line: 1302, col: 5, offset: 35686},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1305, col: 5, offset: 35837},
+						pos: position{line: 1303, col: 5, offset: 35715},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1305, col: 5, offset: 35837},
+							pos:        position{line: 1303, col: 5, offset: 35715},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1306, col: 5, offset: 35866},
+						pos: position{line: 1304, col: 5, offset: 35744},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1306, col: 5, offset: 35866},
+							pos:        position{line: 1304, col: 5, offset: 35744},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -10887,30 +10887,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1308, col: 1, offset: 35892},
+			pos:  position{line: 1306, col: 1, offset: 35770},
 			expr: &choiceExpr{
-				pos: position{line: 1309, col: 5, offset: 35910},
+				pos: position{line: 1307, col: 5, offset: 35788},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 35910},
+						pos: position{line: 1307, col: 5, offset: 35788},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1309, col: 5, offset: 35910},
+							pos:        position{line: 1307, col: 5, offset: 35788},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 35938},
+						pos: position{line: 1308, col: 5, offset: 35816},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1310, col: 5, offset: 35938},
+							pos:        position{line: 1308, col: 5, offset: 35816},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1311, col: 5, offset: 35966},
+						pos:        position{line: 1309, col: 5, offset: 35844},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10921,41 +10921,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1313, col: 1, offset: 35972},
+			pos:  position{line: 1311, col: 1, offset: 35850},
 			expr: &choiceExpr{
-				pos: position{line: 1314, col: 5, offset: 35990},
+				pos: position{line: 1312, col: 5, offset: 35868},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 35990},
+						pos: position{line: 1312, col: 5, offset: 35868},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1314, col: 5, offset: 35990},
+							pos: position{line: 1312, col: 5, offset: 35868},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1314, col: 5, offset: 35990},
+									pos:        position{line: 1312, col: 5, offset: 35868},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1314, col: 9, offset: 35994},
+									pos:   position{line: 1312, col: 9, offset: 35872},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1314, col: 16, offset: 36001},
+										pos: position{line: 1312, col: 16, offset: 35879},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1314, col: 16, offset: 36001},
+												pos:  position{line: 1312, col: 16, offset: 35879},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1314, col: 25, offset: 36010},
+												pos:  position{line: 1312, col: 25, offset: 35888},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1314, col: 34, offset: 36019},
+												pos:  position{line: 1312, col: 34, offset: 35897},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1314, col: 43, offset: 36028},
+												pos:  position{line: 1312, col: 43, offset: 35906},
 												name: "HexDigit",
 											},
 										},
@@ -10965,63 +10965,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 36091},
+						pos: position{line: 1315, col: 5, offset: 35969},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1317, col: 5, offset: 36091},
+							pos: position{line: 1315, col: 5, offset: 35969},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1317, col: 5, offset: 36091},
+									pos:        position{line: 1315, col: 5, offset: 35969},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1317, col: 9, offset: 36095},
+									pos:        position{line: 1315, col: 9, offset: 35973},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1317, col: 13, offset: 36099},
+									pos:   position{line: 1315, col: 13, offset: 35977},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1317, col: 20, offset: 36106},
+										pos: position{line: 1315, col: 20, offset: 35984},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1317, col: 20, offset: 36106},
+												pos:  position{line: 1315, col: 20, offset: 35984},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 29, offset: 36115},
+												pos: position{line: 1315, col: 29, offset: 35993},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 29, offset: 36115},
+													pos:  position{line: 1315, col: 29, offset: 35993},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 39, offset: 36125},
+												pos: position{line: 1315, col: 39, offset: 36003},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 39, offset: 36125},
+													pos:  position{line: 1315, col: 39, offset: 36003},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 49, offset: 36135},
+												pos: position{line: 1315, col: 49, offset: 36013},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 49, offset: 36135},
+													pos:  position{line: 1315, col: 49, offset: 36013},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 59, offset: 36145},
+												pos: position{line: 1315, col: 59, offset: 36023},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 59, offset: 36145},
+													pos:  position{line: 1315, col: 59, offset: 36023},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 69, offset: 36155},
+												pos: position{line: 1315, col: 69, offset: 36033},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 69, offset: 36155},
+													pos:  position{line: 1315, col: 69, offset: 36033},
 													name: "HexDigit",
 												},
 											},
@@ -11029,7 +11029,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1317, col: 80, offset: 36166},
+									pos:        position{line: 1315, col: 80, offset: 36044},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11041,35 +11041,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1321, col: 1, offset: 36220},
+			pos:  position{line: 1319, col: 1, offset: 36098},
 			expr: &actionExpr{
-				pos: position{line: 1322, col: 5, offset: 36238},
+				pos: position{line: 1320, col: 5, offset: 36116},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1322, col: 5, offset: 36238},
+					pos: position{line: 1320, col: 5, offset: 36116},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1322, col: 5, offset: 36238},
+							pos:        position{line: 1320, col: 5, offset: 36116},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1322, col: 9, offset: 36242},
+							pos:   position{line: 1320, col: 9, offset: 36120},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1322, col: 14, offset: 36247},
+								pos:  position{line: 1320, col: 14, offset: 36125},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1322, col: 25, offset: 36258},
+							pos:        position{line: 1320, col: 25, offset: 36136},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1322, col: 29, offset: 36262},
+							pos: position{line: 1320, col: 29, offset: 36140},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1322, col: 30, offset: 36263},
+								pos:  position{line: 1320, col: 30, offset: 36141},
 								name: "KeyWordStart",
 							},
 						},
@@ -11079,32 +11079,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1324, col: 1, offset: 36298},
+			pos:  position{line: 1322, col: 1, offset: 36176},
 			expr: &actionExpr{
-				pos: position{line: 1325, col: 5, offset: 36313},
+				pos: position{line: 1323, col: 5, offset: 36191},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1325, col: 5, offset: 36313},
+					pos: position{line: 1323, col: 5, offset: 36191},
 					expr: &choiceExpr{
-						pos: position{line: 1325, col: 6, offset: 36314},
+						pos: position{line: 1323, col: 6, offset: 36192},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1325, col: 6, offset: 36314},
+								pos:        position{line: 1323, col: 6, offset: 36192},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1325, col: 15, offset: 36323},
+								pos: position{line: 1323, col: 15, offset: 36201},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1325, col: 15, offset: 36323},
+										pos:        position{line: 1323, col: 15, offset: 36201},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1325, col: 20, offset: 36328,
+										line: 1323, col: 20, offset: 36206,
 									},
 								},
 							},
@@ -11115,9 +11115,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1327, col: 1, offset: 36364},
+			pos:  position{line: 1325, col: 1, offset: 36242},
 			expr: &charClassMatcher{
-				pos:        position{line: 1328, col: 5, offset: 36380},
+				pos:        position{line: 1326, col: 5, offset: 36258},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11127,42 +11127,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1330, col: 1, offset: 36395},
+			pos:  position{line: 1328, col: 1, offset: 36273},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1330, col: 6, offset: 36400},
+				pos: position{line: 1328, col: 6, offset: 36278},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1330, col: 6, offset: 36400},
+					pos:  position{line: 1328, col: 6, offset: 36278},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1332, col: 1, offset: 36411},
+			pos:  position{line: 1330, col: 1, offset: 36289},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1332, col: 6, offset: 36416},
+				pos: position{line: 1330, col: 6, offset: 36294},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1332, col: 6, offset: 36416},
+					pos:  position{line: 1330, col: 6, offset: 36294},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1334, col: 1, offset: 36427},
+			pos:  position{line: 1332, col: 1, offset: 36305},
 			expr: &choiceExpr{
-				pos: position{line: 1335, col: 5, offset: 36440},
+				pos: position{line: 1333, col: 5, offset: 36318},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1335, col: 5, offset: 36440},
+						pos:  position{line: 1333, col: 5, offset: 36318},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1336, col: 5, offset: 36455},
+						pos:  position{line: 1334, col: 5, offset: 36333},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1337, col: 5, offset: 36474},
+						pos:  position{line: 1335, col: 5, offset: 36352},
 						name: "Comment",
 					},
 				},
@@ -11170,45 +11170,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1339, col: 1, offset: 36483},
+			pos:  position{line: 1337, col: 1, offset: 36361},
 			expr: &anyMatcher{
-				line: 1340, col: 5, offset: 36503,
+				line: 1338, col: 5, offset: 36381,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1342, col: 1, offset: 36506},
+			pos:         position{line: 1340, col: 1, offset: 36384},
 			expr: &choiceExpr{
-				pos: position{line: 1343, col: 5, offset: 36534},
+				pos: position{line: 1341, col: 5, offset: 36412},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1343, col: 5, offset: 36534},
+						pos:        position{line: 1341, col: 5, offset: 36412},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1344, col: 5, offset: 36543},
+						pos:        position{line: 1342, col: 5, offset: 36421},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1345, col: 5, offset: 36552},
+						pos:        position{line: 1343, col: 5, offset: 36430},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1346, col: 5, offset: 36561},
+						pos:        position{line: 1344, col: 5, offset: 36439},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1347, col: 5, offset: 36569},
+						pos:        position{line: 1345, col: 5, offset: 36447},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1348, col: 5, offset: 36582},
+						pos:        position{line: 1346, col: 5, offset: 36460},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11217,9 +11217,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1350, col: 1, offset: 36592},
+			pos:  position{line: 1348, col: 1, offset: 36470},
 			expr: &charClassMatcher{
-				pos:        position{line: 1351, col: 5, offset: 36611},
+				pos:        position{line: 1349, col: 5, offset: 36489},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11229,45 +11229,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1357, col: 1, offset: 36941},
+			pos:         position{line: 1355, col: 1, offset: 36819},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1360, col: 5, offset: 37012},
+				pos:  position{line: 1358, col: 5, offset: 36890},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1362, col: 1, offset: 37031},
+			pos:  position{line: 1360, col: 1, offset: 36909},
 			expr: &seqExpr{
-				pos: position{line: 1363, col: 5, offset: 37052},
+				pos: position{line: 1361, col: 5, offset: 36930},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1363, col: 5, offset: 37052},
+						pos:        position{line: 1361, col: 5, offset: 36930},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1363, col: 10, offset: 37057},
+						pos: position{line: 1361, col: 10, offset: 36935},
 						expr: &seqExpr{
-							pos: position{line: 1363, col: 11, offset: 37058},
+							pos: position{line: 1361, col: 11, offset: 36936},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1363, col: 11, offset: 37058},
+									pos: position{line: 1361, col: 11, offset: 36936},
 									expr: &litMatcher{
-										pos:        position{line: 1363, col: 12, offset: 37059},
+										pos:        position{line: 1361, col: 12, offset: 36937},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1363, col: 17, offset: 37064},
+									pos:  position{line: 1361, col: 17, offset: 36942},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1363, col: 35, offset: 37082},
+						pos:        position{line: 1361, col: 35, offset: 36960},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11276,29 +11276,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1365, col: 1, offset: 37088},
+			pos:  position{line: 1363, col: 1, offset: 36966},
 			expr: &seqExpr{
-				pos: position{line: 1366, col: 5, offset: 37110},
+				pos: position{line: 1364, col: 5, offset: 36988},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1366, col: 5, offset: 37110},
+						pos:        position{line: 1364, col: 5, offset: 36988},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1366, col: 10, offset: 37115},
+						pos: position{line: 1364, col: 10, offset: 36993},
 						expr: &seqExpr{
-							pos: position{line: 1366, col: 11, offset: 37116},
+							pos: position{line: 1364, col: 11, offset: 36994},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1366, col: 11, offset: 37116},
+									pos: position{line: 1364, col: 11, offset: 36994},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 12, offset: 37117},
+										pos:  position{line: 1364, col: 12, offset: 36995},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1366, col: 27, offset: 37132},
+									pos:  position{line: 1364, col: 27, offset: 37010},
 									name: "SourceCharacter",
 								},
 							},
@@ -11309,19 +11309,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1368, col: 1, offset: 37151},
+			pos:  position{line: 1366, col: 1, offset: 37029},
 			expr: &seqExpr{
-				pos: position{line: 1368, col: 7, offset: 37157},
+				pos: position{line: 1366, col: 7, offset: 37035},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1368, col: 7, offset: 37157},
+						pos: position{line: 1366, col: 7, offset: 37035},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1368, col: 7, offset: 37157},
+							pos:  position{line: 1366, col: 7, offset: 37035},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 19, offset: 37169},
+						pos:  position{line: 1366, col: 19, offset: 37047},
 						name: "LineTerminator",
 					},
 				},
@@ -11329,16 +11329,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1370, col: 1, offset: 37185},
+			pos:  position{line: 1368, col: 1, offset: 37063},
 			expr: &choiceExpr{
-				pos: position{line: 1370, col: 7, offset: 37191},
+				pos: position{line: 1368, col: 7, offset: 37069},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1370, col: 7, offset: 37191},
+						pos:  position{line: 1368, col: 7, offset: 37069},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1370, col: 11, offset: 37195},
+						pos:  position{line: 1368, col: 11, offset: 37073},
 						name: "EOF",
 					},
 				},
@@ -11346,11 +11346,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1372, col: 1, offset: 37200},
+			pos:  position{line: 1370, col: 1, offset: 37078},
 			expr: &notExpr{
-				pos: position{line: 1372, col: 7, offset: 37206},
+				pos: position{line: 1370, col: 7, offset: 37084},
 				expr: &anyMatcher{
-					line: 1372, col: 8, offset: 37207,
+					line: 1370, col: 8, offset: 37085,
 				},
 			},
 		},
@@ -12315,13 +12315,11 @@ func (c *current) onSampleProc1(e interface{}) (interface{}, error) {
 
 			"limit": 0},
 
-		map[string]interface{}{"kind": "Cut",
+		map[string]interface{}{"kind": "Yield",
 
-			"args": []interface{}{map[string]interface{}{"kind": "Assignment",
+			"exprs": []interface{}{
 
-				"lhs": nil,
-
-				"rhs": map[string]interface{}{"kind": "ID", "name": "sample"}}}}}}, nil
+				map[string]interface{}{"kind": "ID", "name": "sample"}}}}}, nil
 
 }
 

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -490,13 +490,11 @@ function peg$parse(input, options) {
                 
             "limit": 0},
               
-            {"kind": "Cut",
+            {"kind": "Yield",
+                
+            "exprs": [
                   
-            "args": [{"kind": "Assignment",
-                                      
-            "lhs": null,
-                                      
-            "rhs": {"kind": "ID", "name": "sample"}}]}]}
+            {"kind": "ID", "name": "sample"}]}]}
           
           },
       peg$c189 = function(a) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -426,10 +426,9 @@ SampleProc
                                          "expr": e,
                                          "where": NULL))),
           "limit": 0),
-        MAP("kind": "Cut",
-            "args": ARRAY(MAP("kind": "Assignment",
-                                "lhs": NULL,
-                                "rhs": MAP("kind": "ID", "name": "sample")))))))
+        MAP("kind": "Yield",
+          "exprs": ARRAY(
+            MAP("kind": "ID", "name": "sample"))))))
     }
 
 // OpAssignment is a top level operator that contains a list of assignment

--- a/compiler/parser/ztests/sample-expr.yaml
+++ b/compiler/parser/ztests/sample-expr.yaml
@@ -8,5 +8,5 @@ input: |
   {s1:"b",s2:"a"}
 
 output: |
-  {sample:0}
-  {sample:"b"}
+  0
+  "b"

--- a/compiler/parser/ztests/sample.yaml
+++ b/compiler/parser/ztests/sample.yaml
@@ -8,5 +8,5 @@ input: |
   {s1:"b",s2:"a"}
 
 output: |
-  {sample:{s1:"a",s2:0}}
-  {sample:{s1:"a",s2:"b"}}
+  {s1:"a",s2:"b"}
+  {s1:"a",s2:0}


### PR DESCRIPTION
The sample operator produces records of the form {sample:value}.
Simplify by dropping the record wrapper and emitting just the value.