### PR TITLE
has_error function

### DIFF
--- a/docs/zq/functions/has_error.md
+++ b/docs/zq/functions/has_error.md
@@ -11,7 +11,7 @@ has_error(val: any [, ... val: any]) -> bool
 
 The _has_error_ function returns true if its argument has an error.
 _has_error_ is different from _is_error_ in that _has_error_ will recurse 
-into value's leafs to determine if there is an error in the value.
+into value's leaves to determine if there is an error in the value.
 
 ### Examples
 

--- a/docs/zq/functions/has_error.md
+++ b/docs/zq/functions/has_error.md
@@ -5,7 +5,7 @@
 ### Synopsis
 
 ```
-has_error(val: any [, ... val: any]) -> bool
+has_error(val: any) -> bool
 ```
 ### Description
 

--- a/docs/zq/functions/has_error.md
+++ b/docs/zq/functions/has_error.md
@@ -9,7 +9,7 @@ has_error(val: any) -> bool
 ```
 ### Description
 
-The _has_error_ function returns true if its argument has an error.
+The _has_error_ function returns true if its argument is or contains an error.
 _has_error_ is different from _is_error_ in that _has_error_ will recurse 
 into value's leaves to determine if there is an error in the value.
 

--- a/docs/zq/functions/has_error.md
+++ b/docs/zq/functions/has_error.md
@@ -1,0 +1,26 @@
+### Function
+
+&emsp; **has_error** &mdash; test if a value has an error
+
+### Synopsis
+
+```
+has_error(val: any [, ... val: any]) -> bool
+```
+### Description
+
+The _has_error_ function returns true if its argument has an error.
+_has_error_ is different from _is_error_ in that _has_error_ will recurse 
+into value's leafs to determine if there is an error in the value.
+
+### Examples
+
+```mdtest-command
+echo '{a:{b:"foo"}}' | zq -z 'yield has_error(this)' -
+echo '{a:{b:"foo"}}' | zq -z 'a.x := a.y + 1 | yield has_error(this)' -
+```
+=>
+```mdtest-output
+false
+true
+```

--- a/docs/zq/functions/has_error.md
+++ b/docs/zq/functions/has_error.md
@@ -1,6 +1,6 @@
 ### Function
 
-&emsp; **has_error** &mdash; test if a value has an error
+&emsp; **has_error** &mdash; test if a value is or contains an error
 
 ### Synopsis
 

--- a/docs/zq/reference.md
+++ b/docs/zq/reference.md
@@ -61,6 +61,7 @@ to take on any Zed type.
 * [floor](functions/floor.md) - floor of a number
 * [grep](functions/grep.md) - search strings inside of values
 * [has](functions/has.md) - test existence of values
+* [has_error](functions/has_error.md) - test if a value has an error
 * [is](functions/is.md) - test a value's type
 * [is_error](functions/is_error.md) - test if a value is an error
 * [join](functions/join.md) - concatenate array of strings with a separator

--- a/runtime/expr/function/function.go
+++ b/runtime/expr/function/function.go
@@ -107,6 +107,8 @@ func New(zctx *zed.Context, name string, narg int) (Interface, field.Path, error
 		f = &NameOf{zctx: zctx}
 	case "fields":
 		f = NewFields(zctx)
+	case "has_error":
+		f = NewHasError()
 	case "is":
 		argmin = 1
 		argmax = 2
@@ -155,7 +157,7 @@ func New(zctx *zed.Context, name string, narg int) (Interface, field.Path, error
 // signatures so the return type can be introspected.
 func HasBoolResult(name string) bool {
 	switch name {
-	case "is_error", "is", "has", "missing", "cidr_match":
+	case "has", "has_error", "is_error", "is", "missing", "cidr_match":
 		return true
 	}
 	return false

--- a/runtime/expr/function/types.go
+++ b/runtime/expr/function/types.go
@@ -131,6 +131,10 @@ func (h *HasError) hasError(t zed.Type, b zcode.Bytes) (bool, bool) {
 	if _, ok := typ.(*zed.TypeError); ok {
 		return true, false
 	}
+	// If a value is null we can skip since an null error is not an error.
+	if b == nil {
+		return false, false
+	}
 	if hasErr, ok := h.cached[t.ID()]; ok {
 		return hasErr, true
 	}

--- a/runtime/expr/function/types.go
+++ b/runtime/expr/function/types.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zson"
 )
 
@@ -105,6 +106,78 @@ func (i *Is) Call(_ zed.Allocator, args []zed.Value) *zed.Value {
 		return zed.True
 	}
 	return zed.False
+}
+
+type HasError struct {
+	cached map[int]bool
+}
+
+func NewHasError() *HasError {
+	return &HasError{
+		cached: make(map[int]bool),
+	}
+}
+
+func (h *HasError) Call(_ zed.Allocator, args []zed.Value) *zed.Value {
+	v := args[0]
+	if yes, _ := h.hasError(v.Type, v.Bytes); yes {
+		return zed.True
+	}
+	return zed.False
+}
+
+func (h *HasError) hasError(t zed.Type, b zcode.Bytes) (bool, bool) {
+	typ := zed.TypeUnder(t)
+	if _, ok := typ.(*zed.TypeError); ok {
+		return true, false
+	}
+	if hasErr, ok := h.cached[t.ID()]; ok {
+		return hasErr, true
+	}
+	var hasErr bool
+	canCache := true
+	switch typ := typ.(type) {
+	case *zed.TypeRecord:
+		it := b.Iter()
+		for _, col := range typ.Columns {
+			e, c := h.hasError(col.Type, it.Next())
+			hasErr = hasErr || e
+			canCache = !canCache || c
+		}
+	case *zed.TypeArray, *zed.TypeSet:
+		inner := zed.InnerType(typ)
+		for it := b.Iter(); !it.Done(); {
+			e, c := h.hasError(inner, it.Next())
+			hasErr = hasErr || e
+			canCache = !canCache || c
+		}
+	case *zed.TypeMap:
+		for it := b.Iter(); !it.Done(); {
+			e, c := h.hasError(typ.KeyType, it.Next())
+			hasErr = hasErr || e
+			canCache = !canCache || c
+			e, c = h.hasError(typ.ValType, it.Next())
+			hasErr = hasErr || e
+			canCache = !canCache || c
+		}
+	case *zed.TypeUnion:
+		for _, typ := range typ.Types {
+			_, isErr := zed.TypeUnder(typ).(*zed.TypeError)
+			canCache = !canCache || isErr
+		}
+		if typ, b := typ.SplitZNG(b); b != nil {
+			// Check mb is not nil to avoid infinite recursion.
+			var cc bool
+			hasErr, cc = h.hasError(typ, b)
+			canCache = !canCache || cc
+		}
+	}
+	// We cannot cache a type if the type or one of its children has a union
+	// with an error member.
+	if canCache {
+		h.cached[t.ID()] = hasErr
+	}
+	return hasErr, canCache
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#quiet

--- a/runtime/expr/ztests/has_error.yaml
+++ b/runtime/expr/ztests/has_error.yaml
@@ -1,0 +1,15 @@
+zed: "yield has_error(this)"
+
+input: |
+  null
+  error(0)
+  {f1:127.0.0.1,f2:error("error")}
+  [1,2]([(int64,error(string))])
+  |{"key":error(0)((int64,error(int64)))}|
+
+output: |
+  false
+  true
+  true
+  false
+  true


### PR DESCRIPTION
Add has_error function which will recurse a zed value and return true if
the value or any of its leafs an error. has_error memoizes the types it
has seen so it won't have to recurse types more than once (unless the it
contains an error type in a union in which case it'll always have to
recurse).

Closes #3719