### PR TITLE
Fix markdown lint issues

### DIFF
--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -315,7 +315,7 @@ A named type is encoded as follows:
 ```
 where `<name>` is an identifier representing the new type name with a new type ID
 allocated as the next available type ID in the stream that refers to the
-existing type ID `<type-id>.  `<type-id> is encoded as a `uvarint` and `<name>`
+existing type ID `<type-id>`.  `<type-id>` is encoded as a `uvarint` and `<name>`
 is encoded as a `uvarint` representing the length of the name in bytes,
 followed by that many bytes of UTF-8 string.
 

--- a/docs/zed/api.md
+++ b/docs/zed/api.md
@@ -125,7 +125,7 @@ POST /pool/{pool}/branch/{branch}/delete
 | Name | Type | In | Description |
 | ---- | ---- | -- | ----------- |
 | pool | string | path | ID of the pool. |
-| object_ids | `array<string>` | body | Commit IDs or object IDs to be deleted. |
+| object_ids | [string] | body | Commit IDs or object IDs to be deleted. |
 
 #### Merge Branches
 

--- a/docs/zed/api.md
+++ b/docs/zed/api.md
@@ -45,7 +45,7 @@ POST /pool
 | ---- | ---- | -- | ----------- |
 | name | string | body | **Required.** Name of the pool. Must be unique to lake. |
 | layout.order | string | body | Order of value storage in pool. Possible values: desc, asc. Default: asc. |
-| layout.keys | array<string> | body | Primary key(s) of pool. Default: ts. |
+| layout.keys | `array<string>` | body | Primary key(s) of pool. Default: ts. |
 | thresh | int | body | The size in bytes of each seek index. |
 
 #### Rename pool
@@ -125,7 +125,7 @@ POST /pool/{pool}/branch/{branch}/delete
 | Name | Type | In | Description |
 | ---- | ---- | -- | ----------- |
 | pool | string | path | ID of the pool. |
-| object_ids | array<string> | body | Commit IDs or object IDs to be deleted. |
+| object_ids | `array<string>` | body | Commit IDs or object IDs to be deleted. |
 
 #### Merge Branches
 

--- a/docs/zed/api.md
+++ b/docs/zed/api.md
@@ -45,7 +45,7 @@ POST /pool
 | ---- | ---- | -- | ----------- |
 | name | string | body | **Required.** Name of the pool. Must be unique to lake. |
 | layout.order | string | body | Order of value storage in pool. Possible values: desc, asc. Default: asc. |
-| layout.keys | `array<string>` | body | Primary key(s) of pool. Default: ts. |
+| layout.keys | [string] | body | Primary key(s) of pool. Default: ts. |
 | thresh | int | body | The size in bytes of each seek index. |
 
 #### Rename pool

--- a/docs/zq/operators/put.md
+++ b/docs/zq/operators/put.md
@@ -25,7 +25,7 @@ to re-use a computed result, this can be done by chaining multiple `put` operato
 The "put" keyword is optional since it is an
 [implied operators](../language.md#implied-operators).
 
-Each <field> expression must be a field reference expressed as a dotted path or one more
+Each `<field>` expression must be a field reference expressed as a dotted path or one more
 constant index operations on `this`, e.g., `a.b`, `this["a"]["b"]`,
 etc.
 

--- a/docs/zq/operators/rename.md
+++ b/docs/zq/operators/rename.md
@@ -15,7 +15,7 @@ exist, there is no effect and the input is copied to the output.
 
 Non-record inputs are copied to the output without modification.
 
-Each <field> must be a field reference as a dotted path and the old name
+Each `<field>` must be a field reference as a dotted path and the old name
 and new name must refer to the same record in the case of nested records.
 That is, the dotted path prefix before the final field name must be the
 same on the left- and right-hand sides.  To perform more sophisticated


### PR DESCRIPTION
Uses of <> must be either escaped or wrapped in code markdown otherwise
docusaurus throws an error while parsing.