### PR TITLE
Add markdown lint make rule

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,7 +9,7 @@ on:
       - '**.md'
 
 jobs:
-  markdown-link-check:
+  markdown-link:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -29,6 +29,6 @@ jobs:
         slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_DOCS }}
         slack_json: |
           {
-            "username": "markdown-link-check",
+            "username": "markdown-link",
             "text": "Markdown link check failed: https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}"
           }

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,4 +1,4 @@
-name: Markdown link check
+name: Markdown lint
 
 on:
   schedule:
@@ -16,6 +16,8 @@ jobs:
     - name: Extract branch name
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       id: extract_branch
+    - name: Lint
+      run: make markdown-lint
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: .github/workflows/markdown-link-check-config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 /bin/
 /compiler/parser/deps/
 /dist/
-/zed-sample-data/
 /node_modules/
+/zed-sample-data/
 
 .idea
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /compiler/parser/deps/
 /dist/
 /zed-sample-data/
+/node_modules/
 
 .idea
 .DS_Store

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,13 @@
+default: false
+
+# Tags
+spelling: true
+indentation: false
+links: true
+whitespace: true
+html: true
+
+# Individual tweaks
+MD010:
+  code_blocks: false # Disallow hard tabs except in code blocks.
+MD028: false # Allow blank lines between blockquotes.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,11 +1,11 @@
 default: false
 
 # Tags
-spelling: true
+html: true
 indentation: false
 links: true
+spelling: true
 whitespace: true
-html: true
 
 # Individual tweaks
 MD010:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -10,4 +10,3 @@ whitespace: true
 # Individual tweaks
 MD010:
   code_blocks: false # Disallow hard tabs except in code blocks.
-MD028: false # Allow blank lines between blockquotes.

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,11 @@ peg: $(PEG_GEN)
 peg-run: $(PEG_GEN)
 	go run ./cmd/zc -repl
 
+.PHONY: markdown-lint
+markdown-lint:
+	@npm install --no-save markdownlint-cli
+	@npx markdownlint docs
+
 # CI performs these actions individually since that looks nicer in the UI;
 # this is a shortcut so that a local dev can easily run everything.
 test-ci: fmt tidy vet test-generate test-unit test-system test-heavy

--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -260,7 +260,6 @@ followed by the type code of the value.
 ```
 Each `<type-id>` is encoded as `uvarint`.
 
-
 #### 2.1.5 Union Typedef
 
 A union typedef creates a new type ID equal to the next stream type ID
@@ -503,7 +502,6 @@ For each ZNG primitive type, the following table describes:
 
 All fixed-size multi-byte sequences representing machine words
 are serialized in little-endian format.
-
 
 | Type         | ID |    N     |       ZNG Value Interpretation                 |
 |--------------|---:|:--------:|------------------------------------------------|

--- a/docs/formats/zst.md
+++ b/docs/formats/zst.md
@@ -87,7 +87,7 @@ blobs of ZNG data.
 > (the "mice") to perform well amongst high-volume record types (the "elephants"),
 > i.e., there are not a bunch of seeks with tiny reads of mice data interspersed
 > throughout the elephants.
-
+>
 > TBD: The mice/elephants model creates an interesting and challenging layout
 > problem.  If you let the row indexes get too far apart (call this "skew"), then
 > you have to buffer very large amounts of data to keep the column data aligned.
@@ -108,7 +108,7 @@ independently of each other, similar to ZNG compression framing.
 > TBD: use the
 > [same compression format](zng.md#312-compressed-value-message-block)
 > exactly?
-
+>
 > The intent here is that segments are sized so that sequential read access
 > performs well (e.g., 5MB) while frames are comparatively smaller (say 32KB)
 > so that they can be decompressed and processed in a multi-threaded fashion where
@@ -126,7 +126,7 @@ from column streams, i.e., to map columns back to composite values.
 > to be read and searched efficiently without ever needing to reconstruct
 > the original rows.  How performant this is all done is up to any particular
 > ZST implementation.
-
+>
 > Also, the reassembly section is in generally vastly smaller than the data section
 > so the goal here isn't to express information in cute and obscure compact forms
 > but rather to represent data in easy-to-digest, programmer-friendly form that

--- a/docs/tutorials/lake.md
+++ b/docs/tutorials/lake.md
@@ -431,7 +431,6 @@ zed map id.orig_h=10.47.6.173 | zq -f text "sum(resp_bytes)" -
 ```
 and you will get the same answer.
 
-
 ## Map-reduce
 
 What's really going on here is map-reduce style computation on your log archives

--- a/docs/tutorials/zed-primer.md
+++ b/docs/tutorials/zed-primer.md
@@ -54,7 +54,6 @@ pool created: prs <unique pool ID>
 
 Using `zed ls` we can view all the pools in the lake:
 
-
 ```bash
 $ zed ls
 ```

--- a/docs/zed/api.md
+++ b/docs/zed/api.md
@@ -26,7 +26,6 @@
     - [Delete Index Rule](#delete-index-rule)
 * [Media Types](#media-types)
 
-
 ## Endpoints
 
 ### Pools
@@ -113,7 +112,7 @@ DELETE /pool/{pool}/branch/{branch}
 
 #### Delete Data
 
-Takes a list of commit IDs or object IDs in a branch and creates a deletion 
+Takes a list of commit IDs or object IDs in a branch and creates a deletion
 commit of all referenced objects.
 
 ```
@@ -238,4 +237,3 @@ The supported mime types are as follows:
 | zjson | application/x-zjson |
 | zson | application/x-zson |
 | zng | application/x-zng |
-

--- a/docs/zed/design.md
+++ b/docs/zed/design.md
@@ -306,7 +306,7 @@ data during any key-range scan.
 > amplification that occurs for a given workload.  There is an explicit
 > tradeoff here between overhead of merging overlapping objects on read
 > and LSM write amplification to organize the data to avoid such overlaps.
-
+>
 > Note: we are showing here manual, CLI-driven steps to accomplish these tasks
 > but a live data pipeline would automate all of this with orchestration that
 > performs these functions via a service API, i.e., the same service API

--- a/docs/zed/design.md
+++ b/docs/zed/design.md
@@ -312,7 +312,6 @@ data during any key-range scan.
 > performs these functions via a service API, i.e., the same service API
 > used by the CLI operators.
 
-
 ### Object Naming
 
 ```

--- a/docs/zq/functions/has_error.md
+++ b/docs/zq/functions/has_error.md
@@ -10,7 +10,7 @@ has_error(val: any) -> bool
 ### Description
 
 The _has_error_ function returns true if its argument is or contains an error.
-_has_error_ is different from _is_error_ in that _has_error_ will recurse 
+_has_error_ is different from _is_error_ in that _has_error_ will recurse
 into value's leaves to determine if there is an error in the value.
 
 ### Examples

--- a/docs/zq/functions/len.md
+++ b/docs/zq/functions/len.md
@@ -24,7 +24,6 @@ Supported types include:
 - net
 - type
 
-
 #### Example:
 
 Take the length of various types:

--- a/docs/zq/functions/parse_zson.md
+++ b/docs/zq/functions/parse_zson.md
@@ -13,7 +13,6 @@ The _parse_zson_ function parses the `s` argument that must be in the form
 of ZSON into a Zed value of any type.  This is analogous to JavaScript's
 `JSON.parse()` function.
 
-
 ### Examples
 
 ```mdtest-command

--- a/docs/zq/functions/replace.md
+++ b/docs/zq/functions/replace.md
@@ -12,7 +12,6 @@ replace(s: string, old: string, new: string) -> string
 The _replace_ function substitutes all instances of the string `old`
 that occur in string `s` with the string `new`.
 
-
 #### Example:
 
 ```mdtest-command

--- a/docs/zq/functions/round.md
+++ b/docs/zq/functions/round.md
@@ -8,8 +8,6 @@
 round(val: number) -> number
 ```
 ### Description
-`
-`round`
 
 The _round_ function returns the number `val` rounded to the nearest integer value.
 which must be a numeric type.  The return type retains the type of the argument.

--- a/docs/zq/language.md
+++ b/docs/zq/language.md
@@ -347,7 +347,6 @@ This style of "assignment" to a record value is distinguished from the `=`
 token which binds a locally scoped name to a value that can be referenced
 in later expressions.
 
-
 ### 2.6 Implied Operators
 
 When Zed is run in an application like [Brim](https://github.com/brimdata/brim),

--- a/docs/zq/operators/over.md
+++ b/docs/zq/operators/over.md
@@ -52,7 +52,6 @@ to variables that may be referenced by name in the lateral scope.
 Lateral queries may be nested to arbitrary depth and accesses to variables
 in parent lateral query bodies follows lexical scoping.
 
-
 ### Examples
 
 _Over evaluates each expression and emits it_

--- a/docs/zq/operators/put.md
+++ b/docs/zq/operators/put.md
@@ -59,7 +59,7 @@ echo '{a:1,b:2}' | zq -z 'c:=3' -
 ```mdtest-output
 {a:1,b:2,c:3}
 ```
-_A _put_ operation can also be done with a record literal_
+_A `put` operation can also be done with a record literal_
 ```mdtest-command
 echo '{a:1,b:2}' | zq -z 'yield {...this, c:3}' -
 ```

--- a/docs/zq/operators/summarize.md
+++ b/docs/zq/operators/summarize.md
@@ -32,7 +32,6 @@ and the results merged into final results using an external merge sort.
 The same mechanism that spills to storage can also spill across the network
 to a cluster of workers in an adaptive shuffle, though this is not yet implemented.
 
-
 ### Examples
 
 Sum the input sequence:


### PR DESCRIPTION
Add (light) markdown linting from
https://github.com/igorshubovych/markdownlint-cli. Adjust github
workflow so this is run when markdown files are editted.