### PR TITLE
fix flakiness in compiler/parser/ztests/sample.yaml

### DIFF
--- a/compiler/parser/ztests/sample.yaml
+++ b/compiler/parser/ztests/sample.yaml
@@ -1,4 +1,4 @@
-zed: sample | sort
+zed: sample | sort this
 
 input: |
   {s1:"a",s2:"b"}
@@ -8,5 +8,5 @@ input: |
   {s1:"b",s2:"a"}
 
 output: |
-  {s1:"a",s2:"b"}
   {s1:"a",s2:0}
+  {s1:"a",s2:"b"}


### PR DESCRIPTION
The test in compiler/parser/ztests/sample.yaml went flaky in #3695
because the sort operator picks field s1 as the sort key if the first
value it sees is {s1:"a",s2:"b"}.  Fix by sorting on this.