### PR TITLE
add -j flag to zed and zq as a shortcut for -f json

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -24,6 +24,7 @@ type Flags struct {
 	split         string
 	outputFile    string
 	forceBinary   bool
+	jsonShortcut  bool
 	zsonShortcut  bool
 	zsonPretty    bool
 	zsonPersist   string
@@ -68,6 +69,7 @@ func (f *Flags) SetFormatFlags(fs *flag.FlagSet) {
 		f.DefaultFormat = "zng"
 	}
 	fs.StringVar(&f.Format, "f", f.DefaultFormat, "format for output data [zng,zst,json,parquet,table,text,csv,lake,zeek,zjson,zson]")
+	fs.BoolVar(&f.jsonShortcut, "j", false, "use line-oriented JSON output independent of -f option")
 	fs.BoolVar(&f.zsonShortcut, "z", false, "use line-oriented zson output independent of -f option")
 	fs.BoolVar(&f.zsonPretty, "Z", false, "use formatted zson output independent of -f option")
 	fs.BoolVar(&f.forceBinary, "B", false, "allow binary zng be sent to a terminal output")
@@ -81,7 +83,12 @@ func (f *Flags) Init() error {
 		}
 		f.ZSON.Persist = re
 	}
-	if f.zsonShortcut || f.zsonPretty {
+	if f.jsonShortcut {
+		if f.Format != f.DefaultFormat || f.zsonShortcut || f.zsonPretty {
+			return errors.New("cannot use -j with -f, -z, or -Z")
+		}
+		f.Format = "json"
+	} else if f.zsonShortcut || f.zsonPretty {
 		if f.Format != f.DefaultFormat {
 			return errors.New("cannot use -z or -Z with -f")
 		}

--- a/cmd/zq/ztests/j-flag.yaml
+++ b/cmd/zq/ztests/j-flag.yaml
@@ -1,0 +1,20 @@
+script: |
+  zq -j in.zson
+  ! zq -j -f zson in.zson
+  ! zq -j -z in.zson
+  ! zq -j -Z in.zson
+
+inputs:
+  - name: in.zson
+    data: |
+      {a:1}
+
+outputs:
+  - name: stdout
+    data: |
+      {"a":1}
+  - name: stderr
+    data: |
+      cannot use -j with -f, -z, or -Z
+      cannot use -j with -f, -z, or -Z
+      cannot use -j with -f, -z, or -Z

--- a/docs/zq/README.md
+++ b/docs/zq/README.md
@@ -204,6 +204,9 @@ Since ZSON is a common format choice, the `-z` flag is a shortcut for
 `-f zson.`  Also, `-Z` is a shortcut for `-f zson` with `-pretty 4` as
 described below.
 
+And since JSON is another common format choice, the `-j` flag is a shortcut for
+`-f json.`
+
 ### 3.1 Output Format Selection
 
 When the format is not specified with `-f`, it defaults to ZSON if the output


### PR DESCRIPTION
Our plan was to make `-j` a shortcut for `-i json -f json`, but paring it back to just `-f json` made both the implementation (given the separation between `cli/inputflags` and `cli/outputflags`) and documentation easier. But if anyone feels strongly about it, I can add `-i json` either here or in another PR.