### PR TITLE
move formats bullet in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,12 @@
 
 The Zed documentation is organized as follows:
 
-* [formats](formats/README.md) - the Zed data model and serialization formats
-of Zed data
 * [zq](zq/README.md) - the `zq` command-line tool and Zed query language
 * [zed](zed/README.md) - the `zed` command-line tool for managing Zed data lakes and the
 API for interacting with a Zed lake
 * [tutorials](tutorials) - tutorials on Zed
+* [formats](formats/README.md) - the Zed data model and serialization formats
+of Zed data
 
 ## Terminology
 

--- a/docs/tutorials/zq-primer.md
+++ b/docs/tutorials/zq-primer.md
@@ -433,13 +433,13 @@ produces
 But more powerfully, types can be used anywhere a value can be used and
 in particular, they can be group-by keys, e.g.,
 ```mdtest-command
-echo '{x:1,y:2}{s:"foo"}{x:3,y:4}' | zq -f table "count() by shape:=typeof(this)" -
+echo '{x:1,y:2}{s:"foo"}{x:3,y:4}' | zq -f table "count() by shape:=typeof(this) | sort count" -
 ```
 produces
 ```mdtest-output
 shape               count
-<{x:int64,y:int64}> 2
 <{s:string}>        1
+<{x:int64,y:int64}> 2
 ```
 When run over large data sets, this gives you an insightful count of
 each "shape" of data in the input.  This is a powerful building block for


### PR DESCRIPTION
This commit moves the formats bullet in docs/README.md to last
position so the bullets are new aligned in priority order for
a new user seeking docs on the system.