### PR TITLE
interpret lone zq arg as query if it begins with file, from, get

### DIFF
--- a/cmd/zq/ztests/from-file.yaml
+++ b/cmd/zq/ztests/from-file.yaml
@@ -1,14 +1,17 @@
 script: |
+  zq -z 'file a.zson'
   zq -z -I query.zed
 
 inputs:
+  - name: a.zson
+    data: |
+      {a:1}
   - name: query.zed
     data: |
       file a.zson
-  - name: a.zson
-    data: &a_zson |
-      {f:1}
 
 outputs:
   - name: stdout
-    data: *a_zson
+    data: |
+      {a:1}
+      {a:1}


### PR DESCRIPTION
zq fails with a "no such file" error when run with a lone argument that
is a valid query beginning with file, from, or get.  Make that work.