### PR TITLE
fix premature EOS in scoped over operator

### DIFF
--- a/runtime/op/traverse/ztests/nested-where-head.yaml
+++ b/runtime/op/traverse/ztests/nested-where-head.yaml
@@ -1,0 +1,14 @@
+zed: |
+  over this => (
+    over this => (
+      where this > 2 | head 1
+    )
+  )
+
+input: |
+  [[1,2],[3,4]]
+  [[4,3],[2,1]]
+
+output: |
+  3
+  4

--- a/runtime/op/traverse/ztests/nested-where.yaml
+++ b/runtime/op/traverse/ztests/nested-where.yaml
@@ -1,0 +1,16 @@
+zed: |
+  over this => (
+    over this => (
+      where this > 2
+    )
+  )
+
+input: |
+  [[1,2],[3,4]]
+  [[4,3],[2,1]]
+
+output: |
+  3
+  4
+  4
+  3

--- a/runtime/op/ztests/over-where.yaml
+++ b/runtime/op/ztests/over-where.yaml
@@ -1,0 +1,9 @@
+zed: |
+  over this => (where this > 1)
+
+input: |
+  [1]
+  [2]
+
+output: |
+  2


### PR DESCRIPTION
The flowgraph for a scoped over operator (i.e., "over ... => (...)")
shuts down prematurely if the scoped flowgraph produces no output for a
given input, as with a where operator.  Fix by adding a channel in
runtime/op/traverse.Scope called parentEOSCh, sending to it when a
Scope's parent returns an EOS, trying to receive from it when
Exit.pullPlatoon pulls an empty platoon, and interpreting the empty
platoon as EOS only if the receive succeeds.

This seems to work but doesn't feel particularly robust.  I think we
might need a different design here if we want something that's more
obviously correct.