### PR TITLE
align Zed map type value syntax with ZSON

### DIFF
--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -10837,12 +10837,12 @@ function peg$parse(input, options) {
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c101;
+                  if (input.charCodeAt(peg$currPos) === 58) {
+                    s5 = peg$c53;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c54); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -8393,7 +8393,7 @@ var g = &grammar{
 								},
 								&litMatcher{
 									pos:        position{line: 1047, col: 29, offset: 29686},
-									val:        ",",
+									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -10969,12 +10969,12 @@ function peg$parse(input, options) {
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c101;
+                  if (input.charCodeAt(peg$currPos) === 58) {
+                    s5 = peg$c53;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c54); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -1044,7 +1044,7 @@ ComplexType
   / "|[" __  typ:Type __ "]|" {
       RETURN(MAP("kind":"TypeSet", "type":typ))
     }
-  / "|{" __ keyType:Type __ "," __ valType:Type __ "}|" {
+  / "|{" __ keyType:Type __ ":" __ valType:Type __ "}|" {
       RETURN(MAP("kind":"TypeMap", "key_type":keyType, "val_type": valType))
     }
 

--- a/compiler/parser/ztests/complex-type.yaml
+++ b/compiler/parser/ztests/complex-type.yaml
@@ -1,0 +1,13 @@
+script: |
+  zc -C 'yield <{a:int64}>'
+  zc -C 'yield <[int64]>'
+  zc -C 'yield <|[int64]|>'
+  zc -C 'yield <|{int64:string}|>'
+
+outputs:
+  - name: stdout
+    data: |
+      yield <{a:int64}>
+      yield <[int64]>
+      yield <|[int64]|>
+      yield <|{int64:string}|>


### PR DESCRIPTION
Zed type value is <|{keyType,valType}|>.  Change it to
<|{keyType:valType}|> to match ZSON.