### PR TITLE
add zed command README

### DIFF
--- a/docs/zed/README.md
+++ b/docs/zed/README.md
@@ -677,7 +677,7 @@ The `date` field here is used by the Zed lake system to do time travel
 through the branch and pool history, allowing you to see the state of
 branches at any time in their commit history.
 
-Arbitrary metadata expressed as any [ZSON value](../foramts/zson.md)
+Arbitrary metadata expressed as any [ZSON value](../formats/zson.md)
 maybe be attached to a commit via the `-meta` flag.  This allows an application
 or user to trasactionally commit metadata alongside committed data for any
 purpose.  This approach allows external applications to implement arbitrary

--- a/docs/zed/README.md
+++ b/docs/zed/README.md
@@ -22,7 +22,7 @@
 > is deployed to manage the lake's data layout and create any needed search indexes
 > via the [lake API](api.md).
 >
-> Enhanced scalability with self-tuning configuration is under developed.
+> Enhanced scalability with self-tuning configuration is under development.
 
 ## Contents
 
@@ -66,7 +66,7 @@ analytics, ETL, data discovery, and data preparation
 at scale based on data represented in accordance
 with the [Zed data model](../formats).
 
-A lake is orgnized into a collection of data pools forming a single
+A lake is organized into a collection of data pools forming a single
 administrative domain.  The current implementation supports
 ACID append and delete semantics at the commit level while
 we have plans to support CRUD updates at the primary-key level
@@ -85,7 +85,7 @@ our goal here is that the Zed lake tooling be as easy and familiar as Git is
 to a technical user.
 
 Since Zed lakes are built around the [Zed data model](../formats/zed.md),
-different kinds of data is easy to get into and out of a lake.
+getting different kinds of data to into and out of a lake is easy.
 There is no need to define schemas or tables and fit
 semi-structured data into schemas before loading data into a lake.
 And because Zed supports a large family of formats and the load endpoint
@@ -132,8 +132,8 @@ commands may reference various lake entities by their ID, e.g.,
 * _Index rule ID_ - the KSUID of an index rule
 * _Index object ID_ - the KSUID of an index object relative to a data object
 
-Data is added and deleted from the the lake only with new commits that
-are implemented in a transactionally conistent fashion.  Thus, each
+Data is added and deleted from the lake only with new commits that
+are implemented in a transactionally consistent fashion.  Thus, each
 commit object (identified by its globally-unique ID) provides a completely
 consistent view of an arbitrary large amount of committed data
 at a specific point in time.
@@ -142,7 +142,7 @@ While this commit model may sound heavyweight, excellent live ingest performance
 can be achieved by micro-batching commits.
 
 Because the Zed lake represents all state transitions with immutable objects,
-the caching of any cloud object (or byte ranges of a cloud objects)
+the caching of any cloud object (or byte ranges of cloud objects)
 is easy and effective since a cached object is never invalid.
 This design makes backup/restore, data migration, archive, and
 replication easy to support and deploy.
@@ -179,8 +179,8 @@ a storage path.  This command initiates a continuous server process
 that serves client requests for the lake at the configured storage path.
 
 Note that a storage path on the file system may be specified either as
-a fully qualifed file URI of the form `file://` or be a standard
-file system path, relative or absolutes, e.g., `/lakes/test`.
+a fully qualified file URI of the form `file://` or be a standard
+file system path, relative or absolute, e.g., `/lakes/test`.
 
 Concurrent access to any Zed lake storage, of course, preserves
 data consistency.  You can run multiple `zed serve` processes while also
@@ -227,7 +227,7 @@ Zed does not currently support multiple parents in the commit object history.
 A branch is simply a named pointer to a commit object in the Zed lake
 and like a pool, a branch name can be any valid UTF-8 string.
 Consistent updates to a branch are made by writing a new commit object that
-points to the previous tip of branch and updating the branch to point at
+points to the previous tip of the branch and updating the branch to point at
 the new commit object.  This update may be made with a transaction constraint
 (e.g., requiring that the previous branch tip is the same as the
 commit object's parent); if the constraint is violated, then the transaction
@@ -238,7 +238,7 @@ or may be persisted across commands with the [use command](#214-use) so that
 `-use` does not have to be specified on each command-line.  For interactive
 workflows, the `use` command is convenient but for automated workflows
 in scripts, it is good practice to explicitly specify the branch in each
-command invocation with `-use` option.
+command invocation with the `-use` option.
 
 ### 1.4.2 Commitish
 
@@ -251,7 +251,7 @@ A commitish is always relative to the pool and has the form:
 * `<pool>@<id>` or
 * `<pool>@<branch>`
 
-where `<pool>` is a pool name or pool ID, `<id>` is a commit object ID, and
+where `<pool>` is a pool name or pool ID, `<id>` is a commit object ID,
 and `<branch>` is a branch name.
 
 In particular, the working branch set by the [use command](#214-use) is a commitish.
@@ -330,7 +330,7 @@ timestamp less than or equal to the desired timestamp.  Likewise, a branch
 can be located in a similar fashion, then its corresponding commit object
 can be used to construct that data of that branch at that past point in time.
 
- > Note that time travel using time stamps is a forthcoming feature.
+ > Note that time travel using timestamps is a forthcoming feature.
 
 ### 1.6 Search Indexes
 
@@ -355,7 +355,7 @@ if the value "bar" is not in that index.
 
 Also, each data object is broken up into seekable chunks and the chunk location
 of each index value is stored in the index so often only parts of large
-data objects need be scanned based on this information.
+data objects need to be scanned based on this information.
 
 This approach works well for "needle in the haystack"-style searches.  When
 a search hits every object, this style of indexing would not eliminate any
@@ -376,9 +376,9 @@ of cloud objects.
 
 Indexes are created and managed with one or more _index rules_.
 
-While you can simply create rules and run `zed index update` to insure
-that indexes are all up to date with committed data, the process under
-the involves indexing each data object and storing its index object
+While you can simply create rules and run `zed index update` to ensure
+that indexes are all up to date with committed data, the process here
+involves indexing each data object and storing its index object
 as another cloud object in the data pool.  Once an index is successfully
 computed, the binding between a data object and its index is transactionally
 committed to its branch so that the query planner always has a consistent
@@ -398,9 +398,9 @@ the [index update command](#265-index-update).
 #### 1.6.2 Indexing Workflows
 
 Indexes are all created and managed explicitly via the `zed index` commands
-and equivalent API endpoints.  It is the resposibility of external agents
+and equivalent API endpoints.  It is the responsibility of external agents
 to create indexes that can be utilized by the service.  This design allows
-the indexing system to be scaled out and run idenpendently from the ingest
+the indexing system to be scaled out and run independently from the ingest
 and query functions and be tailored to diverse workloads, e.g., the needs of
 a real-time log search use case are very different from those of an ETL use
 case but this design allows different workloads like these to be custom tuned.
@@ -409,7 +409,7 @@ case but this design allows different workloads like these to be custom tuned.
 
 ## 2. Zed Commands
 
-The `zed` command is structured is structured as a primary command
+The `zed` command is structured as a primary command
 consististing of a large number of interrelated subcommands, similar to the
 [docker](https://docs.docker.com/engine/reference/commandline/cli/)
 or [kubectl](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands)
@@ -428,7 +428,7 @@ sub-command and so forth.
 zed auth login|logout|method|verify
 ```
 Access to a Zed lake can be secured with [Auth0 authentication](https://auth0.com/).
-Please reach out to use on our Brim community Slack if you'd like help
+Please reach out to us on our Brim community Slack if you'd like help
 setting this up and trying it out.
 
 ### 2.2 Branch
@@ -476,7 +476,7 @@ the data in lake, which may be in ascending or descending order.
 If a pool key is not specified, then it defaults to
 the [special value this](../zq/language.md#23-the-special-value-this).
 
-A newly created pool is intialized with a branch called `main`.
+A newly created pool is initialized with a branch called `main`.
 
 > Zed lakes can be used without thinking about branches.  When referencing a pool without
 > a branch, the tooling presumes the "main" branch as the default, and everything
@@ -492,16 +492,16 @@ simply removes the data from the branch without actually deleting the
 underlying data objects thereby allowing time travel to work in the face
 of deletes.
 
-> A vaccum command to delete permanently from a pool is under development.
+> A vacuum command to delete permanently from a pool is under development.
 
 ### 2.5 Drop
 ```
 zed drop [options] <name>|<id>
 ```
 The `drop` command deletes a pool and all of its constituent data.
-This is DANGER ZONE command you must confirm that you want to delete
+As this is DANGER ZONE command, you must confirm that you want to delete
 the pool to proceed.  The `-f` option can be used to force the deletion
-without confirmattion.
+without confirmation.
 
 ### 2.6 Index
 ```
@@ -548,7 +548,7 @@ commit history so it becomes available to the query optimizer.
 zed index drop <id> [<id> ...]
 ```
 The `index drop` command deletes one or more index rules using by `<id>`.
-Once deleted, no more indexes will be created for that rule but the underying
+Once deleted, no more indexes will be created for that rule but the underlying
 indexes are not actually deleted from the lake.
 
 > Commands to delete the underlying indexes and data from a lake are
@@ -575,7 +575,7 @@ If no index rules are given, the update is performed for all index rules.
 ```
 zed init [path]
 ```
-A new lake is initialized wiht the `init` command.  The `path` argument
+A new lake is initialized with the `init` command.  The `path` argument
 is a [storage path](#12-storage-layer) and is optional.  If not present,
 the path is taken from the ZED_LAKE environment variable, which must be defined.
 
@@ -604,17 +604,17 @@ the input format is auto-detected if `-i` is not provided.  Likewise,
 the inputs may be URLs, in which case, the `load` command streams
 the data from a Web server or S3 and into the lake.
 
-When data loaded, it is broken up into objects of a target sized determined
+When data is loaded, it is broken up into objects of a target sized determined
 by the pool's `threshold` parameter (which defaults 500MiB but can be configured
 when the pool is created).  Each object is sorted by the pool key but
 a sequence of objects is not guaranteed to be globally sorted.  When lots
-of small or unorted commits occur, data can be fragmented impacting performance.
+of small or unsorted commits occur, data can be fragmented impacting performance.
 
 > Note that data is easily compacted by reading from a fragmented pool and writing
 > it back to a target pool so that it is globally sorted and compacted into
 > contiguous large objects.  We will soon introduce a compaction feature that
 > does this automatically inside of pool and can either be run manually or
-> congfigured to run automatically by the server.
+> configured to run automatically by the server.
 
 For example, this command
 ```
@@ -651,7 +651,7 @@ Data added to a pool can arrive in any order with respect to the pool key.
 While each object is sorted before it is written,
 the collection of objects is generally not sorted.
 
-Each load opertion creates a single commit object, which inlcudes:
+Each load operation creates a single commit object, which inlcudes:
 * an author and message string,
 * a timestamp computed by the server, and
 * an optional metadata field of any ZSON type.
@@ -670,7 +670,7 @@ For example, this command sets the `user` and `message` fields:
 zed load -user user@example.com -message "new version of prod dataset" ...
 ```
 If these fields are not specified, then the Zed system will fill them in
-with the user obtained from the session and a message that is desciptive
+with the user obtained from the session and a message that is descriptive
 of the action.
 
 The `date` field here is used by the Zed lake system to do time travel
@@ -678,8 +678,8 @@ through the branch and pool history, allowing you to see the state of
 branches at any time in their commit history.
 
 Arbitrary metadata expressed as any [ZSON value](../formats/zson.md)
-maybe be attached to a commit via the `-meta` flag.  This allows an application
-or user to trasactionally commit metadata alongside committed data for any
+may be attached to a commit via the `-meta` flag.  This allows an application
+or user to transactionally commit metadata alongside committed data for any
 purpose.  This approach allows external applications to implement arbitrary
 data provenance and audit capabilities by embedding custom metadata in the
 commit history.
@@ -697,7 +697,7 @@ zed log -f zng | zq 'has(meta) | yield {id,meta}' -
 zed log [options] [commitish]
 ```
 The `log` command, like `git log`, displays a history of the commit objects
-starting from any commit, expressed as a [commitish](#commitish).  If no arguement is
+starting from any commit, expressed as a [commitish](#commitish).  If no argument is
 given, the tip of the working branch is used.
 
 Run `zed log -h` for a list of command-line options.
@@ -864,7 +864,7 @@ zed query -f lake "from logs@live:objects"
 ```
 zed rename <existing> <new-name>
 ```
-The `rename` commands assigns a new name `<new-name>` to an existing
+The `rename` command assigns a new name `<new-name>` to an existing
 pool `<existing>`, which may be referenced by its ID or its previous name.
 
 ### 2.13 Serve
@@ -881,7 +881,7 @@ specified by the `-l` option, executes the requests, and returns results.
 ```
 zed use <commitish>
 ```
-The `use` command sets set the working branch to the indicated commitish.
+The `use` command sets the working branch to the indicated commitish.
 
 For example,
 ```
@@ -890,7 +890,7 @@ zed use logs
 provides a "pool-only" commitish that sets the working branch to `logs@main`.
 
 To specify a branch in another pool, simply prepend
-the pool name to the dessired branch:
+the pool name to the desired branch:
 ```
 zed use otherpool@otherbranch
 ```

--- a/docs/zed/README.md
+++ b/docs/zed/README.md
@@ -73,7 +73,7 @@ we have plans to support CRUD updates at the primary-key level
 in the near future.
 
 The semantics of a Zed lake loosely follows the nomenclature and
-design patterns of `git`.  In this approach,
+design patterns of [`git`](https://git-scm.com/).  In this approach,
 * a _lake_ is like a GitHub organization,
 * a _pool_ is like a `git` repository,
 * a _branch_ of a _pool_ is like a `git` branch,
@@ -85,8 +85,8 @@ our goal here is that the Zed lake tooling be as easy and familiar as Git is
 to a technical user.
 
 Since Zed lakes are built around the [Zed data model](../formats/zed.md),
-getting different kinds of data to into and out of a lake is easy.
-There is no need to define schemas or tables and fit
+getting different kinds of data into and out of a lake is easy.
+There is no need to define schemas or tables and then fit
 semi-structured data into schemas before loading data into a lake.
 And because Zed supports a large family of formats and the load endpoint
 automatically detects most formats, it's easy to just load data into a lake
@@ -95,7 +95,7 @@ without thinking about how to convert it into the right format.
 ### 1.1 CLI-First Approach
 
 The Zed project has taken a _CLI-first approach_ to designing and implementing
-the system.  Anytime a new piece of functionality is added to the lake,
+the system.  Any time a new piece of functionality is added to the lake,
 it is first implemented as a `zed` command.  This is particularly convenient
 for testing and continuous integration as well as providing intuitive,
 bite-sized chunks for learning how the system works and how the different
@@ -105,7 +105,7 @@ While the CLI-first approach provides these benefits,
 all of the functionality is also exposed through [an API](api.md) to
 a Zed service.  Many use cases involve an application like
 [Brim](https://github.com/brimdata/brim) or a
-programming environment like Python/Pandas rather interacting
+programming environment like Python/Pandas interacting
 with the service API in place of direct use with the `zed` command.
 
 ### 1.2 Storage Layer
@@ -163,7 +163,7 @@ model onto a file system so that Zed lakes can also be deployed on standard file
 The `zed` command provides a single command-line interface to Zed lakes, but
 different personalities are taken on by `zed` depending on the particular
 sub-command executed and the disposition of its `-lake` option
-(which defaults to the value of `ZED_LAKE` environment variable of,
+(which defaults to the value of `ZED_LAKE` environment variable or,
 if `ZED_LAKE` is not set, to the client personality `https://localhost:9867`).
 
 To this end, `zed` can take on one of three personalities:
@@ -194,7 +194,7 @@ all adhere to the consistency semantics of the Zed lake.
 > For a shared file system, the close-to-open cache consistency
 > semantics of NFS should provide the necessary consistency guarantees needed by
 > a Zed lake though this has not been tested.  Multi-process, single-node
-> node access to a local file system has been thoroughly tested and should be
+> access to a local file system has been thoroughly tested and should be
 > deemed reliable, i.e., you can run a direct-access instance of `zed` alongside
 > a server instance of `zed` on the same file system and data consistency will
 > be maintained.
@@ -275,8 +275,8 @@ pool key.
 
 As pool data is often comprised of Zed records (analogous to JSON objects),
 the pool key is typically a field of the stored records.
-When pool data is not structured as records/objects, e.g., scalar or arrays or other
-non-record types, then the pool key would typically be configured
+When pool data is not structured as records/objects (e.g., scalar or arrays or other
+non-record types), then the pool key would typically be configured
 as the [special value `this`](../zq/language.md#23-the-special-value-this).
 
 Data can be efficiently scanned via ranges of values conforming to the pool key.
@@ -325,10 +325,12 @@ past snapshots of the commit history, another means is to use a timestamp.
 Because the entire history of branch updates is stored in a transaction journal
 and each entry contains a timestamp, branch references can be easily
 navigated by time.  For example, a list of branches of a pool's past
-can be created by scanning the branches log and stopping at the largest
-timestamp less than or equal to the desired timestamp.  Likewise, a branch
-can be located in a similar fashion, then its corresponding commit object
-can be used to construct that data of that branch at that past point in time.
+can be created by scanning the internal "pools log" and stopping at the largest
+timestamp less than or equal to the desired timestamp.  Then using that
+historical snapshot of the pools, a branch can be located within the pool
+using that pool's "branches log" in a similar fashion, then its corresponding
+commit object can be used to construct the data of that branch at that
+past point in time.
 
  > Note that time travel using timestamps is a forthcoming feature.
 
@@ -354,7 +356,7 @@ is run, then the scan will consult the "foo" index and skip the data object
 if the value "bar" is not in that index.
 
 Also, each data object is broken up into seekable chunks and the chunk location
-of each index value is stored in the index so often only parts of large
+of each index value is stored in the index so that only parts of large
 data objects need to be scanned based on this information.
 
 This approach works well for "needle in the haystack"-style searches.  When
@@ -410,7 +412,7 @@ case but this design allows different workloads like these to be custom tuned.
 ## 2. Zed Commands
 
 The `zed` command is structured as a primary command
-consististing of a large number of interrelated subcommands, similar to the
+consististing of a large number of interrelated sub-commands, similar to the
 [docker](https://docs.docker.com/engine/reference/commandline/cli/)
 or [kubectl](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands)
 commands.
@@ -419,7 +421,7 @@ The following sections describe each of the available commands, but built-in
 help is also available:
 * `zed -h` with no args displays a list of zed commands.
 * `zed command -h`, where `command` is a sub-command, displays help
-help for that subcommand.
+for that sub-command.
 * `zed command sub-command -h` displays help for a sub-command of a
 sub-command and so forth.
 
@@ -428,8 +430,8 @@ sub-command and so forth.
 zed auth login|logout|method|verify
 ```
 Access to a Zed lake can be secured with [Auth0 authentication](https://auth0.com/).
-Please reach out to us on our Brim community Slack if you'd like help
-setting this up and trying it out.
+Please reach out to us on our [Brim community Slack](https://www.brimdata.io/join-slack/)
+if you'd like help setting this up and trying it out.
 
 ### 2.2 Branch
 ```
@@ -474,7 +476,7 @@ The `-orderby` option indicates the pool key that is used to sort
 the data in lake, which may be in ascending or descending order.
 
 If a pool key is not specified, then it defaults to
-the [special value this](../zq/language.md#23-the-special-value-this).
+the [special value `this`](../zq/language.md#23-the-special-value-this).
 
 A newly created pool is initialized with a branch called `main`.
 
@@ -540,14 +542,14 @@ in a pool, e.g.,
 ```
 zed index apply -use logs@main IndexGroupExample <id>
 ```
-The index is created and a transactionally added to the working branch's
+The index is created and transactionally added to the working branch's
 commit history so it becomes available to the query optimizer.
 
 #### 2.6.3 Index Drop
 ```
 zed index drop <id> [<id> ...]
 ```
-The `index drop` command deletes one or more index rules using by `<id>`.
+The `index drop` command deletes one or more index rules specified by `<id>`.
 Once deleted, no more indexes will be created for that rule but the underlying
 indexes are not actually deleted from the lake.
 
@@ -577,7 +579,7 @@ zed init [path]
 ```
 A new lake is initialized with the `init` command.  The `path` argument
 is a [storage path](#12-storage-layer) and is optional.  If not present,
-the path is taken from the ZED_LAKE environment variable, which must be defined.
+the path is taken from the `ZED_LAKE` environment variable, which must be defined.
 
 If the lake already exists, `init` reports an error and does nothing.
 
@@ -604,7 +606,7 @@ the input format is auto-detected if `-i` is not provided.  Likewise,
 the inputs may be URLs, in which case, the `load` command streams
 the data from a Web server or S3 and into the lake.
 
-When data is loaded, it is broken up into objects of a target sized determined
+When data is loaded, it is broken up into objects of a target size determined
 by the pool's `threshold` parameter (which defaults 500MiB but can be configured
 when the pool is created).  Each object is sorted by the pool key but
 a sequence of objects is not guaranteed to be globally sorted.  When lots
@@ -613,14 +615,14 @@ of small or unsorted commits occur, data can be fragmented impacting performance
 > Note that data is easily compacted by reading from a fragmented pool and writing
 > it back to a target pool so that it is globally sorted and compacted into
 > contiguous large objects.  We will soon introduce a compaction feature that
-> does this automatically inside of pool and can either be run manually or
+> does this automatically inside of a pool and can either be run manually or
 > configured to run automatically by the server.
 
 For example, this command
 ```
 zed load sample1.json sample2.zng sample3.zson
 ```
-loads files of varying type in a single commit to the working branch.
+loads files of varying formats in a single commit to the working branch.
 
 Parquet and ZST formats are not auto-detected so you must currently
 specify `-i` with these formats, e.g.,
@@ -629,7 +631,7 @@ zed load -i parquet sample4.parquet
 zed load -i zst sample5.zst
 ```
 An alternative branch may be specified with a branch reference with the
-`-use` option, i.e., `<pool>@<branch>`.  Supposing there a branch
+`-use` option, i.e., `<pool>@<branch>`.  Supposing a branch
 called `live` existed, data can be committed into this branch as follows:
 ```
 zed load -use logs@live sample.zng
@@ -651,11 +653,11 @@ Data added to a pool can arrive in any order with respect to the pool key.
 While each object is sorted before it is written,
 the collection of objects is generally not sorted.
 
-Each load operation creates a single commit object, which inlcudes:
+Each load operation creates a single commit object, which includes:
 * an author and message string,
 * a timestamp computed by the server, and
-* an optional metadata field of any ZSON type.
-This data has the ZED type signature:
+* an optional metadata field of any Zed type expressed as a ZSON value.
+This data has the Zed type signature:
 ```
 {
     author: string,
@@ -665,7 +667,7 @@ This data has the ZED type signature:
 }
 ```
 where `<any>` is the type of any optionally attached metadata .
-For example, this command sets the `user` and `message` fields:
+For example, this command sets the `author` and `message` fields:
 ```
 zed load -user user@example.com -message "new version of prod dataset" ...
 ```
@@ -712,7 +714,7 @@ referencing the data objects where the new commit object's parent
 points at the branch's previous commit object, thus forming a path
 through the object tree.
 
-The [log command](#29-log) prints the commit ID of each commit object in that path
+The `log` command prints the commit ID of each commit object in that path
 from the current pointer back through history to the first commit object.
 
 A commit object includes
@@ -877,17 +879,26 @@ It listens for Zed lake API requests on the interface and port
 specified by the `-l` option, executes the requests, and returns results.
 
 ### 2.14 Use
-
 ```
-zed use <commitish>
+zed use [<commitish>]
 ```
 The `use` command sets the working branch to the indicated commitish.
+When run without a commitish argument, it displays the current commitish
+in use.
 
 For example,
 ```
 zed use logs
 ```
 provides a "pool-only" commitish that sets the working branch to `logs@main`.
+
+If a `@branch` or commit ID are given without a pool prefix, then the pool of
+the commitish previously in use is presumed.  For example, if you are on
+`logs@main` then run this command:
+```
+zed use @test
+```
+then the working branch is set to `logs@test`.
 
 To specify a branch in another pool, simply prepend
 the pool name to the desired branch:

--- a/docs/zed/design.md
+++ b/docs/zed/design.md
@@ -1,0 +1,483 @@
+# Zed Lake Design Notes
+
+  * [Cloud Object Architecture](#cloud-object-architecture)
+    + [Immutable Objects](#immutable-objects)
+      - [Data Objects](#data-objects)
+      - [Commit History](#commit-history)
+    + [Transaction Journal](#transaction-journal)
+      - [Scaling a Journal](#scaling-a-journal)
+      - [Journal Concurrency Control](#journal-concurrency-control)
+      - [Configuration State](#configuration-state)
+    + [Object Naming](#object-naming)
+  * [Continuous Ingest](#continuous-ingest)
+  * [Derived Analytics](#derived-analytics)
+  * [Keyless Data](#keyless-data)
+  * [Relational Model](#relational-model)
+  * [Current Status](#current-status)
+  * [CLI tool naming conventions](#cli-tool-naming-conventions)
+
+
+## Cloud Object Architecture
+
+The Zed lake semantics defined above are achieved by mapping the
+lake and pool abstractions onto a key-value cloud object store.
+
+Every data element in a Zed lake is either of two fundamental object types:
+* a single-writer _immutable object_, or
+* a multi-writer _transaction journal_.
+
+### Immutable Objects
+
+All imported data in a data pool is composed of immutable objects, which are organized
+around a primary data object.  Each data object is composed of one or more immutable objects
+all of which share a common, globally unique identifier,
+which is referred to below generically as `<id>` below.
+
+These identifiers are [KSUIDs](https://github.com/segmentio/ksuid).
+The KSUID allocation scheme
+provides a decentralized solution for creating globally unique IDs.
+KSUIDs have embedded timestamps so the creation time of
+any object named in this way can be derived.  Also, a simple lexicographic
+sort of the KSUIDs results in a creation-time ordering (though this ordering
+is not relied on for causal relationships since clock skew can violate
+such an assumption).
+
+> While a Zed lake is defined in terms of a cloud object store, it may also
+> be realized on top of a file system, which provides a convenient means for
+> local, small-scale deployments for test/debug workflows.  Thus, for simple use cases,
+> the complexity of running an object-store service may be avoided.
+
+#### Data Objects
+
+An immutable object is created by a single writer using a globally unique name
+with an embedded KSUID.  
+New objects are written in their entirety.  No updates, appends, or modifications
+may be made once an object exists.  Given these semantics, any such object may be
+trivially cached as its name nor content ever change.
+
+Since the object's name is globally unique and the
+resulting object is immutable, there is no possible write concurrency to manage
+with respect to a given object.
+
+A data object is composed of
+* the primary data object stored as one or two objects (for row and/or column layout),
+* an optional seek index, and
+* zero or more search indexes.
+
+Data objects may be either in row form (i.e., ZNG) or column form (i.e., ZST),
+or both forms may be present as a query optimizer may choose to use whatever
+representation is more efficient.
+When both row and column data objects are present, they must contain the same
+underlying Zed data.
+
+Immutable objects are named as follows:
+
+|object type|name|
+|-----------|----|
+|column data|`<pool-id>/data/<id>.zst`|
+|row data|`<pool-id>/data/<id>.zng`|
+|row seek index|`<pool-id>/data/<id>-seek.zng`|
+|search index|`<pool-id>/index/<id>-<index-id>.zng`|
+
+`<id>` is the KSUID of the data object.
+`<index-id>` is the KSUID of an index object created according to the
+index rules described above.  Every index object is defined
+with respect to a data object.
+
+The seek index maps pool key values to seek offset in the ZNG file thereby
+allowing a scan to do a partial GET of the ZNG object when scanning only
+a subset of data.
+
+> Note the ZST format will have seekable checkpoints based on the sort key that
+> are encoded into its metadata section so there is no need to have a separate
+> seek index for the columnar object.
+
+#### Commit History
+
+A pool's commit history is the definitive record of the evolution of data in
+that pool in a transactionally consistent fashion.
+
+Each commit object entry is identified with its `commit ID`.
+Objects are immutable and uniquely named so there is never a concurrent write
+condition.
+
+The "add" and "commit" operations are transactionally stored
+in a chain of commit objects.  Any number of adds (and deletes) may appear
+in a commit object.  All of the operations that belong to a commit are
+identified with a commit identifier (ID).
+
+> TBD: when a scan encounters an object that was physically deleted for
+> whatever reason, it should simply continue on and issue a warning on
+> the query endpoint "warnings channel".
+
+As each commit object points to its parent (except for the initial commit
+in main), the collection of commit objects in a pool forms a tree.
+
+Each commit object contains a sequence of _actions_:
+
+* `Add` to add a data object reference to a pool,
+* `Delete` to delete a data object reference from a pool,
+* `AddIndex` to bind an index object to a data object to prune the data object
+from a scan when possible using the index,
+* `DeleteIndex` to remove an index object reference to its data object, and
+* `Commit` for providing metadata about each commit.
+
+The actions are not grouped directly by their commit tag but instead each
+action embeds the KSUID of its commit tag.
+
+By default, `zed log` outputs an abbreviated form of the log as text to
+stdout, similar to the output of `git log`.
+
+However, the log represents the definitive record of a pool's present
+and historical content, and accessing its complete detail can provide
+insights about data layout, provenance, history, and so forth.  Thus,
+Zed lake provides a means to query a pool's configuration state as well,
+thereby allowing past versions of the complete pool and branch configurations
+as well as all of their underlying data to be subject to time travel.
+To interrogate the underlying transaction history of the branches and
+their pointers, simply query a pool's "branchlog" via the syntax `<pool>:branchlog`.
+
+For example, to aggregate a count of each journal entry type of the pool
+called `logs`, you can simply say:
+```
+zed query "from logs:branchlog | count() by typeof(this)"
+```
+Since the Zed system "typedefs" each journal record with a named type,
+this kind of query gives intuitive results.  There is no need to implement
+a long list of features for journal introspection since the data in its entirety
+can be simply and efficiently processed as a ZNG stream.
+
+> Note that the branchlog meta-query source is not yet implemented.
+
+### Transaction Journal
+
+State that is mutable is built upon a transaction journal of immutable
+collections of entries.  In this way, there are no objects in the
+storage footprint that are ever modified.  Instead, the journal captures
+changes and journal snapshots are used to provide synchronization points
+for efficient access to the journal (so the entire journal need not be
+read to create the current state) and old journal entries may be removed
+based on retention policy.
+
+The journal may be updated concurrently by multiple writers so concurrency
+controls are included (see [Journal Concurrency Control](#journal-concurrency-control)
+below) to provide atomic updates.
+
+A journal entry simply contains actions that modify the visible "state" of
+the pool by changing branch name to commit object mappings.  Note that
+adding a commit object to a pool changes nothing until a branch pointer
+is mutated to point at that object.
+
+Each atomic journal commit object is a ZNG file numbered 1 to the end of journal (HEAD),
+e.g., `1.zng`, `2.zng`, etc., each number corresponding to a journal ID.
+The 0 value is reserved as the null journal ID.
+The journal's TAIL begins at 1 and is increased as journal entries are purged.
+Entries are added at the HEAD and removed from the TAIL.
+Once created, a journal entry is never modified but it may be deleted and
+never again allocated.
+There may be 1 or more entries in each commit object.
+
+Each journal entry implies a snapshot of the data in a pool.  A snapshot
+is computed by applying the transactions in sequence from entry TAIL to
+the journal entry in question, up to HEAD.  This gives the set of commit tags
+that comprise a snapshot.
+
+The set of branch pointers in a pool is assembled at any point in the journal's history
+by scanning a journal that includes ADD, UPDATE, and DELETE actions for the
+mapping of a branch name to a commit object.  A timestamp is recorded in
+each action to provide for time travel.
+
+For efficiency, a journal entry's snapshot may be stored as a "cached snapshot"
+alongside the journal entry.  This way, the snapshot at HEAD may be
+efficiently computed by locating the most recent cached snapshot and scanning
+forward to HEAD.
+
+#### Scaling a Journal
+
+When the sizes of the journal snapshot files exceed a certain size
+(and thus becomes too large to conveniently handle in memory),
+the snapshots can be converted to and stored
+in an internal sub-pool called the "snapshot pool".  The snapshot pool's
+pool key is the "from" value (of its parent pool key) from each commit action.
+In this case, commits to the parent pool are made in the same fashion,
+but instead of snapshotting updates into a snapshot ZNG file,
+the snapshots are committed to the journal sub-pool.  In this way, commit histories
+can be rolled up and organized by the pool key.  Likewise, retention policies
+based on the pool key can remove not just data objects from the main pool but
+also data objects in the journal pool comprising committed data that falls
+outside of the retention boundary.
+
+> Note we currently record a delete using only the object ID.  In order to
+> organize add and delete actions around key spans, we need to add the span
+> metadata to the delete action just as it exists in the add action.
+
+#### Journal Concurrency Control
+
+To provide for atomic commits, a writer must be able to atomically update
+the HEAD of the log.  There are three strategies for doing so.
+
+First, if the cloud service offers "put-if-missing" semantics, then a writer
+can simply read the HEAD file and use put-if-missing to write to the
+journal at position HEAD+1.  If this fails because of a race, then the writer
+can simply write at position HEAD+2 and so forth until it succeeds (and
+then update the HEAD object).  Note that there can be a race in updating
+HEAD, but HEAD is always less than or equal to the real end of journal,
+and this condition can be self-corrected by probing for HEAD+1 whenever
+the HEAD of the journal is accessed.
+
+> Note that put-if-missing can be emulated on a local file system by opening
+> a file for exclusive access and checking that it has zero length after
+> a successful open.
+
+Second, strong read/write ordering semantics (as exists in Amazon S3)
+can be used to implement transactional journal updates as follows:
+* _TBD: this is worked out but needs to be written up_
+
+Finally, since the above algorithm requires many round trips to the storage
+system and such round trips can be tens of milliseconds, another approach
+is to simply run a lock service as part of a cloud deployment that manages
+a mutex lock for each pool's journal.
+
+#### Configuration State
+
+Configuration state describing a lake or pool is also stored in mutable objects.
+Zed lakes simply use a commit journal to store configuration like the
+list of pools and pool attributes, indexing rules used across pools,
+etc.  Here, a generic interface to a commit journal manages any configuration
+state simply as a key-value store of snapshots providing time travel over
+the configuration history.
+
+### Merge on Read
+
+To support _sorted scans_,
+data from overlapping objects is read in parallel and merged in sorted order.
+This is called the _merge scan_.
+
+However, if many overlapping data objects arise, performing a merge scan
+on every read can be inefficient.
+This can arise when
+many random data `load` operations involving perhaps "late" data
+(e.g., the pool key is a timestamp and records with old timestamp values regularly
+show up and need to be inserted into the past).  The data layout can become
+fragmented and less efficient to scan, requiring a scan to merge data
+from a potentially large number of different objects.
+
+To solve this problem, the Zed lake design follows the
+[LSM](https://en.wikipedia.org/wiki/Log-structured_merge-tree) design pattern.
+Since records in each data object are stored in sorted order, a total order over
+a collection of objects (e.g., the collection coming from a specific set of commits)
+can be produced by executing a sorted scan and rewriting the results back to the pool
+in a new commit.  In addition, the objects comprising the total order
+do not overlap.  This is just the basic LSM algorithm at work.
+
+To perform an LSM rollup, the `compact` command (implementation tracked
+via [zed/2977](https://github.com/brimdata/zed/issues/2977))
+is like a "squash" to perform LSM-like compaction function, e.g.,
+```
+zed compact <id> [<id> ...]
+(merged commit <id> printed to stdout)
+```
+After compaction, all of the objects comprising the new commit are sorted
+and non-overlapping.
+Here, the objects from the given commit IDs are read and compacted into
+a new commit.  Again, until the data is actually committed,
+no readers will see any change.
+
+Unlike other systems based on LSM, the rollups here are envisioned to be
+run by orchestration agents operating on the Zed lake API.  Using
+meta-queries, an agent can introspect the layout of data, perform
+some computational geometry, and decide how and what to compact.
+The nature of this orchestration is highly workload dependent so we plan
+to develop a family of data-management orchestration agents optimized
+for various use cases (e.g., continuously ingested logs vs. collections of
+metrics that should be optimized with columnar form vs. slowly-changing
+dimensional datasets like threat intel tables).
+
+An orchestration layer outside of the Zed lake is responsible for defining
+policy over
+how data is ingested and committed and rolled up.  Depending on the
+use case and workflow, we envision that some amount of overlapping data objects
+would persist at small scale and always be "mixed in" with other overlapping
+data during any key-range scan.
+
+> Note: since this style of data organization follows the LSM pattern,
+> how data is rolled up (or not) can control the degree of LSM write
+> amplification that occurs for a given workload.  There is an explicit
+> tradeoff here between overhead of merging overlapping objects on read
+> and LSM write amplification to organize the data to avoid such overlaps.
+
+> Note: we are showing here manual, CLI-driven steps to accomplish these tasks
+> but a live data pipeline would automate all of this with orchestration that
+> performs these functions via a service API, i.e., the same service API
+> used by the CLI operators.
+
+
+### Object Naming
+
+```
+<lake-path>/
+  lake.zng
+  pools/
+    HEAD
+    TAIL
+    1.zng
+    2.zng
+    ...
+  index_rules/
+    HEAD
+    TAIL
+    1.zng
+    2.zng
+    ...
+    ...
+  <pool-id-1>/
+    branches/
+      HEAD
+      TAIL
+      1.zng
+      2.zng
+      ...
+    commits/
+      <id1>.zng
+      <id2>.zng
+      ...
+    data/
+      <id1>.{zng,zst}
+      <id2>.{zng,zst}
+      ...
+    index/
+      <id1>-<index-id-1>.zng
+      <id1>-<index-id-2>.zng
+      ...
+      <id2>-<index-id-1>.zng
+      ...
+  <pool-id-2>/
+  ...
+```
+
+## Continuous Ingest
+
+While the description above is very batch oriented, the Zed lake design is
+intended to perform scalably for continuous streaming applications.  In this
+approach, many small commits may be continuously executed as data arrives and
+after each commit, the data is immediately readable.
+
+To handle this use case, the _journal_ of branch commits is designed
+to scale to arbitrarily large footprints as described earlier.
+
+## Derived Analytics
+
+To improve the performance of predictable workloads, many use cases of a
+Zed lake pre-compute _derived analytics_ or a particular set of _partial
+aggregations_.
+
+For example, the Brim app displays a histogram of event counts grouped by
+a category over time.  The partial aggregation for such a computation can be
+configured to run automatically and store the result in a pool designed to
+hold such results.  Then, when a scan is run, the Zed analytics engine
+recognizes when the DAG of a query can be rewritten to assemble the
+partial results instead of deriving the answers from scratch.
+
+When and how such partial aggregations are performed is simply a matter of
+writing Zed queries that take the raw data and produce the derived analytics
+while conforming to a naming model that allows the Zed lake to recognize
+the relationship between the raw data and the derived data.
+
+> TBD: Work out these details which are reminiscent of the analytics cache
+> developed in our earlier prototype.
+
+## Keyless Data
+
+This is TBD.  Data without a key should be accepted some way or another.
+One approach is to simply assign the "zero-value" as the pool key; another
+is to use a configured default value.  This would make key-based
+retention policies more complicated.
+
+Another approach would be to create a sub-pool on demand when the first
+keyless data is encountered, e.g., `pool-name.$nokey` where the pool key
+is configured to be "this".  This way, an app or user could query this pool
+by this name to scan keyless data.
+
+## Relational Model
+
+Since a Zed lake can provide strong consistency, workflows that manipulate
+data in a lake can utilize a model where updates are made to the data
+in place.  Such updates involve creating new commits from the old data
+where the new data is a modified form of the old data.  This provides
+emulation of row-based updates and deletes.
+
+If the pool-key is chosen to be "this" for such a use case, then unique
+rows can be maintained by trivially detected duplicates (because any
+duplicate row will be adjacent when sorted by "this") so that duplicates are
+trivially detected.
+
+Efficient upserts can be accomplished because each data object is sorted by the
+pool key.  Thus, an upsert can be sorted then merge-joined with each
+overlapping object.  Where data objects produce changes and additions, they can
+be forwarded to a streaming add operator and the list of modified objects
+accumulated.  At the end of the operation, then new commit(s) along with
+the to-be-deleted objects can be added to the journal in a single atomic
+operation.  A write conflict occurs if there are any other deletes added to
+the list of to-be-deleted objects.  When this occurs, the transaction can
+simply be restarted.  To avoid inefficiency of many restarts, an upsert can
+be partitioned into smaller objects if the use case allows for it.
+
+> TBD: Finish working through this use case, its requirements, and the
+> mechanisms needed to implement it.  Write conflicts will need to be
+> managed at a layer above the journal or the journal extended with the
+> needed functionality.
+
+
+#### 1.5.3 Type Rule
+
+A type rule indicates that all values of any field of a specified type
+be indexed where the type signature uses Zed type syntax.
+For example,
+```
+zed index create IndexGroupEx type ip
+```
+creates a rule that indexes all IP addresses appearing in fields of type `ip`
+in the index group `IndexGroupEx`.
+
+#### 1.5.4 Aggregation Rule
+
+An aggregation rule allows the creation of any index keyed by one or more fields
+(primary, second, etc.), typically the result of an aggregation.
+The aggregation is specified as a Zed query.
+For example,
+```
+zed index create IndexGroupEx agg "count() by field"
+```
+creates a rule that creates an index keyed by the group-by keys whose
+values are the partial-result aggregation given by the Zed expression.
+
+> This is not yet implemented.  The query planner would replace any full object
+> scan with the needed aggregation with the result given in the index.
+> Where a filter is applied to match one row of the index, that result could
+> likewise be extracted instead of scanning the entire object.
+> This capability is not generally useful for interactive search and analytics
+> (except for optimizations that suit the interactive app) but rather is a powerful
+> capability for application-specific workflows that know the pre-computed
+> aggregations that they will use ahead of time, e.g., beacon analysis
+> of network security logs.
+
+### Vacuum Support
+
+While data objects currently can be deleted from a lake, the underlying data
+is retained to support time travel.
+
+The system must also support purging of old data so that retention policies
+can be implemented.
+
+This could be supoprted with the DANGER-ZONE command `zed vacuum`
+(implementation tracked in [zed/2545](https://github.com/brimdata/zed/issues/2545)).
+The commits still appear in the log but scans at any time-travel point
+where the commit is present will fail to scan the deleted data.
+In this case, perhaps we should emit a structured Zed error describing
+the meta-data of the object that was unavailable.
+
+Alternatively, old data can be removed from the system using a safer
+command (but still in the DANGER-ZONE), `zed vacate` (also
+[zed/2545](https://github.com/brimdata/zed/issues/2545)) which moves
+the tail of the commit journal forward and removes any data no longer
+accessible through the modified commit journal.

--- a/docs/zed/design.md
+++ b/docs/zed/design.md
@@ -8,18 +8,19 @@
       - [Scaling a Journal](#scaling-a-journal)
       - [Journal Concurrency Control](#journal-concurrency-control)
       - [Configuration State](#configuration-state)
+    + [Merge on Read](#merge-on-read)
     + [Object Naming](#object-naming)
   * [Continuous Ingest](#continuous-ingest)
   * [Derived Analytics](#derived-analytics)
   * [Keyless Data](#keyless-data)
   * [Relational Model](#relational-model)
-  * [Current Status](#current-status)
-  * [CLI tool naming conventions](#cli-tool-naming-conventions)
-
+  * [Type Rule](#type-rule)
+  * [Aggregation Rule](#aggregation-rule)
+  * [Vacuum Support](#vacuum-support)
 
 ## Cloud Object Architecture
 
-The Zed lake semantics defined above are achieved by mapping the
+The Zed lake semantics are achieved by mapping the
 lake and pool abstractions onto a key-value cloud object store.
 
 Every data element in a Zed lake is either of two fundamental object types:
@@ -53,7 +54,7 @@ An immutable object is created by a single writer using a globally unique name
 with an embedded KSUID.  
 New objects are written in their entirety.  No updates, appends, or modifications
 may be made once an object exists.  Given these semantics, any such object may be
-trivially cached as its name nor content ever change.
+trivially cached as neither its name nor content ever change.
 
 Since the object's name is globally unique and the
 resulting object is immutable, there is no possible write concurrency to manage
@@ -84,7 +85,7 @@ Immutable objects are named as follows:
 index rules described above.  Every index object is defined
 with respect to a data object.
 
-The seek index maps pool key values to seek offset in the ZNG file thereby
+The seek index maps pool key values to seek offsets in the ZNG file thereby
 allowing a scan to do a partial GET of the ZNG object when scanning only
 a subset of data.
 
@@ -130,7 +131,7 @@ stdout, similar to the output of `git log`.
 
 However, the log represents the definitive record of a pool's present
 and historical content, and accessing its complete detail can provide
-insights about data layout, provenance, history, and so forth.  Thus,
+insights about data layout, provenance, history, and so forth.  Thus, the
 Zed lake provides a means to query a pool's configuration state as well,
 thereby allowing past versions of the complete pool and branch configurations
 as well as all of their underlying data to be subject to time travel.
@@ -427,8 +428,7 @@ be partitioned into smaller objects if the use case allows for it.
 > managed at a layer above the journal or the journal extended with the
 > needed functionality.
 
-
-#### 1.5.3 Type Rule
+## Type Rule
 
 A type rule indicates that all values of any field of a specified type
 be indexed where the type signature uses Zed type syntax.
@@ -439,7 +439,7 @@ zed index create IndexGroupEx type ip
 creates a rule that indexes all IP addresses appearing in fields of type `ip`
 in the index group `IndexGroupEx`.
 
-#### 1.5.4 Aggregation Rule
+## Aggregation Rule
 
 An aggregation rule allows the creation of any index keyed by one or more fields
 (primary, second, etc.), typically the result of an aggregation.
@@ -461,7 +461,7 @@ values are the partial-result aggregation given by the Zed expression.
 > aggregations that they will use ahead of time, e.g., beacon analysis
 > of network security logs.
 
-### Vacuum Support
+## Vacuum Support
 
 While data objects currently can be deleted from a lake, the underlying data
 is retained to support time travel.
@@ -469,7 +469,7 @@ is retained to support time travel.
 The system must also support purging of old data so that retention policies
 can be implemented.
 
-This could be supoprted with the DANGER-ZONE command `zed vacuum`
+This could be supported with the DANGER-ZONE command `zed vacuum`
 (implementation tracked in [zed/2545](https://github.com/brimdata/zed/issues/2545)).
 The commits still appear in the log but scans at any time-travel point
 where the commit is present will fail to scan the deleted data.


### PR DESCRIPTION
Ths doc adds the zed command README and factors out the design
discussion as design notes in an unlinked markdown doc design.md.

This needs quite a bit more work to add detail, document all the
options, and make the presentation more uniform but we will get to
this in our next big chunk of work on the lake.
