### PR TITLE
handle non-record types in fuse operator

### DIFF
--- a/docs/zq/operators/fuse.md
+++ b/docs/zq/operators/fuse.md
@@ -67,8 +67,8 @@ echo '{a:[1,2]}{a:["foo","bar"],b:10.0.0.1}' | zq -z fuse -
 ```
 =>
 ```mdtest-output
-{a:[1,2](([int64],[string])),b:null(ip)}
-{a:["foo","bar"](([int64],[string])),b:10.0.0.1}
+{a:[1,2]([(int64,string)]),b:null(ip)}
+{a:["foo","bar"]([(int64,string)]),b:10.0.0.1}
 ```
 _The table format clarifies what fuse does_
 ```mdtest-command

--- a/runtime/expr/agg/fuse.go
+++ b/runtime/expr/agg/fuse.go
@@ -7,7 +7,7 @@ import (
 )
 
 type fuse struct {
-	shapes   map[*zed.TypeRecord]int
+	shapes   map[zed.Type]int
 	partials []zed.Value
 }
 
@@ -15,16 +15,13 @@ var _ Function = (*fuse)(nil)
 
 func newFuse() *fuse {
 	return &fuse{
-		shapes: make(map[*zed.TypeRecord]int),
+		shapes: make(map[zed.Type]int),
 	}
 }
 
 func (f *fuse) Consume(val *zed.Value) {
-	// only works for record types, e.g., fuse(foo.x) where foo.x is a record
-	if typ := zed.TypeRecordOf(val.Type); typ != nil {
-		if _, ok := f.shapes[typ]; !ok {
-			f.shapes[typ] = len(f.shapes)
-		}
+	if _, ok := f.shapes[val.Type]; !ok {
+		f.shapes[val.Type] = len(f.shapes)
 	}
 }
 
@@ -39,13 +36,9 @@ func (f *fuse) Result(zctx *zed.Context) *zed.Value {
 		if err != nil {
 			panic(fmt.Errorf("fuse: invalid partial value: %w", err))
 		}
-		recType, ok := typ.(*zed.TypeRecord)
-		if !ok {
-			panic(fmt.Errorf("fuse: unexpected partial type %s", typ))
-		}
-		schema.Mixin(recType)
+		schema.Mixin(typ)
 	}
-	shapes := make([]*zed.TypeRecord, len(f.shapes))
+	shapes := make([]zed.Type, len(f.shapes))
 	for typ, i := range f.shapes {
 		shapes[i] = typ
 	}

--- a/runtime/op/fuse/fuser.go
+++ b/runtime/op/fuse/fuser.go
@@ -52,9 +52,7 @@ func (f *Fuser) Write(rec *zed.Value) error {
 	}
 	if _, ok := f.types[rec.Type]; !ok {
 		f.types[rec.Type] = struct{}{}
-		if err := f.uberSchema.Mixin(zed.TypeRecordOf(rec.Type)); err != nil {
-			return err
-		}
+		f.uberSchema.Mixin(rec.Type)
 	}
 	if f.spiller != nil {
 		return f.spiller.Write(rec)

--- a/runtime/op/fuse/ztests/array-of-record.yaml
+++ b/runtime/op/fuse/ztests/array-of-record.yaml
@@ -1,0 +1,13 @@
+zed: fuse
+
+input: |
+  [{a:1}]
+  [{b:2}]
+  [{a:3},{b:3}]
+  [{a:3,b:3}]
+
+output: |
+  [{a:1,b:null(int64)}]
+  [{a:null(int64),b:2}]
+  [{a:3,b:null(int64)},{a:null(int64),b:3}]
+  [{a:3,b:3}]

--- a/runtime/op/fuse/ztests/mixed.yaml
+++ b/runtime/op/fuse/ztests/mixed.yaml
@@ -1,0 +1,19 @@
+zed: fuse
+
+input: |
+  {a:1}
+  {a:"s"}
+  1
+  "s"
+  [1]
+  ["s"]
+
+# XXX The first two output values should be shaped to the union type but
+# are not.
+output: |
+  {a:1}
+  {a:"s"}
+  1((int64,string,{a:(int64,string)},[int64],[string]))
+  "s"((int64,string,{a:(int64,string)},[int64],[string]))
+  [1]((int64,string,{a:(int64,string)},[int64],[string]))
+  ["s"]((int64,string,{a:(int64,string)},[int64],[string]))


### PR DESCRIPTION
As mentioned in the comment in runtime/op/fuse/ztests/mixed.yaml, a
shaper bug prevents this from working correctly when the input contains
a mix of record and non-record types.