### PR TITLE
fix Zed union bug in zio/jsonio.Writer

### DIFF
--- a/zio/jsonio/marshal.go
+++ b/zio/jsonio/marshal.go
@@ -51,7 +51,7 @@ func marshalAny(typ zed.Type, bytes zcode.Bytes) interface{} {
 	case *zed.TypeMap:
 		return marshalMap(typ, bytes)
 	case *zed.TypeUnion:
-		return marshalUnion(typ, bytes)
+		return marshalAny(typ.SplitZNG(bytes))
 	case *zed.TypeEnum:
 		return marshalEnum(typ, bytes)
 	case *zed.TypeError:
@@ -132,16 +132,6 @@ func marshalMap(typ *zed.TypeMap, bytes zcode.Bytes) interface{} {
 		entries = append(entries, Entry{key, val})
 	}
 	return entries
-}
-
-func marshalUnion(typ *zed.TypeUnion, bytes zcode.Bytes) interface{} {
-	it := bytes.Iter()
-	selector := int(zed.DecodeUint(it.Next()))
-	inner, err := typ.Type(selector)
-	if err != nil {
-		return err
-	}
-	return marshalAny(inner, it.Next())
 }
 
 func marshalEnum(typ *zed.TypeEnum, bytes zcode.Bytes) interface{} {

--- a/zio/jsonio/ztests/union-output.yaml
+++ b/zio/jsonio/ztests/union-output.yaml
@@ -1,0 +1,11 @@
+zed: '*'
+
+input: |
+  1((int64,string))
+  "one"((int64,string))
+
+output-flags: -f json
+
+output: |
+  1
+  "one"


### PR DESCRIPTION
zio/jsonio.marshalUnion decodes a Zed union selector as a uvarint, but
it's actually a varint.  Fix by using zed.TypeUnion.SplitZNG for
decoding.