### PR TITLE
infer OpAssignment in zfmt

### DIFF
--- a/docs/zq/ztests/language-operators-1.yaml
+++ b/docs/zq/ztests/language-operators-1.yaml
@@ -15,4 +15,4 @@ outputs:
       search widget
       | summarize
           count() by color
-      | COLOR:=upper(color)
+      | put COLOR:=upper(color)

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -489,7 +489,13 @@ func (c *canon) proc(p ast.Proc) {
 		c.close()
 	case *ast.OpAssignment:
 		c.next()
+		which := "put "
+		if isAggAssignments(p.Assignments) {
+			which = "summarize "
+		}
+		c.open(which)
 		c.assignments(p.Assignments)
+		c.close()
 	//case *ast.SqlExpression:
 	//	//XXX TBD
 	//	c.open("sql")
@@ -570,6 +576,15 @@ func IsBool(e ast.Expr) bool {
 	default:
 		return false
 	}
+}
+
+func isAggAssignments(assigns []ast.Assignment) bool {
+	for _, a := range assigns {
+		if isAggFunc(a.RHS) == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func IsSearch(e ast.Expr) bool {

--- a/zfmt/ztests/implied-assignment.yaml
+++ b/zfmt/ztests/implied-assignment.yaml
@@ -1,0 +1,12 @@
+script: |
+  zc -C 'x:=1'
+  zc -C 'x:=1,y:=lower(s)'
+  zc -C 'x:=count(),sum(x)'
+
+outputs:
+  - name: stdout
+    data: |
+      put x:=1
+      put x:=1,y:=lower(s)
+      summarize
+          x:=count(),sum(x)


### PR DESCRIPTION
This commit improves the canonical Zed formatter to infer whether
an implied assignment is a "summarize" or a "put".
