### PR TITLE
remove let proc and as clause from over

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -296,7 +296,6 @@ type (
 	Over struct {
 		Kind  string      `json:"kind" unpack:""`
 		Exprs []Expr      `json:"exprs"`
-		As    string      `json:"as"`
 		Scope *Sequential `json:"scope"`
 	}
 	Let struct {

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -159,6 +159,7 @@ function peg$parse(input, options) {
               
             "expr":{"kind":"TypeValue","value":{"kind":"TypeDef","name":id,"type":typ}}}
           
+
           },
       peg$c14 = "fork",
       peg$c15 = peg$literalExpectation("fork", false),
@@ -577,41 +578,30 @@ function peg$parse(input, options) {
       peg$c251 = function(expr) {
       	  return {"kind":"Merge", "expr":expr}
           },
-      peg$c252 = function(over) {
-            return {"kind":"Let", "locals":null, "over":over}
+      peg$c252 = "over",
+      peg$c253 = peg$literalExpectation("over", false),
+      peg$c254 = function(exprs, locals, scope) {
+            return {"kind":"Let", "locals":locals, "over":{"kind":"Over", "exprs":exprs, "scope":scope}}
           },
-      peg$c253 = "over",
-      peg$c254 = peg$literalExpectation("over", false),
-      peg$c255 = function(exprs) {
-            return {"kind":"Over", "exprs":exprs, "scope":null, "as":""}
+      peg$c255 = function(exprs, scope) {
+            return {"kind":"Over", "exprs":exprs, "scope":scope}
           },
-      peg$c256 = function(exprs, as, scope) {
-            return {"kind":"Over", "exprs":exprs, "scope":scope, "as":as}
+      peg$c256 = function(exprs) {
+            return {"kind":"Over", "exprs":exprs, "scope":null}
           },
-      peg$c257 = function(exprs, locals, scope) {
-            return {"kind":"Let", "locals":locals, "over":{"kind":"Over", "exprs":exprs, "scope":scope, "as":""}}
-          },
-      peg$c258 = "as",
-      peg$c259 = peg$literalExpectation("as", false),
-      peg$c260 = function() { return "" },
-      peg$c261 = "let",
-      peg$c262 = peg$literalExpectation("let", false),
-      peg$c263 = function(locals, over) {
-            return {"kind":"Let", "locals":locals, "over":over}
-          },
-      peg$c264 = function(seq) { return seq },
-      peg$c265 = function(first, a) { return a },
-      peg$c266 = function(id) {
+      peg$c257 = function(seq) { return seq },
+      peg$c258 = function(first, a) { return a },
+      peg$c259 = function(id) {
             return {"name":id, "expr":{"kind":"ID","name":id}}
           },
-      peg$c267 = "yield",
-      peg$c268 = peg$literalExpectation("yield", false),
-      peg$c269 = function(exprs) {
+      peg$c260 = "yield",
+      peg$c261 = peg$literalExpectation("yield", false),
+      peg$c262 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c270 = function(typ) { return typ},
-      peg$c271 = function(lhs) { return lhs },
-      peg$c273 = function(first, rest) {
+      peg$c263 = function(typ) { return typ},
+      peg$c264 = function(lhs) { return lhs },
+      peg$c266 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -620,119 +610,119 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c274 = function(first, rest) {
+      peg$c267 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c275 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c276 = "?",
-      peg$c277 = peg$literalExpectation("?", false),
-      peg$c278 = function(condition, thenClause, elseClause) {
+      peg$c268 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c269 = "?",
+      peg$c270 = peg$literalExpectation("?", false),
+      peg$c271 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c279 = function(first, op, expr) { return [op, expr] },
-      peg$c280 = function(first, rest) {
+      peg$c272 = function(first, op, expr) { return [op, expr] },
+      peg$c273 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c281 = function(lhs, op, rhs) {
+      peg$c274 = function(lhs, op, rhs) {
               return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c282 = function(lhs, rhs) {
+      peg$c275 = function(lhs, rhs) {
               return {"kind": "BinaryExpr", "op": "~", "lhs": lhs, "rhs": rhs}
           },
-      peg$c283 = "+",
-      peg$c284 = peg$literalExpectation("+", false),
-      peg$c285 = "-",
-      peg$c286 = peg$literalExpectation("-", false),
-      peg$c287 = "/",
-      peg$c288 = peg$literalExpectation("/", false),
-      peg$c289 = "%",
-      peg$c290 = peg$literalExpectation("%", false),
-      peg$c291 = function(e) {
+      peg$c276 = "+",
+      peg$c277 = peg$literalExpectation("+", false),
+      peg$c278 = "-",
+      peg$c279 = peg$literalExpectation("-", false),
+      peg$c280 = "/",
+      peg$c281 = peg$literalExpectation("/", false),
+      peg$c282 = "%",
+      peg$c283 = peg$literalExpectation("%", false),
+      peg$c284 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c292 = function(e) {
+      peg$c285 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c293 = "not",
-      peg$c294 = peg$literalExpectation("not", false),
-      peg$c295 = "select",
-      peg$c296 = peg$literalExpectation("select", false),
-      peg$c297 = function(typ, expr) {
+      peg$c286 = "not",
+      peg$c287 = peg$literalExpectation("not", false),
+      peg$c288 = "select",
+      peg$c289 = peg$literalExpectation("select", false),
+      peg$c290 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c298 = function(fn, args, where) {
+      peg$c291 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c299 = "grep",
-      peg$c300 = peg$literalExpectation("grep", false),
-      peg$c301 = function(pattern) {
+      peg$c292 = "grep",
+      peg$c293 = peg$literalExpectation("grep", false),
+      peg$c294 = function(pattern) {
             return {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
           },
-      peg$c302 = function(pattern, expr) {
+      peg$c295 = function(pattern, expr) {
             return {"kind": "Grep", "pattern": pattern, "expr": expr}
           },
-      peg$c303 = function(s) {
+      peg$c296 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c304 = function(first, e) { return e },
-      peg$c305 = "]",
-      peg$c306 = peg$literalExpectation("]", false),
-      peg$c307 = function(from, to) {
+      peg$c297 = function(first, e) { return e },
+      peg$c298 = "]",
+      peg$c299 = peg$literalExpectation("]", false),
+      peg$c300 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c308 = function(to) {
+      peg$c301 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c309 = function(from) {
+      peg$c302 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c310 = function(expr) { return ["[", expr] },
-      peg$c311 = function(id) { return [".", id] },
-      peg$c312 = "}",
-      peg$c313 = peg$literalExpectation("}", false),
-      peg$c314 = function(elems) {
+      peg$c303 = function(expr) { return ["[", expr] },
+      peg$c304 = function(id) { return [".", id] },
+      peg$c305 = "}",
+      peg$c306 = peg$literalExpectation("}", false),
+      peg$c307 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c315 = function(elem) { return elem },
-      peg$c316 = "...",
-      peg$c317 = peg$literalExpectation("...", false),
-      peg$c318 = function(expr) {
+      peg$c308 = function(elem) { return elem },
+      peg$c309 = "...",
+      peg$c310 = peg$literalExpectation("...", false),
+      peg$c311 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c319 = function(name, value) {
+      peg$c312 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c320 = function(exprs) {
+      peg$c313 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c321 = "|[",
-      peg$c322 = peg$literalExpectation("|[", false),
-      peg$c323 = "]|",
-      peg$c324 = peg$literalExpectation("]|", false),
-      peg$c325 = function(exprs) {
+      peg$c314 = "|[",
+      peg$c315 = peg$literalExpectation("|[", false),
+      peg$c316 = "]|",
+      peg$c317 = peg$literalExpectation("]|", false),
+      peg$c318 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c326 = "|{",
-      peg$c327 = peg$literalExpectation("|{", false),
-      peg$c328 = "}|",
-      peg$c329 = peg$literalExpectation("}|", false),
-      peg$c330 = function(exprs) {
+      peg$c319 = "|{",
+      peg$c320 = peg$literalExpectation("|{", false),
+      peg$c321 = "}|",
+      peg$c322 = peg$literalExpectation("}|", false),
+      peg$c323 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c331 = function(e) { return e },
-      peg$c332 = function(key, value) {
+      peg$c324 = function(e) { return e },
+      peg$c325 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c333 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c326 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -754,13 +744,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c334 = function(assignments) { return assignments },
-      peg$c335 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c336 = function(table, alias) {
+      peg$c327 = function(assignments) { return assignments },
+      peg$c328 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c329 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c337 = function(first, join) { return join },
-      peg$c338 = function(style, table, alias, leftKey, rightKey) {
+      peg$c330 = function(first, join) { return join },
+      peg$c331 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -773,117 +763,122 @@ function peg$parse(input, options) {
               
             "alias": alias}
           
+
+
+
+
           },
-      peg$c339 = function(style) { return style },
-      peg$c340 = function(keys, order) {
+      peg$c332 = function(style) { return style },
+      peg$c333 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c341 = function(dir) { return dir },
-      peg$c342 = function(count) { return count },
-      peg$c343 = peg$literalExpectation("select", true),
-      peg$c344 = function() { return "select" },
-      peg$c345 = peg$literalExpectation("as", true),
-      peg$c346 = function() { return "as" },
-      peg$c347 = peg$literalExpectation("from", true),
-      peg$c348 = function() { return "from" },
-      peg$c349 = peg$literalExpectation("join", true),
-      peg$c350 = function() { return "join" },
-      peg$c351 = peg$literalExpectation("where", true),
-      peg$c352 = function() { return "where" },
-      peg$c353 = "group",
-      peg$c354 = peg$literalExpectation("group", true),
-      peg$c355 = function() { return "group" },
-      peg$c356 = "by",
-      peg$c357 = peg$literalExpectation("by", true),
-      peg$c358 = function() { return "by" },
-      peg$c359 = "having",
-      peg$c360 = peg$literalExpectation("having", true),
-      peg$c361 = function() { return "having" },
-      peg$c362 = peg$literalExpectation("order", true),
-      peg$c363 = function() { return "order" },
-      peg$c364 = "on",
-      peg$c365 = peg$literalExpectation("on", true),
-      peg$c366 = function() { return "on" },
-      peg$c367 = "limit",
-      peg$c368 = peg$literalExpectation("limit", true),
-      peg$c369 = function() { return "limit" },
-      peg$c370 = peg$literalExpectation("asc", true),
-      peg$c371 = peg$literalExpectation("desc", true),
-      peg$c372 = peg$literalExpectation("anti", true),
-      peg$c373 = peg$literalExpectation("left", true),
-      peg$c374 = peg$literalExpectation("right", true),
-      peg$c375 = peg$literalExpectation("inner", true),
-      peg$c376 = function(v) {
+      peg$c334 = function(dir) { return dir },
+      peg$c335 = function(count) { return count },
+      peg$c336 = peg$literalExpectation("select", true),
+      peg$c337 = function() { return "select" },
+      peg$c338 = "as",
+      peg$c339 = peg$literalExpectation("as", true),
+      peg$c340 = function() { return "as" },
+      peg$c341 = peg$literalExpectation("from", true),
+      peg$c342 = function() { return "from" },
+      peg$c343 = peg$literalExpectation("join", true),
+      peg$c344 = function() { return "join" },
+      peg$c345 = peg$literalExpectation("where", true),
+      peg$c346 = function() { return "where" },
+      peg$c347 = "group",
+      peg$c348 = peg$literalExpectation("group", true),
+      peg$c349 = function() { return "group" },
+      peg$c350 = "by",
+      peg$c351 = peg$literalExpectation("by", true),
+      peg$c352 = function() { return "by" },
+      peg$c353 = "having",
+      peg$c354 = peg$literalExpectation("having", true),
+      peg$c355 = function() { return "having" },
+      peg$c356 = peg$literalExpectation("order", true),
+      peg$c357 = function() { return "order" },
+      peg$c358 = "on",
+      peg$c359 = peg$literalExpectation("on", true),
+      peg$c360 = function() { return "on" },
+      peg$c361 = "limit",
+      peg$c362 = peg$literalExpectation("limit", true),
+      peg$c363 = function() { return "limit" },
+      peg$c364 = peg$literalExpectation("asc", true),
+      peg$c365 = peg$literalExpectation("desc", true),
+      peg$c366 = peg$literalExpectation("anti", true),
+      peg$c367 = peg$literalExpectation("left", true),
+      peg$c368 = peg$literalExpectation("right", true),
+      peg$c369 = peg$literalExpectation("inner", true),
+      peg$c370 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c377 = function(v) {
+      peg$c371 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c378 = function(v) {
+      peg$c372 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c379 = function(v) {
+      peg$c373 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c380 = "true",
-      peg$c381 = peg$literalExpectation("true", false),
-      peg$c382 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c383 = "false",
-      peg$c384 = peg$literalExpectation("false", false),
-      peg$c385 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c386 = "null",
-      peg$c387 = peg$literalExpectation("null", false),
-      peg$c388 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c389 = "0x",
-      peg$c390 = peg$literalExpectation("0x", false),
-      peg$c391 = function() {
+      peg$c374 = "true",
+      peg$c375 = peg$literalExpectation("true", false),
+      peg$c376 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c377 = "false",
+      peg$c378 = peg$literalExpectation("false", false),
+      peg$c379 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c380 = "null",
+      peg$c381 = peg$literalExpectation("null", false),
+      peg$c382 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c383 = "0x",
+      peg$c384 = peg$literalExpectation("0x", false),
+      peg$c385 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c392 = function(typ) {
+      peg$c386 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c393 = function(name) { return name },
-      peg$c394 = function(name, typ) {
+      peg$c387 = function(name) { return name },
+      peg$c388 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c395 = function(name) {
+      peg$c389 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c396 = function(u) { return u },
-      peg$c397 = function(types) {
+      peg$c390 = function(u) { return u },
+      peg$c391 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c398 = function(typ) { return typ },
-      peg$c399 = function(fields) {
+      peg$c392 = function(typ) { return typ },
+      peg$c393 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c400 = function(typ) {
+      peg$c394 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c401 = function(typ) {
+      peg$c395 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c402 = function(keyType, valType) {
+      peg$c396 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c403 = function(v) {
+      peg$c397 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c404 = "\"",
-      peg$c405 = peg$literalExpectation("\"", false),
-      peg$c406 = "'",
-      peg$c407 = peg$literalExpectation("'", false),
-      peg$c408 = function(v) {
+      peg$c398 = "\"",
+      peg$c399 = peg$literalExpectation("\"", false),
+      peg$c400 = "'",
+      peg$c401 = peg$literalExpectation("'", false),
+      peg$c402 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c409 = "\\",
-      peg$c410 = peg$literalExpectation("\\", false),
-      peg$c411 = "${",
-      peg$c412 = peg$literalExpectation("${", false),
-      peg$c413 = function(e) { 
+      peg$c403 = "\\",
+      peg$c404 = peg$literalExpectation("\\", false),
+      peg$c405 = "${",
+      peg$c406 = peg$literalExpectation("${", false),
+      peg$c407 = function(e) {
             return {
               
             "kind": "Cast",
@@ -896,192 +891,196 @@ function peg$parse(input, options) {
                 
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
+
+
+
+
           },
-      peg$c414 = "uint8",
-      peg$c415 = peg$literalExpectation("uint8", false),
-      peg$c416 = "uint16",
-      peg$c417 = peg$literalExpectation("uint16", false),
-      peg$c418 = "uint32",
-      peg$c419 = peg$literalExpectation("uint32", false),
-      peg$c420 = "uint64",
-      peg$c421 = peg$literalExpectation("uint64", false),
-      peg$c422 = "int8",
-      peg$c423 = peg$literalExpectation("int8", false),
-      peg$c424 = "int16",
-      peg$c425 = peg$literalExpectation("int16", false),
-      peg$c426 = "int32",
-      peg$c427 = peg$literalExpectation("int32", false),
-      peg$c428 = "int64",
-      peg$c429 = peg$literalExpectation("int64", false),
-      peg$c430 = "float32",
-      peg$c431 = peg$literalExpectation("float32", false),
-      peg$c432 = "float64",
-      peg$c433 = peg$literalExpectation("float64", false),
-      peg$c434 = "bool",
-      peg$c435 = peg$literalExpectation("bool", false),
-      peg$c436 = "string",
-      peg$c437 = peg$literalExpectation("string", false),
-      peg$c438 = "duration",
-      peg$c439 = peg$literalExpectation("duration", false),
-      peg$c440 = "time",
-      peg$c441 = peg$literalExpectation("time", false),
-      peg$c442 = "bytes",
-      peg$c443 = peg$literalExpectation("bytes", false),
-      peg$c444 = "ip",
-      peg$c445 = peg$literalExpectation("ip", false),
-      peg$c446 = "net",
-      peg$c447 = peg$literalExpectation("net", false),
-      peg$c448 = function() {
+      peg$c408 = "uint8",
+      peg$c409 = peg$literalExpectation("uint8", false),
+      peg$c410 = "uint16",
+      peg$c411 = peg$literalExpectation("uint16", false),
+      peg$c412 = "uint32",
+      peg$c413 = peg$literalExpectation("uint32", false),
+      peg$c414 = "uint64",
+      peg$c415 = peg$literalExpectation("uint64", false),
+      peg$c416 = "int8",
+      peg$c417 = peg$literalExpectation("int8", false),
+      peg$c418 = "int16",
+      peg$c419 = peg$literalExpectation("int16", false),
+      peg$c420 = "int32",
+      peg$c421 = peg$literalExpectation("int32", false),
+      peg$c422 = "int64",
+      peg$c423 = peg$literalExpectation("int64", false),
+      peg$c424 = "float32",
+      peg$c425 = peg$literalExpectation("float32", false),
+      peg$c426 = "float64",
+      peg$c427 = peg$literalExpectation("float64", false),
+      peg$c428 = "bool",
+      peg$c429 = peg$literalExpectation("bool", false),
+      peg$c430 = "string",
+      peg$c431 = peg$literalExpectation("string", false),
+      peg$c432 = "duration",
+      peg$c433 = peg$literalExpectation("duration", false),
+      peg$c434 = "time",
+      peg$c435 = peg$literalExpectation("time", false),
+      peg$c436 = "bytes",
+      peg$c437 = peg$literalExpectation("bytes", false),
+      peg$c438 = "ip",
+      peg$c439 = peg$literalExpectation("ip", false),
+      peg$c440 = "net",
+      peg$c441 = peg$literalExpectation("net", false),
+      peg$c442 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c449 = function(name, typ) {
+      peg$c443 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c450 = "and",
-      peg$c451 = peg$literalExpectation("and", false),
-      peg$c452 = "AND",
-      peg$c453 = peg$literalExpectation("AND", false),
-      peg$c454 = function() { return "and" },
-      peg$c455 = "or",
-      peg$c456 = peg$literalExpectation("or", false),
-      peg$c457 = "OR",
-      peg$c458 = peg$literalExpectation("OR", false),
-      peg$c459 = function() { return "or" },
-      peg$c461 = "NOT",
-      peg$c462 = peg$literalExpectation("NOT", false),
-      peg$c463 = function() { return "not" },
-      peg$c464 = peg$literalExpectation("by", false),
-      peg$c465 = /^[A-Za-z_$]/,
-      peg$c466 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c467 = /^[0-9]/,
-      peg$c468 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c469 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c470 = "$",
-      peg$c471 = peg$literalExpectation("$", false),
-      peg$c472 = "T",
-      peg$c473 = peg$literalExpectation("T", false),
-      peg$c474 = function() {
+      peg$c444 = "and",
+      peg$c445 = peg$literalExpectation("and", false),
+      peg$c446 = "AND",
+      peg$c447 = peg$literalExpectation("AND", false),
+      peg$c448 = function() { return "and" },
+      peg$c449 = "or",
+      peg$c450 = peg$literalExpectation("or", false),
+      peg$c451 = "OR",
+      peg$c452 = peg$literalExpectation("OR", false),
+      peg$c453 = function() { return "or" },
+      peg$c455 = "NOT",
+      peg$c456 = peg$literalExpectation("NOT", false),
+      peg$c457 = function() { return "not" },
+      peg$c458 = peg$literalExpectation("by", false),
+      peg$c459 = /^[A-Za-z_$]/,
+      peg$c460 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c461 = /^[0-9]/,
+      peg$c462 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c463 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c464 = "$",
+      peg$c465 = peg$literalExpectation("$", false),
+      peg$c466 = "T",
+      peg$c467 = peg$literalExpectation("T", false),
+      peg$c468 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c475 = "Z",
-      peg$c476 = peg$literalExpectation("Z", false),
-      peg$c477 = function() {
+      peg$c469 = "Z",
+      peg$c470 = peg$literalExpectation("Z", false),
+      peg$c471 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c478 = "ns",
-      peg$c479 = peg$literalExpectation("ns", false),
-      peg$c480 = "us",
-      peg$c481 = peg$literalExpectation("us", false),
-      peg$c482 = "ms",
-      peg$c483 = peg$literalExpectation("ms", false),
-      peg$c484 = "s",
-      peg$c485 = peg$literalExpectation("s", false),
-      peg$c486 = "m",
-      peg$c487 = peg$literalExpectation("m", false),
-      peg$c488 = "h",
-      peg$c489 = peg$literalExpectation("h", false),
-      peg$c490 = "d",
-      peg$c491 = peg$literalExpectation("d", false),
-      peg$c492 = "w",
-      peg$c493 = peg$literalExpectation("w", false),
-      peg$c494 = "y",
-      peg$c495 = peg$literalExpectation("y", false),
-      peg$c496 = function(a, b) {
+      peg$c472 = "ns",
+      peg$c473 = peg$literalExpectation("ns", false),
+      peg$c474 = "us",
+      peg$c475 = peg$literalExpectation("us", false),
+      peg$c476 = "ms",
+      peg$c477 = peg$literalExpectation("ms", false),
+      peg$c478 = "s",
+      peg$c479 = peg$literalExpectation("s", false),
+      peg$c480 = "m",
+      peg$c481 = peg$literalExpectation("m", false),
+      peg$c482 = "h",
+      peg$c483 = peg$literalExpectation("h", false),
+      peg$c484 = "d",
+      peg$c485 = peg$literalExpectation("d", false),
+      peg$c486 = "w",
+      peg$c487 = peg$literalExpectation("w", false),
+      peg$c488 = "y",
+      peg$c489 = peg$literalExpectation("y", false),
+      peg$c490 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c497 = "::",
-      peg$c498 = peg$literalExpectation("::", false),
-      peg$c499 = function(a, b, d, e) {
+      peg$c491 = "::",
+      peg$c492 = peg$literalExpectation("::", false),
+      peg$c493 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c500 = function(a, b) {
+      peg$c494 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c501 = function(a, b) {
+      peg$c495 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c502 = function() {
+      peg$c496 = function() {
             return "::"
           },
-      peg$c503 = function(v) { return ":" + v },
-      peg$c504 = function(v) { return v + ":" },
-      peg$c505 = function(a, m) {
+      peg$c497 = function(v) { return ":" + v },
+      peg$c498 = function(v) { return v + ":" },
+      peg$c499 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c506 = function(a, m) {
+      peg$c500 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c507 = function(s) { return parseInt(s) },
-      peg$c508 = function() {
+      peg$c501 = function(s) { return parseInt(s) },
+      peg$c502 = function() {
             return text()
           },
-      peg$c509 = "e",
-      peg$c510 = peg$literalExpectation("e", true),
-      peg$c511 = /^[+\-]/,
-      peg$c512 = peg$classExpectation(["+", "-"], false, false),
-      peg$c513 = "NaN",
-      peg$c514 = peg$literalExpectation("NaN", false),
-      peg$c515 = "Inf",
-      peg$c516 = peg$literalExpectation("Inf", false),
-      peg$c517 = /^[0-9a-fA-F]/,
-      peg$c518 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c519 = function(v) { return joinChars(v) },
-      peg$c520 = peg$anyExpectation(),
-      peg$c521 = function(head, tail) { return head + joinChars(tail) },
-      peg$c522 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c523 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c524 = function(head, tail) {
+      peg$c503 = "e",
+      peg$c504 = peg$literalExpectation("e", true),
+      peg$c505 = /^[+\-]/,
+      peg$c506 = peg$classExpectation(["+", "-"], false, false),
+      peg$c507 = "NaN",
+      peg$c508 = peg$literalExpectation("NaN", false),
+      peg$c509 = "Inf",
+      peg$c510 = peg$literalExpectation("Inf", false),
+      peg$c511 = /^[0-9a-fA-F]/,
+      peg$c512 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c513 = function(v) { return joinChars(v) },
+      peg$c514 = peg$anyExpectation(),
+      peg$c515 = function(head, tail) { return head + joinChars(tail) },
+      peg$c516 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c517 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c518 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c525 = function() { return "*"},
-      peg$c526 = function() { return "=" },
-      peg$c527 = function() { return "\\*" },
-      peg$c528 = "b",
-      peg$c529 = peg$literalExpectation("b", false),
-      peg$c530 = function() { return "\b" },
-      peg$c531 = "f",
-      peg$c532 = peg$literalExpectation("f", false),
-      peg$c533 = function() { return "\f" },
-      peg$c534 = "n",
-      peg$c535 = peg$literalExpectation("n", false),
-      peg$c536 = function() { return "\n" },
-      peg$c537 = "r",
-      peg$c538 = peg$literalExpectation("r", false),
-      peg$c539 = function() { return "\r" },
-      peg$c540 = "t",
-      peg$c541 = peg$literalExpectation("t", false),
-      peg$c542 = function() { return "\t" },
-      peg$c543 = "v",
-      peg$c544 = peg$literalExpectation("v", false),
-      peg$c545 = function() { return "\v" },
-      peg$c546 = function() { return "*" },
-      peg$c547 = "u",
-      peg$c548 = peg$literalExpectation("u", false),
-      peg$c549 = function(chars) {
+      peg$c519 = function() { return "*"},
+      peg$c520 = function() { return "=" },
+      peg$c521 = function() { return "\\*" },
+      peg$c522 = "b",
+      peg$c523 = peg$literalExpectation("b", false),
+      peg$c524 = function() { return "\b" },
+      peg$c525 = "f",
+      peg$c526 = peg$literalExpectation("f", false),
+      peg$c527 = function() { return "\f" },
+      peg$c528 = "n",
+      peg$c529 = peg$literalExpectation("n", false),
+      peg$c530 = function() { return "\n" },
+      peg$c531 = "r",
+      peg$c532 = peg$literalExpectation("r", false),
+      peg$c533 = function() { return "\r" },
+      peg$c534 = "t",
+      peg$c535 = peg$literalExpectation("t", false),
+      peg$c536 = function() { return "\t" },
+      peg$c537 = "v",
+      peg$c538 = peg$literalExpectation("v", false),
+      peg$c539 = function() { return "\v" },
+      peg$c540 = function() { return "*" },
+      peg$c541 = "u",
+      peg$c542 = peg$literalExpectation("u", false),
+      peg$c543 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c550 = /^[^\/\\]/,
-      peg$c551 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c552 = /^[\0-\x1F\\]/,
-      peg$c553 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c554 = peg$otherExpectation("whitespace"),
-      peg$c555 = "\t",
-      peg$c556 = peg$literalExpectation("\t", false),
-      peg$c557 = "\x0B",
-      peg$c558 = peg$literalExpectation("\x0B", false),
-      peg$c559 = "\f",
-      peg$c560 = peg$literalExpectation("\f", false),
-      peg$c561 = " ",
-      peg$c562 = peg$literalExpectation(" ", false),
-      peg$c563 = "\xA0",
-      peg$c564 = peg$literalExpectation("\xA0", false),
-      peg$c565 = "\uFEFF",
-      peg$c566 = peg$literalExpectation("\uFEFF", false),
-      peg$c567 = /^[\n\r\u2028\u2029]/,
-      peg$c568 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c569 = peg$otherExpectation("comment"),
-      peg$c574 = "//",
-      peg$c575 = peg$literalExpectation("//", false),
+      peg$c544 = /^[^\/\\]/,
+      peg$c545 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c546 = /^[\0-\x1F\\]/,
+      peg$c547 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c548 = peg$otherExpectation("whitespace"),
+      peg$c549 = "\t",
+      peg$c550 = peg$literalExpectation("\t", false),
+      peg$c551 = "\x0B",
+      peg$c552 = peg$literalExpectation("\x0B", false),
+      peg$c553 = "\f",
+      peg$c554 = peg$literalExpectation("\f", false),
+      peg$c555 = " ",
+      peg$c556 = peg$literalExpectation(" ", false),
+      peg$c557 = "\xA0",
+      peg$c558 = peg$literalExpectation("\xA0", false),
+      peg$c559 = "\uFEFF",
+      peg$c560 = peg$literalExpectation("\uFEFF", false),
+      peg$c561 = /^[\n\r\u2028\u2029]/,
+      peg$c562 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c563 = peg$otherExpectation("comment"),
+      peg$c568 = "//",
+      peg$c569 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -3762,14 +3761,11 @@ function peg$parse(input, options) {
                                     if (s0 === peg$FAILED) {
                                       s0 = peg$parseExplodeProc();
                                       if (s0 === peg$FAILED) {
-                                        s0 = peg$parseLetProc();
+                                        s0 = peg$parseMergeProc();
                                         if (s0 === peg$FAILED) {
-                                          s0 = peg$parseMergeProc();
+                                          s0 = peg$parseOverProc();
                                           if (s0 === peg$FAILED) {
-                                            s0 = peg$parseOverProc();
-                                            if (s0 === peg$FAILED) {
-                                              s0 = peg$parseYieldProc();
-                                            }
+                                            s0 = peg$parseYieldProc();
                                           }
                                         }
                                       }
@@ -5972,112 +5968,15 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOverProc() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseScopedOver();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c252(s1);
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c253) {
-        s1 = peg$c253;
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c254); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseExprs();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c255(s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseScopedOver() {
-    var s0, s1, s2, s3, s4, s5, s6;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c253) {
-      s1 = peg$c253;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseExprs();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseAs();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parse__();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseScope();
-              if (s6 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c256(s3, s4, s6);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseOverWith() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c253) {
-      s1 = peg$c253;
+    if (input.substr(peg$currPos, 4) === peg$c252) {
+      s1 = peg$c252;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6103,7 +6002,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseScope();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c257(s3, s7, s9);
+                      s1 = peg$c254(s3, s7, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6141,83 +6040,31 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-
-    return s0;
-  }
-
-  function peg$parseAs() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse_();
-    if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c258) {
-        s2 = peg$c258;
-        peg$currPos += 2;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c259); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseIdentifierName();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c212(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c260();
+      if (input.substr(peg$currPos, 4) === peg$c252) {
+        s1 = peg$c252;
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c253); }
       }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseLetProc() {
-    var s0, s1, s2, s3, s4, s5;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c261) {
-      s1 = peg$c261;
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c262); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseLetAssignments();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseScopedOver();
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c263(s3, s5);
-              s0 = s1;
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseExprs();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseScope();
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c255(s3, s5);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -6234,12 +6081,36 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseOverWith();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 4) === peg$c252) {
+          s1 = peg$c252;
+          peg$currPos += 4;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c253); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parse_();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parseExprs();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c256(s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
     }
 
     return s0;
@@ -6282,7 +6153,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c264(s5);
+                  s1 = peg$c257(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6339,7 +6210,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLetAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c265(s1, s7);
+              s4 = peg$c258(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6375,7 +6246,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLetAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c265(s1, s7);
+                s4 = peg$c258(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6458,7 +6329,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIdentifierName();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1);
+        s1 = peg$c259(s1);
       }
       s0 = s1;
     }
@@ -6470,12 +6341,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c267) {
-      s1 = peg$c267;
+    if (input.substr(peg$currPos, 5) === peg$c260) {
+      s1 = peg$c260;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c261); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6483,7 +6354,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c269(s3);
+          s1 = peg$c262(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6514,7 +6385,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s4);
+            s1 = peg$c263(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6549,7 +6420,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c271(s4);
+            s1 = peg$c264(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6649,7 +6520,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6686,7 +6557,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c265(s1, s7);
+              s4 = peg$c258(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6722,7 +6593,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c265(s1, s7);
+                s4 = peg$c258(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6743,7 +6614,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6778,7 +6649,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c275(s1, s5);
+              s1 = peg$c268(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6821,11 +6692,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c276;
+          s3 = peg$c269;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6847,7 +6718,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c278(s1, s5, s9);
+                      s1 = peg$c271(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6909,7 +6780,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c279(s1, s5, s7);
+              s4 = peg$c272(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6939,7 +6810,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c279(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6960,7 +6831,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6991,7 +6862,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c279(s1, s5, s7);
+              s4 = peg$c272(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7021,7 +6892,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c279(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7042,7 +6913,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7071,7 +6942,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAdditiveExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c281(s1, s3, s5);
+              s1 = peg$c274(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7112,7 +6983,7 @@ function peg$parse(input, options) {
               s5 = peg$parseRegexp();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c282(s1, s5);
+                s1 = peg$c275(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7159,7 +7030,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c279(s1, s5, s7);
+              s4 = peg$c272(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7189,7 +7060,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c279(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7210,7 +7081,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7229,19 +7100,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c283;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c285;
+        s1 = peg$c278;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c286); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7270,7 +7141,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c279(s1, s5, s7);
+              s4 = peg$c272(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7300,7 +7171,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c279(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7321,7 +7192,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7348,19 +7219,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c287;
+        s1 = peg$c280;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c281); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c289;
+          s1 = peg$c282;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c290); }
+          if (peg$silentFails === 0) { peg$fail(peg$c283); }
         }
       }
     }
@@ -7390,7 +7261,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c291(s3);
+          s1 = peg$c284(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7427,11 +7298,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c285;
+        s2 = peg$c278;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c286); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7439,7 +7310,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c292(s4);
+            s1 = peg$c285(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7558,20 +7429,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c293) {
-      s0 = peg$c293;
+    if (input.substr(peg$currPos, 3) === peg$c286) {
+      s0 = peg$c286;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c287); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c295) {
-        s0 = peg$c295;
+      if (input.substr(peg$currPos, 6) === peg$c288) {
+        s0 = peg$c288;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c296); }
+        if (peg$silentFails === 0) { peg$fail(peg$c289); }
       }
     }
 
@@ -7609,7 +7480,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c297(s1, s5);
+                  s1 = peg$c290(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7692,7 +7563,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c298(s2, s6, s9);
+                        s1 = peg$c291(s2, s6, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7739,12 +7610,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c299) {
-      s1 = peg$c299;
+    if (input.substr(peg$currPos, 4) === peg$c292) {
+      s1 = peg$c292;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
+      if (peg$silentFails === 0) { peg$fail(peg$c293); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7772,7 +7643,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c301(s5);
+                  s1 = peg$c294(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7804,12 +7675,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c299) {
-        s1 = peg$c299;
+      if (input.substr(peg$currPos, 4) === peg$c292) {
+        s1 = peg$c292;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c300); }
+        if (peg$silentFails === 0) { peg$fail(peg$c293); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7851,7 +7722,7 @@ function peg$parse(input, options) {
                           }
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c302(s5, s9);
+                            s1 = peg$c295(s5, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7913,7 +7784,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c303(s1);
+          s1 = peg$c296(s1);
         }
         s0 = s1;
       }
@@ -7962,7 +7833,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c304(s1, s7);
+              s4 = peg$c297(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7998,7 +7869,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c304(s1, s7);
+                s4 = peg$c297(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8105,15 +7976,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c305;
+                  s7 = peg$c298;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c307(s2, s6);
+                  s1 = peg$c300(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8168,15 +8039,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c305;
+                  s6 = peg$c298;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c308(s5);
+                  s1 = peg$c301(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8227,15 +8098,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c305;
+                    s6 = peg$c298;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c299); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c309(s2);
+                    s1 = peg$c302(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8274,15 +8145,15 @@ function peg$parse(input, options) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c305;
+                s3 = peg$c298;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                if (peg$silentFails === 0) { peg$fail(peg$c299); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c310(s2);
+                s1 = peg$c303(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8309,7 +8180,7 @@ function peg$parse(input, options) {
               s2 = peg$parseIdentifier();
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c311(s2);
+                s1 = peg$c304(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8414,15 +8285,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c312;
+              s5 = peg$c305;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314(s3);
+              s1 = peg$c307(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8462,7 +8333,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8504,7 +8375,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c315(s4);
+            s1 = peg$c308(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8544,12 +8415,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c316) {
-      s1 = peg$c316;
+    if (input.substr(peg$currPos, 3) === peg$c309) {
+      s1 = peg$c309;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c310); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8557,7 +8428,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c318(s3);
+          s1 = peg$c311(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8596,7 +8467,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319(s1, s5);
+              s1 = peg$c312(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8641,15 +8512,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c305;
+              s5 = peg$c298;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s3);
+              s1 = peg$c313(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8679,12 +8550,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c321) {
-      s1 = peg$c321;
+    if (input.substr(peg$currPos, 2) === peg$c314) {
+      s1 = peg$c314;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8693,16 +8564,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c323) {
-              s5 = peg$c323;
+            if (input.substr(peg$currPos, 2) === peg$c316) {
+              s5 = peg$c316;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c324); }
+              if (peg$silentFails === 0) { peg$fail(peg$c317); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c325(s3);
+              s1 = peg$c318(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8732,12 +8603,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c326) {
-      s1 = peg$c326;
+    if (input.substr(peg$currPos, 2) === peg$c319) {
+      s1 = peg$c319;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8746,16 +8617,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c328) {
-              s5 = peg$c328;
+            if (input.substr(peg$currPos, 2) === peg$c321) {
+              s5 = peg$c321;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c329); }
+              if (peg$silentFails === 0) { peg$fail(peg$c322); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s3);
+              s1 = peg$c323(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8795,7 +8666,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8837,7 +8708,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c331(s4);
+            s1 = peg$c324(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8880,7 +8751,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c332(s1, s5);
+              s1 = peg$c325(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8945,7 +8816,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c333(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c326(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9023,7 +8894,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334(s3);
+            s1 = peg$c327(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9057,7 +8928,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c335(s1, s5);
+              s1 = peg$c328(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9204,7 +9075,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c336(s4, s5);
+              s1 = peg$c329(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9359,7 +9230,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c337(s1, s4);
+        s4 = peg$c330(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9368,7 +9239,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c337(s1, s4);
+          s4 = peg$c330(s1, s4);
         }
         s3 = s4;
       }
@@ -9430,7 +9301,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c338(s1, s5, s6, s10, s14);
+                                s1 = peg$c331(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9510,7 +9381,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c339(s2);
+        s1 = peg$c332(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9669,7 +9540,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c340(s6, s7);
+                  s1 = peg$c333(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9715,7 +9586,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c341(s2);
+        s1 = peg$c334(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9751,7 +9622,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c342(s4);
+            s1 = peg$c335(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9786,16 +9657,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c295) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c288) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c336); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c344();
+      s1 = peg$c337();
     }
     s0 = s1;
 
@@ -9806,16 +9677,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c258) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c338) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+      if (peg$silentFails === 0) { peg$fail(peg$c339); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c346();
+      s1 = peg$c340();
     }
     s0 = s1;
 
@@ -9831,11 +9702,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -9851,11 +9722,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -9871,6 +9742,46 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c346();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseGROUP() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c347) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c349();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseBY() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c350) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c351); }
     }
     if (s1 !== peg$FAILED) {
@@ -9882,13 +9793,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseGROUP() {
+  function peg$parseHAVING() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c353) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c353) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c354); }
@@ -9896,46 +9807,6 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
       s1 = peg$c355();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseBY() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c356) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c358();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseHAVING() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c359) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -9951,11 +9822,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c362); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c363();
+      s1 = peg$c357();
     }
     s0 = s1;
 
@@ -9966,16 +9837,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c364) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c358) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c359); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c366();
+      s1 = peg$c360();
     }
     s0 = s1;
 
@@ -9986,16 +9857,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c367) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c361) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c362); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c369();
+      s1 = peg$c363();
     }
     s0 = s1;
 
@@ -10011,7 +9882,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10031,7 +9902,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10051,7 +9922,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10071,7 +9942,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10091,7 +9962,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10111,7 +9982,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c375); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10213,7 +10084,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c370(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10228,7 +10099,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c370(s1);
       }
       s0 = s1;
     }
@@ -10254,7 +10125,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s1);
+        s1 = peg$c371(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10269,7 +10140,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s1);
+        s1 = peg$c371(s1);
       }
       s0 = s1;
     }
@@ -10284,7 +10155,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c378(s1);
+      s1 = peg$c372(s1);
     }
     s0 = s1;
 
@@ -10298,7 +10169,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c379(s1);
+      s1 = peg$c373(s1);
     }
     s0 = s1;
 
@@ -10306,6 +10177,41 @@ function peg$parse(input, options) {
   }
 
   function peg$parseBooleanLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4) === peg$c374) {
+      s1 = peg$c374;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c375); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c376();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c377) {
+        s1 = peg$c377;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c378); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c379();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseNullLiteral() {
     var s0, s1;
 
     s0 = peg$currPos;
@@ -10321,41 +10227,6 @@ function peg$parse(input, options) {
       s1 = peg$c382();
     }
     s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c383) {
-        s1 = peg$c383;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c384); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c385();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseNullLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c386) {
-      s1 = peg$c386;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c388();
-    }
-    s0 = s1;
 
     return s0;
   }
@@ -10364,12 +10235,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c389) {
-      s1 = peg$c389;
+    if (input.substr(peg$currPos, 2) === peg$c383) {
+      s1 = peg$c383;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c384); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10380,7 +10251,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391();
+        s1 = peg$c385();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10417,7 +10288,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c392(s2);
+          s1 = peg$c386(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10444,7 +10315,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c392(s1);
+        s1 = peg$c386(s1);
       }
       s0 = s1;
     }
@@ -10484,7 +10355,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c393(s1);
+        s1 = peg$c387(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10513,7 +10384,7 @@ function peg$parse(input, options) {
               s5 = peg$parseType();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c394(s1, s5);
+                s1 = peg$c388(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10540,7 +10411,7 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c395(s1);
+          s1 = peg$c389(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10566,7 +10437,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c396(s3);
+                  s1 = peg$c390(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10598,7 +10469,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c397(s1);
+      s1 = peg$c391(s1);
     }
     s0 = s1;
 
@@ -10623,7 +10494,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10656,7 +10527,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c398(s4);
+            s1 = peg$c392(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10697,15 +10568,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c312;
+              s5 = peg$c305;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c399(s3);
+              s1 = peg$c393(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10744,15 +10615,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c305;
+                s5 = peg$c298;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                if (peg$silentFails === 0) { peg$fail(peg$c299); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c400(s3);
+                s1 = peg$c394(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10776,12 +10647,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c321) {
-          s1 = peg$c321;
+        if (input.substr(peg$currPos, 2) === peg$c314) {
+          s1 = peg$c314;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c322); }
+          if (peg$silentFails === 0) { peg$fail(peg$c315); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10790,16 +10661,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c323) {
-                  s5 = peg$c323;
+                if (input.substr(peg$currPos, 2) === peg$c316) {
+                  s5 = peg$c316;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c317); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c401(s3);
+                  s1 = peg$c395(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10823,12 +10694,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c326) {
-            s1 = peg$c326;
+          if (input.substr(peg$currPos, 2) === peg$c319) {
+            s1 = peg$c319;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c320); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10851,16 +10722,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c328) {
-                            s9 = peg$c328;
+                          if (input.substr(peg$currPos, 2) === peg$c321) {
+                            s9 = peg$c321;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c329); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c322); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c402(s3, s7);
+                            s1 = peg$c396(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10912,7 +10783,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c403(s1);
+      s1 = peg$c397(s1);
     }
     s0 = s1;
 
@@ -10924,11 +10795,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c404;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10939,11 +10810,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c404;
+          s3 = peg$c398;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c405); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -10964,11 +10835,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c406;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -10979,11 +10850,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c406;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c407); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11024,7 +10895,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c408(s1);
+        s1 = peg$c402(s1);
       }
       s0 = s1;
     }
@@ -11037,19 +10908,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c409;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c411) {
-        s2 = peg$c411;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11067,12 +10938,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c411) {
-        s2 = peg$c411;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11118,7 +10989,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c408(s1);
+        s1 = peg$c402(s1);
       }
       s0 = s1;
     }
@@ -11131,19 +11002,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c409;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c411) {
-        s2 = peg$c411;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11161,12 +11032,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c411) {
-        s2 = peg$c411;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11198,12 +11069,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c411) {
-      s1 = peg$c411;
+    if (input.substr(peg$currPos, 2) === peg$c405) {
+      s1 = peg$c405;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c412); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11213,15 +11084,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c312;
+              s5 = peg$c305;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c413(s3);
+              s1 = peg$c407(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11251,140 +11122,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c414) {
-      s1 = peg$c414;
+    if (input.substr(peg$currPos, 5) === peg$c408) {
+      s1 = peg$c408;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c415); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c416) {
-        s1 = peg$c416;
+      if (input.substr(peg$currPos, 6) === peg$c410) {
+        s1 = peg$c410;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c417); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c418) {
-          s1 = peg$c418;
+        if (input.substr(peg$currPos, 6) === peg$c412) {
+          s1 = peg$c412;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c419); }
+          if (peg$silentFails === 0) { peg$fail(peg$c413); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c420) {
-            s1 = peg$c420;
+          if (input.substr(peg$currPos, 6) === peg$c414) {
+            s1 = peg$c414;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c415); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c422) {
-              s1 = peg$c422;
+            if (input.substr(peg$currPos, 4) === peg$c416) {
+              s1 = peg$c416;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c423); }
+              if (peg$silentFails === 0) { peg$fail(peg$c417); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c424) {
-                s1 = peg$c424;
+              if (input.substr(peg$currPos, 5) === peg$c418) {
+                s1 = peg$c418;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                if (peg$silentFails === 0) { peg$fail(peg$c419); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c426) {
-                  s1 = peg$c426;
+                if (input.substr(peg$currPos, 5) === peg$c420) {
+                  s1 = peg$c420;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c427); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c421); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c428) {
-                    s1 = peg$c428;
+                  if (input.substr(peg$currPos, 5) === peg$c422) {
+                    s1 = peg$c422;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c423); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c430) {
-                      s1 = peg$c430;
+                    if (input.substr(peg$currPos, 7) === peg$c424) {
+                      s1 = peg$c424;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c431); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c432) {
-                        s1 = peg$c432;
+                      if (input.substr(peg$currPos, 7) === peg$c426) {
+                        s1 = peg$c426;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c433); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c427); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c434) {
-                          s1 = peg$c434;
+                        if (input.substr(peg$currPos, 4) === peg$c428) {
+                          s1 = peg$c428;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c435); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c429); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c436) {
-                            s1 = peg$c436;
+                          if (input.substr(peg$currPos, 6) === peg$c430) {
+                            s1 = peg$c430;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c437); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c431); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c438) {
-                              s1 = peg$c438;
+                            if (input.substr(peg$currPos, 8) === peg$c432) {
+                              s1 = peg$c432;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c439); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c433); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c440) {
-                                s1 = peg$c440;
+                              if (input.substr(peg$currPos, 4) === peg$c434) {
+                                s1 = peg$c434;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c441); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c435); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c442) {
-                                  s1 = peg$c442;
+                                if (input.substr(peg$currPos, 5) === peg$c436) {
+                                  s1 = peg$c436;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c443); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c437); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c444) {
-                                    s1 = peg$c444;
+                                  if (input.substr(peg$currPos, 2) === peg$c438) {
+                                    s1 = peg$c438;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c445); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c439); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c446) {
-                                      s1 = peg$c446;
+                                    if (input.substr(peg$currPos, 3) === peg$c440) {
+                                      s1 = peg$c440;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c447); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c441); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c11) {
@@ -11395,12 +11266,12 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c12); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c386) {
-                                          s1 = peg$c386;
+                                        if (input.substr(peg$currPos, 4) === peg$c380) {
+                                          s1 = peg$c380;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c387); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c381); }
                                         }
                                       }
                                     }
@@ -11422,7 +11293,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c448();
+      s1 = peg$c442();
     }
     s0 = s1;
 
@@ -11443,7 +11314,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11485,7 +11356,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c398(s4);
+            s1 = peg$c392(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11528,7 +11399,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c449(s1, s5);
+              s1 = peg$c443(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11569,20 +11440,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c450) {
-      s1 = peg$c450;
+    if (input.substr(peg$currPos, 3) === peg$c444) {
+      s1 = peg$c444;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c451); }
+      if (peg$silentFails === 0) { peg$fail(peg$c445); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c452) {
-        s1 = peg$c452;
+      if (input.substr(peg$currPos, 3) === peg$c446) {
+        s1 = peg$c446;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c453); }
+        if (peg$silentFails === 0) { peg$fail(peg$c447); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11598,7 +11469,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c454();
+        s1 = peg$c448();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11616,20 +11487,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c455) {
-      s1 = peg$c455;
+    if (input.substr(peg$currPos, 2) === peg$c449) {
+      s1 = peg$c449;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c456); }
+      if (peg$silentFails === 0) { peg$fail(peg$c450); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c457) {
-        s1 = peg$c457;
+      if (input.substr(peg$currPos, 2) === peg$c451) {
+        s1 = peg$c451;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c458); }
+        if (peg$silentFails === 0) { peg$fail(peg$c452); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11645,7 +11516,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c459();
+        s1 = peg$c453();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11663,20 +11534,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c293) {
-      s1 = peg$c293;
+    if (input.substr(peg$currPos, 3) === peg$c286) {
+      s1 = peg$c286;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c287); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c461) {
-        s1 = peg$c461;
+      if (input.substr(peg$currPos, 3) === peg$c455) {
+        s1 = peg$c455;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c462); }
+        if (peg$silentFails === 0) { peg$fail(peg$c456); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11692,7 +11563,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c463();
+        s1 = peg$c457();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11710,12 +11581,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c356) {
-      s1 = peg$c356;
+    if (input.substr(peg$currPos, 2) === peg$c350) {
+      s1 = peg$c350;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c458); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11730,7 +11601,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c358();
+        s1 = peg$c352();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11747,12 +11618,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c465.test(input.charAt(peg$currPos))) {
+    if (peg$c459.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c460); }
     }
 
     return s0;
@@ -11763,12 +11634,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
     }
 
@@ -11782,7 +11653,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c469(s1);
+      s1 = peg$c463(s1);
     }
     s0 = s1;
 
@@ -11854,11 +11725,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c470;
+        s1 = peg$c464;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c465); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11868,11 +11739,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c409;
+          s1 = peg$c403;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c410); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -11980,17 +11851,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c472;
+        s2 = peg$c466;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c473); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c474();
+          s1 = peg$c468();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12015,21 +11886,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c285;
+        s2 = peg$c278;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c286); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c285;
+            s4 = peg$c278;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c286); }
+            if (peg$silentFails === 0) { peg$fail(peg$c279); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12064,36 +11935,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c467.test(input.charAt(peg$currPos))) {
+    if (peg$c461.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c467.test(input.charAt(peg$currPos))) {
+        if (peg$c461.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c468); }
+          if (peg$silentFails === 0) { peg$fail(peg$c462); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c467.test(input.charAt(peg$currPos))) {
+          if (peg$c461.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c468); }
+            if (peg$silentFails === 0) { peg$fail(peg$c462); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12122,20 +11993,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c467.test(input.charAt(peg$currPos))) {
+    if (peg$c461.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12210,22 +12081,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c467.test(input.charAt(peg$currPos))) {
+                if (peg$c461.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c462); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c467.test(input.charAt(peg$currPos))) {
+                    if (peg$c461.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c462); }
                     }
                   }
                 } else {
@@ -12280,28 +12151,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c475;
+      s0 = peg$c469;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c470); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c283;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c285;
+          s1 = peg$c278;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c279); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12327,22 +12198,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c467.test(input.charAt(peg$currPos))) {
+                if (peg$c461.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c462); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c467.test(input.charAt(peg$currPos))) {
+                    if (peg$c461.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c462); }
                     }
                   }
                 } else {
@@ -12395,11 +12266,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c285;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12445,7 +12316,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c477();
+        s1 = peg$c471();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12507,76 +12378,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c478) {
-      s0 = peg$c478;
+    if (input.substr(peg$currPos, 2) === peg$c472) {
+      s0 = peg$c472;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c479); }
+      if (peg$silentFails === 0) { peg$fail(peg$c473); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c480) {
-        s0 = peg$c480;
+      if (input.substr(peg$currPos, 2) === peg$c474) {
+        s0 = peg$c474;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c481); }
+        if (peg$silentFails === 0) { peg$fail(peg$c475); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c482) {
-          s0 = peg$c482;
+        if (input.substr(peg$currPos, 2) === peg$c476) {
+          s0 = peg$c476;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c483); }
+          if (peg$silentFails === 0) { peg$fail(peg$c477); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c484;
+            s0 = peg$c478;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c485); }
+            if (peg$silentFails === 0) { peg$fail(peg$c479); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c486;
+              s0 = peg$c480;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c487); }
+              if (peg$silentFails === 0) { peg$fail(peg$c481); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c488;
+                s0 = peg$c482;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c489); }
+                if (peg$silentFails === 0) { peg$fail(peg$c483); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c490;
+                  s0 = peg$c484;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c491); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c485); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c492;
+                    s0 = peg$c486;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c487); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c494;
+                      s0 = peg$c488;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c495); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c489); }
                     }
                   }
                 }
@@ -12761,7 +12632,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c496(s1, s2);
+        s1 = peg$c490(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12782,12 +12653,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c497) {
-            s3 = peg$c497;
+          if (input.substr(peg$currPos, 2) === peg$c491) {
+            s3 = peg$c491;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c498); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12800,7 +12671,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c499(s1, s2, s4, s5);
+                s1 = peg$c493(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12824,12 +12695,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c497) {
-          s1 = peg$c497;
+        if (input.substr(peg$currPos, 2) === peg$c491) {
+          s1 = peg$c491;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c498); }
+          if (peg$silentFails === 0) { peg$fail(peg$c492); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12842,7 +12713,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c500(s2, s3);
+              s1 = peg$c494(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12867,16 +12738,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c497) {
-                s3 = peg$c497;
+              if (input.substr(peg$currPos, 2) === peg$c491) {
+                s3 = peg$c491;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c498); }
+                if (peg$silentFails === 0) { peg$fail(peg$c492); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c501(s1, s2);
+                s1 = peg$c495(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12892,16 +12763,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c497) {
-              s1 = peg$c497;
+            if (input.substr(peg$currPos, 2) === peg$c491) {
+              s1 = peg$c491;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c498); }
+              if (peg$silentFails === 0) { peg$fail(peg$c492); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c502();
+              s1 = peg$c496();
             }
             s0 = s1;
           }
@@ -12938,7 +12809,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c503(s2);
+        s1 = peg$c497(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12967,7 +12838,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c504(s1);
+        s1 = peg$c498(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12988,17 +12859,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c287;
+        s2 = peg$c280;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c281); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c505(s1, s3);
+          s1 = peg$c499(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13023,17 +12894,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c287;
+        s2 = peg$c280;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c281); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c506(s1, s3);
+          s1 = peg$c500(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13058,7 +12929,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c507(s1);
+      s1 = peg$c501(s1);
     }
     s0 = s1;
 
@@ -13081,22 +12952,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c467.test(input.charAt(peg$currPos))) {
+    if (peg$c461.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c467.test(input.charAt(peg$currPos))) {
+        if (peg$c461.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c468); }
+          if (peg$silentFails === 0) { peg$fail(peg$c462); }
         }
       }
     } else {
@@ -13116,11 +12987,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c285;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13145,33 +13016,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c285;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c467.test(input.charAt(peg$currPos))) {
+          if (peg$c461.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c468); }
+            if (peg$silentFails === 0) { peg$fail(peg$c462); }
           }
         }
       } else {
@@ -13187,21 +13058,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c467.test(input.charAt(peg$currPos))) {
+          if (peg$c461.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c468); }
+            if (peg$silentFails === 0) { peg$fail(peg$c462); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c467.test(input.charAt(peg$currPos))) {
+            if (peg$c461.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c468); }
+              if (peg$silentFails === 0) { peg$fail(peg$c462); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13211,7 +13082,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c508();
+              s1 = peg$c502();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13236,11 +13107,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c285;
+        s1 = peg$c278;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c286); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13255,22 +13126,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c467.test(input.charAt(peg$currPos))) {
+          if (peg$c461.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c468); }
+            if (peg$silentFails === 0) { peg$fail(peg$c462); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c467.test(input.charAt(peg$currPos))) {
+              if (peg$c461.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                if (peg$silentFails === 0) { peg$fail(peg$c462); }
               }
             }
           } else {
@@ -13283,7 +13154,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c508();
+              s1 = peg$c502();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13322,20 +13193,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c509) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c503) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c510); }
+      if (peg$silentFails === 0) { peg$fail(peg$c504); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c511.test(input.charAt(peg$currPos))) {
+      if (peg$c505.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c512); }
+        if (peg$silentFails === 0) { peg$fail(peg$c506); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13364,12 +13235,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c513) {
-      s0 = peg$c513;
+    if (input.substr(peg$currPos, 3) === peg$c507) {
+      s0 = peg$c507;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c508); }
     }
 
     return s0;
@@ -13380,31 +13251,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c285;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c283;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c515) {
-        s2 = peg$c515;
+      if (input.substr(peg$currPos, 3) === peg$c509) {
+        s2 = peg$c509;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c510); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13447,12 +13318,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c517.test(input.charAt(peg$currPos))) {
+    if (peg$c511.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c518); }
+      if (peg$silentFails === 0) { peg$fail(peg$c512); }
     }
 
     return s0;
@@ -13463,11 +13334,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c404;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13478,15 +13349,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c404;
+          s3 = peg$c398;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c405); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c519(s2);
+          s1 = peg$c513(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13503,11 +13374,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c406;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13518,15 +13389,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c406;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c407); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c519(s2);
+            s1 = peg$c513(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13552,11 +13423,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c404;
+      s2 = peg$c398;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13574,7 +13445,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c520); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13591,11 +13462,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c409;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c410); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13630,7 +13501,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c521(s1, s2);
+        s1 = peg$c515(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13659,12 +13530,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c522.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c523); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13680,12 +13551,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
     }
 
@@ -13697,11 +13568,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c409;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13760,7 +13631,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c524(s3, s4);
+            s1 = peg$c518(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13871,7 +13742,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c525();
+          s1 = peg$c519();
         }
         s0 = s1;
       }
@@ -13885,12 +13756,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
     }
 
@@ -13902,11 +13773,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c409;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -13942,7 +13813,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c526();
+      s1 = peg$c520();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -13956,16 +13827,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c527();
+        s1 = peg$c521();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c511.test(input.charAt(peg$currPos))) {
+        if (peg$c505.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c512); }
+          if (peg$silentFails === 0) { peg$fail(peg$c506); }
         }
       }
     }
@@ -13980,11 +13851,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c406;
+      s2 = peg$c400;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c407); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14002,7 +13873,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c520); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14019,11 +13890,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c409;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c410); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14059,20 +13930,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c406;
+      s0 = peg$c400;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c407); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c404;
+        s1 = peg$c398;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c399); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14081,94 +13952,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c409;
+          s0 = peg$c403;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c410); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c528;
+            s1 = peg$c522;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c529); }
+            if (peg$silentFails === 0) { peg$fail(peg$c523); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c530();
+            s1 = peg$c524();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c531;
+              s1 = peg$c525;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c532); }
+              if (peg$silentFails === 0) { peg$fail(peg$c526); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c533();
+              s1 = peg$c527();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c534;
+                s1 = peg$c528;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c535); }
+                if (peg$silentFails === 0) { peg$fail(peg$c529); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c536();
+                s1 = peg$c530();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c537;
+                  s1 = peg$c531;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c538); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c532); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c539();
+                  s1 = peg$c533();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c540;
+                    s1 = peg$c534;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c541); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c535); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c542();
+                    s1 = peg$c536();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c543;
+                      s1 = peg$c537;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c544); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c538); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c545();
+                      s1 = peg$c539();
                     }
                     s0 = s1;
                   }
@@ -14196,7 +14067,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c526();
+      s1 = peg$c520();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14210,16 +14081,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c546();
+        s1 = peg$c540();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c511.test(input.charAt(peg$currPos))) {
+        if (peg$c505.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c512); }
+          if (peg$silentFails === 0) { peg$fail(peg$c506); }
         }
       }
     }
@@ -14232,11 +14103,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c547;
+      s1 = peg$c541;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c548); }
+      if (peg$silentFails === 0) { peg$fail(peg$c542); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14268,7 +14139,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c549(s2);
+        s1 = peg$c543(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14281,11 +14152,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c547;
+        s1 = peg$c541;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c548); }
+        if (peg$silentFails === 0) { peg$fail(peg$c542); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14352,15 +14223,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c312;
+              s4 = peg$c305;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c549(s3);
+              s1 = peg$c543(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14388,21 +14259,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c287;
+      s1 = peg$c280;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c288); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c287;
+          s3 = peg$c280;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c288); }
+          if (peg$silentFails === 0) { peg$fail(peg$c281); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14444,21 +14315,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c550.test(input.charAt(peg$currPos))) {
+    if (peg$c544.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c551); }
+      if (peg$silentFails === 0) { peg$fail(peg$c545); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c409;
+        s3 = peg$c403;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c410); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14466,7 +14337,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c520); }
+          if (peg$silentFails === 0) { peg$fail(peg$c514); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14483,21 +14354,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c550.test(input.charAt(peg$currPos))) {
+        if (peg$c544.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c551); }
+          if (peg$silentFails === 0) { peg$fail(peg$c545); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c409;
+            s3 = peg$c403;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c410); }
+            if (peg$silentFails === 0) { peg$fail(peg$c404); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14505,7 +14376,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c520); }
+              if (peg$silentFails === 0) { peg$fail(peg$c514); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14535,12 +14406,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c552.test(input.charAt(peg$currPos))) {
+    if (peg$c546.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c553); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
 
     return s0;
@@ -14598,7 +14469,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c520); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
 
     return s0;
@@ -14609,51 +14480,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c555;
+      s0 = peg$c549;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c556); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c557;
+        s0 = peg$c551;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c558); }
+        if (peg$silentFails === 0) { peg$fail(peg$c552); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c559;
+          s0 = peg$c553;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c560); }
+          if (peg$silentFails === 0) { peg$fail(peg$c554); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c561;
+            s0 = peg$c555;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c562); }
+            if (peg$silentFails === 0) { peg$fail(peg$c556); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c563;
+              s0 = peg$c557;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c564); }
+              if (peg$silentFails === 0) { peg$fail(peg$c558); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c565;
+                s0 = peg$c559;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c566); }
+                if (peg$silentFails === 0) { peg$fail(peg$c560); }
               }
             }
           }
@@ -14662,7 +14533,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c554); }
+      if (peg$silentFails === 0) { peg$fail(peg$c548); }
     }
 
     return s0;
@@ -14671,12 +14542,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c567.test(input.charAt(peg$currPos))) {
+    if (peg$c561.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c568); }
+      if (peg$silentFails === 0) { peg$fail(peg$c562); }
     }
 
     return s0;
@@ -14689,7 +14560,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c569); }
+      if (peg$silentFails === 0) { peg$fail(peg$c563); }
     }
 
     return s0;
@@ -14699,12 +14570,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c574) {
-      s1 = peg$c574;
+    if (input.substr(peg$currPos, 2) === peg$c568) {
+      s1 = peg$c568;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c575); }
+      if (peg$silentFails === 0) { peg$fail(peg$c569); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14784,7 +14655,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c520); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -317,47 +317,47 @@ var g = &grammar{
 		},
 		{
 			name: "Operation",
-			pos:  position{line: 38, col: 1, offset: 1015},
+			pos:  position{line: 39, col: 1, offset: 1016},
 			expr: &choiceExpr{
-				pos: position{line: 39, col: 5, offset: 1029},
+				pos: position{line: 40, col: 5, offset: 1030},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 39, col: 5, offset: 1029},
+						pos: position{line: 40, col: 5, offset: 1030},
 						run: (*parser).callonOperation2,
 						expr: &seqExpr{
-							pos: position{line: 39, col: 5, offset: 1029},
+							pos: position{line: 40, col: 5, offset: 1030},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 39, col: 5, offset: 1029},
+									pos:        position{line: 40, col: 5, offset: 1030},
 									val:        "fork",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 39, col: 12, offset: 1036},
+									pos:  position{line: 40, col: 12, offset: 1037},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 39, col: 15, offset: 1039},
+									pos:        position{line: 40, col: 15, offset: 1040},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 39, col: 19, offset: 1043},
+									pos:   position{line: 40, col: 19, offset: 1044},
 									label: "procArray",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 39, col: 29, offset: 1053},
+										pos: position{line: 40, col: 29, offset: 1054},
 										expr: &ruleRefExpr{
-											pos:  position{line: 39, col: 29, offset: 1053},
+											pos:  position{line: 40, col: 29, offset: 1054},
 											name: "Leg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 39, col: 34, offset: 1058},
+									pos:  position{line: 40, col: 34, offset: 1059},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 39, col: 37, offset: 1061},
+									pos:        position{line: 40, col: 37, offset: 1062},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -365,54 +365,54 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 42, col: 5, offset: 1158},
+						pos: position{line: 43, col: 5, offset: 1159},
 						run: (*parser).callonOperation12,
 						expr: &seqExpr{
-							pos: position{line: 42, col: 5, offset: 1158},
+							pos: position{line: 43, col: 5, offset: 1159},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 42, col: 5, offset: 1158},
+									pos:        position{line: 43, col: 5, offset: 1159},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 42, col: 14, offset: 1167},
+									pos:  position{line: 43, col: 14, offset: 1168},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 42, col: 16, offset: 1169},
+									pos:   position{line: 43, col: 16, offset: 1170},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 42, col: 21, offset: 1174},
+										pos:  position{line: 43, col: 21, offset: 1175},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 42, col: 26, offset: 1179},
+									pos:  position{line: 43, col: 26, offset: 1180},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 42, col: 28, offset: 1181},
+									pos:        position{line: 43, col: 28, offset: 1182},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 42, col: 32, offset: 1185},
+									pos:   position{line: 43, col: 32, offset: 1186},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 42, col: 38, offset: 1191},
+										pos: position{line: 43, col: 38, offset: 1192},
 										expr: &ruleRefExpr{
-											pos:  position{line: 42, col: 38, offset: 1191},
+											pos:  position{line: 43, col: 38, offset: 1192},
 											name: "SwitchLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 42, col: 49, offset: 1202},
+									pos:  position{line: 43, col: 49, offset: 1203},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 42, col: 52, offset: 1205},
+									pos:        position{line: 43, col: 52, offset: 1206},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -420,42 +420,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 45, col: 5, offset: 1310},
+						pos: position{line: 46, col: 5, offset: 1311},
 						run: (*parser).callonOperation25,
 						expr: &seqExpr{
-							pos: position{line: 45, col: 5, offset: 1310},
+							pos: position{line: 46, col: 5, offset: 1311},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 45, col: 5, offset: 1310},
+									pos:        position{line: 46, col: 5, offset: 1311},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 45, col: 14, offset: 1319},
+									pos:  position{line: 46, col: 14, offset: 1320},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 45, col: 17, offset: 1322},
+									pos:        position{line: 46, col: 17, offset: 1323},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 45, col: 21, offset: 1326},
+									pos:   position{line: 46, col: 21, offset: 1327},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 45, col: 27, offset: 1332},
+										pos: position{line: 46, col: 27, offset: 1333},
 										expr: &ruleRefExpr{
-											pos:  position{line: 45, col: 27, offset: 1332},
+											pos:  position{line: 46, col: 27, offset: 1333},
 											name: "SwitchLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 45, col: 38, offset: 1343},
+									pos:  position{line: 46, col: 38, offset: 1344},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 45, col: 41, offset: 1346},
+									pos:        position{line: 46, col: 41, offset: 1347},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -463,42 +463,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 48, col: 5, offset: 1450},
+						pos: position{line: 49, col: 5, offset: 1451},
 						run: (*parser).callonOperation35,
 						expr: &seqExpr{
-							pos: position{line: 48, col: 5, offset: 1450},
+							pos: position{line: 49, col: 5, offset: 1451},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 48, col: 5, offset: 1450},
+									pos:        position{line: 49, col: 5, offset: 1451},
 									val:        "from",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 48, col: 12, offset: 1457},
+									pos:  position{line: 49, col: 12, offset: 1458},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 48, col: 15, offset: 1460},
+									pos:        position{line: 49, col: 15, offset: 1461},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 48, col: 19, offset: 1464},
+									pos:   position{line: 49, col: 19, offset: 1465},
 									label: "trunks",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 48, col: 26, offset: 1471},
+										pos: position{line: 49, col: 26, offset: 1472},
 										expr: &ruleRefExpr{
-											pos:  position{line: 48, col: 26, offset: 1471},
+											pos:  position{line: 49, col: 26, offset: 1472},
 											name: "FromLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 48, col: 35, offset: 1480},
+									pos:  position{line: 49, col: 35, offset: 1481},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 48, col: 38, offset: 1483},
+									pos:        position{line: 49, col: 38, offset: 1484},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -506,31 +506,31 @@ var g = &grammar{
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 51, col: 5, offset: 1574},
+						pos:   position{line: 52, col: 5, offset: 1575},
 						label: "op",
 						expr: &ruleRefExpr{
-							pos:  position{line: 51, col: 8, offset: 1577},
+							pos:  position{line: 52, col: 8, offset: 1578},
 							name: "Operator",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 52, col: 5, offset: 1590},
+						pos: position{line: 53, col: 5, offset: 1591},
 						run: (*parser).callonOperation47,
 						expr: &seqExpr{
-							pos: position{line: 52, col: 5, offset: 1590},
+							pos: position{line: 53, col: 5, offset: 1591},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 52, col: 5, offset: 1590},
+									pos:   position{line: 53, col: 5, offset: 1591},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 52, col: 7, offset: 1592},
+										pos:  position{line: 53, col: 7, offset: 1593},
 										name: "OpAssignment",
 									},
 								},
 								&andExpr{
-									pos: position{line: 52, col: 20, offset: 1605},
+									pos: position{line: 53, col: 20, offset: 1606},
 									expr: &ruleRefExpr{
-										pos:  position{line: 52, col: 21, offset: 1606},
+										pos:  position{line: 53, col: 21, offset: 1607},
 										name: "EndOfOp",
 									},
 								},
@@ -538,39 +538,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 53, col: 5, offset: 1636},
+						pos: position{line: 54, col: 5, offset: 1637},
 						run: (*parser).callonOperation53,
 						expr: &seqExpr{
-							pos: position{line: 53, col: 5, offset: 1636},
+							pos: position{line: 54, col: 5, offset: 1637},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 53, col: 5, offset: 1636},
+									pos: position{line: 54, col: 5, offset: 1637},
 									expr: &seqExpr{
-										pos: position{line: 53, col: 7, offset: 1638},
+										pos: position{line: 54, col: 7, offset: 1639},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 53, col: 7, offset: 1638},
+												pos:  position{line: 54, col: 7, offset: 1639},
 												name: "Function",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 53, col: 16, offset: 1647},
+												pos:  position{line: 54, col: 16, offset: 1648},
 												name: "EndOfOp",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 53, col: 25, offset: 1656},
+									pos:   position{line: 54, col: 25, offset: 1657},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 53, col: 27, offset: 1658},
+										pos:  position{line: 54, col: 27, offset: 1659},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 53, col: 39, offset: 1670},
+									pos: position{line: 54, col: 39, offset: 1671},
 									expr: &ruleRefExpr{
-										pos:  position{line: 53, col: 40, offset: 1671},
+										pos:  position{line: 54, col: 40, offset: 1672},
 										name: "EndOfOp",
 									},
 								},
@@ -578,25 +578,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 54, col: 5, offset: 1702},
+						pos: position{line: 55, col: 5, offset: 1703},
 						run: (*parser).callonOperation63,
 						expr: &seqExpr{
-							pos: position{line: 54, col: 5, offset: 1702},
+							pos: position{line: 55, col: 5, offset: 1703},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 54, col: 5, offset: 1702},
+									pos:        position{line: 55, col: 5, offset: 1703},
 									val:        "search",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 54, col: 14, offset: 1711},
+									pos:  position{line: 55, col: 14, offset: 1712},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 54, col: 16, offset: 1713},
+									pos:   position{line: 55, col: 16, offset: 1714},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 54, col: 21, offset: 1718},
+										pos:  position{line: 55, col: 21, offset: 1719},
 										name: "SearchBoolean",
 									},
 								},
@@ -604,37 +604,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 57, col: 5, offset: 1817},
+						pos: position{line: 58, col: 5, offset: 1818},
 						run: (*parser).callonOperation69,
 						expr: &labeledExpr{
-							pos:   position{line: 57, col: 5, offset: 1817},
+							pos:   position{line: 58, col: 5, offset: 1818},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 57, col: 10, offset: 1822},
+								pos:  position{line: 58, col: 10, offset: 1823},
 								name: "SearchBoolean",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 60, col: 5, offset: 1921},
+						pos: position{line: 61, col: 5, offset: 1922},
 						run: (*parser).callonOperation72,
 						expr: &labeledExpr{
-							pos:   position{line: 60, col: 5, offset: 1921},
+							pos:   position{line: 61, col: 5, offset: 1922},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 60, col: 10, offset: 1926},
+								pos:  position{line: 61, col: 10, offset: 1927},
 								name: "Cast",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 63, col: 5, offset: 2014},
+						pos: position{line: 64, col: 5, offset: 2015},
 						run: (*parser).callonOperation75,
 						expr: &labeledExpr{
-							pos:   position{line: 63, col: 5, offset: 2014},
+							pos:   position{line: 64, col: 5, offset: 2015},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 63, col: 10, offset: 2019},
+								pos:  position{line: 64, col: 10, offset: 2020},
 								name: "Expr",
 							},
 						},
@@ -644,37 +644,37 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 67, col: 1, offset: 2106},
+			pos:  position{line: 68, col: 1, offset: 2107},
 			expr: &seqExpr{
-				pos: position{line: 67, col: 11, offset: 2116},
+				pos: position{line: 68, col: 11, offset: 2117},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 67, col: 11, offset: 2116},
+						pos:  position{line: 68, col: 11, offset: 2117},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 67, col: 15, offset: 2120},
+						pos: position{line: 68, col: 15, offset: 2121},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 67, col: 15, offset: 2120},
+								pos:  position{line: 68, col: 15, offset: 2121},
 								name: "Pipe",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 67, col: 22, offset: 2127},
+								pos:  position{line: 68, col: 22, offset: 2128},
 								name: "SearchKeywordGuard",
 							},
 							&litMatcher{
-								pos:        position{line: 67, col: 43, offset: 2148},
+								pos:        position{line: 68, col: 43, offset: 2149},
 								val:        "=>",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 67, col: 50, offset: 2155},
+								pos:        position{line: 68, col: 50, offset: 2156},
 								val:        ")",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 67, col: 56, offset: 2161},
+								pos:  position{line: 68, col: 56, offset: 2162},
 								name: "EOF",
 							},
 						},
@@ -684,27 +684,27 @@ var g = &grammar{
 		},
 		{
 			name: "Pipe",
-			pos:  position{line: 68, col: 1, offset: 2166},
+			pos:  position{line: 69, col: 1, offset: 2167},
 			expr: &seqExpr{
-				pos: position{line: 68, col: 8, offset: 2173},
+				pos: position{line: 69, col: 8, offset: 2174},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 68, col: 8, offset: 2173},
+						pos:        position{line: 69, col: 8, offset: 2174},
 						val:        "|",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 68, col: 12, offset: 2177},
+						pos: position{line: 69, col: 12, offset: 2178},
 						expr: &choiceExpr{
-							pos: position{line: 68, col: 14, offset: 2179},
+							pos: position{line: 69, col: 14, offset: 2180},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 68, col: 14, offset: 2179},
+									pos:        position{line: 69, col: 14, offset: 2180},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 68, col: 20, offset: 2185},
+									pos:        position{line: 69, col: 20, offset: 2186},
 									val:        "[",
 									ignoreCase: false,
 								},
@@ -716,31 +716,31 @@ var g = &grammar{
 		},
 		{
 			name: "Leg",
-			pos:  position{line: 70, col: 1, offset: 2191},
+			pos:  position{line: 71, col: 1, offset: 2192},
 			expr: &actionExpr{
-				pos: position{line: 71, col: 5, offset: 2199},
+				pos: position{line: 72, col: 5, offset: 2200},
 				run: (*parser).callonLeg1,
 				expr: &seqExpr{
-					pos: position{line: 71, col: 5, offset: 2199},
+					pos: position{line: 72, col: 5, offset: 2200},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 71, col: 5, offset: 2199},
+							pos:  position{line: 72, col: 5, offset: 2200},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 71, col: 8, offset: 2202},
+							pos:        position{line: 72, col: 8, offset: 2203},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 71, col: 13, offset: 2207},
+							pos:  position{line: 72, col: 13, offset: 2208},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 71, col: 16, offset: 2210},
+							pos:   position{line: 72, col: 16, offset: 2211},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 71, col: 18, offset: 2212},
+								pos:  position{line: 72, col: 18, offset: 2213},
 								name: "Sequential",
 							},
 						},
@@ -750,43 +750,43 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchLeg",
-			pos:  position{line: 73, col: 1, offset: 2242},
+			pos:  position{line: 74, col: 1, offset: 2243},
 			expr: &actionExpr{
-				pos: position{line: 74, col: 5, offset: 2256},
+				pos: position{line: 75, col: 5, offset: 2257},
 				run: (*parser).callonSwitchLeg1,
 				expr: &seqExpr{
-					pos: position{line: 74, col: 5, offset: 2256},
+					pos: position{line: 75, col: 5, offset: 2257},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 74, col: 5, offset: 2256},
+							pos:  position{line: 75, col: 5, offset: 2257},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 74, col: 8, offset: 2259},
+							pos:   position{line: 75, col: 8, offset: 2260},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 74, col: 13, offset: 2264},
+								pos:  position{line: 75, col: 13, offset: 2265},
 								name: "Case",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 74, col: 18, offset: 2269},
+							pos:  position{line: 75, col: 18, offset: 2270},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 74, col: 21, offset: 2272},
+							pos:        position{line: 75, col: 21, offset: 2273},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 74, col: 26, offset: 2277},
+							pos:  position{line: 75, col: 26, offset: 2278},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 74, col: 29, offset: 2280},
+							pos:   position{line: 75, col: 29, offset: 2281},
 							label: "proc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 74, col: 34, offset: 2285},
+								pos:  position{line: 75, col: 34, offset: 2286},
 								name: "Sequential",
 							},
 						},
@@ -796,30 +796,30 @@ var g = &grammar{
 		},
 		{
 			name: "Case",
-			pos:  position{line: 78, col: 1, offset: 2374},
+			pos:  position{line: 79, col: 1, offset: 2375},
 			expr: &choiceExpr{
-				pos: position{line: 79, col: 5, offset: 2383},
+				pos: position{line: 80, col: 5, offset: 2384},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 79, col: 5, offset: 2383},
+						pos: position{line: 80, col: 5, offset: 2384},
 						run: (*parser).callonCase2,
 						expr: &seqExpr{
-							pos: position{line: 79, col: 5, offset: 2383},
+							pos: position{line: 80, col: 5, offset: 2384},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 79, col: 5, offset: 2383},
+									pos:        position{line: 80, col: 5, offset: 2384},
 									val:        "case",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 79, col: 12, offset: 2390},
+									pos:  position{line: 80, col: 12, offset: 2391},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 79, col: 14, offset: 2392},
+									pos:   position{line: 80, col: 14, offset: 2393},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 79, col: 19, offset: 2397},
+										pos:  position{line: 80, col: 19, offset: 2398},
 										name: "Expr",
 									},
 								},
@@ -827,10 +827,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 80, col: 5, offset: 2427},
+						pos: position{line: 81, col: 5, offset: 2428},
 						run: (*parser).callonCase8,
 						expr: &litMatcher{
-							pos:        position{line: 80, col: 5, offset: 2427},
+							pos:        position{line: 81, col: 5, offset: 2428},
 							val:        "default",
 							ignoreCase: false,
 						},
@@ -840,37 +840,37 @@ var g = &grammar{
 		},
 		{
 			name: "FromLeg",
-			pos:  position{line: 82, col: 1, offset: 2458},
+			pos:  position{line: 83, col: 1, offset: 2459},
 			expr: &choiceExpr{
-				pos: position{line: 83, col: 5, offset: 2470},
+				pos: position{line: 84, col: 5, offset: 2471},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 83, col: 5, offset: 2470},
+						pos: position{line: 84, col: 5, offset: 2471},
 						run: (*parser).callonFromLeg2,
 						expr: &seqExpr{
-							pos: position{line: 83, col: 5, offset: 2470},
+							pos: position{line: 84, col: 5, offset: 2471},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 83, col: 5, offset: 2470},
+									pos:  position{line: 84, col: 5, offset: 2471},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 83, col: 8, offset: 2473},
+									pos:   position{line: 84, col: 8, offset: 2474},
 									label: "source",
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 15, offset: 2480},
+										pos:  position{line: 84, col: 15, offset: 2481},
 										name: "FromHead",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 83, col: 24, offset: 2489},
+									pos:  position{line: 84, col: 24, offset: 2490},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 83, col: 28, offset: 2493},
+									pos:   position{line: 84, col: 28, offset: 2494},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 32, offset: 2497},
+										pos:  position{line: 84, col: 32, offset: 2498},
 										name: "Sequential",
 									},
 								},
@@ -878,20 +878,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 86, col: 5, offset: 2608},
+						pos: position{line: 87, col: 5, offset: 2609},
 						run: (*parser).callonFromLeg10,
 						expr: &seqExpr{
-							pos: position{line: 86, col: 5, offset: 2608},
+							pos: position{line: 87, col: 5, offset: 2609},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 86, col: 5, offset: 2608},
+									pos:  position{line: 87, col: 5, offset: 2609},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 86, col: 8, offset: 2611},
+									pos:   position{line: 87, col: 8, offset: 2612},
 									label: "source",
 									expr: &ruleRefExpr{
-										pos:  position{line: 86, col: 15, offset: 2618},
+										pos:  position{line: 87, col: 15, offset: 2619},
 										name: "FromSource",
 									},
 								},
@@ -903,27 +903,27 @@ var g = &grammar{
 		},
 		{
 			name: "FromHead",
-			pos:  position{line: 90, col: 1, offset: 2726},
+			pos:  position{line: 91, col: 1, offset: 2727},
 			expr: &actionExpr{
-				pos: position{line: 91, col: 5, offset: 2739},
+				pos: position{line: 92, col: 5, offset: 2740},
 				run: (*parser).callonFromHead1,
 				expr: &seqExpr{
-					pos: position{line: 91, col: 5, offset: 2739},
+					pos: position{line: 92, col: 5, offset: 2740},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 91, col: 5, offset: 2739},
+							pos:   position{line: 92, col: 5, offset: 2740},
 							label: "src",
 							expr: &ruleRefExpr{
-								pos:  position{line: 91, col: 9, offset: 2743},
+								pos:  position{line: 92, col: 9, offset: 2744},
 								name: "FromSource",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 91, col: 20, offset: 2754},
+							pos:  position{line: 92, col: 20, offset: 2755},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 91, col: 23, offset: 2757},
+							pos:        position{line: 92, col: 23, offset: 2758},
 							val:        "=>",
 							ignoreCase: false,
 						},
@@ -933,24 +933,24 @@ var g = &grammar{
 		},
 		{
 			name: "FromSource",
-			pos:  position{line: 93, col: 1, offset: 2783},
+			pos:  position{line: 94, col: 1, offset: 2784},
 			expr: &choiceExpr{
-				pos: position{line: 94, col: 5, offset: 2798},
+				pos: position{line: 95, col: 5, offset: 2799},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 94, col: 5, offset: 2798},
+						pos:  position{line: 95, col: 5, offset: 2799},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 95, col: 5, offset: 2807},
+						pos:  position{line: 96, col: 5, offset: 2808},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 96, col: 5, offset: 2815},
+						pos:  position{line: 97, col: 5, offset: 2816},
 						name: "Pool",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 97, col: 5, offset: 2824},
+						pos:  position{line: 98, col: 5, offset: 2825},
 						name: "PassProc",
 					},
 				},
@@ -958,59 +958,59 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 99, col: 1, offset: 2834},
+			pos:  position{line: 100, col: 1, offset: 2835},
 			expr: &seqExpr{
-				pos: position{line: 99, col: 13, offset: 2846},
+				pos: position{line: 100, col: 13, offset: 2847},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 99, col: 13, offset: 2846},
+						pos:  position{line: 100, col: 13, offset: 2847},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 99, col: 17, offset: 2850},
+						pos: position{line: 100, col: 17, offset: 2851},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 99, col: 18, offset: 2851},
+								pos: position{line: 100, col: 18, offset: 2852},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 99, col: 18, offset: 2851},
+										pos: position{line: 100, col: 18, offset: 2852},
 										expr: &litMatcher{
-											pos:        position{line: 99, col: 19, offset: 2852},
+											pos:        position{line: 100, col: 19, offset: 2853},
 											val:        "=>",
 											ignoreCase: false,
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 99, col: 24, offset: 2857},
+										pos:  position{line: 100, col: 24, offset: 2858},
 										name: "Comparator",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 99, col: 38, offset: 2871},
+								pos:  position{line: 100, col: 38, offset: 2872},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 99, col: 57, offset: 2890},
+								pos:  position{line: 100, col: 57, offset: 2891},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 99, col: 82, offset: 2915},
+								pos:        position{line: 100, col: 82, offset: 2916},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 99, col: 88, offset: 2921},
+								pos:        position{line: 100, col: 88, offset: 2922},
 								val:        "(",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 99, col: 94, offset: 2927},
+								pos:        position{line: 100, col: 94, offset: 2928},
 								val:        "[",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 99, col: 100, offset: 2933},
+								pos:        position{line: 100, col: 100, offset: 2934},
 								val:        "~",
 								ignoreCase: false,
 							},
@@ -1021,57 +1021,57 @@ var g = &grammar{
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 101, col: 1, offset: 2939},
+			pos:  position{line: 102, col: 1, offset: 2940},
 			expr: &actionExpr{
-				pos: position{line: 101, col: 14, offset: 2952},
+				pos: position{line: 102, col: 14, offset: 2953},
 				run: (*parser).callonComparator1,
 				expr: &choiceExpr{
-					pos: position{line: 101, col: 15, offset: 2953},
+					pos: position{line: 102, col: 15, offset: 2954},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 101, col: 15, offset: 2953},
+							pos:        position{line: 102, col: 15, offset: 2954},
 							val:        "==",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 101, col: 22, offset: 2960},
+							pos:        position{line: 102, col: 22, offset: 2961},
 							val:        "!=",
 							ignoreCase: false,
 						},
 						&seqExpr{
-							pos: position{line: 101, col: 30, offset: 2968},
+							pos: position{line: 102, col: 30, offset: 2969},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 101, col: 30, offset: 2968},
+									pos:        position{line: 102, col: 30, offset: 2969},
 									val:        "in",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 101, col: 35, offset: 2973},
+									pos: position{line: 102, col: 35, offset: 2974},
 									expr: &ruleRefExpr{
-										pos:  position{line: 101, col: 36, offset: 2974},
+										pos:  position{line: 102, col: 36, offset: 2975},
 										name: "IdentifierRest",
 									},
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 101, col: 54, offset: 2992},
+							pos:        position{line: 102, col: 54, offset: 2993},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 101, col: 61, offset: 2999},
+							pos:        position{line: 102, col: 61, offset: 3000},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 101, col: 67, offset: 3005},
+							pos:        position{line: 102, col: 67, offset: 3006},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 101, col: 74, offset: 3012},
+							pos:        position{line: 102, col: 74, offset: 3013},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1081,28 +1081,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 103, col: 1, offset: 3049},
+			pos:  position{line: 104, col: 1, offset: 3050},
 			expr: &actionExpr{
-				pos: position{line: 104, col: 5, offset: 3067},
+				pos: position{line: 105, col: 5, offset: 3068},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 104, col: 5, offset: 3067},
+					pos: position{line: 105, col: 5, offset: 3068},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 104, col: 5, offset: 3067},
+							pos:   position{line: 105, col: 5, offset: 3068},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 104, col: 11, offset: 3073},
+								pos:  position{line: 105, col: 11, offset: 3074},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 104, col: 21, offset: 3083},
+							pos:   position{line: 105, col: 21, offset: 3084},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 104, col: 26, offset: 3088},
+								pos: position{line: 105, col: 26, offset: 3089},
 								expr: &ruleRefExpr{
-									pos:  position{line: 104, col: 26, offset: 3088},
+									pos:  position{line: 105, col: 26, offset: 3089},
 									name: "SearchOrTerm",
 								},
 							},
@@ -1113,30 +1113,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 108, col: 1, offset: 3162},
+			pos:  position{line: 109, col: 1, offset: 3163},
 			expr: &actionExpr{
-				pos: position{line: 108, col: 16, offset: 3177},
+				pos: position{line: 109, col: 16, offset: 3178},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 108, col: 16, offset: 3177},
+					pos: position{line: 109, col: 16, offset: 3178},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 108, col: 16, offset: 3177},
+							pos:  position{line: 109, col: 16, offset: 3178},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 108, col: 18, offset: 3179},
+							pos:  position{line: 109, col: 18, offset: 3180},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 108, col: 26, offset: 3187},
+							pos:  position{line: 109, col: 26, offset: 3188},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 108, col: 28, offset: 3189},
+							pos:   position{line: 109, col: 28, offset: 3190},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 108, col: 30, offset: 3191},
+								pos:  position{line: 109, col: 30, offset: 3192},
 								name: "SearchAnd",
 							},
 						},
@@ -1146,73 +1146,73 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 110, col: 1, offset: 3241},
+			pos:  position{line: 111, col: 1, offset: 3242},
 			expr: &actionExpr{
-				pos: position{line: 111, col: 5, offset: 3255},
+				pos: position{line: 112, col: 5, offset: 3256},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 111, col: 5, offset: 3255},
+					pos: position{line: 112, col: 5, offset: 3256},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 111, col: 5, offset: 3255},
+							pos:   position{line: 112, col: 5, offset: 3256},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 111, col: 11, offset: 3261},
+								pos:  position{line: 112, col: 11, offset: 3262},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 112, col: 5, offset: 3278},
+							pos:   position{line: 113, col: 5, offset: 3279},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 112, col: 10, offset: 3283},
+								pos: position{line: 113, col: 10, offset: 3284},
 								expr: &actionExpr{
-									pos: position{line: 112, col: 11, offset: 3284},
+									pos: position{line: 113, col: 11, offset: 3285},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 112, col: 11, offset: 3284},
+										pos: position{line: 113, col: 11, offset: 3285},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 112, col: 11, offset: 3284},
+												pos: position{line: 113, col: 11, offset: 3285},
 												expr: &seqExpr{
-													pos: position{line: 112, col: 12, offset: 3285},
+													pos: position{line: 113, col: 12, offset: 3286},
 													exprs: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 112, col: 12, offset: 3285},
+															pos:  position{line: 113, col: 12, offset: 3286},
 															name: "_",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 112, col: 14, offset: 3287},
+															pos:  position{line: 113, col: 14, offset: 3288},
 															name: "AndToken",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 112, col: 25, offset: 3298},
+												pos:  position{line: 113, col: 25, offset: 3299},
 												name: "_",
 											},
 											&notExpr{
-												pos: position{line: 112, col: 27, offset: 3300},
+												pos: position{line: 113, col: 27, offset: 3301},
 												expr: &choiceExpr{
-													pos: position{line: 112, col: 29, offset: 3302},
+													pos: position{line: 113, col: 29, offset: 3303},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 112, col: 29, offset: 3302},
+															pos:  position{line: 113, col: 29, offset: 3303},
 															name: "OrToken",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 112, col: 39, offset: 3312},
+															pos:  position{line: 113, col: 39, offset: 3313},
 															name: "SearchKeywordGuard",
 														},
 													},
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 112, col: 59, offset: 3332},
+												pos:   position{line: 113, col: 59, offset: 3333},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 112, col: 64, offset: 3337},
+													pos:  position{line: 113, col: 64, offset: 3338},
 													name: "SearchFactor",
 												},
 											},
@@ -1227,32 +1227,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchKeywordGuard",
-			pos:  position{line: 116, col: 1, offset: 3453},
+			pos:  position{line: 117, col: 1, offset: 3454},
 			expr: &choiceExpr{
-				pos: position{line: 117, col: 5, offset: 3476},
+				pos: position{line: 118, col: 5, offset: 3477},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 117, col: 5, offset: 3476},
+						pos: position{line: 118, col: 5, offset: 3477},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 117, col: 5, offset: 3476},
+								pos:  position{line: 118, col: 5, offset: 3477},
 								name: "FromHead",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 117, col: 14, offset: 3485},
+								pos:  position{line: 118, col: 14, offset: 3486},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 118, col: 5, offset: 3492},
+						pos: position{line: 119, col: 5, offset: 3493},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 118, col: 5, offset: 3492},
+								pos:  position{line: 119, col: 5, offset: 3493},
 								name: "Case",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 118, col: 10, offset: 3497},
+								pos:  position{line: 119, col: 10, offset: 3498},
 								name: "__",
 							},
 						},
@@ -1262,42 +1262,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 120, col: 1, offset: 3501},
+			pos:  position{line: 121, col: 1, offset: 3502},
 			expr: &choiceExpr{
-				pos: position{line: 121, col: 5, offset: 3518},
+				pos: position{line: 122, col: 5, offset: 3519},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 121, col: 5, offset: 3518},
+						pos: position{line: 122, col: 5, offset: 3519},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 121, col: 5, offset: 3518},
+							pos: position{line: 122, col: 5, offset: 3519},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 121, col: 6, offset: 3519},
+									pos: position{line: 122, col: 6, offset: 3520},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 121, col: 6, offset: 3519},
+											pos: position{line: 122, col: 6, offset: 3520},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 121, col: 6, offset: 3519},
+													pos:  position{line: 122, col: 6, offset: 3520},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 121, col: 15, offset: 3528},
+													pos:  position{line: 122, col: 15, offset: 3529},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 121, col: 19, offset: 3532},
+											pos: position{line: 122, col: 19, offset: 3533},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 121, col: 19, offset: 3532},
+													pos:        position{line: 122, col: 19, offset: 3533},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 121, col: 23, offset: 3536},
+													pos:  position{line: 122, col: 23, offset: 3537},
 													name: "__",
 												},
 											},
@@ -1305,10 +1305,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 121, col: 27, offset: 3540},
+									pos:   position{line: 122, col: 27, offset: 3541},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 121, col: 29, offset: 3542},
+										pos:  position{line: 122, col: 29, offset: 3543},
 										name: "SearchFactor",
 									},
 								},
@@ -1316,34 +1316,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 124, col: 5, offset: 3654},
+						pos: position{line: 125, col: 5, offset: 3655},
 						run: (*parser).callonSearchFactor13,
 						expr: &seqExpr{
-							pos: position{line: 124, col: 5, offset: 3654},
+							pos: position{line: 125, col: 5, offset: 3655},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 124, col: 5, offset: 3654},
+									pos:        position{line: 125, col: 5, offset: 3655},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 124, col: 9, offset: 3658},
+									pos:  position{line: 125, col: 9, offset: 3659},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 124, col: 12, offset: 3661},
+									pos:   position{line: 125, col: 12, offset: 3662},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 124, col: 17, offset: 3666},
+										pos:  position{line: 125, col: 17, offset: 3667},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 124, col: 31, offset: 3680},
+									pos:  position{line: 125, col: 31, offset: 3681},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 124, col: 34, offset: 3683},
+									pos:        position{line: 125, col: 34, offset: 3684},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1351,7 +1351,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 125, col: 5, offset: 3712},
+						pos:  position{line: 126, col: 5, offset: 3713},
 						name: "SearchExpr",
 					},
 				},
@@ -1359,43 +1359,43 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 127, col: 1, offset: 3724},
+			pos:  position{line: 128, col: 1, offset: 3725},
 			expr: &choiceExpr{
-				pos: position{line: 128, col: 5, offset: 3739},
+				pos: position{line: 129, col: 5, offset: 3740},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 128, col: 5, offset: 3739},
+						pos:  position{line: 129, col: 5, offset: 3740},
 						name: "Glob",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 129, col: 5, offset: 3748},
+						pos:  position{line: 130, col: 5, offset: 3749},
 						name: "Regexp",
 					},
 					&actionExpr{
-						pos: position{line: 130, col: 5, offset: 3759},
+						pos: position{line: 131, col: 5, offset: 3760},
 						run: (*parser).callonSearchExpr4,
 						expr: &seqExpr{
-							pos: position{line: 130, col: 5, offset: 3759},
+							pos: position{line: 131, col: 5, offset: 3760},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 130, col: 5, offset: 3759},
+									pos:   position{line: 131, col: 5, offset: 3760},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 130, col: 7, offset: 3761},
+										pos:  position{line: 131, col: 7, offset: 3762},
 										name: "SearchValue",
 									},
 								},
 								&andExpr{
-									pos: position{line: 130, col: 19, offset: 3773},
+									pos: position{line: 131, col: 19, offset: 3774},
 									expr: &seqExpr{
-										pos: position{line: 130, col: 21, offset: 3775},
+										pos: position{line: 131, col: 21, offset: 3776},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 130, col: 21, offset: 3775},
+												pos:  position{line: 131, col: 21, offset: 3776},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 130, col: 23, offset: 3777},
+												pos:  position{line: 131, col: 23, offset: 3778},
 												name: "Glob",
 											},
 										},
@@ -1405,23 +1405,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 133, col: 5, offset: 3888},
+						pos: position{line: 134, col: 5, offset: 3889},
 						run: (*parser).callonSearchExpr12,
 						expr: &seqExpr{
-							pos: position{line: 133, col: 5, offset: 3888},
+							pos: position{line: 134, col: 5, offset: 3889},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 133, col: 5, offset: 3888},
+									pos:   position{line: 134, col: 5, offset: 3889},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 133, col: 7, offset: 3890},
+										pos:  position{line: 134, col: 7, offset: 3891},
 										name: "SearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 133, col: 19, offset: 3902},
+									pos: position{line: 134, col: 19, offset: 3903},
 									expr: &ruleRefExpr{
-										pos:  position{line: 133, col: 20, offset: 3903},
+										pos:  position{line: 134, col: 20, offset: 3904},
 										name: "ExprGuard",
 									},
 								},
@@ -1429,20 +1429,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 136, col: 5, offset: 4018},
+						pos: position{line: 137, col: 5, offset: 4019},
 						run: (*parser).callonSearchExpr18,
 						expr: &seqExpr{
-							pos: position{line: 136, col: 5, offset: 4018},
+							pos: position{line: 137, col: 5, offset: 4019},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 136, col: 5, offset: 4018},
+									pos:        position{line: 137, col: 5, offset: 4019},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 136, col: 9, offset: 4022},
+									pos: position{line: 137, col: 9, offset: 4023},
 									expr: &ruleRefExpr{
-										pos:  position{line: 136, col: 10, offset: 4023},
+										pos:  position{line: 137, col: 10, offset: 4024},
 										name: "ExprGuard",
 									},
 								},
@@ -1450,7 +1450,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 139, col: 5, offset: 4139},
+						pos:  position{line: 140, col: 5, offset: 4140},
 						name: "SearchPredicate",
 					},
 				},
@@ -1458,45 +1458,45 @@ var g = &grammar{
 		},
 		{
 			name: "SearchPredicate",
-			pos:  position{line: 141, col: 1, offset: 4156},
+			pos:  position{line: 142, col: 1, offset: 4157},
 			expr: &choiceExpr{
-				pos: position{line: 142, col: 5, offset: 4176},
+				pos: position{line: 143, col: 5, offset: 4177},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 142, col: 5, offset: 4176},
+						pos: position{line: 143, col: 5, offset: 4177},
 						run: (*parser).callonSearchPredicate2,
 						expr: &seqExpr{
-							pos: position{line: 142, col: 5, offset: 4176},
+							pos: position{line: 143, col: 5, offset: 4177},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 142, col: 5, offset: 4176},
+									pos:   position{line: 143, col: 5, offset: 4177},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 142, col: 9, offset: 4180},
+										pos:  position{line: 143, col: 9, offset: 4181},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 142, col: 22, offset: 4193},
+									pos:  position{line: 143, col: 22, offset: 4194},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 142, col: 25, offset: 4196},
+									pos:   position{line: 143, col: 25, offset: 4197},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 142, col: 28, offset: 4199},
+										pos:  position{line: 143, col: 28, offset: 4200},
 										name: "Comparator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 142, col: 39, offset: 4210},
+									pos:  position{line: 143, col: 39, offset: 4211},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 142, col: 42, offset: 4213},
+									pos:   position{line: 143, col: 42, offset: 4214},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 142, col: 46, offset: 4217},
+										pos:  position{line: 143, col: 46, offset: 4218},
 										name: "AdditiveExpr",
 									},
 								},
@@ -1504,26 +1504,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 145, col: 6, offset: 4340},
+						pos: position{line: 146, col: 6, offset: 4341},
 						run: (*parser).callonSearchPredicate12,
 						expr: &seqExpr{
-							pos: position{line: 145, col: 6, offset: 4340},
+							pos: position{line: 146, col: 6, offset: 4341},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 145, col: 6, offset: 4340},
+									pos:   position{line: 146, col: 6, offset: 4341},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 145, col: 12, offset: 4346},
+										pos:  position{line: 146, col: 12, offset: 4347},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 145, col: 21, offset: 4355},
+									pos:   position{line: 146, col: 21, offset: 4356},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 145, col: 26, offset: 4360},
+										pos: position{line: 146, col: 26, offset: 4361},
 										expr: &ruleRefExpr{
-											pos:  position{line: 145, col: 27, offset: 4361},
+											pos:  position{line: 146, col: 27, offset: 4362},
 											name: "Deref",
 										},
 									},
@@ -1536,32 +1536,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 149, col: 1, offset: 4433},
+			pos:  position{line: 150, col: 1, offset: 4434},
 			expr: &choiceExpr{
-				pos: position{line: 150, col: 5, offset: 4449},
+				pos: position{line: 151, col: 5, offset: 4450},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 150, col: 5, offset: 4449},
+						pos:  position{line: 151, col: 5, offset: 4450},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 151, col: 5, offset: 4461},
+						pos: position{line: 152, col: 5, offset: 4462},
 						run: (*parser).callonSearchValue3,
 						expr: &seqExpr{
-							pos: position{line: 151, col: 5, offset: 4461},
+							pos: position{line: 152, col: 5, offset: 4462},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 151, col: 5, offset: 4461},
+									pos: position{line: 152, col: 5, offset: 4462},
 									expr: &ruleRefExpr{
-										pos:  position{line: 151, col: 6, offset: 4462},
+										pos:  position{line: 152, col: 6, offset: 4463},
 										name: "RegexpPattern",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 151, col: 20, offset: 4476},
+									pos:   position{line: 152, col: 20, offset: 4477},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 151, col: 22, offset: 4478},
+										pos:  position{line: 152, col: 22, offset: 4479},
 										name: "KeyWord",
 									},
 								},
@@ -1573,15 +1573,15 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 155, col: 1, offset: 4586},
+			pos:  position{line: 156, col: 1, offset: 4587},
 			expr: &actionExpr{
-				pos: position{line: 156, col: 5, offset: 4595},
+				pos: position{line: 157, col: 5, offset: 4596},
 				run: (*parser).callonGlob1,
 				expr: &labeledExpr{
-					pos:   position{line: 156, col: 5, offset: 4595},
+					pos:   position{line: 157, col: 5, offset: 4596},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 156, col: 13, offset: 4603},
+						pos:  position{line: 157, col: 13, offset: 4604},
 						name: "GlobPattern",
 					},
 				},
@@ -1589,15 +1589,15 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 160, col: 1, offset: 4699},
+			pos:  position{line: 161, col: 1, offset: 4700},
 			expr: &actionExpr{
-				pos: position{line: 161, col: 5, offset: 4710},
+				pos: position{line: 162, col: 5, offset: 4711},
 				run: (*parser).callonRegexp1,
 				expr: &labeledExpr{
-					pos:   position{line: 161, col: 5, offset: 4710},
+					pos:   position{line: 162, col: 5, offset: 4711},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 161, col: 13, offset: 4718},
+						pos:  position{line: 162, col: 13, offset: 4719},
 						name: "RegexpPattern",
 					},
 				},
@@ -1605,36 +1605,36 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 167, col: 1, offset: 4844},
+			pos:  position{line: 168, col: 1, offset: 4845},
 			expr: &choiceExpr{
-				pos: position{line: 168, col: 5, offset: 4860},
+				pos: position{line: 169, col: 5, offset: 4861},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 168, col: 5, offset: 4860},
+						pos: position{line: 169, col: 5, offset: 4861},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 168, col: 5, offset: 4860},
+							pos: position{line: 169, col: 5, offset: 4861},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 168, col: 5, offset: 4860},
+									pos: position{line: 169, col: 5, offset: 4861},
 									expr: &ruleRefExpr{
-										pos:  position{line: 168, col: 5, offset: 4860},
+										pos:  position{line: 169, col: 5, offset: 4861},
 										name: "Summarize",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 168, col: 16, offset: 4871},
+									pos:   position{line: 169, col: 16, offset: 4872},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 168, col: 21, offset: 4876},
+										pos:  position{line: 169, col: 21, offset: 4877},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 168, col: 33, offset: 4888},
+									pos:   position{line: 169, col: 33, offset: 4889},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 168, col: 39, offset: 4894},
+										pos:  position{line: 169, col: 39, offset: 4895},
 										name: "LimitArg",
 									},
 								},
@@ -1642,40 +1642,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 171, col: 5, offset: 5020},
+						pos: position{line: 172, col: 5, offset: 5021},
 						run: (*parser).callonAggregation10,
 						expr: &seqExpr{
-							pos: position{line: 171, col: 5, offset: 5020},
+							pos: position{line: 172, col: 5, offset: 5021},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 171, col: 5, offset: 5020},
+									pos: position{line: 172, col: 5, offset: 5021},
 									expr: &ruleRefExpr{
-										pos:  position{line: 171, col: 5, offset: 5020},
+										pos:  position{line: 172, col: 5, offset: 5021},
 										name: "Summarize",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 171, col: 16, offset: 5031},
+									pos:   position{line: 172, col: 16, offset: 5032},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 171, col: 21, offset: 5036},
+										pos:  position{line: 172, col: 21, offset: 5037},
 										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 171, col: 36, offset: 5051},
+									pos:   position{line: 172, col: 36, offset: 5052},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 171, col: 41, offset: 5056},
+										pos: position{line: 172, col: 41, offset: 5057},
 										expr: &seqExpr{
-											pos: position{line: 171, col: 42, offset: 5057},
+											pos: position{line: 172, col: 42, offset: 5058},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 171, col: 42, offset: 5057},
+													pos:  position{line: 172, col: 42, offset: 5058},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 171, col: 44, offset: 5059},
+													pos:  position{line: 172, col: 44, offset: 5060},
 													name: "GroupByKeys",
 												},
 											},
@@ -1683,10 +1683,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 171, col: 58, offset: 5073},
+									pos:   position{line: 172, col: 58, offset: 5074},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 171, col: 64, offset: 5079},
+										pos:  position{line: 172, col: 64, offset: 5080},
 										name: "LimitArg",
 									},
 								},
@@ -1698,17 +1698,17 @@ var g = &grammar{
 		},
 		{
 			name: "Summarize",
-			pos:  position{line: 179, col: 1, offset: 5293},
+			pos:  position{line: 180, col: 1, offset: 5294},
 			expr: &seqExpr{
-				pos: position{line: 179, col: 13, offset: 5305},
+				pos: position{line: 180, col: 13, offset: 5306},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 179, col: 13, offset: 5305},
+						pos:        position{line: 180, col: 13, offset: 5306},
 						val:        "summarize",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 179, col: 25, offset: 5317},
+						pos:  position{line: 180, col: 25, offset: 5318},
 						name: "_",
 					},
 				},
@@ -1716,26 +1716,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 181, col: 1, offset: 5320},
+			pos:  position{line: 182, col: 1, offset: 5321},
 			expr: &actionExpr{
-				pos: position{line: 182, col: 5, offset: 5336},
+				pos: position{line: 183, col: 5, offset: 5337},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 182, col: 5, offset: 5336},
+					pos: position{line: 183, col: 5, offset: 5337},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 182, col: 5, offset: 5336},
+							pos:  position{line: 183, col: 5, offset: 5337},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 182, col: 13, offset: 5344},
+							pos:  position{line: 183, col: 13, offset: 5345},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 182, col: 15, offset: 5346},
+							pos:   position{line: 183, col: 15, offset: 5347},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 182, col: 23, offset: 5354},
+								pos:  position{line: 183, col: 23, offset: 5355},
 								name: "FlexAssignments",
 							},
 						},
@@ -1745,43 +1745,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 184, col: 1, offset: 5395},
+			pos:  position{line: 185, col: 1, offset: 5396},
 			expr: &choiceExpr{
-				pos: position{line: 185, col: 5, offset: 5408},
+				pos: position{line: 186, col: 5, offset: 5409},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 185, col: 5, offset: 5408},
+						pos: position{line: 186, col: 5, offset: 5409},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 185, col: 5, offset: 5408},
+							pos: position{line: 186, col: 5, offset: 5409},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 185, col: 5, offset: 5408},
+									pos:  position{line: 186, col: 5, offset: 5409},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 185, col: 7, offset: 5410},
+									pos:        position{line: 186, col: 7, offset: 5411},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 185, col: 14, offset: 5417},
+									pos:  position{line: 186, col: 14, offset: 5418},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 185, col: 16, offset: 5419},
+									pos:        position{line: 186, col: 16, offset: 5420},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 185, col: 25, offset: 5428},
+									pos:  position{line: 186, col: 25, offset: 5429},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 185, col: 27, offset: 5430},
+									pos:   position{line: 186, col: 27, offset: 5431},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 185, col: 33, offset: 5436},
+										pos:  position{line: 186, col: 33, offset: 5437},
 										name: "UInt",
 									},
 								},
@@ -1789,10 +1789,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 186, col: 5, offset: 5467},
+						pos: position{line: 187, col: 5, offset: 5468},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 186, col: 5, offset: 5467},
+							pos:        position{line: 187, col: 5, offset: 5468},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -1802,22 +1802,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 191, col: 1, offset: 5727},
+			pos:  position{line: 192, col: 1, offset: 5728},
 			expr: &choiceExpr{
-				pos: position{line: 192, col: 5, offset: 5746},
+				pos: position{line: 193, col: 5, offset: 5747},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 5, offset: 5746},
+						pos:  position{line: 193, col: 5, offset: 5747},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 193, col: 5, offset: 5761},
+						pos: position{line: 194, col: 5, offset: 5762},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 193, col: 5, offset: 5761},
+							pos:   position{line: 194, col: 5, offset: 5762},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 193, col: 10, offset: 5766},
+								pos:  position{line: 194, col: 10, offset: 5767},
 								name: "Expr",
 							},
 						},
@@ -1827,50 +1827,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 195, col: 1, offset: 5858},
+			pos:  position{line: 196, col: 1, offset: 5859},
 			expr: &actionExpr{
-				pos: position{line: 196, col: 5, offset: 5878},
+				pos: position{line: 197, col: 5, offset: 5879},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 196, col: 5, offset: 5878},
+					pos: position{line: 197, col: 5, offset: 5879},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 196, col: 5, offset: 5878},
+							pos:   position{line: 197, col: 5, offset: 5879},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 196, col: 11, offset: 5884},
+								pos:  position{line: 197, col: 11, offset: 5885},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 196, col: 26, offset: 5899},
+							pos:   position{line: 197, col: 26, offset: 5900},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 196, col: 31, offset: 5904},
+								pos: position{line: 197, col: 31, offset: 5905},
 								expr: &actionExpr{
-									pos: position{line: 196, col: 32, offset: 5905},
+									pos: position{line: 197, col: 32, offset: 5906},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 196, col: 32, offset: 5905},
+										pos: position{line: 197, col: 32, offset: 5906},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 196, col: 32, offset: 5905},
+												pos:  position{line: 197, col: 32, offset: 5906},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 196, col: 35, offset: 5908},
+												pos:        position{line: 197, col: 35, offset: 5909},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 196, col: 39, offset: 5912},
+												pos:  position{line: 197, col: 39, offset: 5913},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 196, col: 42, offset: 5915},
+												pos:   position{line: 197, col: 42, offset: 5916},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 196, col: 47, offset: 5920},
+													pos:  position{line: 197, col: 47, offset: 5921},
 													name: "FlexAssignment",
 												},
 											},
@@ -1885,42 +1885,42 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignment",
-			pos:  position{line: 200, col: 1, offset: 6042},
+			pos:  position{line: 201, col: 1, offset: 6043},
 			expr: &choiceExpr{
-				pos: position{line: 201, col: 5, offset: 6060},
+				pos: position{line: 202, col: 5, offset: 6061},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 201, col: 5, offset: 6060},
+						pos: position{line: 202, col: 5, offset: 6061},
 						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 201, col: 5, offset: 6060},
+							pos: position{line: 202, col: 5, offset: 6061},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 201, col: 5, offset: 6060},
+									pos:   position{line: 202, col: 5, offset: 6061},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 201, col: 10, offset: 6065},
+										pos:  position{line: 202, col: 10, offset: 6066},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 201, col: 15, offset: 6070},
+									pos:  position{line: 202, col: 15, offset: 6071},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 201, col: 18, offset: 6073},
+									pos:        position{line: 202, col: 18, offset: 6074},
 									val:        ":=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 201, col: 23, offset: 6078},
+									pos:  position{line: 202, col: 23, offset: 6079},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 201, col: 26, offset: 6081},
+									pos:   position{line: 202, col: 26, offset: 6082},
 									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 201, col: 30, offset: 6085},
+										pos:  position{line: 202, col: 30, offset: 6086},
 										name: "Agg",
 									},
 								},
@@ -1928,13 +1928,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 204, col: 5, offset: 6189},
+						pos: position{line: 205, col: 5, offset: 6190},
 						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 204, col: 5, offset: 6189},
+							pos:   position{line: 205, col: 5, offset: 6190},
 							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 204, col: 9, offset: 6193},
+								pos:  position{line: 205, col: 9, offset: 6194},
 								name: "Agg",
 							},
 						},
@@ -1944,72 +1944,72 @@ var g = &grammar{
 		},
 		{
 			name: "Agg",
-			pos:  position{line: 208, col: 1, offset: 6293},
+			pos:  position{line: 209, col: 1, offset: 6294},
 			expr: &actionExpr{
-				pos: position{line: 209, col: 5, offset: 6301},
+				pos: position{line: 210, col: 5, offset: 6302},
 				run: (*parser).callonAgg1,
 				expr: &seqExpr{
-					pos: position{line: 209, col: 5, offset: 6301},
+					pos: position{line: 210, col: 5, offset: 6302},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 209, col: 5, offset: 6301},
+							pos: position{line: 210, col: 5, offset: 6302},
 							expr: &ruleRefExpr{
-								pos:  position{line: 209, col: 6, offset: 6302},
+								pos:  position{line: 210, col: 6, offset: 6303},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 209, col: 16, offset: 6312},
+							pos:   position{line: 210, col: 16, offset: 6313},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 209, col: 19, offset: 6315},
+								pos:  position{line: 210, col: 19, offset: 6316},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 27, offset: 6323},
+							pos:  position{line: 210, col: 27, offset: 6324},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 209, col: 30, offset: 6326},
+							pos:        position{line: 210, col: 30, offset: 6327},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 34, offset: 6330},
+							pos:  position{line: 210, col: 34, offset: 6331},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 209, col: 37, offset: 6333},
+							pos:   position{line: 210, col: 37, offset: 6334},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 209, col: 42, offset: 6338},
+								pos: position{line: 210, col: 42, offset: 6339},
 								expr: &ruleRefExpr{
-									pos:  position{line: 209, col: 42, offset: 6338},
+									pos:  position{line: 210, col: 42, offset: 6339},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 49, offset: 6345},
+							pos:  position{line: 210, col: 49, offset: 6346},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 209, col: 52, offset: 6348},
+							pos:        position{line: 210, col: 52, offset: 6349},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 209, col: 56, offset: 6352},
+							pos: position{line: 210, col: 56, offset: 6353},
 							expr: &seqExpr{
-								pos: position{line: 209, col: 58, offset: 6354},
+								pos: position{line: 210, col: 58, offset: 6355},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 209, col: 58, offset: 6354},
+										pos:  position{line: 210, col: 58, offset: 6355},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 209, col: 61, offset: 6357},
+										pos:        position{line: 210, col: 61, offset: 6358},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -2017,12 +2017,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 209, col: 66, offset: 6362},
+							pos:   position{line: 210, col: 66, offset: 6363},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 209, col: 72, offset: 6368},
+								pos: position{line: 210, col: 72, offset: 6369},
 								expr: &ruleRefExpr{
-									pos:  position{line: 209, col: 72, offset: 6368},
+									pos:  position{line: 210, col: 72, offset: 6369},
 									name: "WhereClause",
 								},
 							},
@@ -2033,20 +2033,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 217, col: 1, offset: 6558},
+			pos:  position{line: 218, col: 1, offset: 6559},
 			expr: &choiceExpr{
-				pos: position{line: 218, col: 5, offset: 6570},
+				pos: position{line: 219, col: 5, offset: 6571},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 218, col: 5, offset: 6570},
+						pos:  position{line: 219, col: 5, offset: 6571},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 5, offset: 6589},
+						pos:  position{line: 220, col: 5, offset: 6590},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 220, col: 5, offset: 6602},
+						pos:  position{line: 221, col: 5, offset: 6603},
 						name: "OrToken",
 					},
 				},
@@ -2054,31 +2054,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 222, col: 1, offset: 6611},
+			pos:  position{line: 223, col: 1, offset: 6612},
 			expr: &actionExpr{
-				pos: position{line: 222, col: 15, offset: 6625},
+				pos: position{line: 223, col: 15, offset: 6626},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 222, col: 15, offset: 6625},
+					pos: position{line: 223, col: 15, offset: 6626},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 222, col: 15, offset: 6625},
+							pos:  position{line: 223, col: 15, offset: 6626},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 222, col: 17, offset: 6627},
+							pos:        position{line: 223, col: 17, offset: 6628},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 222, col: 25, offset: 6635},
+							pos:  position{line: 223, col: 25, offset: 6636},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 222, col: 27, offset: 6637},
+							pos:   position{line: 223, col: 27, offset: 6638},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 222, col: 32, offset: 6642},
+								pos:  position{line: 223, col: 32, offset: 6643},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -2088,44 +2088,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 224, col: 1, offset: 6678},
+			pos:  position{line: 225, col: 1, offset: 6679},
 			expr: &actionExpr{
-				pos: position{line: 225, col: 5, offset: 6697},
+				pos: position{line: 226, col: 5, offset: 6698},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 225, col: 5, offset: 6697},
+					pos: position{line: 226, col: 5, offset: 6698},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 225, col: 5, offset: 6697},
+							pos:   position{line: 226, col: 5, offset: 6698},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 225, col: 11, offset: 6703},
+								pos:  position{line: 226, col: 11, offset: 6704},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 225, col: 25, offset: 6717},
+							pos:   position{line: 226, col: 25, offset: 6718},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 225, col: 30, offset: 6722},
+								pos: position{line: 226, col: 30, offset: 6723},
 								expr: &seqExpr{
-									pos: position{line: 225, col: 31, offset: 6723},
+									pos: position{line: 226, col: 31, offset: 6724},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 31, offset: 6723},
+											pos:  position{line: 226, col: 31, offset: 6724},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 225, col: 34, offset: 6726},
+											pos:        position{line: 226, col: 34, offset: 6727},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 38, offset: 6730},
+											pos:  position{line: 226, col: 38, offset: 6731},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 41, offset: 6733},
+											pos:  position{line: 226, col: 41, offset: 6734},
 											name: "AggAssignment",
 										},
 									},
@@ -2138,96 +2138,92 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 235, col: 1, offset: 6969},
+			pos:  position{line: 236, col: 1, offset: 6970},
 			expr: &choiceExpr{
-				pos: position{line: 236, col: 5, offset: 6982},
+				pos: position{line: 237, col: 5, offset: 6983},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 236, col: 5, offset: 6982},
+						pos:  position{line: 237, col: 5, offset: 6983},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 237, col: 5, offset: 6995},
+						pos:  position{line: 238, col: 5, offset: 6996},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 238, col: 5, offset: 7007},
+						pos:  position{line: 239, col: 5, offset: 7008},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 239, col: 5, offset: 7019},
+						pos:  position{line: 240, col: 5, offset: 7020},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 240, col: 5, offset: 7032},
+						pos:  position{line: 241, col: 5, offset: 7033},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 241, col: 5, offset: 7045},
+						pos:  position{line: 242, col: 5, offset: 7046},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 242, col: 5, offset: 7058},
+						pos:  position{line: 243, col: 5, offset: 7059},
 						name: "WhereProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 243, col: 5, offset: 7072},
+						pos:  position{line: 244, col: 5, offset: 7073},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 244, col: 5, offset: 7085},
+						pos:  position{line: 245, col: 5, offset: 7086},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 5, offset: 7097},
+						pos:  position{line: 246, col: 5, offset: 7098},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 246, col: 5, offset: 7112},
+						pos:  position{line: 247, col: 5, offset: 7113},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 247, col: 5, offset: 7125},
+						pos:  position{line: 248, col: 5, offset: 7126},
 						name: "ShapeProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 248, col: 5, offset: 7139},
+						pos:  position{line: 249, col: 5, offset: 7140},
 						name: "JoinProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 249, col: 5, offset: 7152},
+						pos:  position{line: 250, col: 5, offset: 7153},
 						name: "SampleProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 250, col: 5, offset: 7167},
+						pos:  position{line: 251, col: 5, offset: 7168},
 						name: "SQLProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 251, col: 5, offset: 7179},
+						pos:  position{line: 252, col: 5, offset: 7180},
 						name: "FromProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 252, col: 5, offset: 7192},
+						pos:  position{line: 253, col: 5, offset: 7193},
 						name: "PassProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 253, col: 5, offset: 7205},
+						pos:  position{line: 254, col: 5, offset: 7206},
 						name: "ExplodeProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 254, col: 5, offset: 7221},
-						name: "LetProc",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 255, col: 5, offset: 7233},
+						pos:  position{line: 255, col: 5, offset: 7222},
 						name: "MergeProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 256, col: 5, offset: 7247},
+						pos:  position{line: 256, col: 5, offset: 7236},
 						name: "OverProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 5, offset: 7260},
+						pos:  position{line: 257, col: 5, offset: 7249},
 						name: "YieldProc",
 					},
 				},
@@ -2235,46 +2231,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 259, col: 1, offset: 7271},
+			pos:  position{line: 259, col: 1, offset: 7260},
 			expr: &actionExpr{
-				pos: position{line: 260, col: 5, offset: 7284},
+				pos: position{line: 260, col: 5, offset: 7273},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 260, col: 5, offset: 7284},
+					pos: position{line: 260, col: 5, offset: 7273},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 260, col: 5, offset: 7284},
+							pos:        position{line: 260, col: 5, offset: 7273},
 							val:        "sort",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 260, col: 12, offset: 7291},
+							pos:   position{line: 260, col: 12, offset: 7280},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 260, col: 17, offset: 7296},
+								pos:  position{line: 260, col: 17, offset: 7285},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 260, col: 26, offset: 7305},
+							pos:   position{line: 260, col: 26, offset: 7294},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 260, col: 31, offset: 7310},
+								pos: position{line: 260, col: 31, offset: 7299},
 								expr: &actionExpr{
-									pos: position{line: 260, col: 32, offset: 7311},
+									pos: position{line: 260, col: 32, offset: 7300},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 260, col: 32, offset: 7311},
+										pos: position{line: 260, col: 32, offset: 7300},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 260, col: 32, offset: 7311},
+												pos:  position{line: 260, col: 32, offset: 7300},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 260, col: 34, offset: 7313},
+												pos:   position{line: 260, col: 34, offset: 7302},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 260, col: 36, offset: 7315},
+													pos:  position{line: 260, col: 36, offset: 7304},
 													name: "Exprs",
 												},
 											},
@@ -2289,30 +2285,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 274, col: 1, offset: 7734},
+			pos:  position{line: 274, col: 1, offset: 7723},
 			expr: &actionExpr{
-				pos: position{line: 274, col: 12, offset: 7745},
+				pos: position{line: 274, col: 12, offset: 7734},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 274, col: 12, offset: 7745},
+					pos:   position{line: 274, col: 12, offset: 7734},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 274, col: 17, offset: 7750},
+						pos: position{line: 274, col: 17, offset: 7739},
 						expr: &actionExpr{
-							pos: position{line: 274, col: 18, offset: 7751},
+							pos: position{line: 274, col: 18, offset: 7740},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 274, col: 18, offset: 7751},
+								pos: position{line: 274, col: 18, offset: 7740},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 274, col: 18, offset: 7751},
+										pos:  position{line: 274, col: 18, offset: 7740},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 274, col: 20, offset: 7753},
+										pos:   position{line: 274, col: 20, offset: 7742},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 274, col: 22, offset: 7755},
+											pos:  position{line: 274, col: 22, offset: 7744},
 											name: "SortArg",
 										},
 									},
@@ -2325,50 +2321,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 276, col: 1, offset: 7811},
+			pos:  position{line: 276, col: 1, offset: 7800},
 			expr: &choiceExpr{
-				pos: position{line: 277, col: 5, offset: 7823},
+				pos: position{line: 277, col: 5, offset: 7812},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 277, col: 5, offset: 7823},
+						pos: position{line: 277, col: 5, offset: 7812},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 277, col: 5, offset: 7823},
+							pos:        position{line: 277, col: 5, offset: 7812},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 278, col: 5, offset: 7898},
+						pos: position{line: 278, col: 5, offset: 7887},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 278, col: 5, offset: 7898},
+							pos: position{line: 278, col: 5, offset: 7887},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 278, col: 5, offset: 7898},
+									pos:        position{line: 278, col: 5, offset: 7887},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 278, col: 14, offset: 7907},
+									pos:  position{line: 278, col: 14, offset: 7896},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 278, col: 16, offset: 7909},
+									pos:   position{line: 278, col: 16, offset: 7898},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 278, col: 23, offset: 7916},
+										pos: position{line: 278, col: 23, offset: 7905},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 278, col: 24, offset: 7917},
+											pos: position{line: 278, col: 24, offset: 7906},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 278, col: 24, offset: 7917},
+													pos:        position{line: 278, col: 24, offset: 7906},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 278, col: 34, offset: 7927},
+													pos:        position{line: 278, col: 34, offset: 7916},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2384,38 +2380,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 280, col: 1, offset: 8041},
+			pos:  position{line: 280, col: 1, offset: 8030},
 			expr: &actionExpr{
-				pos: position{line: 281, col: 5, offset: 8053},
+				pos: position{line: 281, col: 5, offset: 8042},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 281, col: 5, offset: 8053},
+					pos: position{line: 281, col: 5, offset: 8042},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 281, col: 5, offset: 8053},
+							pos:        position{line: 281, col: 5, offset: 8042},
 							val:        "top",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 11, offset: 8059},
+							pos:   position{line: 281, col: 11, offset: 8048},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 17, offset: 8065},
+								pos: position{line: 281, col: 17, offset: 8054},
 								expr: &actionExpr{
-									pos: position{line: 281, col: 18, offset: 8066},
+									pos: position{line: 281, col: 18, offset: 8055},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 281, col: 18, offset: 8066},
+										pos: position{line: 281, col: 18, offset: 8055},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 281, col: 18, offset: 8066},
+												pos:  position{line: 281, col: 18, offset: 8055},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 281, col: 20, offset: 8068},
+												pos:   position{line: 281, col: 20, offset: 8057},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 281, col: 22, offset: 8070},
+													pos:  position{line: 281, col: 22, offset: 8059},
 													name: "UInt",
 												},
 											},
@@ -2425,19 +2421,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 46, offset: 8094},
+							pos:   position{line: 281, col: 46, offset: 8083},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 52, offset: 8100},
+								pos: position{line: 281, col: 52, offset: 8089},
 								expr: &seqExpr{
-									pos: position{line: 281, col: 53, offset: 8101},
+									pos: position{line: 281, col: 53, offset: 8090},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 53, offset: 8101},
+											pos:  position{line: 281, col: 53, offset: 8090},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 281, col: 55, offset: 8103},
+											pos:        position{line: 281, col: 55, offset: 8092},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2446,25 +2442,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 66, offset: 8114},
+							pos:   position{line: 281, col: 66, offset: 8103},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 73, offset: 8121},
+								pos: position{line: 281, col: 73, offset: 8110},
 								expr: &actionExpr{
-									pos: position{line: 281, col: 74, offset: 8122},
+									pos: position{line: 281, col: 74, offset: 8111},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 281, col: 74, offset: 8122},
+										pos: position{line: 281, col: 74, offset: 8111},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 281, col: 74, offset: 8122},
+												pos:  position{line: 281, col: 74, offset: 8111},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 281, col: 76, offset: 8124},
+												pos:   position{line: 281, col: 76, offset: 8113},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 281, col: 78, offset: 8126},
+													pos:  position{line: 281, col: 78, offset: 8115},
 													name: "FieldExprs",
 												},
 											},
@@ -2479,27 +2475,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 295, col: 1, offset: 8471},
+			pos:  position{line: 295, col: 1, offset: 8460},
 			expr: &actionExpr{
-				pos: position{line: 296, col: 5, offset: 8483},
+				pos: position{line: 296, col: 5, offset: 8472},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 296, col: 5, offset: 8483},
+					pos: position{line: 296, col: 5, offset: 8472},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 296, col: 5, offset: 8483},
+							pos:        position{line: 296, col: 5, offset: 8472},
 							val:        "cut",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 296, col: 11, offset: 8489},
+							pos:  position{line: 296, col: 11, offset: 8478},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 296, col: 13, offset: 8491},
+							pos:   position{line: 296, col: 13, offset: 8480},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 296, col: 18, offset: 8496},
+								pos:  position{line: 296, col: 18, offset: 8485},
 								name: "FlexAssignments",
 							},
 						},
@@ -2509,27 +2505,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 300, col: 1, offset: 8591},
+			pos:  position{line: 300, col: 1, offset: 8580},
 			expr: &actionExpr{
-				pos: position{line: 301, col: 5, offset: 8604},
+				pos: position{line: 301, col: 5, offset: 8593},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 301, col: 5, offset: 8604},
+					pos: position{line: 301, col: 5, offset: 8593},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 301, col: 5, offset: 8604},
+							pos:        position{line: 301, col: 5, offset: 8593},
 							val:        "drop",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 301, col: 12, offset: 8611},
+							pos:  position{line: 301, col: 12, offset: 8600},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 301, col: 14, offset: 8613},
+							pos:   position{line: 301, col: 14, offset: 8602},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 301, col: 19, offset: 8618},
+								pos:  position{line: 301, col: 19, offset: 8607},
 								name: "FieldExprs",
 							},
 						},
@@ -2539,30 +2535,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 305, col: 1, offset: 8709},
+			pos:  position{line: 305, col: 1, offset: 8698},
 			expr: &choiceExpr{
-				pos: position{line: 306, col: 5, offset: 8722},
+				pos: position{line: 306, col: 5, offset: 8711},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 306, col: 5, offset: 8722},
+						pos: position{line: 306, col: 5, offset: 8711},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 306, col: 5, offset: 8722},
+							pos: position{line: 306, col: 5, offset: 8711},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 306, col: 5, offset: 8722},
+									pos:        position{line: 306, col: 5, offset: 8711},
 									val:        "head",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 306, col: 12, offset: 8729},
+									pos:  position{line: 306, col: 12, offset: 8718},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 306, col: 14, offset: 8731},
+									pos:   position{line: 306, col: 14, offset: 8720},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 306, col: 20, offset: 8737},
+										pos:  position{line: 306, col: 20, offset: 8726},
 										name: "UInt",
 									},
 								},
@@ -2570,10 +2566,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 307, col: 5, offset: 8817},
+						pos: position{line: 307, col: 5, offset: 8806},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 307, col: 5, offset: 8817},
+							pos:        position{line: 307, col: 5, offset: 8806},
 							val:        "head",
 							ignoreCase: false,
 						},
@@ -2583,30 +2579,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 309, col: 1, offset: 8892},
+			pos:  position{line: 309, col: 1, offset: 8881},
 			expr: &choiceExpr{
-				pos: position{line: 310, col: 5, offset: 8905},
+				pos: position{line: 310, col: 5, offset: 8894},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 310, col: 5, offset: 8905},
+						pos: position{line: 310, col: 5, offset: 8894},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 310, col: 5, offset: 8905},
+							pos: position{line: 310, col: 5, offset: 8894},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 310, col: 5, offset: 8905},
+									pos:        position{line: 310, col: 5, offset: 8894},
 									val:        "tail",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 310, col: 12, offset: 8912},
+									pos:  position{line: 310, col: 12, offset: 8901},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 310, col: 14, offset: 8914},
+									pos:   position{line: 310, col: 14, offset: 8903},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 310, col: 20, offset: 8920},
+										pos:  position{line: 310, col: 20, offset: 8909},
 										name: "UInt",
 									},
 								},
@@ -2614,10 +2610,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 311, col: 5, offset: 9000},
+						pos: position{line: 311, col: 5, offset: 8989},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 311, col: 5, offset: 9000},
+							pos:        position{line: 311, col: 5, offset: 8989},
 							val:        "tail",
 							ignoreCase: false,
 						},
@@ -2627,27 +2623,27 @@ var g = &grammar{
 		},
 		{
 			name: "WhereProc",
-			pos:  position{line: 313, col: 1, offset: 9075},
+			pos:  position{line: 313, col: 1, offset: 9064},
 			expr: &actionExpr{
-				pos: position{line: 314, col: 5, offset: 9089},
+				pos: position{line: 314, col: 5, offset: 9078},
 				run: (*parser).callonWhereProc1,
 				expr: &seqExpr{
-					pos: position{line: 314, col: 5, offset: 9089},
+					pos: position{line: 314, col: 5, offset: 9078},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 314, col: 5, offset: 9089},
+							pos:        position{line: 314, col: 5, offset: 9078},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 314, col: 13, offset: 9097},
+							pos:  position{line: 314, col: 13, offset: 9086},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 314, col: 15, offset: 9099},
+							pos:   position{line: 314, col: 15, offset: 9088},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 314, col: 20, offset: 9104},
+								pos:  position{line: 314, col: 20, offset: 9093},
 								name: "Expr",
 							},
 						},
@@ -2657,27 +2653,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 318, col: 1, offset: 9190},
+			pos:  position{line: 318, col: 1, offset: 9179},
 			expr: &choiceExpr{
-				pos: position{line: 319, col: 5, offset: 9203},
+				pos: position{line: 319, col: 5, offset: 9192},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 319, col: 5, offset: 9203},
+						pos: position{line: 319, col: 5, offset: 9192},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 319, col: 5, offset: 9203},
+							pos: position{line: 319, col: 5, offset: 9192},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 319, col: 5, offset: 9203},
+									pos:        position{line: 319, col: 5, offset: 9192},
 									val:        "uniq",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 319, col: 12, offset: 9210},
+									pos:  position{line: 319, col: 12, offset: 9199},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 319, col: 14, offset: 9212},
+									pos:        position{line: 319, col: 14, offset: 9201},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2685,10 +2681,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 322, col: 5, offset: 9301},
+						pos: position{line: 322, col: 5, offset: 9290},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 322, col: 5, offset: 9301},
+							pos:        position{line: 322, col: 5, offset: 9290},
 							val:        "uniq",
 							ignoreCase: false,
 						},
@@ -2698,27 +2694,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 326, col: 1, offset: 9390},
+			pos:  position{line: 326, col: 1, offset: 9379},
 			expr: &actionExpr{
-				pos: position{line: 327, col: 5, offset: 9402},
+				pos: position{line: 327, col: 5, offset: 9391},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 327, col: 5, offset: 9402},
+					pos: position{line: 327, col: 5, offset: 9391},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 327, col: 5, offset: 9402},
+							pos:        position{line: 327, col: 5, offset: 9391},
 							val:        "put",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 327, col: 11, offset: 9408},
+							pos:  position{line: 327, col: 11, offset: 9397},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 327, col: 13, offset: 9410},
+							pos:   position{line: 327, col: 13, offset: 9399},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 327, col: 18, offset: 9415},
+								pos:  position{line: 327, col: 18, offset: 9404},
 								name: "Assignments",
 							},
 						},
@@ -2728,59 +2724,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 331, col: 1, offset: 9506},
+			pos:  position{line: 331, col: 1, offset: 9495},
 			expr: &actionExpr{
-				pos: position{line: 332, col: 5, offset: 9521},
+				pos: position{line: 332, col: 5, offset: 9510},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 332, col: 5, offset: 9521},
+					pos: position{line: 332, col: 5, offset: 9510},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 332, col: 5, offset: 9521},
+							pos:        position{line: 332, col: 5, offset: 9510},
 							val:        "rename",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 332, col: 14, offset: 9530},
+							pos:  position{line: 332, col: 14, offset: 9519},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 16, offset: 9532},
+							pos:   position{line: 332, col: 16, offset: 9521},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 332, col: 22, offset: 9538},
+								pos:  position{line: 332, col: 22, offset: 9527},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 33, offset: 9549},
+							pos:   position{line: 332, col: 33, offset: 9538},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 332, col: 38, offset: 9554},
+								pos: position{line: 332, col: 38, offset: 9543},
 								expr: &actionExpr{
-									pos: position{line: 332, col: 39, offset: 9555},
+									pos: position{line: 332, col: 39, offset: 9544},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 332, col: 39, offset: 9555},
+										pos: position{line: 332, col: 39, offset: 9544},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 332, col: 39, offset: 9555},
+												pos:  position{line: 332, col: 39, offset: 9544},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 332, col: 42, offset: 9558},
+												pos:        position{line: 332, col: 42, offset: 9547},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 332, col: 46, offset: 9562},
+												pos:  position{line: 332, col: 46, offset: 9551},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 332, col: 49, offset: 9565},
+												pos:   position{line: 332, col: 49, offset: 9554},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 332, col: 52, offset: 9568},
+													pos:  position{line: 332, col: 52, offset: 9557},
 													name: "Assignment",
 												},
 											},
@@ -2795,29 +2791,29 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 340, col: 1, offset: 9977},
+			pos:  position{line: 340, col: 1, offset: 9966},
 			expr: &actionExpr{
-				pos: position{line: 341, col: 5, offset: 9990},
+				pos: position{line: 341, col: 5, offset: 9979},
 				run: (*parser).callonFuseProc1,
 				expr: &seqExpr{
-					pos: position{line: 341, col: 5, offset: 9990},
+					pos: position{line: 341, col: 5, offset: 9979},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 341, col: 5, offset: 9990},
+							pos:        position{line: 341, col: 5, offset: 9979},
 							val:        "fuse",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 341, col: 12, offset: 9997},
+							pos: position{line: 341, col: 12, offset: 9986},
 							expr: &seqExpr{
-								pos: position{line: 341, col: 14, offset: 9999},
+								pos: position{line: 341, col: 14, offset: 9988},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 341, col: 14, offset: 9999},
+										pos:  position{line: 341, col: 14, offset: 9988},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 341, col: 17, offset: 10002},
+										pos:        position{line: 341, col: 17, offset: 9991},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -2830,29 +2826,29 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeProc",
-			pos:  position{line: 345, col: 1, offset: 10073},
+			pos:  position{line: 345, col: 1, offset: 10062},
 			expr: &actionExpr{
-				pos: position{line: 346, col: 5, offset: 10087},
+				pos: position{line: 346, col: 5, offset: 10076},
 				run: (*parser).callonShapeProc1,
 				expr: &seqExpr{
-					pos: position{line: 346, col: 5, offset: 10087},
+					pos: position{line: 346, col: 5, offset: 10076},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 346, col: 5, offset: 10087},
+							pos:        position{line: 346, col: 5, offset: 10076},
 							val:        "shape",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 346, col: 13, offset: 10095},
+							pos: position{line: 346, col: 13, offset: 10084},
 							expr: &seqExpr{
-								pos: position{line: 346, col: 15, offset: 10097},
+								pos: position{line: 346, col: 15, offset: 10086},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 346, col: 15, offset: 10097},
+										pos:  position{line: 346, col: 15, offset: 10086},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 346, col: 18, offset: 10100},
+										pos:        position{line: 346, col: 18, offset: 10089},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -2865,84 +2861,84 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 350, col: 1, offset: 10172},
+			pos:  position{line: 350, col: 1, offset: 10161},
 			expr: &choiceExpr{
-				pos: position{line: 351, col: 5, offset: 10185},
+				pos: position{line: 351, col: 5, offset: 10174},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 351, col: 5, offset: 10185},
+						pos: position{line: 351, col: 5, offset: 10174},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 351, col: 5, offset: 10185},
+							pos: position{line: 351, col: 5, offset: 10174},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 351, col: 5, offset: 10185},
+									pos:   position{line: 351, col: 5, offset: 10174},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 351, col: 11, offset: 10191},
+										pos:  position{line: 351, col: 11, offset: 10180},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 351, col: 21, offset: 10201},
+									pos:        position{line: 351, col: 21, offset: 10190},
 									val:        "join",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 28, offset: 10208},
+									pos:  position{line: 351, col: 28, offset: 10197},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 30, offset: 10210},
+									pos:  position{line: 351, col: 30, offset: 10199},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 33, offset: 10213},
+									pos:  position{line: 351, col: 33, offset: 10202},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 35, offset: 10215},
+									pos:   position{line: 351, col: 35, offset: 10204},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 351, col: 43, offset: 10223},
+										pos:  position{line: 351, col: 43, offset: 10212},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 51, offset: 10231},
+									pos:  position{line: 351, col: 51, offset: 10220},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 351, col: 54, offset: 10234},
+									pos:        position{line: 351, col: 54, offset: 10223},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 58, offset: 10238},
+									pos:  position{line: 351, col: 58, offset: 10227},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 61, offset: 10241},
+									pos:   position{line: 351, col: 61, offset: 10230},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 351, col: 70, offset: 10250},
+										pos:  position{line: 351, col: 70, offset: 10239},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 78, offset: 10258},
+									pos:   position{line: 351, col: 78, offset: 10247},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 351, col: 86, offset: 10266},
+										pos: position{line: 351, col: 86, offset: 10255},
 										expr: &seqExpr{
-											pos: position{line: 351, col: 87, offset: 10267},
+											pos: position{line: 351, col: 87, offset: 10256},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 351, col: 87, offset: 10267},
+													pos:  position{line: 351, col: 87, offset: 10256},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 351, col: 89, offset: 10269},
+													pos:  position{line: 351, col: 89, offset: 10258},
 													name: "FlexAssignments",
 												},
 											},
@@ -2953,58 +2949,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 358, col: 5, offset: 10535},
+						pos: position{line: 358, col: 5, offset: 10524},
 						run: (*parser).callonJoinProc22,
 						expr: &seqExpr{
-							pos: position{line: 358, col: 5, offset: 10535},
+							pos: position{line: 358, col: 5, offset: 10524},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 358, col: 5, offset: 10535},
+									pos:   position{line: 358, col: 5, offset: 10524},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 358, col: 11, offset: 10541},
+										pos:  position{line: 358, col: 11, offset: 10530},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 358, col: 22, offset: 10552},
+									pos:        position{line: 358, col: 22, offset: 10541},
 									val:        "join",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 29, offset: 10559},
+									pos:  position{line: 358, col: 29, offset: 10548},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 31, offset: 10561},
+									pos:  position{line: 358, col: 31, offset: 10550},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 34, offset: 10564},
+									pos:  position{line: 358, col: 34, offset: 10553},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 358, col: 36, offset: 10566},
+									pos:   position{line: 358, col: 36, offset: 10555},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 358, col: 40, offset: 10570},
+										pos:  position{line: 358, col: 40, offset: 10559},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 358, col: 48, offset: 10578},
+									pos:   position{line: 358, col: 48, offset: 10567},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 358, col: 56, offset: 10586},
+										pos: position{line: 358, col: 56, offset: 10575},
 										expr: &seqExpr{
-											pos: position{line: 358, col: 57, offset: 10587},
+											pos: position{line: 358, col: 57, offset: 10576},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 358, col: 57, offset: 10587},
+													pos:  position{line: 358, col: 57, offset: 10576},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 358, col: 59, offset: 10589},
+													pos:  position{line: 358, col: 59, offset: 10578},
 													name: "FlexAssignments",
 												},
 											},
@@ -3019,87 +3015,87 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 366, col: 1, offset: 10843},
+			pos:  position{line: 366, col: 1, offset: 10832},
 			expr: &choiceExpr{
-				pos: position{line: 367, col: 5, offset: 10857},
+				pos: position{line: 367, col: 5, offset: 10846},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 367, col: 5, offset: 10857},
+						pos: position{line: 367, col: 5, offset: 10846},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 367, col: 5, offset: 10857},
+							pos: position{line: 367, col: 5, offset: 10846},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 367, col: 5, offset: 10857},
+									pos:        position{line: 367, col: 5, offset: 10846},
 									val:        "anti",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 367, col: 12, offset: 10864},
+									pos:  position{line: 367, col: 12, offset: 10853},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 368, col: 5, offset: 10894},
+						pos: position{line: 368, col: 5, offset: 10883},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 368, col: 5, offset: 10894},
+							pos: position{line: 368, col: 5, offset: 10883},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 368, col: 5, offset: 10894},
+									pos:        position{line: 368, col: 5, offset: 10883},
 									val:        "inner",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 368, col: 13, offset: 10902},
+									pos:  position{line: 368, col: 13, offset: 10891},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 369, col: 5, offset: 10932},
+						pos: position{line: 369, col: 5, offset: 10921},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 369, col: 5, offset: 10932},
+							pos: position{line: 369, col: 5, offset: 10921},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 369, col: 5, offset: 10932},
+									pos:        position{line: 369, col: 5, offset: 10921},
 									val:        "left",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 369, col: 13, offset: 10940},
+									pos:  position{line: 369, col: 13, offset: 10929},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 10969},
+						pos: position{line: 370, col: 5, offset: 10958},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 370, col: 5, offset: 10969},
+							pos: position{line: 370, col: 5, offset: 10958},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 370, col: 5, offset: 10969},
+									pos:        position{line: 370, col: 5, offset: 10958},
 									val:        "right",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 370, col: 13, offset: 10977},
+									pos:  position{line: 370, col: 13, offset: 10966},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 371, col: 5, offset: 11007},
+						pos: position{line: 371, col: 5, offset: 10996},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 371, col: 5, offset: 11007},
+							pos:        position{line: 371, col: 5, offset: 10996},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3109,35 +3105,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 373, col: 1, offset: 11043},
+			pos:  position{line: 373, col: 1, offset: 11032},
 			expr: &choiceExpr{
-				pos: position{line: 374, col: 5, offset: 11055},
+				pos: position{line: 374, col: 5, offset: 11044},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 374, col: 5, offset: 11055},
+						pos:  position{line: 374, col: 5, offset: 11044},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 375, col: 5, offset: 11064},
+						pos: position{line: 375, col: 5, offset: 11053},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 375, col: 5, offset: 11064},
+							pos: position{line: 375, col: 5, offset: 11053},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 375, col: 5, offset: 11064},
+									pos:        position{line: 375, col: 5, offset: 11053},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 375, col: 9, offset: 11068},
+									pos:   position{line: 375, col: 9, offset: 11057},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 375, col: 14, offset: 11073},
+										pos:  position{line: 375, col: 14, offset: 11062},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 375, col: 19, offset: 11078},
+									pos:        position{line: 375, col: 19, offset: 11067},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3149,23 +3145,23 @@ var g = &grammar{
 		},
 		{
 			name: "SampleProc",
-			pos:  position{line: 377, col: 1, offset: 11104},
+			pos:  position{line: 377, col: 1, offset: 11093},
 			expr: &actionExpr{
-				pos: position{line: 378, col: 5, offset: 11119},
+				pos: position{line: 378, col: 5, offset: 11108},
 				run: (*parser).callonSampleProc1,
 				expr: &seqExpr{
-					pos: position{line: 378, col: 5, offset: 11119},
+					pos: position{line: 378, col: 5, offset: 11108},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 378, col: 5, offset: 11119},
+							pos:        position{line: 378, col: 5, offset: 11108},
 							val:        "sample",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 378, col: 14, offset: 11128},
+							pos:   position{line: 378, col: 14, offset: 11117},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 16, offset: 11130},
+								pos:  position{line: 378, col: 16, offset: 11119},
 								name: "SampleExpr",
 							},
 						},
@@ -3175,15 +3171,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 420, col: 1, offset: 12624},
+			pos:  position{line: 420, col: 1, offset: 12613},
 			expr: &actionExpr{
-				pos: position{line: 421, col: 5, offset: 12641},
+				pos: position{line: 421, col: 5, offset: 12630},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 421, col: 5, offset: 12641},
+					pos:   position{line: 421, col: 5, offset: 12630},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 421, col: 7, offset: 12643},
+						pos:  position{line: 421, col: 7, offset: 12632},
 						name: "Assignments",
 					},
 				},
@@ -3191,25 +3187,25 @@ var g = &grammar{
 		},
 		{
 			name: "SampleExpr",
-			pos:  position{line: 425, col: 1, offset: 12743},
+			pos:  position{line: 425, col: 1, offset: 12732},
 			expr: &choiceExpr{
-				pos: position{line: 426, col: 5, offset: 12758},
+				pos: position{line: 426, col: 5, offset: 12747},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 426, col: 5, offset: 12758},
+						pos: position{line: 426, col: 5, offset: 12747},
 						run: (*parser).callonSampleExpr2,
 						expr: &seqExpr{
-							pos: position{line: 426, col: 5, offset: 12758},
+							pos: position{line: 426, col: 5, offset: 12747},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 426, col: 5, offset: 12758},
+									pos:  position{line: 426, col: 5, offset: 12747},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 426, col: 7, offset: 12760},
+									pos:   position{line: 426, col: 7, offset: 12749},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 426, col: 12, offset: 12765},
+										pos:  position{line: 426, col: 12, offset: 12754},
 										name: "Lval",
 									},
 								},
@@ -3217,10 +3213,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 427, col: 5, offset: 12794},
+						pos: position{line: 427, col: 5, offset: 12783},
 						run: (*parser).callonSampleExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 427, col: 5, offset: 12794},
+							pos:        position{line: 427, col: 5, offset: 12783},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3230,15 +3226,15 @@ var g = &grammar{
 		},
 		{
 			name: "FromProc",
-			pos:  position{line: 429, col: 1, offset: 12865},
+			pos:  position{line: 429, col: 1, offset: 12854},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 12878},
+				pos: position{line: 430, col: 5, offset: 12867},
 				run: (*parser).callonFromProc1,
 				expr: &labeledExpr{
-					pos:   position{line: 430, col: 5, offset: 12878},
+					pos:   position{line: 430, col: 5, offset: 12867},
 					label: "source",
 					expr: &ruleRefExpr{
-						pos:  position{line: 430, col: 12, offset: 12885},
+						pos:  position{line: 430, col: 12, offset: 12874},
 						name: "FromAny",
 					},
 				},
@@ -3246,20 +3242,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromAny",
-			pos:  position{line: 434, col: 1, offset: 13041},
+			pos:  position{line: 434, col: 1, offset: 13030},
 			expr: &choiceExpr{
-				pos: position{line: 435, col: 5, offset: 13053},
+				pos: position{line: 435, col: 5, offset: 13042},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 435, col: 5, offset: 13053},
+						pos:  position{line: 435, col: 5, offset: 13042},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 436, col: 5, offset: 13062},
+						pos:  position{line: 436, col: 5, offset: 13051},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 437, col: 5, offset: 13070},
+						pos:  position{line: 437, col: 5, offset: 13059},
 						name: "From",
 					},
 				},
@@ -3267,48 +3263,48 @@ var g = &grammar{
 		},
 		{
 			name: "File",
-			pos:  position{line: 439, col: 1, offset: 13076},
+			pos:  position{line: 439, col: 1, offset: 13065},
 			expr: &actionExpr{
-				pos: position{line: 440, col: 5, offset: 13085},
+				pos: position{line: 440, col: 5, offset: 13074},
 				run: (*parser).callonFile1,
 				expr: &seqExpr{
-					pos: position{line: 440, col: 5, offset: 13085},
+					pos: position{line: 440, col: 5, offset: 13074},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 440, col: 5, offset: 13085},
+							pos:        position{line: 440, col: 5, offset: 13074},
 							val:        "file",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 440, col: 12, offset: 13092},
+							pos:  position{line: 440, col: 12, offset: 13081},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 14, offset: 13094},
+							pos:   position{line: 440, col: 14, offset: 13083},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 440, col: 19, offset: 13099},
+								pos:  position{line: 440, col: 19, offset: 13088},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 24, offset: 13104},
+							pos:   position{line: 440, col: 24, offset: 13093},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 440, col: 31, offset: 13111},
+								pos: position{line: 440, col: 31, offset: 13100},
 								expr: &ruleRefExpr{
-									pos:  position{line: 440, col: 31, offset: 13111},
+									pos:  position{line: 440, col: 31, offset: 13100},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 42, offset: 13122},
+							pos:   position{line: 440, col: 42, offset: 13111},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 440, col: 49, offset: 13129},
+								pos: position{line: 440, col: 49, offset: 13118},
 								expr: &ruleRefExpr{
-									pos:  position{line: 440, col: 49, offset: 13129},
+									pos:  position{line: 440, col: 49, offset: 13118},
 									name: "LayoutArg",
 								},
 							},
@@ -3319,27 +3315,27 @@ var g = &grammar{
 		},
 		{
 			name: "From",
-			pos:  position{line: 444, col: 1, offset: 13258},
+			pos:  position{line: 444, col: 1, offset: 13247},
 			expr: &actionExpr{
-				pos: position{line: 445, col: 5, offset: 13267},
+				pos: position{line: 445, col: 5, offset: 13256},
 				run: (*parser).callonFrom1,
 				expr: &seqExpr{
-					pos: position{line: 445, col: 5, offset: 13267},
+					pos: position{line: 445, col: 5, offset: 13256},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 445, col: 5, offset: 13267},
+							pos:        position{line: 445, col: 5, offset: 13256},
 							val:        "from",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 445, col: 12, offset: 13274},
+							pos:  position{line: 445, col: 12, offset: 13263},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 14, offset: 13276},
+							pos:   position{line: 445, col: 14, offset: 13265},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 19, offset: 13281},
+								pos:  position{line: 445, col: 19, offset: 13270},
 								name: "PoolBody",
 							},
 						},
@@ -3349,27 +3345,27 @@ var g = &grammar{
 		},
 		{
 			name: "Pool",
-			pos:  position{line: 447, col: 1, offset: 13312},
+			pos:  position{line: 447, col: 1, offset: 13301},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 5, offset: 13321},
+				pos: position{line: 448, col: 5, offset: 13310},
 				run: (*parser).callonPool1,
 				expr: &seqExpr{
-					pos: position{line: 448, col: 5, offset: 13321},
+					pos: position{line: 448, col: 5, offset: 13310},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 448, col: 5, offset: 13321},
+							pos:        position{line: 448, col: 5, offset: 13310},
 							val:        "pool",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 448, col: 12, offset: 13328},
+							pos:  position{line: 448, col: 12, offset: 13317},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 448, col: 14, offset: 13330},
+							pos:   position{line: 448, col: 14, offset: 13319},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 448, col: 19, offset: 13335},
+								pos:  position{line: 448, col: 19, offset: 13324},
 								name: "PoolBody",
 							},
 						},
@@ -3379,50 +3375,50 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBody",
-			pos:  position{line: 450, col: 1, offset: 13366},
+			pos:  position{line: 450, col: 1, offset: 13355},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 13379},
+				pos: position{line: 451, col: 5, offset: 13368},
 				run: (*parser).callonPoolBody1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 13379},
+					pos: position{line: 451, col: 5, offset: 13368},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 13379},
+							pos:   position{line: 451, col: 5, offset: 13368},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 10, offset: 13384},
+								pos:  position{line: 451, col: 10, offset: 13373},
 								name: "PoolSpec",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 19, offset: 13393},
+							pos:   position{line: 451, col: 19, offset: 13382},
 							label: "at",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 22, offset: 13396},
+								pos: position{line: 451, col: 22, offset: 13385},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 22, offset: 13396},
+									pos:  position{line: 451, col: 22, offset: 13385},
 									name: "PoolAt",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 30, offset: 13404},
+							pos:   position{line: 451, col: 30, offset: 13393},
 							label: "over",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 35, offset: 13409},
+								pos: position{line: 451, col: 35, offset: 13398},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 35, offset: 13409},
+									pos:  position{line: 451, col: 35, offset: 13398},
 									name: "PoolRange",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 46, offset: 13420},
+							pos:   position{line: 451, col: 46, offset: 13409},
 							label: "order",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 52, offset: 13426},
+								pos: position{line: 451, col: 52, offset: 13415},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 52, offset: 13426},
+									pos:  position{line: 451, col: 52, offset: 13415},
 									name: "OrderArg",
 								},
 							},
@@ -3433,48 +3429,48 @@ var g = &grammar{
 		},
 		{
 			name: "Get",
-			pos:  position{line: 455, col: 1, offset: 13562},
+			pos:  position{line: 455, col: 1, offset: 13551},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 5, offset: 13570},
+				pos: position{line: 456, col: 5, offset: 13559},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 456, col: 5, offset: 13570},
+					pos: position{line: 456, col: 5, offset: 13559},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 456, col: 5, offset: 13570},
+							pos:        position{line: 456, col: 5, offset: 13559},
 							val:        "get",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 456, col: 11, offset: 13576},
+							pos:  position{line: 456, col: 11, offset: 13565},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 13, offset: 13578},
+							pos:   position{line: 456, col: 13, offset: 13567},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 456, col: 17, offset: 13582},
+								pos:  position{line: 456, col: 17, offset: 13571},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 21, offset: 13586},
+							pos:   position{line: 456, col: 21, offset: 13575},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 456, col: 28, offset: 13593},
+								pos: position{line: 456, col: 28, offset: 13582},
 								expr: &ruleRefExpr{
-									pos:  position{line: 456, col: 28, offset: 13593},
+									pos:  position{line: 456, col: 28, offset: 13582},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 39, offset: 13604},
+							pos:   position{line: 456, col: 39, offset: 13593},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 456, col: 46, offset: 13611},
+								pos: position{line: 456, col: 46, offset: 13600},
 								expr: &ruleRefExpr{
-									pos:  position{line: 456, col: 46, offset: 13611},
+									pos:  position{line: 456, col: 46, offset: 13600},
 									name: "LayoutArg",
 								},
 							},
@@ -3485,30 +3481,30 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 460, col: 1, offset: 13737},
+			pos:  position{line: 460, col: 1, offset: 13726},
 			expr: &actionExpr{
-				pos: position{line: 460, col: 7, offset: 13743},
+				pos: position{line: 460, col: 7, offset: 13732},
 				run: (*parser).callonURL1,
 				expr: &seqExpr{
-					pos: position{line: 460, col: 7, offset: 13743},
+					pos: position{line: 460, col: 7, offset: 13732},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 460, col: 8, offset: 13744},
+							pos: position{line: 460, col: 8, offset: 13733},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 460, col: 8, offset: 13744},
+									pos:        position{line: 460, col: 8, offset: 13733},
 									val:        "http:",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 460, col: 18, offset: 13754},
+									pos:        position{line: 460, col: 18, offset: 13743},
 									val:        "https:",
 									ignoreCase: false,
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 460, col: 28, offset: 13764},
+							pos:  position{line: 460, col: 28, offset: 13753},
 							name: "Path",
 						},
 					},
@@ -3517,29 +3513,29 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 462, col: 1, offset: 13801},
+			pos:  position{line: 462, col: 1, offset: 13790},
 			expr: &choiceExpr{
-				pos: position{line: 463, col: 5, offset: 13810},
+				pos: position{line: 463, col: 5, offset: 13799},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 463, col: 5, offset: 13810},
+						pos: position{line: 463, col: 5, offset: 13799},
 						run: (*parser).callonPath2,
 						expr: &labeledExpr{
-							pos:   position{line: 463, col: 5, offset: 13810},
+							pos:   position{line: 463, col: 5, offset: 13799},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 463, col: 7, offset: 13812},
+								pos:  position{line: 463, col: 7, offset: 13801},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 464, col: 5, offset: 13847},
+						pos: position{line: 464, col: 5, offset: 13836},
 						run: (*parser).callonPath5,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 464, col: 5, offset: 13847},
+							pos: position{line: 464, col: 5, offset: 13836},
 							expr: &charClassMatcher{
-								pos:        position{line: 464, col: 5, offset: 13847},
+								pos:        position{line: 464, col: 5, offset: 13836},
 								val:        "[0-9a-zA-Z!@$%^&*()_=<>,./?:[\\]{}~|+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '(', ')', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '|', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -3553,31 +3549,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 467, col: 1, offset: 13952},
+			pos:  position{line: 467, col: 1, offset: 13941},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 5, offset: 13963},
+				pos: position{line: 468, col: 5, offset: 13952},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 468, col: 5, offset: 13963},
+					pos: position{line: 468, col: 5, offset: 13952},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 5, offset: 13963},
+							pos:  position{line: 468, col: 5, offset: 13952},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 468, col: 7, offset: 13965},
+							pos:        position{line: 468, col: 7, offset: 13954},
 							val:        "at",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 12, offset: 13970},
+							pos:  position{line: 468, col: 12, offset: 13959},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 14, offset: 13972},
+							pos:   position{line: 468, col: 14, offset: 13961},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 17, offset: 13975},
+								pos:  position{line: 468, col: 17, offset: 13964},
 								name: "KSUID",
 							},
 						},
@@ -3587,14 +3583,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 471, col: 1, offset: 14041},
+			pos:  position{line: 471, col: 1, offset: 14030},
 			expr: &actionExpr{
-				pos: position{line: 471, col: 9, offset: 14049},
+				pos: position{line: 471, col: 9, offset: 14038},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 471, col: 9, offset: 14049},
+					pos: position{line: 471, col: 9, offset: 14038},
 					expr: &charClassMatcher{
-						pos:        position{line: 471, col: 10, offset: 14050},
+						pos:        position{line: 471, col: 10, offset: 14039},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -3605,52 +3601,52 @@ var g = &grammar{
 		},
 		{
 			name: "PoolRange",
-			pos:  position{line: 473, col: 1, offset: 14096},
+			pos:  position{line: 473, col: 1, offset: 14085},
 			expr: &actionExpr{
-				pos: position{line: 474, col: 5, offset: 14110},
+				pos: position{line: 474, col: 5, offset: 14099},
 				run: (*parser).callonPoolRange1,
 				expr: &seqExpr{
-					pos: position{line: 474, col: 5, offset: 14110},
+					pos: position{line: 474, col: 5, offset: 14099},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 5, offset: 14110},
+							pos:  position{line: 474, col: 5, offset: 14099},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 7, offset: 14112},
+							pos:        position{line: 474, col: 7, offset: 14101},
 							val:        "range",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 15, offset: 14120},
+							pos:  position{line: 474, col: 15, offset: 14109},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 17, offset: 14122},
+							pos:   position{line: 474, col: 17, offset: 14111},
 							label: "lower",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 23, offset: 14128},
+								pos:  position{line: 474, col: 23, offset: 14117},
 								name: "Literal",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 31, offset: 14136},
+							pos:  position{line: 474, col: 31, offset: 14125},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 33, offset: 14138},
+							pos:        position{line: 474, col: 33, offset: 14127},
 							val:        "to",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 38, offset: 14143},
+							pos:  position{line: 474, col: 38, offset: 14132},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 40, offset: 14145},
+							pos:   position{line: 474, col: 40, offset: 14134},
 							label: "upper",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 46, offset: 14151},
+								pos:  position{line: 474, col: 46, offset: 14140},
 								name: "Literal",
 							},
 						},
@@ -3660,42 +3656,42 @@ var g = &grammar{
 		},
 		{
 			name: "PoolSpec",
-			pos:  position{line: 478, col: 1, offset: 14256},
+			pos:  position{line: 478, col: 1, offset: 14245},
 			expr: &choiceExpr{
-				pos: position{line: 479, col: 5, offset: 14269},
+				pos: position{line: 479, col: 5, offset: 14258},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 479, col: 5, offset: 14269},
+						pos: position{line: 479, col: 5, offset: 14258},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 479, col: 5, offset: 14269},
+							pos: position{line: 479, col: 5, offset: 14258},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 479, col: 5, offset: 14269},
+									pos:   position{line: 479, col: 5, offset: 14258},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 10, offset: 14274},
+										pos:  position{line: 479, col: 10, offset: 14263},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 19, offset: 14283},
+									pos:   position{line: 479, col: 19, offset: 14272},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 479, col: 26, offset: 14290},
+										pos: position{line: 479, col: 26, offset: 14279},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 26, offset: 14290},
+											pos:  position{line: 479, col: 26, offset: 14279},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 38, offset: 14302},
+									pos:   position{line: 479, col: 38, offset: 14291},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 479, col: 43, offset: 14307},
+										pos: position{line: 479, col: 43, offset: 14296},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 43, offset: 14307},
+											pos:  position{line: 479, col: 43, offset: 14296},
 											name: "PoolMeta",
 										},
 									},
@@ -3704,13 +3700,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 14416},
+						pos: position{line: 482, col: 5, offset: 14405},
 						run: (*parser).callonPoolSpec12,
 						expr: &labeledExpr{
-							pos:   position{line: 482, col: 5, offset: 14416},
+							pos:   position{line: 482, col: 5, offset: 14405},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 482, col: 10, offset: 14421},
+								pos:  position{line: 482, col: 10, offset: 14410},
 								name: "PoolMeta",
 							},
 						},
@@ -3720,23 +3716,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 486, col: 1, offset: 14522},
+			pos:  position{line: 486, col: 1, offset: 14511},
 			expr: &actionExpr{
-				pos: position{line: 487, col: 5, offset: 14537},
+				pos: position{line: 487, col: 5, offset: 14526},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 487, col: 5, offset: 14537},
+					pos: position{line: 487, col: 5, offset: 14526},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 487, col: 5, offset: 14537},
+							pos:        position{line: 487, col: 5, offset: 14526},
 							val:        "@",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 487, col: 9, offset: 14541},
+							pos:   position{line: 487, col: 9, offset: 14530},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 487, col: 16, offset: 14548},
+								pos:  position{line: 487, col: 16, offset: 14537},
 								name: "PoolName",
 							},
 						},
@@ -3746,23 +3742,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 489, col: 1, offset: 14581},
+			pos:  position{line: 489, col: 1, offset: 14570},
 			expr: &actionExpr{
-				pos: position{line: 490, col: 5, offset: 14594},
+				pos: position{line: 490, col: 5, offset: 14583},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 490, col: 5, offset: 14594},
+					pos: position{line: 490, col: 5, offset: 14583},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 490, col: 5, offset: 14594},
+							pos:        position{line: 490, col: 5, offset: 14583},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 490, col: 9, offset: 14598},
+							pos:   position{line: 490, col: 9, offset: 14587},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 490, col: 14, offset: 14603},
+								pos:  position{line: 490, col: 14, offset: 14592},
 								name: "PoolIdentifier",
 							},
 						},
@@ -3772,20 +3768,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 492, col: 1, offset: 14640},
+			pos:  position{line: 492, col: 1, offset: 14629},
 			expr: &choiceExpr{
-				pos: position{line: 493, col: 5, offset: 14653},
+				pos: position{line: 493, col: 5, offset: 14642},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 493, col: 5, offset: 14653},
+						pos:  position{line: 493, col: 5, offset: 14642},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 494, col: 5, offset: 14672},
+						pos:  position{line: 494, col: 5, offset: 14661},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 495, col: 5, offset: 14682},
+						pos:  position{line: 495, col: 5, offset: 14671},
 						name: "QuotedString",
 					},
 				},
@@ -3793,38 +3789,38 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 497, col: 1, offset: 14696},
+			pos:  position{line: 497, col: 1, offset: 14685},
 			expr: &actionExpr{
-				pos: position{line: 498, col: 5, offset: 14715},
+				pos: position{line: 498, col: 5, offset: 14704},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 498, col: 5, offset: 14715},
+					pos: position{line: 498, col: 5, offset: 14704},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 498, col: 6, offset: 14716},
+							pos: position{line: 498, col: 6, offset: 14705},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 498, col: 6, offset: 14716},
+									pos:  position{line: 498, col: 6, offset: 14705},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 498, col: 24, offset: 14734},
+									pos:        position{line: 498, col: 24, offset: 14723},
 									val:        ".",
 									ignoreCase: false,
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 498, col: 29, offset: 14739},
+							pos: position{line: 498, col: 29, offset: 14728},
 							expr: &choiceExpr{
-								pos: position{line: 498, col: 30, offset: 14740},
+								pos: position{line: 498, col: 30, offset: 14729},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 498, col: 30, offset: 14740},
+										pos:  position{line: 498, col: 30, offset: 14729},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 498, col: 47, offset: 14757},
+										pos:        position{line: 498, col: 47, offset: 14746},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -3837,39 +3833,39 @@ var g = &grammar{
 		},
 		{
 			name: "LayoutArg",
-			pos:  position{line: 500, col: 1, offset: 14796},
+			pos:  position{line: 500, col: 1, offset: 14785},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 14810},
+				pos: position{line: 501, col: 5, offset: 14799},
 				run: (*parser).callonLayoutArg1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 14810},
+					pos: position{line: 501, col: 5, offset: 14799},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 5, offset: 14810},
+							pos:  position{line: 501, col: 5, offset: 14799},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 7, offset: 14812},
+							pos:        position{line: 501, col: 7, offset: 14801},
 							val:        "order",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 15, offset: 14820},
+							pos:  position{line: 501, col: 15, offset: 14809},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 17, offset: 14822},
+							pos:   position{line: 501, col: 17, offset: 14811},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 22, offset: 14827},
+								pos:  position{line: 501, col: 22, offset: 14816},
 								name: "FieldExprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 33, offset: 14838},
+							pos:   position{line: 501, col: 33, offset: 14827},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 39, offset: 14844},
+								pos:  position{line: 501, col: 39, offset: 14833},
 								name: "OrderSuffix",
 							},
 						},
@@ -3879,31 +3875,31 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 505, col: 1, offset: 14954},
+			pos:  position{line: 505, col: 1, offset: 14943},
 			expr: &actionExpr{
-				pos: position{line: 506, col: 5, offset: 14968},
+				pos: position{line: 506, col: 5, offset: 14957},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 506, col: 5, offset: 14968},
+					pos: position{line: 506, col: 5, offset: 14957},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 5, offset: 14968},
+							pos:  position{line: 506, col: 5, offset: 14957},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 506, col: 7, offset: 14970},
+							pos:        position{line: 506, col: 7, offset: 14959},
 							val:        "format",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 16, offset: 14979},
+							pos:  position{line: 506, col: 16, offset: 14968},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 506, col: 18, offset: 14981},
+							pos:   position{line: 506, col: 18, offset: 14970},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 506, col: 22, offset: 14985},
+								pos:  position{line: 506, col: 22, offset: 14974},
 								name: "IdentifierName",
 							},
 						},
@@ -3913,33 +3909,33 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 508, col: 1, offset: 15021},
+			pos:  position{line: 508, col: 1, offset: 15010},
 			expr: &choiceExpr{
-				pos: position{line: 509, col: 5, offset: 15037},
+				pos: position{line: 509, col: 5, offset: 15026},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 509, col: 5, offset: 15037},
+						pos: position{line: 509, col: 5, offset: 15026},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 509, col: 5, offset: 15037},
+							pos:        position{line: 509, col: 5, offset: 15026},
 							val:        ":asc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 15071},
+						pos: position{line: 510, col: 5, offset: 15060},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 510, col: 5, offset: 15071},
+							pos:        position{line: 510, col: 5, offset: 15060},
 							val:        ":desc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 511, col: 5, offset: 15107},
+						pos: position{line: 511, col: 5, offset: 15096},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 511, col: 5, offset: 15107},
+							pos:        position{line: 511, col: 5, offset: 15096},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3949,31 +3945,31 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 513, col: 1, offset: 15133},
+			pos:  position{line: 513, col: 1, offset: 15122},
 			expr: &choiceExpr{
-				pos: position{line: 514, col: 5, offset: 15146},
+				pos: position{line: 514, col: 5, offset: 15135},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 15146},
+						pos: position{line: 514, col: 5, offset: 15135},
 						run: (*parser).callonOrderArg2,
 						expr: &seqExpr{
-							pos: position{line: 514, col: 5, offset: 15146},
+							pos: position{line: 514, col: 5, offset: 15135},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 5, offset: 15146},
+									pos:  position{line: 514, col: 5, offset: 15135},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 7, offset: 15148},
+									pos:        position{line: 514, col: 7, offset: 15137},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 15, offset: 15156},
+									pos:  position{line: 514, col: 15, offset: 15145},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 17, offset: 15158},
+									pos:        position{line: 514, col: 17, offset: 15147},
 									val:        "asc",
 									ignoreCase: false,
 								},
@@ -3981,26 +3977,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 515, col: 5, offset: 15191},
+						pos: position{line: 515, col: 5, offset: 15180},
 						run: (*parser).callonOrderArg8,
 						expr: &seqExpr{
-							pos: position{line: 515, col: 5, offset: 15191},
+							pos: position{line: 515, col: 5, offset: 15180},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 515, col: 5, offset: 15191},
+									pos:  position{line: 515, col: 5, offset: 15180},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 515, col: 7, offset: 15193},
+									pos:        position{line: 515, col: 7, offset: 15182},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 515, col: 15, offset: 15201},
+									pos:  position{line: 515, col: 15, offset: 15190},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 515, col: 17, offset: 15203},
+									pos:        position{line: 515, col: 17, offset: 15192},
 									val:        "desc",
 									ignoreCase: false,
 								},
@@ -4012,12 +4008,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassProc",
-			pos:  position{line: 517, col: 1, offset: 15235},
+			pos:  position{line: 517, col: 1, offset: 15224},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 5, offset: 15248},
+				pos: position{line: 518, col: 5, offset: 15237},
 				run: (*parser).callonPassProc1,
 				expr: &litMatcher{
-					pos:        position{line: 518, col: 5, offset: 15248},
+					pos:        position{line: 518, col: 5, offset: 15237},
 					val:        "pass",
 					ignoreCase: false,
 				},
@@ -4025,45 +4021,45 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeProc",
-			pos:  position{line: 524, col: 1, offset: 15442},
+			pos:  position{line: 524, col: 1, offset: 15431},
 			expr: &actionExpr{
-				pos: position{line: 525, col: 5, offset: 15458},
+				pos: position{line: 525, col: 5, offset: 15447},
 				run: (*parser).callonExplodeProc1,
 				expr: &seqExpr{
-					pos: position{line: 525, col: 5, offset: 15458},
+					pos: position{line: 525, col: 5, offset: 15447},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 525, col: 5, offset: 15458},
+							pos:        position{line: 525, col: 5, offset: 15447},
 							val:        "explode",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 525, col: 15, offset: 15468},
+							pos:  position{line: 525, col: 15, offset: 15457},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 17, offset: 15470},
+							pos:   position{line: 525, col: 17, offset: 15459},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 22, offset: 15475},
+								pos:  position{line: 525, col: 22, offset: 15464},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 28, offset: 15481},
+							pos:   position{line: 525, col: 28, offset: 15470},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 32, offset: 15485},
+								pos:  position{line: 525, col: 32, offset: 15474},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 40, offset: 15493},
+							pos:   position{line: 525, col: 40, offset: 15482},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 525, col: 43, offset: 15496},
+								pos: position{line: 525, col: 43, offset: 15485},
 								expr: &ruleRefExpr{
-									pos:  position{line: 525, col: 43, offset: 15496},
+									pos:  position{line: 525, col: 43, offset: 15485},
 									name: "AsArg",
 								},
 							},
@@ -4074,27 +4070,27 @@ var g = &grammar{
 		},
 		{
 			name: "MergeProc",
-			pos:  position{line: 529, col: 1, offset: 15608},
+			pos:  position{line: 529, col: 1, offset: 15597},
 			expr: &actionExpr{
-				pos: position{line: 530, col: 5, offset: 15622},
+				pos: position{line: 530, col: 5, offset: 15611},
 				run: (*parser).callonMergeProc1,
 				expr: &seqExpr{
-					pos: position{line: 530, col: 5, offset: 15622},
+					pos: position{line: 530, col: 5, offset: 15611},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 530, col: 5, offset: 15622},
+							pos:        position{line: 530, col: 5, offset: 15611},
 							val:        "merge",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 530, col: 13, offset: 15630},
+							pos:  position{line: 530, col: 13, offset: 15619},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 15, offset: 15632},
+							pos:   position{line: 530, col: 15, offset: 15621},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 20, offset: 15637},
+								pos:  position{line: 530, col: 20, offset: 15626},
 								name: "Expr",
 							},
 						},
@@ -4104,42 +4100,127 @@ var g = &grammar{
 		},
 		{
 			name: "OverProc",
-			pos:  position{line: 534, col: 1, offset: 15718},
+			pos:  position{line: 534, col: 1, offset: 15707},
 			expr: &choiceExpr{
-				pos: position{line: 535, col: 5, offset: 15731},
+				pos: position{line: 535, col: 5, offset: 15720},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 535, col: 5, offset: 15731},
+						pos: position{line: 535, col: 5, offset: 15720},
 						run: (*parser).callonOverProc2,
-						expr: &labeledExpr{
-							pos:   position{line: 535, col: 5, offset: 15731},
-							label: "over",
-							expr: &ruleRefExpr{
-								pos:  position{line: 535, col: 10, offset: 15736},
-								name: "ScopedOver",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 15841},
-						run: (*parser).callonOverProc5,
 						expr: &seqExpr{
-							pos: position{line: 538, col: 5, offset: 15841},
+							pos: position{line: 535, col: 5, offset: 15720},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 538, col: 5, offset: 15841},
+									pos:        position{line: 535, col: 5, offset: 15720},
 									val:        "over",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 538, col: 12, offset: 15848},
+									pos:  position{line: 535, col: 12, offset: 15727},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 538, col: 14, offset: 15850},
+									pos:   position{line: 535, col: 14, offset: 15729},
 									label: "exprs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 538, col: 20, offset: 15856},
+										pos:  position{line: 535, col: 20, offset: 15735},
+										name: "Exprs",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 535, col: 26, offset: 15741},
+									name: "_",
+								},
+								&litMatcher{
+									pos:        position{line: 535, col: 28, offset: 15743},
+									val:        "with",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 535, col: 35, offset: 15750},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 535, col: 37, offset: 15752},
+									label: "locals",
+									expr: &ruleRefExpr{
+										pos:  position{line: 535, col: 44, offset: 15759},
+										name: "LetAssignments",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 535, col: 59, offset: 15774},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 535, col: 62, offset: 15777},
+									label: "scope",
+									expr: &ruleRefExpr{
+										pos:  position{line: 535, col: 68, offset: 15783},
+										name: "Scope",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 538, col: 5, offset: 15949},
+						run: (*parser).callonOverProc16,
+						expr: &seqExpr{
+							pos: position{line: 538, col: 5, offset: 15949},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 538, col: 5, offset: 15949},
+									val:        "over",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 538, col: 12, offset: 15956},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 538, col: 14, offset: 15958},
+									label: "exprs",
+									expr: &ruleRefExpr{
+										pos:  position{line: 538, col: 20, offset: 15964},
+										name: "Exprs",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 538, col: 26, offset: 15970},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 538, col: 29, offset: 15973},
+									label: "scope",
+									expr: &ruleRefExpr{
+										pos:  position{line: 538, col: 35, offset: 15979},
+										name: "Scope",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 541, col: 5, offset: 16083},
+						run: (*parser).callonOverProc25,
+						expr: &seqExpr{
+							pos: position{line: 541, col: 5, offset: 16083},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 541, col: 5, offset: 16083},
+									val:        "over",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 541, col: 12, offset: 16090},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 541, col: 14, offset: 16092},
+									label: "exprs",
+									expr: &ruleRefExpr{
+										pos:  position{line: 541, col: 20, offset: 16098},
 										name: "Exprs",
 									},
 								},
@@ -4150,258 +4231,46 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "ScopedOver",
-			pos:  position{line: 542, col: 1, offset: 15964},
-			expr: &actionExpr{
-				pos: position{line: 543, col: 5, offset: 15979},
-				run: (*parser).callonScopedOver1,
-				expr: &seqExpr{
-					pos: position{line: 543, col: 5, offset: 15979},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 543, col: 5, offset: 15979},
-							val:        "over",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 543, col: 12, offset: 15986},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 543, col: 14, offset: 15988},
-							label: "exprs",
-							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 20, offset: 15994},
-								name: "Exprs",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 543, col: 26, offset: 16000},
-							label: "as",
-							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 29, offset: 16003},
-								name: "As",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 543, col: 32, offset: 16006},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 543, col: 35, offset: 16009},
-							label: "scope",
-							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 41, offset: 16015},
-								name: "Scope",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "OverWith",
-			pos:  position{line: 547, col: 1, offset: 16125},
-			expr: &actionExpr{
-				pos: position{line: 548, col: 5, offset: 16138},
-				run: (*parser).callonOverWith1,
-				expr: &seqExpr{
-					pos: position{line: 548, col: 5, offset: 16138},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 548, col: 5, offset: 16138},
-							val:        "over",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 548, col: 12, offset: 16145},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 548, col: 14, offset: 16147},
-							label: "exprs",
-							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 20, offset: 16153},
-								name: "Exprs",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 548, col: 26, offset: 16159},
-							name: "_",
-						},
-						&litMatcher{
-							pos:        position{line: 548, col: 28, offset: 16161},
-							val:        "with",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 548, col: 35, offset: 16168},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 548, col: 37, offset: 16170},
-							label: "locals",
-							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 44, offset: 16177},
-								name: "LetAssignments",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 548, col: 59, offset: 16192},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 548, col: 62, offset: 16195},
-							label: "scope",
-							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 68, offset: 16201},
-								name: "Scope",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "As",
-			pos:  position{line: 552, col: 1, offset: 16373},
-			expr: &choiceExpr{
-				pos: position{line: 553, col: 5, offset: 16380},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 553, col: 5, offset: 16380},
-						run: (*parser).callonAs2,
-						expr: &seqExpr{
-							pos: position{line: 553, col: 5, offset: 16380},
-							exprs: []interface{}{
-								&ruleRefExpr{
-									pos:  position{line: 553, col: 5, offset: 16380},
-									name: "_",
-								},
-								&litMatcher{
-									pos:        position{line: 553, col: 7, offset: 16382},
-									val:        "as",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 553, col: 12, offset: 16387},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 553, col: 14, offset: 16389},
-									label: "id",
-									expr: &ruleRefExpr{
-										pos:  position{line: 553, col: 17, offset: 16392},
-										name: "IdentifierName",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 16430},
-						run: (*parser).callonAs9,
-						expr: &litMatcher{
-							pos:        position{line: 554, col: 5, offset: 16430},
-							val:        "",
-							ignoreCase: false,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "LetProc",
-			pos:  position{line: 556, col: 1, offset: 16453},
-			expr: &choiceExpr{
-				pos: position{line: 557, col: 5, offset: 16465},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 557, col: 5, offset: 16465},
-						run: (*parser).callonLetProc2,
-						expr: &seqExpr{
-							pos: position{line: 557, col: 5, offset: 16465},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 557, col: 5, offset: 16465},
-									val:        "let",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 557, col: 11, offset: 16471},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 557, col: 13, offset: 16473},
-									label: "locals",
-									expr: &ruleRefExpr{
-										pos:  position{line: 557, col: 20, offset: 16480},
-										name: "LetAssignments",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 557, col: 35, offset: 16495},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 557, col: 38, offset: 16498},
-									label: "over",
-									expr: &ruleRefExpr{
-										pos:  position{line: 557, col: 43, offset: 16503},
-										name: "ScopedOver",
-									},
-								},
-							},
-						},
-					},
-					&ruleRefExpr{
-						pos:  position{line: 560, col: 5, offset: 16611},
-						name: "OverWith",
-					},
-				},
-			},
-		},
-		{
 			name: "Scope",
-			pos:  position{line: 562, col: 1, offset: 16621},
+			pos:  position{line: 545, col: 1, offset: 16197},
 			expr: &actionExpr{
-				pos: position{line: 562, col: 9, offset: 16629},
+				pos: position{line: 545, col: 9, offset: 16205},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 562, col: 9, offset: 16629},
+					pos: position{line: 545, col: 9, offset: 16205},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 562, col: 9, offset: 16629},
+							pos:        position{line: 545, col: 9, offset: 16205},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 14, offset: 16634},
+							pos:  position{line: 545, col: 14, offset: 16210},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 562, col: 17, offset: 16637},
+							pos:        position{line: 545, col: 17, offset: 16213},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 21, offset: 16641},
+							pos:  position{line: 545, col: 21, offset: 16217},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 562, col: 24, offset: 16644},
+							pos:   position{line: 545, col: 24, offset: 16220},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 28, offset: 16648},
+								pos:  position{line: 545, col: 28, offset: 16224},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 39, offset: 16659},
+							pos:  position{line: 545, col: 39, offset: 16235},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 562, col: 42, offset: 16662},
+							pos:        position{line: 545, col: 42, offset: 16238},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4411,50 +4280,50 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignments",
-			pos:  position{line: 564, col: 1, offset: 16687},
+			pos:  position{line: 547, col: 1, offset: 16263},
 			expr: &actionExpr{
-				pos: position{line: 565, col: 5, offset: 16706},
+				pos: position{line: 548, col: 5, offset: 16282},
 				run: (*parser).callonLetAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 565, col: 5, offset: 16706},
+					pos: position{line: 548, col: 5, offset: 16282},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 565, col: 5, offset: 16706},
+							pos:   position{line: 548, col: 5, offset: 16282},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 565, col: 11, offset: 16712},
+								pos:  position{line: 548, col: 11, offset: 16288},
 								name: "LetAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 565, col: 25, offset: 16726},
+							pos:   position{line: 548, col: 25, offset: 16302},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 565, col: 30, offset: 16731},
+								pos: position{line: 548, col: 30, offset: 16307},
 								expr: &actionExpr{
-									pos: position{line: 565, col: 31, offset: 16732},
+									pos: position{line: 548, col: 31, offset: 16308},
 									run: (*parser).callonLetAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 565, col: 31, offset: 16732},
+										pos: position{line: 548, col: 31, offset: 16308},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 565, col: 31, offset: 16732},
+												pos:  position{line: 548, col: 31, offset: 16308},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 565, col: 34, offset: 16735},
+												pos:        position{line: 548, col: 34, offset: 16311},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 565, col: 38, offset: 16739},
+												pos:  position{line: 548, col: 38, offset: 16315},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 565, col: 41, offset: 16742},
+												pos:   position{line: 548, col: 41, offset: 16318},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 565, col: 43, offset: 16744},
+													pos:  position{line: 548, col: 43, offset: 16320},
 													name: "LetAssignment",
 												},
 											},
@@ -4469,42 +4338,42 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignment",
-			pos:  position{line: 569, col: 1, offset: 16862},
+			pos:  position{line: 552, col: 1, offset: 16438},
 			expr: &choiceExpr{
-				pos: position{line: 570, col: 5, offset: 16880},
+				pos: position{line: 553, col: 5, offset: 16456},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 570, col: 5, offset: 16880},
+						pos: position{line: 553, col: 5, offset: 16456},
 						run: (*parser).callonLetAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 570, col: 5, offset: 16880},
+							pos: position{line: 553, col: 5, offset: 16456},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 570, col: 5, offset: 16880},
+									pos:   position{line: 553, col: 5, offset: 16456},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 570, col: 8, offset: 16883},
+										pos:  position{line: 553, col: 8, offset: 16459},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 23, offset: 16898},
+									pos:  position{line: 553, col: 23, offset: 16474},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 570, col: 26, offset: 16901},
+									pos:        position{line: 553, col: 26, offset: 16477},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 30, offset: 16905},
+									pos:  position{line: 553, col: 30, offset: 16481},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 570, col: 33, offset: 16908},
+									pos:   position{line: 553, col: 33, offset: 16484},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 570, col: 38, offset: 16913},
+										pos:  position{line: 553, col: 38, offset: 16489},
 										name: "Expr",
 									},
 								},
@@ -4512,13 +4381,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 573, col: 5, offset: 16995},
+						pos: position{line: 556, col: 5, offset: 16571},
 						run: (*parser).callonLetAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 573, col: 5, offset: 16995},
+							pos:   position{line: 556, col: 5, offset: 16571},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 573, col: 8, offset: 16998},
+								pos:  position{line: 556, col: 8, offset: 16574},
 								name: "IdentifierName",
 							},
 						},
@@ -4528,27 +4397,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldProc",
-			pos:  position{line: 577, col: 1, offset: 17128},
+			pos:  position{line: 560, col: 1, offset: 16704},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 5, offset: 17142},
+				pos: position{line: 561, col: 5, offset: 16718},
 				run: (*parser).callonYieldProc1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 5, offset: 17142},
+					pos: position{line: 561, col: 5, offset: 16718},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 578, col: 5, offset: 17142},
+							pos:        position{line: 561, col: 5, offset: 16718},
 							val:        "yield",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 578, col: 13, offset: 17150},
+							pos:  position{line: 561, col: 13, offset: 16726},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 578, col: 15, offset: 17152},
+							pos:   position{line: 561, col: 15, offset: 16728},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 578, col: 21, offset: 17158},
+								pos:  position{line: 561, col: 21, offset: 16734},
 								name: "Exprs",
 							},
 						},
@@ -4558,30 +4427,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 582, col: 1, offset: 17242},
+			pos:  position{line: 565, col: 1, offset: 16818},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 5, offset: 17254},
+				pos: position{line: 566, col: 5, offset: 16830},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 583, col: 5, offset: 17254},
+					pos: position{line: 566, col: 5, offset: 16830},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 5, offset: 17254},
+							pos:  position{line: 566, col: 5, offset: 16830},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 7, offset: 17256},
+							pos:  position{line: 566, col: 7, offset: 16832},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 10, offset: 17259},
+							pos:  position{line: 566, col: 10, offset: 16835},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 12, offset: 17261},
+							pos:   position{line: 566, col: 12, offset: 16837},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 16, offset: 17265},
+								pos:  position{line: 566, col: 16, offset: 16841},
 								name: "Type",
 							},
 						},
@@ -4591,30 +4460,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 585, col: 1, offset: 17290},
+			pos:  position{line: 568, col: 1, offset: 16866},
 			expr: &actionExpr{
-				pos: position{line: 586, col: 5, offset: 17300},
+				pos: position{line: 569, col: 5, offset: 16876},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 586, col: 5, offset: 17300},
+					pos: position{line: 569, col: 5, offset: 16876},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 5, offset: 17300},
+							pos:  position{line: 569, col: 5, offset: 16876},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 7, offset: 17302},
+							pos:  position{line: 569, col: 7, offset: 16878},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 10, offset: 17305},
+							pos:  position{line: 569, col: 10, offset: 16881},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 586, col: 12, offset: 17307},
+							pos:   position{line: 569, col: 12, offset: 16883},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 586, col: 16, offset: 17311},
+								pos:  position{line: 569, col: 16, offset: 16887},
 								name: "Lval",
 							},
 						},
@@ -4624,58 +4493,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 590, col: 1, offset: 17362},
+			pos:  position{line: 573, col: 1, offset: 16938},
 			expr: &ruleRefExpr{
-				pos:  position{line: 590, col: 8, offset: 17369},
+				pos:  position{line: 573, col: 8, offset: 16945},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 592, col: 1, offset: 17380},
+			pos:  position{line: 575, col: 1, offset: 16956},
 			expr: &actionExpr{
-				pos: position{line: 593, col: 5, offset: 17390},
+				pos: position{line: 576, col: 5, offset: 16966},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 593, col: 5, offset: 17390},
+					pos: position{line: 576, col: 5, offset: 16966},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 593, col: 5, offset: 17390},
+							pos:   position{line: 576, col: 5, offset: 16966},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 593, col: 11, offset: 17396},
+								pos:  position{line: 576, col: 11, offset: 16972},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 593, col: 16, offset: 17401},
+							pos:   position{line: 576, col: 16, offset: 16977},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 593, col: 21, offset: 17406},
+								pos: position{line: 576, col: 21, offset: 16982},
 								expr: &actionExpr{
-									pos: position{line: 593, col: 22, offset: 17407},
+									pos: position{line: 576, col: 22, offset: 16983},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 593, col: 22, offset: 17407},
+										pos: position{line: 576, col: 22, offset: 16983},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 593, col: 22, offset: 17407},
+												pos:  position{line: 576, col: 22, offset: 16983},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 593, col: 25, offset: 17410},
+												pos:        position{line: 576, col: 25, offset: 16986},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 593, col: 29, offset: 17414},
+												pos:  position{line: 576, col: 29, offset: 16990},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 593, col: 32, offset: 17417},
+												pos:   position{line: 576, col: 32, offset: 16993},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 593, col: 37, offset: 17422},
+													pos:  position{line: 576, col: 37, offset: 16998},
 													name: "Lval",
 												},
 											},
@@ -4690,52 +4559,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 597, col: 1, offset: 17534},
+			pos:  position{line: 580, col: 1, offset: 17110},
 			expr: &ruleRefExpr{
-				pos:  position{line: 597, col: 13, offset: 17546},
+				pos:  position{line: 580, col: 13, offset: 17122},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 599, col: 1, offset: 17552},
+			pos:  position{line: 582, col: 1, offset: 17128},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 5, offset: 17567},
+				pos: position{line: 583, col: 5, offset: 17143},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 5, offset: 17567},
+					pos: position{line: 583, col: 5, offset: 17143},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 600, col: 5, offset: 17567},
+							pos:   position{line: 583, col: 5, offset: 17143},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 600, col: 11, offset: 17573},
+								pos:  position{line: 583, col: 11, offset: 17149},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 21, offset: 17583},
+							pos:   position{line: 583, col: 21, offset: 17159},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 600, col: 26, offset: 17588},
+								pos: position{line: 583, col: 26, offset: 17164},
 								expr: &seqExpr{
-									pos: position{line: 600, col: 27, offset: 17589},
+									pos: position{line: 583, col: 27, offset: 17165},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 27, offset: 17589},
+											pos:  position{line: 583, col: 27, offset: 17165},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 600, col: 30, offset: 17592},
+											pos:        position{line: 583, col: 30, offset: 17168},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 34, offset: 17596},
+											pos:  position{line: 583, col: 34, offset: 17172},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 37, offset: 17599},
+											pos:  position{line: 583, col: 37, offset: 17175},
 											name: "FieldExpr",
 										},
 									},
@@ -4748,50 +4617,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 610, col: 1, offset: 17798},
+			pos:  position{line: 593, col: 1, offset: 17374},
 			expr: &actionExpr{
-				pos: position{line: 611, col: 5, offset: 17814},
+				pos: position{line: 594, col: 5, offset: 17390},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 611, col: 5, offset: 17814},
+					pos: position{line: 594, col: 5, offset: 17390},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 611, col: 5, offset: 17814},
+							pos:   position{line: 594, col: 5, offset: 17390},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 11, offset: 17820},
+								pos:  position{line: 594, col: 11, offset: 17396},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 22, offset: 17831},
+							pos:   position{line: 594, col: 22, offset: 17407},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 611, col: 27, offset: 17836},
+								pos: position{line: 594, col: 27, offset: 17412},
 								expr: &actionExpr{
-									pos: position{line: 611, col: 28, offset: 17837},
+									pos: position{line: 594, col: 28, offset: 17413},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 611, col: 28, offset: 17837},
+										pos: position{line: 594, col: 28, offset: 17413},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 28, offset: 17837},
+												pos:  position{line: 594, col: 28, offset: 17413},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 611, col: 31, offset: 17840},
+												pos:        position{line: 594, col: 31, offset: 17416},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 35, offset: 17844},
+												pos:  position{line: 594, col: 35, offset: 17420},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 611, col: 38, offset: 17847},
+												pos:   position{line: 594, col: 38, offset: 17423},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 611, col: 40, offset: 17849},
+													pos:  position{line: 594, col: 40, offset: 17425},
 													name: "Assignment",
 												},
 											},
@@ -4806,39 +4675,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 615, col: 1, offset: 17960},
+			pos:  position{line: 598, col: 1, offset: 17536},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 5, offset: 17975},
+				pos: position{line: 599, col: 5, offset: 17551},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 5, offset: 17975},
+					pos: position{line: 599, col: 5, offset: 17551},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 616, col: 5, offset: 17975},
+							pos:   position{line: 599, col: 5, offset: 17551},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 9, offset: 17979},
+								pos:  position{line: 599, col: 9, offset: 17555},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 616, col: 14, offset: 17984},
+							pos:  position{line: 599, col: 14, offset: 17560},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 616, col: 17, offset: 17987},
+							pos:        position{line: 599, col: 17, offset: 17563},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 616, col: 22, offset: 17992},
+							pos:  position{line: 599, col: 22, offset: 17568},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 616, col: 25, offset: 17995},
+							pos:   position{line: 599, col: 25, offset: 17571},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 29, offset: 17999},
+								pos:  position{line: 599, col: 29, offset: 17575},
 								name: "Expr",
 							},
 						},
@@ -4848,71 +4717,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 618, col: 1, offset: 18090},
+			pos:  position{line: 601, col: 1, offset: 17666},
 			expr: &ruleRefExpr{
-				pos:  position{line: 618, col: 8, offset: 18097},
+				pos:  position{line: 601, col: 8, offset: 17673},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 620, col: 1, offset: 18114},
+			pos:  position{line: 603, col: 1, offset: 17690},
 			expr: &choiceExpr{
-				pos: position{line: 621, col: 5, offset: 18134},
+				pos: position{line: 604, col: 5, offset: 17710},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 621, col: 5, offset: 18134},
+						pos: position{line: 604, col: 5, offset: 17710},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 621, col: 5, offset: 18134},
+							pos: position{line: 604, col: 5, offset: 17710},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 621, col: 5, offset: 18134},
+									pos:   position{line: 604, col: 5, offset: 17710},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 15, offset: 18144},
+										pos:  position{line: 604, col: 15, offset: 17720},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 29, offset: 18158},
+									pos:  position{line: 604, col: 29, offset: 17734},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 621, col: 32, offset: 18161},
+									pos:        position{line: 604, col: 32, offset: 17737},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 36, offset: 18165},
+									pos:  position{line: 604, col: 36, offset: 17741},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 621, col: 39, offset: 18168},
+									pos:   position{line: 604, col: 39, offset: 17744},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 50, offset: 18179},
+										pos:  position{line: 604, col: 50, offset: 17755},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 55, offset: 18184},
+									pos:  position{line: 604, col: 55, offset: 17760},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 621, col: 58, offset: 18187},
+									pos:        position{line: 604, col: 58, offset: 17763},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 621, col: 62, offset: 18191},
+									pos:  position{line: 604, col: 62, offset: 17767},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 621, col: 65, offset: 18194},
+									pos:   position{line: 604, col: 65, offset: 17770},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 621, col: 76, offset: 18205},
+										pos:  position{line: 604, col: 76, offset: 17781},
 										name: "Expr",
 									},
 								},
@@ -4920,7 +4789,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 5, offset: 18345},
+						pos:  position{line: 607, col: 5, offset: 17921},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4928,53 +4797,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 626, col: 1, offset: 18360},
+			pos:  position{line: 609, col: 1, offset: 17936},
 			expr: &actionExpr{
-				pos: position{line: 627, col: 5, offset: 18378},
+				pos: position{line: 610, col: 5, offset: 17954},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 627, col: 5, offset: 18378},
+					pos: position{line: 610, col: 5, offset: 17954},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 627, col: 5, offset: 18378},
+							pos:   position{line: 610, col: 5, offset: 17954},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 627, col: 11, offset: 18384},
+								pos:  position{line: 610, col: 11, offset: 17960},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 628, col: 5, offset: 18403},
+							pos:   position{line: 611, col: 5, offset: 17979},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 628, col: 10, offset: 18408},
+								pos: position{line: 611, col: 10, offset: 17984},
 								expr: &actionExpr{
-									pos: position{line: 628, col: 11, offset: 18409},
+									pos: position{line: 611, col: 11, offset: 17985},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 628, col: 11, offset: 18409},
+										pos: position{line: 611, col: 11, offset: 17985},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 628, col: 11, offset: 18409},
+												pos:  position{line: 611, col: 11, offset: 17985},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 628, col: 14, offset: 18412},
+												pos:   position{line: 611, col: 14, offset: 17988},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 628, col: 17, offset: 18415},
+													pos:  position{line: 611, col: 17, offset: 17991},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 628, col: 25, offset: 18423},
+												pos:  position{line: 611, col: 25, offset: 17999},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 628, col: 28, offset: 18426},
+												pos:   position{line: 611, col: 28, offset: 18002},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 628, col: 33, offset: 18431},
+													pos:  position{line: 611, col: 33, offset: 18007},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4989,53 +4858,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 632, col: 1, offset: 18549},
+			pos:  position{line: 615, col: 1, offset: 18125},
 			expr: &actionExpr{
-				pos: position{line: 633, col: 5, offset: 18568},
+				pos: position{line: 616, col: 5, offset: 18144},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 633, col: 5, offset: 18568},
+					pos: position{line: 616, col: 5, offset: 18144},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 633, col: 5, offset: 18568},
+							pos:   position{line: 616, col: 5, offset: 18144},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 11, offset: 18574},
+								pos:  position{line: 616, col: 11, offset: 18150},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 5, offset: 18593},
+							pos:   position{line: 617, col: 5, offset: 18169},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 634, col: 10, offset: 18598},
+								pos: position{line: 617, col: 10, offset: 18174},
 								expr: &actionExpr{
-									pos: position{line: 634, col: 11, offset: 18599},
+									pos: position{line: 617, col: 11, offset: 18175},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 634, col: 11, offset: 18599},
+										pos: position{line: 617, col: 11, offset: 18175},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 634, col: 11, offset: 18599},
+												pos:  position{line: 617, col: 11, offset: 18175},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 634, col: 14, offset: 18602},
+												pos:   position{line: 617, col: 14, offset: 18178},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 634, col: 17, offset: 18605},
+													pos:  position{line: 617, col: 17, offset: 18181},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 634, col: 26, offset: 18614},
+												pos:  position{line: 617, col: 26, offset: 18190},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 634, col: 29, offset: 18617},
+												pos:   position{line: 617, col: 29, offset: 18193},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 634, col: 34, offset: 18622},
+													pos:  position{line: 617, col: 34, offset: 18198},
 													name: "ComparisonExpr",
 												},
 											},
@@ -5050,45 +4919,45 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 638, col: 1, offset: 18740},
+			pos:  position{line: 621, col: 1, offset: 18316},
 			expr: &choiceExpr{
-				pos: position{line: 639, col: 5, offset: 18759},
+				pos: position{line: 622, col: 5, offset: 18335},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 639, col: 5, offset: 18759},
+						pos: position{line: 622, col: 5, offset: 18335},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 639, col: 5, offset: 18759},
+							pos: position{line: 622, col: 5, offset: 18335},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 639, col: 5, offset: 18759},
+									pos:   position{line: 622, col: 5, offset: 18335},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 9, offset: 18763},
+										pos:  position{line: 622, col: 9, offset: 18339},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 639, col: 22, offset: 18776},
+									pos:  position{line: 622, col: 22, offset: 18352},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 639, col: 25, offset: 18779},
+									pos:   position{line: 622, col: 25, offset: 18355},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 28, offset: 18782},
+										pos:  position{line: 622, col: 28, offset: 18358},
 										name: "Comparator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 639, col: 39, offset: 18793},
+									pos:  position{line: 622, col: 39, offset: 18369},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 639, col: 42, offset: 18796},
+									pos:   position{line: 622, col: 42, offset: 18372},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 46, offset: 18800},
+										pos:  position{line: 622, col: 46, offset: 18376},
 										name: "AdditiveExpr",
 									},
 								},
@@ -5096,37 +4965,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 642, col: 5, offset: 18924},
+						pos: position{line: 625, col: 5, offset: 18500},
 						run: (*parser).callonComparisonExpr12,
 						expr: &seqExpr{
-							pos: position{line: 642, col: 5, offset: 18924},
+							pos: position{line: 625, col: 5, offset: 18500},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 642, col: 5, offset: 18924},
+									pos:   position{line: 625, col: 5, offset: 18500},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 642, col: 9, offset: 18928},
+										pos:  position{line: 625, col: 9, offset: 18504},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 642, col: 22, offset: 18941},
+									pos:  position{line: 625, col: 22, offset: 18517},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 642, col: 25, offset: 18944},
+									pos:        position{line: 625, col: 25, offset: 18520},
 									val:        "~",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 642, col: 29, offset: 18948},
+									pos:  position{line: 625, col: 29, offset: 18524},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 642, col: 32, offset: 18951},
+									pos:   position{line: 625, col: 32, offset: 18527},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 642, col: 36, offset: 18955},
+										pos:  position{line: 625, col: 36, offset: 18531},
 										name: "Regexp",
 									},
 								},
@@ -5134,7 +5003,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 645, col: 5, offset: 19074},
+						pos:  position{line: 628, col: 5, offset: 18650},
 						name: "AdditiveExpr",
 					},
 				},
@@ -5142,53 +5011,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 647, col: 1, offset: 19088},
+			pos:  position{line: 630, col: 1, offset: 18664},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 5, offset: 19105},
+				pos: position{line: 631, col: 5, offset: 18681},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 648, col: 5, offset: 19105},
+					pos: position{line: 631, col: 5, offset: 18681},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 648, col: 5, offset: 19105},
+							pos:   position{line: 631, col: 5, offset: 18681},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 648, col: 11, offset: 19111},
+								pos:  position{line: 631, col: 11, offset: 18687},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 5, offset: 19134},
+							pos:   position{line: 632, col: 5, offset: 18710},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 649, col: 10, offset: 19139},
+								pos: position{line: 632, col: 10, offset: 18715},
 								expr: &actionExpr{
-									pos: position{line: 649, col: 11, offset: 19140},
+									pos: position{line: 632, col: 11, offset: 18716},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 649, col: 11, offset: 19140},
+										pos: position{line: 632, col: 11, offset: 18716},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 649, col: 11, offset: 19140},
+												pos:  position{line: 632, col: 11, offset: 18716},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 649, col: 14, offset: 19143},
+												pos:   position{line: 632, col: 14, offset: 18719},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 649, col: 17, offset: 19146},
+													pos:  position{line: 632, col: 17, offset: 18722},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 649, col: 34, offset: 19163},
+												pos:  position{line: 632, col: 34, offset: 18739},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 649, col: 37, offset: 19166},
+												pos:   position{line: 632, col: 37, offset: 18742},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 649, col: 42, offset: 19171},
+													pos:  position{line: 632, col: 42, offset: 18747},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5203,20 +5072,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 653, col: 1, offset: 19293},
+			pos:  position{line: 636, col: 1, offset: 18869},
 			expr: &actionExpr{
-				pos: position{line: 653, col: 20, offset: 19312},
+				pos: position{line: 636, col: 20, offset: 18888},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 653, col: 21, offset: 19313},
+					pos: position{line: 636, col: 21, offset: 18889},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 653, col: 21, offset: 19313},
+							pos:        position{line: 636, col: 21, offset: 18889},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 653, col: 27, offset: 19319},
+							pos:        position{line: 636, col: 27, offset: 18895},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5226,53 +5095,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 655, col: 1, offset: 19356},
+			pos:  position{line: 638, col: 1, offset: 18932},
 			expr: &actionExpr{
-				pos: position{line: 656, col: 5, offset: 19379},
+				pos: position{line: 639, col: 5, offset: 18955},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 656, col: 5, offset: 19379},
+					pos: position{line: 639, col: 5, offset: 18955},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 656, col: 5, offset: 19379},
+							pos:   position{line: 639, col: 5, offset: 18955},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 656, col: 11, offset: 19385},
+								pos:  position{line: 639, col: 11, offset: 18961},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 5, offset: 19397},
+							pos:   position{line: 640, col: 5, offset: 18973},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 657, col: 10, offset: 19402},
+								pos: position{line: 640, col: 10, offset: 18978},
 								expr: &actionExpr{
-									pos: position{line: 657, col: 11, offset: 19403},
+									pos: position{line: 640, col: 11, offset: 18979},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 657, col: 11, offset: 19403},
+										pos: position{line: 640, col: 11, offset: 18979},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 657, col: 11, offset: 19403},
+												pos:  position{line: 640, col: 11, offset: 18979},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 657, col: 14, offset: 19406},
+												pos:   position{line: 640, col: 14, offset: 18982},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 657, col: 17, offset: 19409},
+													pos:  position{line: 640, col: 17, offset: 18985},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 657, col: 40, offset: 19432},
+												pos:  position{line: 640, col: 40, offset: 19008},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 657, col: 43, offset: 19435},
+												pos:   position{line: 640, col: 43, offset: 19011},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 657, col: 48, offset: 19440},
+													pos:  position{line: 640, col: 48, offset: 19016},
 													name: "NotExpr",
 												},
 											},
@@ -5287,25 +5156,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 661, col: 1, offset: 19551},
+			pos:  position{line: 644, col: 1, offset: 19127},
 			expr: &actionExpr{
-				pos: position{line: 661, col: 26, offset: 19576},
+				pos: position{line: 644, col: 26, offset: 19152},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 661, col: 27, offset: 19577},
+					pos: position{line: 644, col: 27, offset: 19153},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 661, col: 27, offset: 19577},
+							pos:        position{line: 644, col: 27, offset: 19153},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 661, col: 33, offset: 19583},
+							pos:        position{line: 644, col: 33, offset: 19159},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 661, col: 39, offset: 19589},
+							pos:        position{line: 644, col: 39, offset: 19165},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5315,30 +5184,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 663, col: 1, offset: 19626},
+			pos:  position{line: 646, col: 1, offset: 19202},
 			expr: &choiceExpr{
-				pos: position{line: 664, col: 5, offset: 19638},
+				pos: position{line: 647, col: 5, offset: 19214},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 19638},
+						pos: position{line: 647, col: 5, offset: 19214},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 664, col: 5, offset: 19638},
+							pos: position{line: 647, col: 5, offset: 19214},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 664, col: 5, offset: 19638},
+									pos:        position{line: 647, col: 5, offset: 19214},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 664, col: 9, offset: 19642},
+									pos:  position{line: 647, col: 9, offset: 19218},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 664, col: 12, offset: 19645},
+									pos:   position{line: 647, col: 12, offset: 19221},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 664, col: 14, offset: 19647},
+										pos:  position{line: 647, col: 14, offset: 19223},
 										name: "NotExpr",
 									},
 								},
@@ -5346,7 +5215,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 19756},
+						pos:  position{line: 650, col: 5, offset: 19332},
 						name: "NegationExpr",
 					},
 				},
@@ -5354,37 +5223,37 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 669, col: 1, offset: 19770},
+			pos:  position{line: 652, col: 1, offset: 19346},
 			expr: &choiceExpr{
-				pos: position{line: 670, col: 5, offset: 19787},
+				pos: position{line: 653, col: 5, offset: 19363},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 670, col: 5, offset: 19787},
+						pos: position{line: 653, col: 5, offset: 19363},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 670, col: 5, offset: 19787},
+							pos: position{line: 653, col: 5, offset: 19363},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 670, col: 5, offset: 19787},
+									pos: position{line: 653, col: 5, offset: 19363},
 									expr: &ruleRefExpr{
-										pos:  position{line: 670, col: 6, offset: 19788},
+										pos:  position{line: 653, col: 6, offset: 19364},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 670, col: 14, offset: 19796},
+									pos:        position{line: 653, col: 14, offset: 19372},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 670, col: 18, offset: 19800},
+									pos:  position{line: 653, col: 18, offset: 19376},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 670, col: 21, offset: 19803},
+									pos:   position{line: 653, col: 21, offset: 19379},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 670, col: 23, offset: 19805},
+										pos:  position{line: 653, col: 23, offset: 19381},
 										name: "FuncExpr",
 									},
 								},
@@ -5392,7 +5261,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 673, col: 5, offset: 19915},
+						pos:  position{line: 656, col: 5, offset: 19491},
 						name: "FuncExpr",
 					},
 				},
@@ -5400,31 +5269,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 675, col: 1, offset: 19925},
+			pos:  position{line: 658, col: 1, offset: 19501},
 			expr: &choiceExpr{
-				pos: position{line: 676, col: 5, offset: 19938},
+				pos: position{line: 659, col: 5, offset: 19514},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 676, col: 5, offset: 19938},
+						pos: position{line: 659, col: 5, offset: 19514},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 676, col: 5, offset: 19938},
+							pos: position{line: 659, col: 5, offset: 19514},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 676, col: 5, offset: 19938},
+									pos:   position{line: 659, col: 5, offset: 19514},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 676, col: 11, offset: 19944},
+										pos:  position{line: 659, col: 11, offset: 19520},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 676, col: 16, offset: 19949},
+									pos:   position{line: 659, col: 16, offset: 19525},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 676, col: 21, offset: 19954},
+										pos: position{line: 659, col: 21, offset: 19530},
 										expr: &ruleRefExpr{
-											pos:  position{line: 676, col: 22, offset: 19955},
+											pos:  position{line: 659, col: 22, offset: 19531},
 											name: "Deref",
 										},
 									},
@@ -5433,26 +5302,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 679, col: 5, offset: 20026},
+						pos: position{line: 662, col: 5, offset: 19602},
 						run: (*parser).callonFuncExpr9,
 						expr: &seqExpr{
-							pos: position{line: 679, col: 5, offset: 20026},
+							pos: position{line: 662, col: 5, offset: 19602},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 679, col: 5, offset: 20026},
+									pos:   position{line: 662, col: 5, offset: 19602},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 679, col: 11, offset: 20032},
+										pos:  position{line: 662, col: 11, offset: 19608},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 679, col: 20, offset: 20041},
+									pos:   position{line: 662, col: 20, offset: 19617},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 679, col: 25, offset: 20046},
+										pos: position{line: 662, col: 25, offset: 19622},
 										expr: &ruleRefExpr{
-											pos:  position{line: 679, col: 26, offset: 20047},
+											pos:  position{line: 662, col: 26, offset: 19623},
 											name: "Deref",
 										},
 									},
@@ -5461,11 +5330,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 682, col: 5, offset: 20118},
+						pos:  position{line: 665, col: 5, offset: 19694},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 683, col: 5, offset: 20132},
+						pos:  position{line: 666, col: 5, offset: 19708},
 						name: "Primary",
 					},
 				},
@@ -5473,20 +5342,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 685, col: 1, offset: 20141},
+			pos:  position{line: 668, col: 1, offset: 19717},
 			expr: &seqExpr{
-				pos: position{line: 685, col: 13, offset: 20153},
+				pos: position{line: 668, col: 13, offset: 19729},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 685, col: 13, offset: 20153},
+						pos:  position{line: 668, col: 13, offset: 19729},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 685, col: 22, offset: 20162},
+						pos:  position{line: 668, col: 22, offset: 19738},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 685, col: 25, offset: 20165},
+						pos:        position{line: 668, col: 25, offset: 19741},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5495,17 +5364,17 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 687, col: 1, offset: 20170},
+			pos:  position{line: 670, col: 1, offset: 19746},
 			expr: &choiceExpr{
-				pos: position{line: 688, col: 5, offset: 20183},
+				pos: position{line: 671, col: 5, offset: 19759},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 688, col: 5, offset: 20183},
+						pos:        position{line: 671, col: 5, offset: 19759},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 689, col: 5, offset: 20193},
+						pos:        position{line: 672, col: 5, offset: 19769},
 						val:        "select",
 						ignoreCase: false,
 					},
@@ -5514,48 +5383,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 691, col: 1, offset: 20203},
+			pos:  position{line: 674, col: 1, offset: 19779},
 			expr: &actionExpr{
-				pos: position{line: 692, col: 5, offset: 20212},
+				pos: position{line: 675, col: 5, offset: 19788},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 692, col: 5, offset: 20212},
+					pos: position{line: 675, col: 5, offset: 19788},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 692, col: 5, offset: 20212},
+							pos:   position{line: 675, col: 5, offset: 19788},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 692, col: 9, offset: 20216},
+								pos:  position{line: 675, col: 9, offset: 19792},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 692, col: 18, offset: 20225},
+							pos:  position{line: 675, col: 18, offset: 19801},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 692, col: 21, offset: 20228},
+							pos:        position{line: 675, col: 21, offset: 19804},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 692, col: 25, offset: 20232},
+							pos:  position{line: 675, col: 25, offset: 19808},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 692, col: 28, offset: 20235},
+							pos:   position{line: 675, col: 28, offset: 19811},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 692, col: 33, offset: 20240},
+								pos:  position{line: 675, col: 33, offset: 19816},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 692, col: 38, offset: 20245},
+							pos:  position{line: 675, col: 38, offset: 19821},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 692, col: 41, offset: 20248},
+							pos:        position{line: 675, col: 41, offset: 19824},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5565,72 +5434,72 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 696, col: 1, offset: 20345},
+			pos:  position{line: 679, col: 1, offset: 19921},
 			expr: &choiceExpr{
-				pos: position{line: 697, col: 5, offset: 20358},
+				pos: position{line: 680, col: 5, offset: 19934},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 697, col: 5, offset: 20358},
+						pos:  position{line: 680, col: 5, offset: 19934},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 698, col: 5, offset: 20367},
+						pos: position{line: 681, col: 5, offset: 19943},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 698, col: 5, offset: 20367},
+							pos: position{line: 681, col: 5, offset: 19943},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 698, col: 5, offset: 20367},
+									pos: position{line: 681, col: 5, offset: 19943},
 									expr: &ruleRefExpr{
-										pos:  position{line: 698, col: 6, offset: 20368},
+										pos:  position{line: 681, col: 6, offset: 19944},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 698, col: 16, offset: 20378},
+									pos:   position{line: 681, col: 16, offset: 19954},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 698, col: 19, offset: 20381},
+										pos:  position{line: 681, col: 19, offset: 19957},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 698, col: 34, offset: 20396},
+									pos:  position{line: 681, col: 34, offset: 19972},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 698, col: 37, offset: 20399},
+									pos:        position{line: 681, col: 37, offset: 19975},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 698, col: 41, offset: 20403},
+									pos:  position{line: 681, col: 41, offset: 19979},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 698, col: 44, offset: 20406},
+									pos:   position{line: 681, col: 44, offset: 19982},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 698, col: 49, offset: 20411},
+										pos:  position{line: 681, col: 49, offset: 19987},
 										name: "OptionalExprs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 698, col: 63, offset: 20425},
+									pos:  position{line: 681, col: 63, offset: 20001},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 698, col: 66, offset: 20428},
+									pos:        position{line: 681, col: 66, offset: 20004},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 698, col: 70, offset: 20432},
+									pos:   position{line: 681, col: 70, offset: 20008},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 698, col: 76, offset: 20438},
+										pos: position{line: 681, col: 76, offset: 20014},
 										expr: &ruleRefExpr{
-											pos:  position{line: 698, col: 76, offset: 20438},
+											pos:  position{line: 681, col: 76, offset: 20014},
 											name: "WhereClause",
 										},
 									},
@@ -5643,48 +5512,48 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 702, col: 1, offset: 20559},
+			pos:  position{line: 685, col: 1, offset: 20135},
 			expr: &choiceExpr{
-				pos: position{line: 703, col: 5, offset: 20568},
+				pos: position{line: 686, col: 5, offset: 20144},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 703, col: 5, offset: 20568},
+						pos: position{line: 686, col: 5, offset: 20144},
 						run: (*parser).callonGrep2,
 						expr: &seqExpr{
-							pos: position{line: 703, col: 5, offset: 20568},
+							pos: position{line: 686, col: 5, offset: 20144},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 703, col: 5, offset: 20568},
+									pos:        position{line: 686, col: 5, offset: 20144},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 703, col: 12, offset: 20575},
+									pos:  position{line: 686, col: 12, offset: 20151},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 703, col: 15, offset: 20578},
+									pos:        position{line: 686, col: 15, offset: 20154},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 703, col: 19, offset: 20582},
+									pos:  position{line: 686, col: 19, offset: 20158},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 703, col: 22, offset: 20585},
+									pos:   position{line: 686, col: 22, offset: 20161},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 703, col: 30, offset: 20593},
+										pos:  position{line: 686, col: 30, offset: 20169},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 703, col: 38, offset: 20601},
+									pos:  position{line: 686, col: 38, offset: 20177},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 703, col: 41, offset: 20604},
+									pos:        position{line: 686, col: 41, offset: 20180},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5692,64 +5561,64 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20759},
+						pos: position{line: 689, col: 5, offset: 20335},
 						run: (*parser).callonGrep12,
 						expr: &seqExpr{
-							pos: position{line: 706, col: 5, offset: 20759},
+							pos: position{line: 689, col: 5, offset: 20335},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 706, col: 5, offset: 20759},
+									pos:        position{line: 689, col: 5, offset: 20335},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 12, offset: 20766},
+									pos:  position{line: 689, col: 12, offset: 20342},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 706, col: 15, offset: 20769},
+									pos:        position{line: 689, col: 15, offset: 20345},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 19, offset: 20773},
+									pos:  position{line: 689, col: 19, offset: 20349},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 706, col: 22, offset: 20776},
+									pos:   position{line: 689, col: 22, offset: 20352},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 706, col: 30, offset: 20784},
+										pos:  position{line: 689, col: 30, offset: 20360},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 38, offset: 20792},
+									pos:  position{line: 689, col: 38, offset: 20368},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 706, col: 42, offset: 20796},
+									pos:        position{line: 689, col: 42, offset: 20372},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 46, offset: 20800},
+									pos:  position{line: 689, col: 46, offset: 20376},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 706, col: 49, offset: 20803},
+									pos:   position{line: 689, col: 49, offset: 20379},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 706, col: 54, offset: 20808},
+										pos:  position{line: 689, col: 54, offset: 20384},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 59, offset: 20813},
+									pos:  position{line: 689, col: 59, offset: 20389},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 706, col: 62, offset: 20816},
+									pos:        position{line: 689, col: 62, offset: 20392},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5761,26 +5630,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 710, col: 1, offset: 20920},
+			pos:  position{line: 693, col: 1, offset: 20496},
 			expr: &choiceExpr{
-				pos: position{line: 711, col: 5, offset: 20932},
+				pos: position{line: 694, col: 5, offset: 20508},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 711, col: 5, offset: 20932},
+						pos:  position{line: 694, col: 5, offset: 20508},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 712, col: 5, offset: 20943},
+						pos:  position{line: 695, col: 5, offset: 20519},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 20952},
+						pos: position{line: 696, col: 5, offset: 20528},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 713, col: 5, offset: 20952},
+							pos:   position{line: 696, col: 5, offset: 20528},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 713, col: 7, offset: 20954},
+								pos:  position{line: 696, col: 7, offset: 20530},
 								name: "QuotedString",
 							},
 						},
@@ -5790,19 +5659,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 717, col: 1, offset: 21046},
+			pos:  position{line: 700, col: 1, offset: 20622},
 			expr: &choiceExpr{
-				pos: position{line: 718, col: 5, offset: 21064},
+				pos: position{line: 701, col: 5, offset: 20640},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 718, col: 5, offset: 21064},
+						pos:  position{line: 701, col: 5, offset: 20640},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 21074},
+						pos: position{line: 702, col: 5, offset: 20650},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 719, col: 5, offset: 21074},
+							pos:  position{line: 702, col: 5, offset: 20650},
 							name: "__",
 						},
 					},
@@ -5811,50 +5680,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 721, col: 1, offset: 21110},
+			pos:  position{line: 704, col: 1, offset: 20686},
 			expr: &actionExpr{
-				pos: position{line: 722, col: 5, offset: 21120},
+				pos: position{line: 705, col: 5, offset: 20696},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 722, col: 5, offset: 21120},
+					pos: position{line: 705, col: 5, offset: 20696},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 722, col: 5, offset: 21120},
+							pos:   position{line: 705, col: 5, offset: 20696},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 722, col: 11, offset: 21126},
+								pos:  position{line: 705, col: 11, offset: 20702},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 722, col: 16, offset: 21131},
+							pos:   position{line: 705, col: 16, offset: 20707},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 722, col: 21, offset: 21136},
+								pos: position{line: 705, col: 21, offset: 20712},
 								expr: &actionExpr{
-									pos: position{line: 722, col: 22, offset: 21137},
+									pos: position{line: 705, col: 22, offset: 20713},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 722, col: 22, offset: 21137},
+										pos: position{line: 705, col: 22, offset: 20713},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 722, col: 22, offset: 21137},
+												pos:  position{line: 705, col: 22, offset: 20713},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 722, col: 25, offset: 21140},
+												pos:        position{line: 705, col: 25, offset: 20716},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 722, col: 29, offset: 21144},
+												pos:  position{line: 705, col: 29, offset: 20720},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 722, col: 32, offset: 21147},
+												pos:   position{line: 705, col: 32, offset: 20723},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 722, col: 34, offset: 21149},
+													pos:  position{line: 705, col: 34, offset: 20725},
 													name: "Expr",
 												},
 											},
@@ -5869,35 +5738,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 726, col: 1, offset: 21258},
+			pos:  position{line: 709, col: 1, offset: 20834},
 			expr: &actionExpr{
-				pos: position{line: 727, col: 5, offset: 21272},
+				pos: position{line: 710, col: 5, offset: 20848},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 727, col: 5, offset: 21272},
+					pos: position{line: 710, col: 5, offset: 20848},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 727, col: 5, offset: 21272},
+							pos: position{line: 710, col: 5, offset: 20848},
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 6, offset: 21273},
+								pos:  position{line: 710, col: 6, offset: 20849},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 10, offset: 21277},
+							pos:   position{line: 710, col: 10, offset: 20853},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 16, offset: 21283},
+								pos:  position{line: 710, col: 16, offset: 20859},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 27, offset: 21294},
+							pos:   position{line: 710, col: 27, offset: 20870},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 727, col: 32, offset: 21299},
+								pos: position{line: 710, col: 32, offset: 20875},
 								expr: &ruleRefExpr{
-									pos:  position{line: 727, col: 33, offset: 21300},
+									pos:  position{line: 710, col: 33, offset: 20876},
 									name: "Deref",
 								},
 							},
@@ -5908,52 +5777,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 731, col: 1, offset: 21368},
+			pos:  position{line: 714, col: 1, offset: 20944},
 			expr: &choiceExpr{
-				pos: position{line: 732, col: 5, offset: 21378},
+				pos: position{line: 715, col: 5, offset: 20954},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 732, col: 5, offset: 21378},
+						pos: position{line: 715, col: 5, offset: 20954},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 732, col: 5, offset: 21378},
+							pos: position{line: 715, col: 5, offset: 20954},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 732, col: 5, offset: 21378},
+									pos:        position{line: 715, col: 5, offset: 20954},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 732, col: 9, offset: 21382},
+									pos:   position{line: 715, col: 9, offset: 20958},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 732, col: 14, offset: 21387},
+										pos:  position{line: 715, col: 14, offset: 20963},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 732, col: 27, offset: 21400},
+									pos:  position{line: 715, col: 27, offset: 20976},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 732, col: 30, offset: 21403},
+									pos:        position{line: 715, col: 30, offset: 20979},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 732, col: 34, offset: 21407},
+									pos:  position{line: 715, col: 34, offset: 20983},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 732, col: 37, offset: 21410},
+									pos:   position{line: 715, col: 37, offset: 20986},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 732, col: 40, offset: 21413},
+										pos:  position{line: 715, col: 40, offset: 20989},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 732, col: 53, offset: 21426},
+									pos:        position{line: 715, col: 53, offset: 21002},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5961,39 +5830,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 738, col: 5, offset: 21597},
+						pos: position{line: 721, col: 5, offset: 21173},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 738, col: 5, offset: 21597},
+							pos: position{line: 721, col: 5, offset: 21173},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 738, col: 5, offset: 21597},
+									pos:        position{line: 721, col: 5, offset: 21173},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 738, col: 9, offset: 21601},
+									pos:  position{line: 721, col: 9, offset: 21177},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 738, col: 12, offset: 21604},
+									pos:        position{line: 721, col: 12, offset: 21180},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 738, col: 16, offset: 21608},
+									pos:  position{line: 721, col: 16, offset: 21184},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 738, col: 19, offset: 21611},
+									pos:   position{line: 721, col: 19, offset: 21187},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 738, col: 22, offset: 21614},
+										pos:  position{line: 721, col: 22, offset: 21190},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 738, col: 35, offset: 21627},
+									pos:        position{line: 721, col: 35, offset: 21203},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6001,39 +5870,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 744, col: 5, offset: 21798},
+						pos: position{line: 727, col: 5, offset: 21374},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 744, col: 5, offset: 21798},
+							pos: position{line: 727, col: 5, offset: 21374},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 744, col: 5, offset: 21798},
+									pos:        position{line: 727, col: 5, offset: 21374},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 744, col: 9, offset: 21802},
+									pos:   position{line: 727, col: 9, offset: 21378},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 744, col: 14, offset: 21807},
+										pos:  position{line: 727, col: 14, offset: 21383},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 744, col: 27, offset: 21820},
+									pos:  position{line: 727, col: 27, offset: 21396},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 744, col: 30, offset: 21823},
+									pos:        position{line: 727, col: 30, offset: 21399},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 744, col: 34, offset: 21827},
+									pos:  position{line: 727, col: 34, offset: 21403},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 744, col: 37, offset: 21830},
+									pos:        position{line: 727, col: 37, offset: 21406},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6041,26 +5910,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 750, col: 5, offset: 22003},
+						pos: position{line: 733, col: 5, offset: 21579},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 750, col: 5, offset: 22003},
+							pos: position{line: 733, col: 5, offset: 21579},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 750, col: 5, offset: 22003},
+									pos:        position{line: 733, col: 5, offset: 21579},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 750, col: 9, offset: 22007},
+									pos:   position{line: 733, col: 9, offset: 21583},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 750, col: 14, offset: 22012},
+										pos:  position{line: 733, col: 14, offset: 21588},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 750, col: 19, offset: 22017},
+									pos:        position{line: 733, col: 19, offset: 21593},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6068,21 +5937,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 751, col: 5, offset: 22066},
+						pos: position{line: 734, col: 5, offset: 21642},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 751, col: 5, offset: 22066},
+							pos: position{line: 734, col: 5, offset: 21642},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 751, col: 5, offset: 22066},
+									pos:        position{line: 734, col: 5, offset: 21642},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 751, col: 9, offset: 22070},
+									pos:   position{line: 734, col: 9, offset: 21646},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 751, col: 12, offset: 22073},
+										pos:  position{line: 734, col: 12, offset: 21649},
 										name: "Identifier",
 									},
 								},
@@ -6094,59 +5963,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 753, col: 1, offset: 22124},
+			pos:  position{line: 736, col: 1, offset: 21700},
 			expr: &choiceExpr{
-				pos: position{line: 754, col: 5, offset: 22136},
+				pos: position{line: 737, col: 5, offset: 21712},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 754, col: 5, offset: 22136},
+						pos:  position{line: 737, col: 5, offset: 21712},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 755, col: 5, offset: 22147},
+						pos:  position{line: 738, col: 5, offset: 21723},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 756, col: 5, offset: 22157},
+						pos:  position{line: 739, col: 5, offset: 21733},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 757, col: 5, offset: 22165},
+						pos:  position{line: 740, col: 5, offset: 21741},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 758, col: 5, offset: 22173},
+						pos:  position{line: 741, col: 5, offset: 21749},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 759, col: 5, offset: 22185},
+						pos: position{line: 742, col: 5, offset: 21761},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 759, col: 5, offset: 22185},
+							pos: position{line: 742, col: 5, offset: 21761},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 759, col: 5, offset: 22185},
+									pos:        position{line: 742, col: 5, offset: 21761},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 759, col: 9, offset: 22189},
+									pos:  position{line: 742, col: 9, offset: 21765},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 759, col: 12, offset: 22192},
+									pos:   position{line: 742, col: 12, offset: 21768},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 759, col: 17, offset: 22197},
+										pos:  position{line: 742, col: 17, offset: 21773},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 759, col: 22, offset: 22202},
+									pos:  position{line: 742, col: 22, offset: 21778},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 759, col: 25, offset: 22205},
+									pos:        position{line: 742, col: 25, offset: 21781},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6158,36 +6027,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 761, col: 1, offset: 22231},
+			pos:  position{line: 744, col: 1, offset: 21807},
 			expr: &actionExpr{
-				pos: position{line: 762, col: 5, offset: 22242},
+				pos: position{line: 745, col: 5, offset: 21818},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 762, col: 5, offset: 22242},
+					pos: position{line: 745, col: 5, offset: 21818},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 762, col: 5, offset: 22242},
+							pos:        position{line: 745, col: 5, offset: 21818},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 762, col: 9, offset: 22246},
+							pos:  position{line: 745, col: 9, offset: 21822},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 762, col: 12, offset: 22249},
+							pos:   position{line: 745, col: 12, offset: 21825},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 762, col: 18, offset: 22255},
+								pos:  position{line: 745, col: 18, offset: 21831},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 762, col: 30, offset: 22267},
+							pos:  position{line: 745, col: 30, offset: 21843},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 762, col: 33, offset: 22270},
+							pos:        position{line: 745, col: 33, offset: 21846},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6197,31 +6066,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 766, col: 1, offset: 22360},
+			pos:  position{line: 749, col: 1, offset: 21936},
 			expr: &choiceExpr{
-				pos: position{line: 767, col: 5, offset: 22376},
+				pos: position{line: 750, col: 5, offset: 21952},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 767, col: 5, offset: 22376},
+						pos: position{line: 750, col: 5, offset: 21952},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 767, col: 5, offset: 22376},
+							pos: position{line: 750, col: 5, offset: 21952},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 767, col: 5, offset: 22376},
+									pos:   position{line: 750, col: 5, offset: 21952},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 767, col: 11, offset: 22382},
+										pos:  position{line: 750, col: 11, offset: 21958},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 767, col: 22, offset: 22393},
+									pos:   position{line: 750, col: 22, offset: 21969},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 767, col: 27, offset: 22398},
+										pos: position{line: 750, col: 27, offset: 21974},
 										expr: &ruleRefExpr{
-											pos:  position{line: 767, col: 27, offset: 22398},
+											pos:  position{line: 750, col: 27, offset: 21974},
 											name: "RecordElemTail",
 										},
 									},
@@ -6230,10 +6099,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 770, col: 5, offset: 22497},
+						pos: position{line: 753, col: 5, offset: 22073},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 770, col: 5, offset: 22497},
+							pos:  position{line: 753, col: 5, offset: 22073},
 							name: "__",
 						},
 					},
@@ -6242,31 +6111,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 772, col: 1, offset: 22533},
+			pos:  position{line: 755, col: 1, offset: 22109},
 			expr: &actionExpr{
-				pos: position{line: 772, col: 18, offset: 22550},
+				pos: position{line: 755, col: 18, offset: 22126},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 772, col: 18, offset: 22550},
+					pos: position{line: 755, col: 18, offset: 22126},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 772, col: 18, offset: 22550},
+							pos:  position{line: 755, col: 18, offset: 22126},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 772, col: 21, offset: 22553},
+							pos:        position{line: 755, col: 21, offset: 22129},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 772, col: 25, offset: 22557},
+							pos:  position{line: 755, col: 25, offset: 22133},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 772, col: 28, offset: 22560},
+							pos:   position{line: 755, col: 28, offset: 22136},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 772, col: 33, offset: 22565},
+								pos:  position{line: 755, col: 33, offset: 22141},
 								name: "RecordElem",
 							},
 						},
@@ -6276,20 +6145,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 774, col: 1, offset: 22598},
+			pos:  position{line: 757, col: 1, offset: 22174},
 			expr: &choiceExpr{
-				pos: position{line: 775, col: 5, offset: 22613},
+				pos: position{line: 758, col: 5, offset: 22189},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 775, col: 5, offset: 22613},
+						pos:  position{line: 758, col: 5, offset: 22189},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 776, col: 5, offset: 22624},
+						pos:  position{line: 759, col: 5, offset: 22200},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 777, col: 5, offset: 22634},
+						pos:  position{line: 760, col: 5, offset: 22210},
 						name: "Identifier",
 					},
 				},
@@ -6297,27 +6166,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 779, col: 1, offset: 22646},
+			pos:  position{line: 762, col: 1, offset: 22222},
 			expr: &actionExpr{
-				pos: position{line: 780, col: 5, offset: 22657},
+				pos: position{line: 763, col: 5, offset: 22233},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 780, col: 5, offset: 22657},
+					pos: position{line: 763, col: 5, offset: 22233},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 780, col: 5, offset: 22657},
+							pos:        position{line: 763, col: 5, offset: 22233},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 780, col: 11, offset: 22663},
+							pos:  position{line: 763, col: 11, offset: 22239},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 780, col: 14, offset: 22666},
+							pos:   position{line: 763, col: 14, offset: 22242},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 780, col: 19, offset: 22671},
+								pos:  position{line: 763, col: 19, offset: 22247},
 								name: "Expr",
 							},
 						},
@@ -6327,39 +6196,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 784, col: 1, offset: 22757},
+			pos:  position{line: 767, col: 1, offset: 22333},
 			expr: &actionExpr{
-				pos: position{line: 785, col: 5, offset: 22767},
+				pos: position{line: 768, col: 5, offset: 22343},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 785, col: 5, offset: 22767},
+					pos: position{line: 768, col: 5, offset: 22343},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 785, col: 5, offset: 22767},
+							pos:   position{line: 768, col: 5, offset: 22343},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 785, col: 10, offset: 22772},
+								pos:  position{line: 768, col: 10, offset: 22348},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 785, col: 20, offset: 22782},
+							pos:  position{line: 768, col: 20, offset: 22358},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 785, col: 23, offset: 22785},
+							pos:        position{line: 768, col: 23, offset: 22361},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 785, col: 27, offset: 22789},
+							pos:  position{line: 768, col: 27, offset: 22365},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 785, col: 30, offset: 22792},
+							pos:   position{line: 768, col: 30, offset: 22368},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 785, col: 36, offset: 22798},
+								pos:  position{line: 768, col: 36, offset: 22374},
 								name: "Expr",
 							},
 						},
@@ -6369,36 +6238,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 789, col: 1, offset: 22898},
+			pos:  position{line: 772, col: 1, offset: 22474},
 			expr: &actionExpr{
-				pos: position{line: 790, col: 5, offset: 22908},
+				pos: position{line: 773, col: 5, offset: 22484},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 790, col: 5, offset: 22908},
+					pos: position{line: 773, col: 5, offset: 22484},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 790, col: 5, offset: 22908},
+							pos:        position{line: 773, col: 5, offset: 22484},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 790, col: 9, offset: 22912},
+							pos:  position{line: 773, col: 9, offset: 22488},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 790, col: 12, offset: 22915},
+							pos:   position{line: 773, col: 12, offset: 22491},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 790, col: 18, offset: 22921},
+								pos:  position{line: 773, col: 18, offset: 22497},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 790, col: 32, offset: 22935},
+							pos:  position{line: 773, col: 32, offset: 22511},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 790, col: 35, offset: 22938},
+							pos:        position{line: 773, col: 35, offset: 22514},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6408,36 +6277,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 794, col: 1, offset: 23028},
+			pos:  position{line: 777, col: 1, offset: 22604},
 			expr: &actionExpr{
-				pos: position{line: 795, col: 5, offset: 23036},
+				pos: position{line: 778, col: 5, offset: 22612},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 795, col: 5, offset: 23036},
+					pos: position{line: 778, col: 5, offset: 22612},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 795, col: 5, offset: 23036},
+							pos:        position{line: 778, col: 5, offset: 22612},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 10, offset: 23041},
+							pos:  position{line: 778, col: 10, offset: 22617},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 13, offset: 23044},
+							pos:   position{line: 778, col: 13, offset: 22620},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 19, offset: 23050},
+								pos:  position{line: 778, col: 19, offset: 22626},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 33, offset: 23064},
+							pos:  position{line: 778, col: 33, offset: 22640},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 795, col: 36, offset: 23067},
+							pos:        position{line: 778, col: 36, offset: 22643},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6447,36 +6316,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 799, col: 1, offset: 23156},
+			pos:  position{line: 782, col: 1, offset: 22732},
 			expr: &actionExpr{
-				pos: position{line: 800, col: 5, offset: 23164},
+				pos: position{line: 783, col: 5, offset: 22740},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 800, col: 5, offset: 23164},
+					pos: position{line: 783, col: 5, offset: 22740},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 800, col: 5, offset: 23164},
+							pos:        position{line: 783, col: 5, offset: 22740},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 800, col: 10, offset: 23169},
+							pos:  position{line: 783, col: 10, offset: 22745},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 800, col: 13, offset: 23172},
+							pos:   position{line: 783, col: 13, offset: 22748},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 800, col: 19, offset: 23178},
+								pos:  position{line: 783, col: 19, offset: 22754},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 800, col: 27, offset: 23186},
+							pos:  position{line: 783, col: 27, offset: 22762},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 800, col: 30, offset: 23189},
+							pos:        position{line: 783, col: 30, offset: 22765},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6486,31 +6355,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 804, col: 1, offset: 23280},
+			pos:  position{line: 787, col: 1, offset: 22856},
 			expr: &choiceExpr{
-				pos: position{line: 805, col: 5, offset: 23292},
+				pos: position{line: 788, col: 5, offset: 22868},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 805, col: 5, offset: 23292},
+						pos: position{line: 788, col: 5, offset: 22868},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 805, col: 5, offset: 23292},
+							pos: position{line: 788, col: 5, offset: 22868},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 805, col: 5, offset: 23292},
+									pos:   position{line: 788, col: 5, offset: 22868},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 805, col: 11, offset: 23298},
+										pos:  position{line: 788, col: 11, offset: 22874},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 805, col: 17, offset: 23304},
+									pos:   position{line: 788, col: 17, offset: 22880},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 805, col: 22, offset: 23309},
+										pos: position{line: 788, col: 22, offset: 22885},
 										expr: &ruleRefExpr{
-											pos:  position{line: 805, col: 22, offset: 23309},
+											pos:  position{line: 788, col: 22, offset: 22885},
 											name: "EntryTail",
 										},
 									},
@@ -6519,10 +6388,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 808, col: 5, offset: 23403},
+						pos: position{line: 791, col: 5, offset: 22979},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 808, col: 5, offset: 23403},
+							pos:  position{line: 791, col: 5, offset: 22979},
 							name: "__",
 						},
 					},
@@ -6531,31 +6400,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 811, col: 1, offset: 23440},
+			pos:  position{line: 794, col: 1, offset: 23016},
 			expr: &actionExpr{
-				pos: position{line: 811, col: 13, offset: 23452},
+				pos: position{line: 794, col: 13, offset: 23028},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 811, col: 13, offset: 23452},
+					pos: position{line: 794, col: 13, offset: 23028},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 811, col: 13, offset: 23452},
+							pos:  position{line: 794, col: 13, offset: 23028},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 811, col: 16, offset: 23455},
+							pos:        position{line: 794, col: 16, offset: 23031},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 811, col: 20, offset: 23459},
+							pos:  position{line: 794, col: 20, offset: 23035},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 811, col: 23, offset: 23462},
+							pos:   position{line: 794, col: 23, offset: 23038},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 811, col: 25, offset: 23464},
+								pos:  position{line: 794, col: 25, offset: 23040},
 								name: "Entry",
 							},
 						},
@@ -6565,39 +6434,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 813, col: 1, offset: 23489},
+			pos:  position{line: 796, col: 1, offset: 23065},
 			expr: &actionExpr{
-				pos: position{line: 814, col: 5, offset: 23499},
+				pos: position{line: 797, col: 5, offset: 23075},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 814, col: 5, offset: 23499},
+					pos: position{line: 797, col: 5, offset: 23075},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 814, col: 5, offset: 23499},
+							pos:   position{line: 797, col: 5, offset: 23075},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 814, col: 9, offset: 23503},
+								pos:  position{line: 797, col: 9, offset: 23079},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 814, col: 14, offset: 23508},
+							pos:  position{line: 797, col: 14, offset: 23084},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 814, col: 17, offset: 23511},
+							pos:        position{line: 797, col: 17, offset: 23087},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 814, col: 21, offset: 23515},
+							pos:  position{line: 797, col: 21, offset: 23091},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 814, col: 24, offset: 23518},
+							pos:   position{line: 797, col: 24, offset: 23094},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 814, col: 30, offset: 23524},
+								pos:  position{line: 797, col: 30, offset: 23100},
 								name: "Expr",
 							},
 						},
@@ -6607,92 +6476,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLProc",
-			pos:  position{line: 820, col: 1, offset: 23631},
+			pos:  position{line: 803, col: 1, offset: 23207},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 5, offset: 23643},
+				pos: position{line: 804, col: 5, offset: 23219},
 				run: (*parser).callonSQLProc1,
 				expr: &seqExpr{
-					pos: position{line: 821, col: 5, offset: 23643},
+					pos: position{line: 804, col: 5, offset: 23219},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 821, col: 5, offset: 23643},
+							pos:   position{line: 804, col: 5, offset: 23219},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 821, col: 15, offset: 23653},
+								pos:  position{line: 804, col: 15, offset: 23229},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 5, offset: 23667},
+							pos:   position{line: 805, col: 5, offset: 23243},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 822, col: 10, offset: 23672},
+								pos: position{line: 805, col: 10, offset: 23248},
 								expr: &ruleRefExpr{
-									pos:  position{line: 822, col: 10, offset: 23672},
+									pos:  position{line: 805, col: 10, offset: 23248},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 823, col: 5, offset: 23685},
+							pos:   position{line: 806, col: 5, offset: 23261},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 823, col: 11, offset: 23691},
+								pos: position{line: 806, col: 11, offset: 23267},
 								expr: &ruleRefExpr{
-									pos:  position{line: 823, col: 11, offset: 23691},
+									pos:  position{line: 806, col: 11, offset: 23267},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 824, col: 5, offset: 23705},
+							pos:   position{line: 807, col: 5, offset: 23281},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 824, col: 11, offset: 23711},
+								pos: position{line: 807, col: 11, offset: 23287},
 								expr: &ruleRefExpr{
-									pos:  position{line: 824, col: 11, offset: 23711},
+									pos:  position{line: 807, col: 11, offset: 23287},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 825, col: 5, offset: 23725},
+							pos:   position{line: 808, col: 5, offset: 23301},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 825, col: 13, offset: 23733},
+								pos: position{line: 808, col: 13, offset: 23309},
 								expr: &ruleRefExpr{
-									pos:  position{line: 825, col: 13, offset: 23733},
+									pos:  position{line: 808, col: 13, offset: 23309},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 826, col: 5, offset: 23749},
+							pos:   position{line: 809, col: 5, offset: 23325},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 826, col: 12, offset: 23756},
+								pos: position{line: 809, col: 12, offset: 23332},
 								expr: &ruleRefExpr{
-									pos:  position{line: 826, col: 12, offset: 23756},
+									pos:  position{line: 809, col: 12, offset: 23332},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 827, col: 5, offset: 23771},
+							pos:   position{line: 810, col: 5, offset: 23347},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 827, col: 13, offset: 23779},
+								pos: position{line: 810, col: 13, offset: 23355},
 								expr: &ruleRefExpr{
-									pos:  position{line: 827, col: 13, offset: 23779},
+									pos:  position{line: 810, col: 13, offset: 23355},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 828, col: 5, offset: 23795},
+							pos:   position{line: 811, col: 5, offset: 23371},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 828, col: 11, offset: 23801},
+								pos:  position{line: 811, col: 11, offset: 23377},
 								name: "SQLLimit",
 							},
 						},
@@ -6702,26 +6571,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 852, col: 1, offset: 24168},
+			pos:  position{line: 835, col: 1, offset: 23744},
 			expr: &choiceExpr{
-				pos: position{line: 853, col: 5, offset: 24182},
+				pos: position{line: 836, col: 5, offset: 23758},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 853, col: 5, offset: 24182},
+						pos: position{line: 836, col: 5, offset: 23758},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 853, col: 5, offset: 24182},
+							pos: position{line: 836, col: 5, offset: 23758},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 853, col: 5, offset: 24182},
+									pos:  position{line: 836, col: 5, offset: 23758},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 853, col: 12, offset: 24189},
+									pos:  position{line: 836, col: 12, offset: 23765},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 853, col: 14, offset: 24191},
+									pos:        position{line: 836, col: 14, offset: 23767},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6729,24 +6598,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 854, col: 5, offset: 24219},
+						pos: position{line: 837, col: 5, offset: 23795},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 854, col: 5, offset: 24219},
+							pos: position{line: 837, col: 5, offset: 23795},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 854, col: 5, offset: 24219},
+									pos:  position{line: 837, col: 5, offset: 23795},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 854, col: 12, offset: 24226},
+									pos:  position{line: 837, col: 12, offset: 23802},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 854, col: 14, offset: 24228},
+									pos:   position{line: 837, col: 14, offset: 23804},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 854, col: 26, offset: 24240},
+										pos:  position{line: 837, col: 26, offset: 23816},
 										name: "SQLAssignments",
 									},
 								},
@@ -6758,41 +6627,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 856, col: 1, offset: 24284},
+			pos:  position{line: 839, col: 1, offset: 23860},
 			expr: &choiceExpr{
-				pos: position{line: 857, col: 5, offset: 24302},
+				pos: position{line: 840, col: 5, offset: 23878},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 857, col: 5, offset: 24302},
+						pos: position{line: 840, col: 5, offset: 23878},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 857, col: 5, offset: 24302},
+							pos: position{line: 840, col: 5, offset: 23878},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 857, col: 5, offset: 24302},
+									pos:   position{line: 840, col: 5, offset: 23878},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 857, col: 9, offset: 24306},
+										pos:  position{line: 840, col: 9, offset: 23882},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 857, col: 14, offset: 24311},
+									pos:  position{line: 840, col: 14, offset: 23887},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 857, col: 16, offset: 24313},
+									pos:  position{line: 840, col: 16, offset: 23889},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 857, col: 19, offset: 24316},
+									pos:  position{line: 840, col: 19, offset: 23892},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 857, col: 21, offset: 24318},
+									pos:   position{line: 840, col: 21, offset: 23894},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 857, col: 25, offset: 24322},
+										pos:  position{line: 840, col: 25, offset: 23898},
 										name: "Lval",
 									},
 								},
@@ -6800,13 +6669,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 858, col: 5, offset: 24416},
+						pos: position{line: 841, col: 5, offset: 23992},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 858, col: 5, offset: 24416},
+							pos:   position{line: 841, col: 5, offset: 23992},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 858, col: 10, offset: 24421},
+								pos:  position{line: 841, col: 10, offset: 23997},
 								name: "Expr",
 							},
 						},
@@ -6816,50 +6685,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 860, col: 1, offset: 24513},
+			pos:  position{line: 843, col: 1, offset: 24089},
 			expr: &actionExpr{
-				pos: position{line: 861, col: 5, offset: 24532},
+				pos: position{line: 844, col: 5, offset: 24108},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 861, col: 5, offset: 24532},
+					pos: position{line: 844, col: 5, offset: 24108},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 861, col: 5, offset: 24532},
+							pos:   position{line: 844, col: 5, offset: 24108},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 861, col: 11, offset: 24538},
+								pos:  position{line: 844, col: 11, offset: 24114},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 25, offset: 24552},
+							pos:   position{line: 844, col: 25, offset: 24128},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 861, col: 30, offset: 24557},
+								pos: position{line: 844, col: 30, offset: 24133},
 								expr: &actionExpr{
-									pos: position{line: 861, col: 31, offset: 24558},
+									pos: position{line: 844, col: 31, offset: 24134},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 861, col: 31, offset: 24558},
+										pos: position{line: 844, col: 31, offset: 24134},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 861, col: 31, offset: 24558},
+												pos:  position{line: 844, col: 31, offset: 24134},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 861, col: 34, offset: 24561},
+												pos:        position{line: 844, col: 34, offset: 24137},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 861, col: 38, offset: 24565},
+												pos:  position{line: 844, col: 38, offset: 24141},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 861, col: 41, offset: 24568},
+												pos:   position{line: 844, col: 41, offset: 24144},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 861, col: 46, offset: 24573},
+													pos:  position{line: 844, col: 46, offset: 24149},
 													name: "SQLAssignment",
 												},
 											},
@@ -6874,43 +6743,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 865, col: 1, offset: 24694},
+			pos:  position{line: 848, col: 1, offset: 24270},
 			expr: &choiceExpr{
-				pos: position{line: 866, col: 5, offset: 24706},
+				pos: position{line: 849, col: 5, offset: 24282},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 866, col: 5, offset: 24706},
+						pos: position{line: 849, col: 5, offset: 24282},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 866, col: 5, offset: 24706},
+							pos: position{line: 849, col: 5, offset: 24282},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 5, offset: 24706},
+									pos:  position{line: 849, col: 5, offset: 24282},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 7, offset: 24708},
+									pos:  position{line: 849, col: 7, offset: 24284},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 866, col: 12, offset: 24713},
+									pos:  position{line: 849, col: 12, offset: 24289},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 866, col: 14, offset: 24715},
+									pos:   position{line: 849, col: 14, offset: 24291},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 866, col: 20, offset: 24721},
+										pos:  position{line: 849, col: 20, offset: 24297},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 866, col: 29, offset: 24730},
+									pos:   position{line: 849, col: 29, offset: 24306},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 866, col: 35, offset: 24736},
+										pos: position{line: 849, col: 35, offset: 24312},
 										expr: &ruleRefExpr{
-											pos:  position{line: 866, col: 35, offset: 24736},
+											pos:  position{line: 849, col: 35, offset: 24312},
 											name: "SQLAlias",
 										},
 									},
@@ -6919,25 +6788,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 869, col: 5, offset: 24831},
+						pos: position{line: 852, col: 5, offset: 24407},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 869, col: 5, offset: 24831},
+							pos: position{line: 852, col: 5, offset: 24407},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 869, col: 5, offset: 24831},
+									pos:  position{line: 852, col: 5, offset: 24407},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 869, col: 7, offset: 24833},
+									pos:  position{line: 852, col: 7, offset: 24409},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 869, col: 12, offset: 24838},
+									pos:  position{line: 852, col: 12, offset: 24414},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 869, col: 14, offset: 24840},
+									pos:        position{line: 852, col: 14, offset: 24416},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6949,33 +6818,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 871, col: 1, offset: 24865},
+			pos:  position{line: 854, col: 1, offset: 24441},
 			expr: &choiceExpr{
-				pos: position{line: 872, col: 5, offset: 24878},
+				pos: position{line: 855, col: 5, offset: 24454},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 872, col: 5, offset: 24878},
+						pos: position{line: 855, col: 5, offset: 24454},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 872, col: 5, offset: 24878},
+							pos: position{line: 855, col: 5, offset: 24454},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 872, col: 5, offset: 24878},
+									pos:  position{line: 855, col: 5, offset: 24454},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 872, col: 7, offset: 24880},
+									pos:  position{line: 855, col: 7, offset: 24456},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 872, col: 10, offset: 24883},
+									pos:  position{line: 855, col: 10, offset: 24459},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 872, col: 12, offset: 24885},
+									pos:   position{line: 855, col: 12, offset: 24461},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 872, col: 15, offset: 24888},
+										pos:  position{line: 855, col: 15, offset: 24464},
 										name: "Lval",
 									},
 								},
@@ -6983,36 +6852,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 873, col: 5, offset: 24916},
+						pos: position{line: 856, col: 5, offset: 24492},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 873, col: 5, offset: 24916},
+							pos: position{line: 856, col: 5, offset: 24492},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 873, col: 5, offset: 24916},
+									pos:  position{line: 856, col: 5, offset: 24492},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 873, col: 7, offset: 24918},
+									pos: position{line: 856, col: 7, offset: 24494},
 									expr: &seqExpr{
-										pos: position{line: 873, col: 9, offset: 24920},
+										pos: position{line: 856, col: 9, offset: 24496},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 873, col: 9, offset: 24920},
+												pos:  position{line: 856, col: 9, offset: 24496},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 873, col: 27, offset: 24938},
+												pos:  position{line: 856, col: 27, offset: 24514},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 873, col: 30, offset: 24941},
+									pos:   position{line: 856, col: 30, offset: 24517},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 873, col: 33, offset: 24944},
+										pos:  position{line: 856, col: 33, offset: 24520},
 										name: "Lval",
 									},
 								},
@@ -7024,42 +6893,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 875, col: 1, offset: 24969},
+			pos:  position{line: 858, col: 1, offset: 24545},
 			expr: &ruleRefExpr{
-				pos:  position{line: 876, col: 5, offset: 24982},
+				pos:  position{line: 859, col: 5, offset: 24558},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 878, col: 1, offset: 24988},
+			pos:  position{line: 861, col: 1, offset: 24564},
 			expr: &actionExpr{
-				pos: position{line: 879, col: 5, offset: 25001},
+				pos: position{line: 862, col: 5, offset: 24577},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 879, col: 5, offset: 25001},
+					pos: position{line: 862, col: 5, offset: 24577},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 879, col: 5, offset: 25001},
+							pos:   position{line: 862, col: 5, offset: 24577},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 11, offset: 25007},
+								pos:  position{line: 862, col: 11, offset: 24583},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 19, offset: 25015},
+							pos:   position{line: 862, col: 19, offset: 24591},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 879, col: 24, offset: 25020},
+								pos: position{line: 862, col: 24, offset: 24596},
 								expr: &actionExpr{
-									pos: position{line: 879, col: 25, offset: 25021},
+									pos: position{line: 862, col: 25, offset: 24597},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 879, col: 25, offset: 25021},
+										pos:   position{line: 862, col: 25, offset: 24597},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 879, col: 30, offset: 25026},
+											pos:  position{line: 862, col: 30, offset: 24602},
 											name: "SQLJoin",
 										},
 									},
@@ -7072,90 +6941,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 883, col: 1, offset: 25141},
+			pos:  position{line: 866, col: 1, offset: 24717},
 			expr: &actionExpr{
-				pos: position{line: 884, col: 5, offset: 25153},
+				pos: position{line: 867, col: 5, offset: 24729},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 884, col: 5, offset: 25153},
+					pos: position{line: 867, col: 5, offset: 24729},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 884, col: 5, offset: 25153},
+							pos:   position{line: 867, col: 5, offset: 24729},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 884, col: 11, offset: 25159},
+								pos:  position{line: 867, col: 11, offset: 24735},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 24, offset: 25172},
+							pos:  position{line: 867, col: 24, offset: 24748},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 26, offset: 25174},
+							pos:  position{line: 867, col: 26, offset: 24750},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 31, offset: 25179},
+							pos:  position{line: 867, col: 31, offset: 24755},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 884, col: 33, offset: 25181},
+							pos:   position{line: 867, col: 33, offset: 24757},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 884, col: 39, offset: 25187},
+								pos:  position{line: 867, col: 39, offset: 24763},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 884, col: 48, offset: 25196},
+							pos:   position{line: 867, col: 48, offset: 24772},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 884, col: 54, offset: 25202},
+								pos: position{line: 867, col: 54, offset: 24778},
 								expr: &ruleRefExpr{
-									pos:  position{line: 884, col: 54, offset: 25202},
+									pos:  position{line: 867, col: 54, offset: 24778},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 64, offset: 25212},
+							pos:  position{line: 867, col: 64, offset: 24788},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 66, offset: 25214},
+							pos:  position{line: 867, col: 66, offset: 24790},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 69, offset: 25217},
+							pos:  position{line: 867, col: 69, offset: 24793},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 884, col: 71, offset: 25219},
+							pos:   position{line: 867, col: 71, offset: 24795},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 884, col: 79, offset: 25227},
+								pos:  position{line: 867, col: 79, offset: 24803},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 87, offset: 25235},
+							pos:  position{line: 867, col: 87, offset: 24811},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 884, col: 90, offset: 25238},
+							pos:        position{line: 867, col: 90, offset: 24814},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 94, offset: 25242},
+							pos:  position{line: 867, col: 94, offset: 24818},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 884, col: 97, offset: 25245},
+							pos:   position{line: 867, col: 97, offset: 24821},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 884, col: 106, offset: 25254},
+								pos:  position{line: 867, col: 106, offset: 24830},
 								name: "JoinKey",
 							},
 						},
@@ -7165,40 +7034,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 899, col: 1, offset: 25485},
+			pos:  position{line: 886, col: 1, offset: 25065},
 			expr: &choiceExpr{
-				pos: position{line: 900, col: 5, offset: 25502},
+				pos: position{line: 887, col: 5, offset: 25082},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 900, col: 5, offset: 25502},
+						pos: position{line: 887, col: 5, offset: 25082},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 900, col: 5, offset: 25502},
+							pos: position{line: 887, col: 5, offset: 25082},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 900, col: 5, offset: 25502},
+									pos:  position{line: 887, col: 5, offset: 25082},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 900, col: 7, offset: 25504},
+									pos:   position{line: 887, col: 7, offset: 25084},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 900, col: 14, offset: 25511},
+										pos: position{line: 887, col: 14, offset: 25091},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 900, col: 14, offset: 25511},
+												pos:  position{line: 887, col: 14, offset: 25091},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 900, col: 21, offset: 25518},
+												pos:  position{line: 887, col: 21, offset: 25098},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 900, col: 29, offset: 25526},
+												pos:  position{line: 887, col: 29, offset: 25106},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 900, col: 36, offset: 25533},
+												pos:  position{line: 887, col: 36, offset: 25113},
 												name: "RIGHT",
 											},
 										},
@@ -7208,10 +7077,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 901, col: 5, offset: 25566},
+						pos: position{line: 888, col: 5, offset: 25146},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 901, col: 5, offset: 25566},
+							pos:        position{line: 888, col: 5, offset: 25146},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7221,30 +7090,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 903, col: 1, offset: 25594},
+			pos:  position{line: 890, col: 1, offset: 25174},
 			expr: &actionExpr{
-				pos: position{line: 904, col: 5, offset: 25607},
+				pos: position{line: 891, col: 5, offset: 25187},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 904, col: 5, offset: 25607},
+					pos: position{line: 891, col: 5, offset: 25187},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 904, col: 5, offset: 25607},
+							pos:  position{line: 891, col: 5, offset: 25187},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 904, col: 7, offset: 25609},
+							pos:  position{line: 891, col: 7, offset: 25189},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 904, col: 13, offset: 25615},
+							pos:  position{line: 891, col: 13, offset: 25195},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 904, col: 15, offset: 25617},
+							pos:   position{line: 891, col: 15, offset: 25197},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 904, col: 20, offset: 25622},
+								pos:  position{line: 891, col: 20, offset: 25202},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7254,38 +7123,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 906, col: 1, offset: 25658},
+			pos:  position{line: 893, col: 1, offset: 25238},
 			expr: &actionExpr{
-				pos: position{line: 907, col: 5, offset: 25673},
+				pos: position{line: 894, col: 5, offset: 25253},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 907, col: 5, offset: 25673},
+					pos: position{line: 894, col: 5, offset: 25253},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 907, col: 5, offset: 25673},
+							pos:  position{line: 894, col: 5, offset: 25253},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 907, col: 7, offset: 25675},
+							pos:  position{line: 894, col: 7, offset: 25255},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 907, col: 13, offset: 25681},
+							pos:  position{line: 894, col: 13, offset: 25261},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 907, col: 15, offset: 25683},
+							pos:  position{line: 894, col: 15, offset: 25263},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 907, col: 18, offset: 25686},
+							pos:  position{line: 894, col: 18, offset: 25266},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 907, col: 20, offset: 25688},
+							pos:   position{line: 894, col: 20, offset: 25268},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 907, col: 28, offset: 25696},
+								pos:  position{line: 894, col: 28, offset: 25276},
 								name: "FieldExprs",
 							},
 						},
@@ -7295,30 +7164,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 909, col: 1, offset: 25732},
+			pos:  position{line: 896, col: 1, offset: 25312},
 			expr: &actionExpr{
-				pos: position{line: 910, col: 5, offset: 25746},
+				pos: position{line: 897, col: 5, offset: 25326},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 910, col: 5, offset: 25746},
+					pos: position{line: 897, col: 5, offset: 25326},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 910, col: 5, offset: 25746},
+							pos:  position{line: 897, col: 5, offset: 25326},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 910, col: 7, offset: 25748},
+							pos:  position{line: 897, col: 7, offset: 25328},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 910, col: 14, offset: 25755},
+							pos:  position{line: 897, col: 14, offset: 25335},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 910, col: 16, offset: 25757},
+							pos:   position{line: 897, col: 16, offset: 25337},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 910, col: 21, offset: 25762},
+								pos:  position{line: 897, col: 21, offset: 25342},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7328,46 +7197,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 912, col: 1, offset: 25798},
+			pos:  position{line: 899, col: 1, offset: 25378},
 			expr: &actionExpr{
-				pos: position{line: 913, col: 5, offset: 25813},
+				pos: position{line: 900, col: 5, offset: 25393},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 913, col: 5, offset: 25813},
+					pos: position{line: 900, col: 5, offset: 25393},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 913, col: 5, offset: 25813},
+							pos:  position{line: 900, col: 5, offset: 25393},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 913, col: 7, offset: 25815},
+							pos:  position{line: 900, col: 7, offset: 25395},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 913, col: 13, offset: 25821},
+							pos:  position{line: 900, col: 13, offset: 25401},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 913, col: 15, offset: 25823},
+							pos:  position{line: 900, col: 15, offset: 25403},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 913, col: 18, offset: 25826},
+							pos:  position{line: 900, col: 18, offset: 25406},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 913, col: 20, offset: 25828},
+							pos:   position{line: 900, col: 20, offset: 25408},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 913, col: 25, offset: 25833},
+								pos:  position{line: 900, col: 25, offset: 25413},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 913, col: 31, offset: 25839},
+							pos:   position{line: 900, col: 31, offset: 25419},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 913, col: 37, offset: 25845},
+								pos:  position{line: 900, col: 37, offset: 25425},
 								name: "SQLOrder",
 							},
 						},
@@ -7377,32 +7246,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 917, col: 1, offset: 25955},
+			pos:  position{line: 904, col: 1, offset: 25535},
 			expr: &choiceExpr{
-				pos: position{line: 918, col: 5, offset: 25968},
+				pos: position{line: 905, col: 5, offset: 25548},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 918, col: 5, offset: 25968},
+						pos: position{line: 905, col: 5, offset: 25548},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 918, col: 5, offset: 25968},
+							pos: position{line: 905, col: 5, offset: 25548},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 918, col: 5, offset: 25968},
+									pos:  position{line: 905, col: 5, offset: 25548},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 918, col: 7, offset: 25970},
+									pos:   position{line: 905, col: 7, offset: 25550},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 918, col: 12, offset: 25975},
+										pos: position{line: 905, col: 12, offset: 25555},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 918, col: 12, offset: 25975},
+												pos:  position{line: 905, col: 12, offset: 25555},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 918, col: 18, offset: 25981},
+												pos:  position{line: 905, col: 18, offset: 25561},
 												name: "DESC",
 											},
 										},
@@ -7412,10 +7281,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 919, col: 5, offset: 26011},
+						pos: position{line: 906, col: 5, offset: 25591},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 919, col: 5, offset: 26011},
+							pos:        position{line: 906, col: 5, offset: 25591},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7425,33 +7294,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 921, col: 1, offset: 26037},
+			pos:  position{line: 908, col: 1, offset: 25617},
 			expr: &choiceExpr{
-				pos: position{line: 922, col: 5, offset: 26050},
+				pos: position{line: 909, col: 5, offset: 25630},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 922, col: 5, offset: 26050},
+						pos: position{line: 909, col: 5, offset: 25630},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 922, col: 5, offset: 26050},
+							pos: position{line: 909, col: 5, offset: 25630},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 5, offset: 26050},
+									pos:  position{line: 909, col: 5, offset: 25630},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 7, offset: 26052},
+									pos:  position{line: 909, col: 7, offset: 25632},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 13, offset: 26058},
+									pos:  position{line: 909, col: 13, offset: 25638},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 922, col: 15, offset: 26060},
+									pos:   position{line: 909, col: 15, offset: 25640},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 922, col: 21, offset: 26066},
+										pos:  position{line: 909, col: 21, offset: 25646},
 										name: "UInt",
 									},
 								},
@@ -7459,10 +7328,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 923, col: 5, offset: 26097},
+						pos: position{line: 910, col: 5, offset: 25677},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 923, col: 5, offset: 26097},
+							pos:        position{line: 910, col: 5, offset: 25677},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7472,12 +7341,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 925, col: 1, offset: 26119},
+			pos:  position{line: 912, col: 1, offset: 25699},
 			expr: &actionExpr{
-				pos: position{line: 925, col: 10, offset: 26128},
+				pos: position{line: 912, col: 10, offset: 25708},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 925, col: 10, offset: 26128},
+					pos:        position{line: 912, col: 10, offset: 25708},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7485,12 +7354,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 926, col: 1, offset: 26163},
+			pos:  position{line: 913, col: 1, offset: 25743},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 6, offset: 26168},
+				pos: position{line: 913, col: 6, offset: 25748},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 926, col: 6, offset: 26168},
+					pos:        position{line: 913, col: 6, offset: 25748},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7498,12 +7367,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 927, col: 1, offset: 26195},
+			pos:  position{line: 914, col: 1, offset: 25775},
 			expr: &actionExpr{
-				pos: position{line: 927, col: 8, offset: 26202},
+				pos: position{line: 914, col: 8, offset: 25782},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 927, col: 8, offset: 26202},
+					pos:        position{line: 914, col: 8, offset: 25782},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7511,12 +7380,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 928, col: 1, offset: 26233},
+			pos:  position{line: 915, col: 1, offset: 25813},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 8, offset: 26240},
+				pos: position{line: 915, col: 8, offset: 25820},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 928, col: 8, offset: 26240},
+					pos:        position{line: 915, col: 8, offset: 25820},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7524,12 +7393,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 929, col: 1, offset: 26271},
+			pos:  position{line: 916, col: 1, offset: 25851},
 			expr: &actionExpr{
-				pos: position{line: 929, col: 9, offset: 26279},
+				pos: position{line: 916, col: 9, offset: 25859},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 929, col: 9, offset: 26279},
+					pos:        position{line: 916, col: 9, offset: 25859},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7537,12 +7406,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 930, col: 1, offset: 26312},
+			pos:  position{line: 917, col: 1, offset: 25892},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 9, offset: 26320},
+				pos: position{line: 917, col: 9, offset: 25900},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 930, col: 9, offset: 26320},
+					pos:        position{line: 917, col: 9, offset: 25900},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7550,12 +7419,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 931, col: 1, offset: 26353},
+			pos:  position{line: 918, col: 1, offset: 25933},
 			expr: &actionExpr{
-				pos: position{line: 931, col: 6, offset: 26358},
+				pos: position{line: 918, col: 6, offset: 25938},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 931, col: 6, offset: 26358},
+					pos:        position{line: 918, col: 6, offset: 25938},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7563,12 +7432,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 932, col: 1, offset: 26385},
+			pos:  position{line: 919, col: 1, offset: 25965},
 			expr: &actionExpr{
-				pos: position{line: 932, col: 10, offset: 26394},
+				pos: position{line: 919, col: 10, offset: 25974},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 932, col: 10, offset: 26394},
+					pos:        position{line: 919, col: 10, offset: 25974},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7576,12 +7445,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 933, col: 1, offset: 26429},
+			pos:  position{line: 920, col: 1, offset: 26009},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 9, offset: 26437},
+				pos: position{line: 920, col: 9, offset: 26017},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 933, col: 9, offset: 26437},
+					pos:        position{line: 920, col: 9, offset: 26017},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7589,12 +7458,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 934, col: 1, offset: 26470},
+			pos:  position{line: 921, col: 1, offset: 26050},
 			expr: &actionExpr{
-				pos: position{line: 934, col: 6, offset: 26475},
+				pos: position{line: 921, col: 6, offset: 26055},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 934, col: 6, offset: 26475},
+					pos:        position{line: 921, col: 6, offset: 26055},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7602,12 +7471,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 935, col: 1, offset: 26502},
+			pos:  position{line: 922, col: 1, offset: 26082},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 9, offset: 26510},
+				pos: position{line: 922, col: 9, offset: 26090},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 935, col: 9, offset: 26510},
+					pos:        position{line: 922, col: 9, offset: 26090},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7615,12 +7484,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 936, col: 1, offset: 26543},
+			pos:  position{line: 923, col: 1, offset: 26123},
 			expr: &actionExpr{
-				pos: position{line: 936, col: 7, offset: 26549},
+				pos: position{line: 923, col: 7, offset: 26129},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 936, col: 7, offset: 26549},
+					pos:        position{line: 923, col: 7, offset: 26129},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7628,12 +7497,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 937, col: 1, offset: 26578},
+			pos:  position{line: 924, col: 1, offset: 26158},
 			expr: &actionExpr{
-				pos: position{line: 937, col: 8, offset: 26585},
+				pos: position{line: 924, col: 8, offset: 26165},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 937, col: 8, offset: 26585},
+					pos:        position{line: 924, col: 8, offset: 26165},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7641,12 +7510,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 938, col: 1, offset: 26616},
+			pos:  position{line: 925, col: 1, offset: 26196},
 			expr: &actionExpr{
-				pos: position{line: 938, col: 8, offset: 26623},
+				pos: position{line: 925, col: 8, offset: 26203},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 938, col: 8, offset: 26623},
+					pos:        position{line: 925, col: 8, offset: 26203},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7654,12 +7523,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 939, col: 1, offset: 26654},
+			pos:  position{line: 926, col: 1, offset: 26234},
 			expr: &actionExpr{
-				pos: position{line: 939, col: 8, offset: 26661},
+				pos: position{line: 926, col: 8, offset: 26241},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 939, col: 8, offset: 26661},
+					pos:        position{line: 926, col: 8, offset: 26241},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7667,12 +7536,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 940, col: 1, offset: 26692},
+			pos:  position{line: 927, col: 1, offset: 26272},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 9, offset: 26700},
+				pos: position{line: 927, col: 9, offset: 26280},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 940, col: 9, offset: 26700},
+					pos:        position{line: 927, col: 9, offset: 26280},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7680,12 +7549,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 941, col: 1, offset: 26733},
+			pos:  position{line: 928, col: 1, offset: 26313},
 			expr: &actionExpr{
-				pos: position{line: 941, col: 9, offset: 26741},
+				pos: position{line: 928, col: 9, offset: 26321},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 941, col: 9, offset: 26741},
+					pos:        position{line: 928, col: 9, offset: 26321},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7693,48 +7562,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 943, col: 1, offset: 26775},
+			pos:  position{line: 930, col: 1, offset: 26355},
 			expr: &choiceExpr{
-				pos: position{line: 944, col: 5, offset: 26797},
+				pos: position{line: 931, col: 5, offset: 26377},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 5, offset: 26797},
+						pos:  position{line: 931, col: 5, offset: 26377},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 14, offset: 26806},
+						pos:  position{line: 931, col: 14, offset: 26386},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 19, offset: 26811},
+						pos:  position{line: 931, col: 19, offset: 26391},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 27, offset: 26819},
+						pos:  position{line: 931, col: 27, offset: 26399},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 34, offset: 26826},
+						pos:  position{line: 931, col: 34, offset: 26406},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 42, offset: 26834},
+						pos:  position{line: 931, col: 42, offset: 26414},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 50, offset: 26842},
+						pos:  position{line: 931, col: 50, offset: 26422},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 59, offset: 26851},
+						pos:  position{line: 931, col: 59, offset: 26431},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 67, offset: 26859},
+						pos:  position{line: 931, col: 67, offset: 26439},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 944, col: 75, offset: 26867},
+						pos:  position{line: 931, col: 75, offset: 26447},
 						name: "ON",
 					},
 				},
@@ -7742,52 +7611,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 948, col: 1, offset: 26893},
+			pos:  position{line: 935, col: 1, offset: 26473},
 			expr: &choiceExpr{
-				pos: position{line: 949, col: 5, offset: 26905},
+				pos: position{line: 936, col: 5, offset: 26485},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 949, col: 5, offset: 26905},
+						pos:  position{line: 936, col: 5, offset: 26485},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 950, col: 5, offset: 26921},
+						pos:  position{line: 937, col: 5, offset: 26501},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 951, col: 5, offset: 26941},
+						pos:  position{line: 938, col: 5, offset: 26521},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 5, offset: 26959},
+						pos:  position{line: 939, col: 5, offset: 26539},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 953, col: 5, offset: 26978},
+						pos:  position{line: 940, col: 5, offset: 26558},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 954, col: 5, offset: 26995},
+						pos:  position{line: 941, col: 5, offset: 26575},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 955, col: 5, offset: 27008},
+						pos:  position{line: 942, col: 5, offset: 26588},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 956, col: 5, offset: 27017},
+						pos:  position{line: 943, col: 5, offset: 26597},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 5, offset: 27034},
+						pos:  position{line: 944, col: 5, offset: 26614},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 958, col: 5, offset: 27053},
+						pos:  position{line: 945, col: 5, offset: 26633},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 959, col: 5, offset: 27072},
+						pos:  position{line: 946, col: 5, offset: 26652},
 						name: "NullLiteral",
 					},
 				},
@@ -7795,28 +7664,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 961, col: 1, offset: 27085},
+			pos:  position{line: 948, col: 1, offset: 26665},
 			expr: &choiceExpr{
-				pos: position{line: 962, col: 5, offset: 27103},
+				pos: position{line: 949, col: 5, offset: 26683},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 962, col: 5, offset: 27103},
+						pos: position{line: 949, col: 5, offset: 26683},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 962, col: 5, offset: 27103},
+							pos: position{line: 949, col: 5, offset: 26683},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 962, col: 5, offset: 27103},
+									pos:   position{line: 949, col: 5, offset: 26683},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 962, col: 7, offset: 27105},
+										pos:  position{line: 949, col: 7, offset: 26685},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 962, col: 14, offset: 27112},
+									pos: position{line: 949, col: 14, offset: 26692},
 									expr: &ruleRefExpr{
-										pos:  position{line: 962, col: 15, offset: 27113},
+										pos:  position{line: 949, col: 15, offset: 26693},
 										name: "IdentifierRest",
 									},
 								},
@@ -7824,13 +7693,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 965, col: 5, offset: 27228},
+						pos: position{line: 952, col: 5, offset: 26808},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 965, col: 5, offset: 27228},
+							pos:   position{line: 952, col: 5, offset: 26808},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 965, col: 7, offset: 27230},
+								pos:  position{line: 952, col: 7, offset: 26810},
 								name: "IP4Net",
 							},
 						},
@@ -7840,28 +7709,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 969, col: 1, offset: 27334},
+			pos:  position{line: 956, col: 1, offset: 26914},
 			expr: &choiceExpr{
-				pos: position{line: 970, col: 5, offset: 27353},
+				pos: position{line: 957, col: 5, offset: 26933},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 970, col: 5, offset: 27353},
+						pos: position{line: 957, col: 5, offset: 26933},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 970, col: 5, offset: 27353},
+							pos: position{line: 957, col: 5, offset: 26933},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 970, col: 5, offset: 27353},
+									pos:   position{line: 957, col: 5, offset: 26933},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 7, offset: 27355},
+										pos:  position{line: 957, col: 7, offset: 26935},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 970, col: 11, offset: 27359},
+									pos: position{line: 957, col: 11, offset: 26939},
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 12, offset: 27360},
+										pos:  position{line: 957, col: 12, offset: 26940},
 										name: "IdentifierRest",
 									},
 								},
@@ -7869,13 +7738,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 973, col: 5, offset: 27474},
+						pos: position{line: 960, col: 5, offset: 27054},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 973, col: 5, offset: 27474},
+							pos:   position{line: 960, col: 5, offset: 27054},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 973, col: 7, offset: 27476},
+								pos:  position{line: 960, col: 7, offset: 27056},
 								name: "IP",
 							},
 						},
@@ -7885,15 +7754,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 977, col: 1, offset: 27575},
+			pos:  position{line: 964, col: 1, offset: 27155},
 			expr: &actionExpr{
-				pos: position{line: 978, col: 5, offset: 27592},
+				pos: position{line: 965, col: 5, offset: 27172},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 978, col: 5, offset: 27592},
+					pos:   position{line: 965, col: 5, offset: 27172},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 978, col: 7, offset: 27594},
+						pos:  position{line: 965, col: 7, offset: 27174},
 						name: "FloatString",
 					},
 				},
@@ -7901,15 +7770,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 982, col: 1, offset: 27707},
+			pos:  position{line: 969, col: 1, offset: 27287},
 			expr: &actionExpr{
-				pos: position{line: 983, col: 5, offset: 27726},
+				pos: position{line: 970, col: 5, offset: 27306},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 983, col: 5, offset: 27726},
+					pos:   position{line: 970, col: 5, offset: 27306},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 983, col: 7, offset: 27728},
+						pos:  position{line: 970, col: 7, offset: 27308},
 						name: "IntString",
 					},
 				},
@@ -7917,24 +7786,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 987, col: 1, offset: 27837},
+			pos:  position{line: 974, col: 1, offset: 27417},
 			expr: &choiceExpr{
-				pos: position{line: 988, col: 5, offset: 27856},
+				pos: position{line: 975, col: 5, offset: 27436},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 988, col: 5, offset: 27856},
+						pos: position{line: 975, col: 5, offset: 27436},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 988, col: 5, offset: 27856},
+							pos:        position{line: 975, col: 5, offset: 27436},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 989, col: 5, offset: 27969},
+						pos: position{line: 976, col: 5, offset: 27549},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 989, col: 5, offset: 27969},
+							pos:        position{line: 976, col: 5, offset: 27549},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7944,12 +7813,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 991, col: 1, offset: 28080},
+			pos:  position{line: 978, col: 1, offset: 27660},
 			expr: &actionExpr{
-				pos: position{line: 992, col: 5, offset: 28096},
+				pos: position{line: 979, col: 5, offset: 27676},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 992, col: 5, offset: 28096},
+					pos:        position{line: 979, col: 5, offset: 27676},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7957,22 +7826,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 994, col: 1, offset: 28202},
+			pos:  position{line: 981, col: 1, offset: 27782},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 5, offset: 28219},
+				pos: position{line: 982, col: 5, offset: 27799},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 995, col: 5, offset: 28219},
+					pos: position{line: 982, col: 5, offset: 27799},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 995, col: 5, offset: 28219},
+							pos:        position{line: 982, col: 5, offset: 27799},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 995, col: 10, offset: 28224},
+							pos: position{line: 982, col: 10, offset: 27804},
 							expr: &ruleRefExpr{
-								pos:  position{line: 995, col: 10, offset: 28224},
+								pos:  position{line: 982, col: 10, offset: 27804},
 								name: "HexDigit",
 							},
 						},
@@ -7982,28 +7851,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 999, col: 1, offset: 28339},
+			pos:  position{line: 986, col: 1, offset: 27919},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 5, offset: 28355},
+				pos: position{line: 987, col: 5, offset: 27935},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1000, col: 5, offset: 28355},
+					pos: position{line: 987, col: 5, offset: 27935},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1000, col: 5, offset: 28355},
+							pos:        position{line: 987, col: 5, offset: 27935},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1000, col: 9, offset: 28359},
+							pos:   position{line: 987, col: 9, offset: 27939},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 13, offset: 28363},
+								pos:  position{line: 987, col: 13, offset: 27943},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1000, col: 18, offset: 28368},
+							pos:        position{line: 987, col: 18, offset: 27948},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -8013,22 +7882,22 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1004, col: 1, offset: 28457},
+			pos:  position{line: 991, col: 1, offset: 28037},
 			expr: &choiceExpr{
-				pos: position{line: 1005, col: 5, offset: 28470},
+				pos: position{line: 992, col: 5, offset: 28050},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 5, offset: 28470},
+						pos:  position{line: 992, col: 5, offset: 28050},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 1006, col: 5, offset: 28486},
+						pos: position{line: 993, col: 5, offset: 28066},
 						run: (*parser).callonCastType3,
 						expr: &labeledExpr{
-							pos:   position{line: 1006, col: 5, offset: 28486},
+							pos:   position{line: 993, col: 5, offset: 28066},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1006, col: 9, offset: 28490},
+								pos:  position{line: 993, col: 9, offset: 28070},
 								name: "PrimitiveType",
 							},
 						},
@@ -8038,20 +7907,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1010, col: 1, offset: 28589},
+			pos:  position{line: 997, col: 1, offset: 28169},
 			expr: &choiceExpr{
-				pos: position{line: 1011, col: 5, offset: 28598},
+				pos: position{line: 998, col: 5, offset: 28178},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1011, col: 5, offset: 28598},
+						pos:  position{line: 998, col: 5, offset: 28178},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1012, col: 5, offset: 28614},
+						pos:  position{line: 999, col: 5, offset: 28194},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 5, offset: 28632},
+						pos:  position{line: 1000, col: 5, offset: 28212},
 						name: "ComplexType",
 					},
 				},
@@ -8059,28 +7928,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1015, col: 1, offset: 28645},
+			pos:  position{line: 1002, col: 1, offset: 28225},
 			expr: &choiceExpr{
-				pos: position{line: 1016, col: 5, offset: 28663},
+				pos: position{line: 1003, col: 5, offset: 28243},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1016, col: 5, offset: 28663},
+						pos: position{line: 1003, col: 5, offset: 28243},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1016, col: 5, offset: 28663},
+							pos: position{line: 1003, col: 5, offset: 28243},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1016, col: 5, offset: 28663},
+									pos:   position{line: 1003, col: 5, offset: 28243},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1016, col: 10, offset: 28668},
+										pos:  position{line: 1003, col: 10, offset: 28248},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1016, col: 24, offset: 28682},
+									pos: position{line: 1003, col: 24, offset: 28262},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1016, col: 25, offset: 28683},
+										pos:  position{line: 1003, col: 25, offset: 28263},
 										name: "IdentifierRest",
 									},
 								},
@@ -8088,37 +7957,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1017, col: 5, offset: 28723},
+						pos: position{line: 1004, col: 5, offset: 28303},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1017, col: 5, offset: 28723},
+							pos: position{line: 1004, col: 5, offset: 28303},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1017, col: 5, offset: 28723},
+									pos:   position{line: 1004, col: 5, offset: 28303},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1017, col: 10, offset: 28728},
+										pos:  position{line: 1004, col: 10, offset: 28308},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1017, col: 25, offset: 28743},
+									pos:  position{line: 1004, col: 25, offset: 28323},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1017, col: 28, offset: 28746},
+									pos:        position{line: 1004, col: 28, offset: 28326},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1017, col: 32, offset: 28750},
+									pos:  position{line: 1004, col: 32, offset: 28330},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1017, col: 35, offset: 28753},
+									pos:   position{line: 1004, col: 35, offset: 28333},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1017, col: 39, offset: 28757},
+										pos:  position{line: 1004, col: 39, offset: 28337},
 										name: "Type",
 									},
 								},
@@ -8126,42 +7995,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1020, col: 5, offset: 28859},
+						pos: position{line: 1007, col: 5, offset: 28439},
 						run: (*parser).callonAmbiguousType17,
 						expr: &labeledExpr{
-							pos:   position{line: 1020, col: 5, offset: 28859},
+							pos:   position{line: 1007, col: 5, offset: 28439},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1020, col: 10, offset: 28864},
+								pos:  position{line: 1007, col: 10, offset: 28444},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 28966},
+						pos: position{line: 1010, col: 5, offset: 28546},
 						run: (*parser).callonAmbiguousType20,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 28966},
+							pos: position{line: 1010, col: 5, offset: 28546},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1023, col: 5, offset: 28966},
+									pos:        position{line: 1010, col: 5, offset: 28546},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 9, offset: 28970},
+									pos:  position{line: 1010, col: 9, offset: 28550},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 12, offset: 28973},
+									pos:   position{line: 1010, col: 12, offset: 28553},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 14, offset: 28975},
+										pos:  position{line: 1010, col: 14, offset: 28555},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 25, offset: 28986},
+									pos:        position{line: 1010, col: 25, offset: 28566},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8173,15 +8042,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1025, col: 1, offset: 29009},
+			pos:  position{line: 1012, col: 1, offset: 28589},
 			expr: &actionExpr{
-				pos: position{line: 1026, col: 5, offset: 29023},
+				pos: position{line: 1013, col: 5, offset: 28603},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1026, col: 5, offset: 29023},
+					pos:   position{line: 1013, col: 5, offset: 28603},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1026, col: 11, offset: 29029},
+						pos:  position{line: 1013, col: 11, offset: 28609},
 						name: "TypeList",
 					},
 				},
@@ -8189,28 +8058,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1030, col: 1, offset: 29125},
+			pos:  position{line: 1017, col: 1, offset: 28705},
 			expr: &actionExpr{
-				pos: position{line: 1031, col: 5, offset: 29138},
+				pos: position{line: 1018, col: 5, offset: 28718},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1031, col: 5, offset: 29138},
+					pos: position{line: 1018, col: 5, offset: 28718},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1031, col: 5, offset: 29138},
+							pos:   position{line: 1018, col: 5, offset: 28718},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1031, col: 11, offset: 29144},
+								pos:  position{line: 1018, col: 11, offset: 28724},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1031, col: 16, offset: 29149},
+							pos:   position{line: 1018, col: 16, offset: 28729},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1031, col: 21, offset: 29154},
+								pos: position{line: 1018, col: 21, offset: 28734},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1031, col: 21, offset: 29154},
+									pos:  position{line: 1018, col: 21, offset: 28734},
 									name: "TypeListTail",
 								},
 							},
@@ -8221,31 +8090,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1035, col: 1, offset: 29248},
+			pos:  position{line: 1022, col: 1, offset: 28828},
 			expr: &actionExpr{
-				pos: position{line: 1035, col: 16, offset: 29263},
+				pos: position{line: 1022, col: 16, offset: 28843},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1035, col: 16, offset: 29263},
+					pos: position{line: 1022, col: 16, offset: 28843},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1035, col: 16, offset: 29263},
+							pos:  position{line: 1022, col: 16, offset: 28843},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1035, col: 19, offset: 29266},
+							pos:        position{line: 1022, col: 19, offset: 28846},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1035, col: 23, offset: 29270},
+							pos:  position{line: 1022, col: 23, offset: 28850},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1035, col: 26, offset: 29273},
+							pos:   position{line: 1022, col: 26, offset: 28853},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1035, col: 30, offset: 29277},
+								pos:  position{line: 1022, col: 30, offset: 28857},
 								name: "Type",
 							},
 						},
@@ -8255,39 +8124,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1037, col: 1, offset: 29303},
+			pos:  position{line: 1024, col: 1, offset: 28883},
 			expr: &choiceExpr{
-				pos: position{line: 1038, col: 5, offset: 29319},
+				pos: position{line: 1025, col: 5, offset: 28899},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1038, col: 5, offset: 29319},
+						pos: position{line: 1025, col: 5, offset: 28899},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1038, col: 5, offset: 29319},
+							pos: position{line: 1025, col: 5, offset: 28899},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1038, col: 5, offset: 29319},
+									pos:        position{line: 1025, col: 5, offset: 28899},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1038, col: 9, offset: 29323},
+									pos:  position{line: 1025, col: 9, offset: 28903},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1038, col: 12, offset: 29326},
+									pos:   position{line: 1025, col: 12, offset: 28906},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1038, col: 19, offset: 29333},
+										pos:  position{line: 1025, col: 19, offset: 28913},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1038, col: 33, offset: 29347},
+									pos:  position{line: 1025, col: 33, offset: 28927},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1038, col: 36, offset: 29350},
+									pos:        position{line: 1025, col: 36, offset: 28930},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8295,34 +8164,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1041, col: 5, offset: 29445},
+						pos: position{line: 1028, col: 5, offset: 29025},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1041, col: 5, offset: 29445},
+							pos: position{line: 1028, col: 5, offset: 29025},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1041, col: 5, offset: 29445},
+									pos:        position{line: 1028, col: 5, offset: 29025},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1041, col: 9, offset: 29449},
+									pos:  position{line: 1028, col: 9, offset: 29029},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1041, col: 12, offset: 29452},
+									pos:   position{line: 1028, col: 12, offset: 29032},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1041, col: 16, offset: 29456},
+										pos:  position{line: 1028, col: 16, offset: 29036},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1041, col: 21, offset: 29461},
+									pos:  position{line: 1028, col: 21, offset: 29041},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1041, col: 24, offset: 29464},
+									pos:        position{line: 1028, col: 24, offset: 29044},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8330,34 +8199,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1044, col: 5, offset: 29553},
+						pos: position{line: 1031, col: 5, offset: 29133},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1044, col: 5, offset: 29553},
+							pos: position{line: 1031, col: 5, offset: 29133},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1044, col: 5, offset: 29553},
+									pos:        position{line: 1031, col: 5, offset: 29133},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1044, col: 10, offset: 29558},
+									pos:  position{line: 1031, col: 10, offset: 29138},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1044, col: 14, offset: 29562},
+									pos:   position{line: 1031, col: 14, offset: 29142},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1044, col: 18, offset: 29566},
+										pos:  position{line: 1031, col: 18, offset: 29146},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1044, col: 23, offset: 29571},
+									pos:  position{line: 1031, col: 23, offset: 29151},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1044, col: 26, offset: 29574},
+									pos:        position{line: 1031, col: 26, offset: 29154},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8365,55 +8234,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1047, col: 5, offset: 29662},
+						pos: position{line: 1034, col: 5, offset: 29242},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1047, col: 5, offset: 29662},
+							pos: position{line: 1034, col: 5, offset: 29242},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1047, col: 5, offset: 29662},
+									pos:        position{line: 1034, col: 5, offset: 29242},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 10, offset: 29667},
+									pos:  position{line: 1034, col: 10, offset: 29247},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1047, col: 13, offset: 29670},
+									pos:   position{line: 1034, col: 13, offset: 29250},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1047, col: 21, offset: 29678},
+										pos:  position{line: 1034, col: 21, offset: 29258},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 26, offset: 29683},
+									pos:  position{line: 1034, col: 26, offset: 29263},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 29, offset: 29686},
+									pos:        position{line: 1034, col: 29, offset: 29266},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 33, offset: 29690},
+									pos:  position{line: 1034, col: 33, offset: 29270},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1047, col: 36, offset: 29693},
+									pos:   position{line: 1034, col: 36, offset: 29273},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1047, col: 44, offset: 29701},
+										pos:  position{line: 1034, col: 44, offset: 29281},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 49, offset: 29706},
+									pos:  position{line: 1034, col: 49, offset: 29286},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 52, offset: 29709},
+									pos:        position{line: 1034, col: 52, offset: 29289},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8425,15 +8294,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1051, col: 1, offset: 29823},
+			pos:  position{line: 1038, col: 1, offset: 29403},
 			expr: &actionExpr{
-				pos: position{line: 1052, col: 5, offset: 29843},
+				pos: position{line: 1039, col: 5, offset: 29423},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1052, col: 5, offset: 29843},
+					pos:   position{line: 1039, col: 5, offset: 29423},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1052, col: 7, offset: 29845},
+						pos:  position{line: 1039, col: 7, offset: 29425},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8441,34 +8310,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1059, col: 1, offset: 30061},
+			pos:  position{line: 1046, col: 1, offset: 29641},
 			expr: &choiceExpr{
-				pos: position{line: 1060, col: 5, offset: 30086},
+				pos: position{line: 1047, col: 5, offset: 29666},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1060, col: 5, offset: 30086},
+						pos: position{line: 1047, col: 5, offset: 29666},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1060, col: 5, offset: 30086},
+							pos: position{line: 1047, col: 5, offset: 29666},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1060, col: 5, offset: 30086},
+									pos:        position{line: 1047, col: 5, offset: 29666},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1060, col: 9, offset: 30090},
+									pos:   position{line: 1047, col: 9, offset: 29670},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1060, col: 11, offset: 30092},
+										pos: position{line: 1047, col: 11, offset: 29672},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1060, col: 11, offset: 30092},
+											pos:  position{line: 1047, col: 11, offset: 29672},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1060, col: 37, offset: 30118},
+									pos:        position{line: 1047, col: 37, offset: 29698},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8476,29 +8345,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1061, col: 5, offset: 30144},
+						pos: position{line: 1048, col: 5, offset: 29724},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1061, col: 5, offset: 30144},
+							pos: position{line: 1048, col: 5, offset: 29724},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1061, col: 5, offset: 30144},
+									pos:        position{line: 1048, col: 5, offset: 29724},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 9, offset: 30148},
+									pos:   position{line: 1048, col: 9, offset: 29728},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1061, col: 11, offset: 30150},
+										pos: position{line: 1048, col: 11, offset: 29730},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1061, col: 11, offset: 30150},
+											pos:  position{line: 1048, col: 11, offset: 29730},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 37, offset: 30176},
+									pos:        position{line: 1048, col: 37, offset: 29756},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8510,24 +8379,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1063, col: 1, offset: 30199},
+			pos:  position{line: 1050, col: 1, offset: 29779},
 			expr: &choiceExpr{
-				pos: position{line: 1064, col: 5, offset: 30228},
+				pos: position{line: 1051, col: 5, offset: 29808},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1064, col: 5, offset: 30228},
+						pos:  position{line: 1051, col: 5, offset: 29808},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 5, offset: 30245},
+						pos: position{line: 1052, col: 5, offset: 29825},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1065, col: 5, offset: 30245},
+							pos:   position{line: 1052, col: 5, offset: 29825},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1065, col: 7, offset: 30247},
+								pos: position{line: 1052, col: 7, offset: 29827},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1065, col: 7, offset: 30247},
+									pos:  position{line: 1052, col: 7, offset: 29827},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8538,26 +8407,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1069, col: 1, offset: 30384},
+			pos:  position{line: 1056, col: 1, offset: 29964},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 5, offset: 30413},
+				pos: position{line: 1057, col: 5, offset: 29993},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 30413},
+						pos: position{line: 1057, col: 5, offset: 29993},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1070, col: 5, offset: 30413},
+							pos: position{line: 1057, col: 5, offset: 29993},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1070, col: 5, offset: 30413},
+									pos:        position{line: 1057, col: 5, offset: 29993},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1070, col: 10, offset: 30418},
+									pos:   position{line: 1057, col: 10, offset: 29998},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1070, col: 12, offset: 30420},
+										pos:        position{line: 1057, col: 12, offset: 30000},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8566,24 +8435,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 30447},
+						pos: position{line: 1058, col: 5, offset: 30027},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1071, col: 5, offset: 30447},
+							pos: position{line: 1058, col: 5, offset: 30027},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1071, col: 5, offset: 30447},
+									pos: position{line: 1058, col: 5, offset: 30027},
 									expr: &litMatcher{
-										pos:        position{line: 1071, col: 8, offset: 30450},
+										pos:        position{line: 1058, col: 8, offset: 30030},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1071, col: 15, offset: 30457},
+									pos:   position{line: 1058, col: 15, offset: 30037},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1071, col: 17, offset: 30459},
+										pos:  position{line: 1058, col: 17, offset: 30039},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8595,24 +8464,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1073, col: 1, offset: 30495},
+			pos:  position{line: 1060, col: 1, offset: 30075},
 			expr: &choiceExpr{
-				pos: position{line: 1074, col: 5, offset: 30524},
+				pos: position{line: 1061, col: 5, offset: 30104},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1074, col: 5, offset: 30524},
+						pos:  position{line: 1061, col: 5, offset: 30104},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1075, col: 5, offset: 30541},
+						pos: position{line: 1062, col: 5, offset: 30121},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1075, col: 5, offset: 30541},
+							pos:   position{line: 1062, col: 5, offset: 30121},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1075, col: 7, offset: 30543},
+								pos: position{line: 1062, col: 7, offset: 30123},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1075, col: 7, offset: 30543},
+									pos:  position{line: 1062, col: 7, offset: 30123},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8623,26 +8492,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1079, col: 1, offset: 30680},
+			pos:  position{line: 1066, col: 1, offset: 30260},
 			expr: &choiceExpr{
-				pos: position{line: 1080, col: 5, offset: 30709},
+				pos: position{line: 1067, col: 5, offset: 30289},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 30709},
+						pos: position{line: 1067, col: 5, offset: 30289},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1080, col: 5, offset: 30709},
+							pos: position{line: 1067, col: 5, offset: 30289},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1080, col: 5, offset: 30709},
+									pos:        position{line: 1067, col: 5, offset: 30289},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 10, offset: 30714},
+									pos:   position{line: 1067, col: 10, offset: 30294},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1080, col: 12, offset: 30716},
+										pos:        position{line: 1067, col: 12, offset: 30296},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8651,24 +8520,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1081, col: 5, offset: 30743},
+						pos: position{line: 1068, col: 5, offset: 30323},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1081, col: 5, offset: 30743},
+							pos: position{line: 1068, col: 5, offset: 30323},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1081, col: 5, offset: 30743},
+									pos: position{line: 1068, col: 5, offset: 30323},
 									expr: &litMatcher{
-										pos:        position{line: 1081, col: 8, offset: 30746},
+										pos:        position{line: 1068, col: 8, offset: 30326},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1081, col: 15, offset: 30753},
+									pos:   position{line: 1068, col: 15, offset: 30333},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1081, col: 17, offset: 30755},
+										pos:  position{line: 1068, col: 17, offset: 30335},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8680,36 +8549,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1083, col: 1, offset: 30791},
+			pos:  position{line: 1070, col: 1, offset: 30371},
 			expr: &actionExpr{
-				pos: position{line: 1084, col: 5, offset: 30808},
+				pos: position{line: 1071, col: 5, offset: 30388},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1084, col: 5, offset: 30808},
+					pos: position{line: 1071, col: 5, offset: 30388},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1084, col: 5, offset: 30808},
+							pos:        position{line: 1071, col: 5, offset: 30388},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1084, col: 10, offset: 30813},
+							pos:  position{line: 1071, col: 10, offset: 30393},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1084, col: 13, offset: 30816},
+							pos:   position{line: 1071, col: 13, offset: 30396},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1084, col: 15, offset: 30818},
+								pos:  position{line: 1071, col: 15, offset: 30398},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1084, col: 20, offset: 30823},
+							pos:  position{line: 1071, col: 20, offset: 30403},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 23, offset: 30826},
+							pos:        position{line: 1071, col: 23, offset: 30406},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8719,105 +8588,105 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1099, col: 1, offset: 31123},
+			pos:  position{line: 1090, col: 1, offset: 30706},
 			expr: &actionExpr{
-				pos: position{line: 1100, col: 5, offset: 31141},
+				pos: position{line: 1091, col: 5, offset: 30724},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1100, col: 9, offset: 31145},
+					pos: position{line: 1091, col: 9, offset: 30728},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1100, col: 9, offset: 31145},
+							pos:        position{line: 1091, col: 9, offset: 30728},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 19, offset: 31155},
+							pos:        position{line: 1091, col: 19, offset: 30738},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 30, offset: 31166},
+							pos:        position{line: 1091, col: 30, offset: 30749},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 41, offset: 31177},
+							pos:        position{line: 1091, col: 41, offset: 30760},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1101, col: 9, offset: 31194},
+							pos:        position{line: 1092, col: 9, offset: 30777},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1101, col: 18, offset: 31203},
+							pos:        position{line: 1092, col: 18, offset: 30786},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1101, col: 28, offset: 31213},
+							pos:        position{line: 1092, col: 28, offset: 30796},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1101, col: 38, offset: 31223},
+							pos:        position{line: 1092, col: 38, offset: 30806},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1102, col: 9, offset: 31239},
+							pos:        position{line: 1093, col: 9, offset: 30822},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1102, col: 21, offset: 31251},
+							pos:        position{line: 1093, col: 21, offset: 30834},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 9, offset: 31269},
+							pos:        position{line: 1094, col: 9, offset: 30852},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 18, offset: 31278},
+							pos:        position{line: 1094, col: 18, offset: 30861},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1104, col: 9, offset: 31295},
+							pos:        position{line: 1095, col: 9, offset: 30878},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1104, col: 22, offset: 31308},
+							pos:        position{line: 1095, col: 22, offset: 30891},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1105, col: 9, offset: 31323},
+							pos:        position{line: 1096, col: 9, offset: 30906},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1106, col: 9, offset: 31339},
+							pos:        position{line: 1097, col: 9, offset: 30922},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1106, col: 16, offset: 31346},
+							pos:        position{line: 1097, col: 16, offset: 30929},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1107, col: 9, offset: 31360},
+							pos:        position{line: 1098, col: 9, offset: 30943},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1107, col: 18, offset: 31369},
+							pos:        position{line: 1098, col: 18, offset: 30952},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8827,31 +8696,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1111, col: 1, offset: 31485},
+			pos:  position{line: 1102, col: 1, offset: 31068},
 			expr: &choiceExpr{
-				pos: position{line: 1112, col: 5, offset: 31503},
+				pos: position{line: 1103, col: 5, offset: 31086},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1112, col: 5, offset: 31503},
+						pos: position{line: 1103, col: 5, offset: 31086},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1112, col: 5, offset: 31503},
+							pos: position{line: 1103, col: 5, offset: 31086},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1112, col: 5, offset: 31503},
+									pos:   position{line: 1103, col: 5, offset: 31086},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1112, col: 11, offset: 31509},
+										pos:  position{line: 1103, col: 11, offset: 31092},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1112, col: 21, offset: 31519},
+									pos:   position{line: 1103, col: 21, offset: 31102},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1112, col: 26, offset: 31524},
+										pos: position{line: 1103, col: 26, offset: 31107},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1112, col: 26, offset: 31524},
+											pos:  position{line: 1103, col: 26, offset: 31107},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -8860,10 +8729,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1115, col: 5, offset: 31626},
+						pos: position{line: 1106, col: 5, offset: 31209},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1115, col: 5, offset: 31626},
+							pos:        position{line: 1106, col: 5, offset: 31209},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8873,31 +8742,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1117, col: 1, offset: 31650},
+			pos:  position{line: 1108, col: 1, offset: 31233},
 			expr: &actionExpr{
-				pos: position{line: 1117, col: 21, offset: 31670},
+				pos: position{line: 1108, col: 21, offset: 31253},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1117, col: 21, offset: 31670},
+					pos: position{line: 1108, col: 21, offset: 31253},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1117, col: 21, offset: 31670},
+							pos:  position{line: 1108, col: 21, offset: 31253},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1117, col: 24, offset: 31673},
+							pos:        position{line: 1108, col: 24, offset: 31256},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1117, col: 28, offset: 31677},
+							pos:  position{line: 1108, col: 28, offset: 31260},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1117, col: 31, offset: 31680},
+							pos:   position{line: 1108, col: 31, offset: 31263},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1117, col: 35, offset: 31684},
+								pos:  position{line: 1108, col: 35, offset: 31267},
 								name: "TypeField",
 							},
 						},
@@ -8907,39 +8776,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1119, col: 1, offset: 31715},
+			pos:  position{line: 1110, col: 1, offset: 31298},
 			expr: &actionExpr{
-				pos: position{line: 1120, col: 5, offset: 31729},
+				pos: position{line: 1111, col: 5, offset: 31312},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1120, col: 5, offset: 31729},
+					pos: position{line: 1111, col: 5, offset: 31312},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1120, col: 5, offset: 31729},
+							pos:   position{line: 1111, col: 5, offset: 31312},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1120, col: 10, offset: 31734},
+								pos:  position{line: 1111, col: 10, offset: 31317},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1120, col: 20, offset: 31744},
+							pos:  position{line: 1111, col: 20, offset: 31327},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1120, col: 23, offset: 31747},
+							pos:        position{line: 1111, col: 23, offset: 31330},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1120, col: 27, offset: 31751},
+							pos:  position{line: 1111, col: 27, offset: 31334},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1120, col: 30, offset: 31754},
+							pos:   position{line: 1111, col: 30, offset: 31337},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1120, col: 34, offset: 31758},
+								pos:  position{line: 1111, col: 34, offset: 31341},
 								name: "Type",
 							},
 						},
@@ -8949,16 +8818,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1124, col: 1, offset: 31840},
+			pos:  position{line: 1115, col: 1, offset: 31423},
 			expr: &choiceExpr{
-				pos: position{line: 1125, col: 5, offset: 31854},
+				pos: position{line: 1116, col: 5, offset: 31437},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1125, col: 5, offset: 31854},
+						pos:  position{line: 1116, col: 5, offset: 31437},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1126, col: 5, offset: 31873},
+						pos:  position{line: 1117, col: 5, offset: 31456},
 						name: "QuotedString",
 					},
 				},
@@ -8966,32 +8835,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1128, col: 1, offset: 31887},
+			pos:  position{line: 1119, col: 1, offset: 31470},
 			expr: &actionExpr{
-				pos: position{line: 1128, col: 12, offset: 31898},
+				pos: position{line: 1119, col: 12, offset: 31481},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1128, col: 12, offset: 31898},
+					pos: position{line: 1119, col: 12, offset: 31481},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1128, col: 13, offset: 31899},
+							pos: position{line: 1119, col: 13, offset: 31482},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1128, col: 13, offset: 31899},
+									pos:        position{line: 1119, col: 13, offset: 31482},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1128, col: 21, offset: 31907},
+									pos:        position{line: 1119, col: 21, offset: 31490},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1128, col: 28, offset: 31914},
+							pos: position{line: 1119, col: 28, offset: 31497},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1128, col: 29, offset: 31915},
+								pos:  position{line: 1119, col: 29, offset: 31498},
 								name: "IdentifierRest",
 							},
 						},
@@ -9001,32 +8870,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1129, col: 1, offset: 31952},
+			pos:  position{line: 1120, col: 1, offset: 31535},
 			expr: &actionExpr{
-				pos: position{line: 1129, col: 11, offset: 31962},
+				pos: position{line: 1120, col: 11, offset: 31545},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1129, col: 11, offset: 31962},
+					pos: position{line: 1120, col: 11, offset: 31545},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1129, col: 12, offset: 31963},
+							pos: position{line: 1120, col: 12, offset: 31546},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1129, col: 12, offset: 31963},
+									pos:        position{line: 1120, col: 12, offset: 31546},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1129, col: 19, offset: 31970},
+									pos:        position{line: 1120, col: 19, offset: 31553},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1129, col: 25, offset: 31976},
+							pos: position{line: 1120, col: 25, offset: 31559},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1129, col: 26, offset: 31977},
+								pos:  position{line: 1120, col: 26, offset: 31560},
 								name: "IdentifierRest",
 							},
 						},
@@ -9036,22 +8905,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1130, col: 1, offset: 32013},
+			pos:  position{line: 1121, col: 1, offset: 31596},
 			expr: &actionExpr{
-				pos: position{line: 1130, col: 11, offset: 32023},
+				pos: position{line: 1121, col: 11, offset: 31606},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1130, col: 11, offset: 32023},
+					pos: position{line: 1121, col: 11, offset: 31606},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1130, col: 11, offset: 32023},
+							pos:        position{line: 1121, col: 11, offset: 31606},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1130, col: 16, offset: 32028},
+							pos: position{line: 1121, col: 16, offset: 31611},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1130, col: 17, offset: 32029},
+								pos:  position{line: 1121, col: 17, offset: 31612},
 								name: "IdentifierRest",
 							},
 						},
@@ -9061,32 +8930,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1131, col: 1, offset: 32065},
+			pos:  position{line: 1122, col: 1, offset: 31648},
 			expr: &actionExpr{
-				pos: position{line: 1131, col: 12, offset: 32076},
+				pos: position{line: 1122, col: 12, offset: 31659},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1131, col: 12, offset: 32076},
+					pos: position{line: 1122, col: 12, offset: 31659},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1131, col: 13, offset: 32077},
+							pos: position{line: 1122, col: 13, offset: 31660},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1131, col: 13, offset: 32077},
+									pos:        position{line: 1122, col: 13, offset: 31660},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1131, col: 21, offset: 32085},
+									pos:        position{line: 1122, col: 21, offset: 31668},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1131, col: 28, offset: 32092},
+							pos: position{line: 1122, col: 28, offset: 31675},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1131, col: 29, offset: 32093},
+								pos:  position{line: 1122, col: 29, offset: 31676},
 								name: "IdentifierRest",
 							},
 						},
@@ -9096,22 +8965,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1132, col: 1, offset: 32130},
+			pos:  position{line: 1123, col: 1, offset: 31713},
 			expr: &actionExpr{
-				pos: position{line: 1132, col: 11, offset: 32140},
+				pos: position{line: 1123, col: 11, offset: 31723},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1132, col: 11, offset: 32140},
+					pos: position{line: 1123, col: 11, offset: 31723},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1132, col: 11, offset: 32140},
+							pos:        position{line: 1123, col: 11, offset: 31723},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1132, col: 16, offset: 32145},
+							pos: position{line: 1123, col: 16, offset: 31728},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1132, col: 17, offset: 32146},
+								pos:  position{line: 1123, col: 17, offset: 31729},
 								name: "IdentifierRest",
 							},
 						},
@@ -9121,9 +8990,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1134, col: 1, offset: 32183},
+			pos:  position{line: 1125, col: 1, offset: 31766},
 			expr: &charClassMatcher{
-				pos:        position{line: 1134, col: 19, offset: 32201},
+				pos:        position{line: 1125, col: 19, offset: 31784},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9133,16 +9002,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1136, col: 1, offset: 32213},
+			pos:  position{line: 1127, col: 1, offset: 31796},
 			expr: &choiceExpr{
-				pos: position{line: 1136, col: 18, offset: 32230},
+				pos: position{line: 1127, col: 18, offset: 31813},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1136, col: 18, offset: 32230},
+						pos:  position{line: 1127, col: 18, offset: 31813},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1136, col: 36, offset: 32248},
+						pos:        position{line: 1127, col: 36, offset: 31831},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9153,15 +9022,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1138, col: 1, offset: 32255},
+			pos:  position{line: 1129, col: 1, offset: 31838},
 			expr: &actionExpr{
-				pos: position{line: 1139, col: 5, offset: 32270},
+				pos: position{line: 1130, col: 5, offset: 31853},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1139, col: 5, offset: 32270},
+					pos:   position{line: 1130, col: 5, offset: 31853},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1139, col: 8, offset: 32273},
+						pos:  position{line: 1130, col: 8, offset: 31856},
 						name: "IdentifierName",
 					},
 				},
@@ -9169,29 +9038,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1141, col: 1, offset: 32354},
+			pos:  position{line: 1132, col: 1, offset: 31937},
 			expr: &choiceExpr{
-				pos: position{line: 1142, col: 5, offset: 32373},
+				pos: position{line: 1133, col: 5, offset: 31956},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1142, col: 5, offset: 32373},
+						pos: position{line: 1133, col: 5, offset: 31956},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1142, col: 5, offset: 32373},
+							pos: position{line: 1133, col: 5, offset: 31956},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1142, col: 5, offset: 32373},
+									pos: position{line: 1133, col: 5, offset: 31956},
 									expr: &seqExpr{
-										pos: position{line: 1142, col: 7, offset: 32375},
+										pos: position{line: 1133, col: 7, offset: 31958},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1142, col: 7, offset: 32375},
+												pos:  position{line: 1133, col: 7, offset: 31958},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1142, col: 15, offset: 32383},
+												pos: position{line: 1133, col: 15, offset: 31966},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1142, col: 16, offset: 32384},
+													pos:  position{line: 1133, col: 16, offset: 31967},
 													name: "IdentifierRest",
 												},
 											},
@@ -9199,13 +9068,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1142, col: 32, offset: 32400},
+									pos:  position{line: 1133, col: 32, offset: 31983},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1142, col: 48, offset: 32416},
+									pos: position{line: 1133, col: 48, offset: 31999},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1142, col: 48, offset: 32416},
+										pos:  position{line: 1133, col: 48, offset: 31999},
 										name: "IdentifierRest",
 									},
 								},
@@ -9213,30 +9082,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1143, col: 5, offset: 32468},
+						pos: position{line: 1134, col: 5, offset: 32051},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1143, col: 5, offset: 32468},
+							pos:        position{line: 1134, col: 5, offset: 32051},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1144, col: 5, offset: 32507},
+						pos: position{line: 1135, col: 5, offset: 32090},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1144, col: 5, offset: 32507},
+							pos: position{line: 1135, col: 5, offset: 32090},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1144, col: 5, offset: 32507},
+									pos:        position{line: 1135, col: 5, offset: 32090},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1144, col: 10, offset: 32512},
+									pos:   position{line: 1135, col: 10, offset: 32095},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1144, col: 13, offset: 32515},
+										pos:  position{line: 1135, col: 13, offset: 32098},
 										name: "IDGuard",
 									},
 								},
@@ -9244,39 +9113,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1146, col: 5, offset: 32606},
+						pos: position{line: 1137, col: 5, offset: 32189},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1146, col: 5, offset: 32606},
+							pos:        position{line: 1137, col: 5, offset: 32189},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1147, col: 5, offset: 32648},
+						pos: position{line: 1138, col: 5, offset: 32231},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1147, col: 5, offset: 32648},
+							pos: position{line: 1138, col: 5, offset: 32231},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1147, col: 5, offset: 32648},
+									pos:   position{line: 1138, col: 5, offset: 32231},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1147, col: 8, offset: 32651},
+										pos:  position{line: 1138, col: 8, offset: 32234},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1147, col: 26, offset: 32669},
+									pos: position{line: 1138, col: 26, offset: 32252},
 									expr: &seqExpr{
-										pos: position{line: 1147, col: 28, offset: 32671},
+										pos: position{line: 1138, col: 28, offset: 32254},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1147, col: 28, offset: 32671},
+												pos:  position{line: 1138, col: 28, offset: 32254},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1147, col: 31, offset: 32674},
+												pos:        position{line: 1138, col: 31, offset: 32257},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9291,24 +9160,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1149, col: 1, offset: 32699},
+			pos:  position{line: 1140, col: 1, offset: 32282},
 			expr: &choiceExpr{
-				pos: position{line: 1150, col: 5, offset: 32711},
+				pos: position{line: 1141, col: 5, offset: 32294},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1150, col: 5, offset: 32711},
+						pos:  position{line: 1141, col: 5, offset: 32294},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1151, col: 5, offset: 32730},
+						pos:  position{line: 1142, col: 5, offset: 32313},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1152, col: 5, offset: 32746},
+						pos:  position{line: 1143, col: 5, offset: 32329},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 5, offset: 32754},
+						pos:  position{line: 1144, col: 5, offset: 32337},
 						name: "Infinity",
 					},
 				},
@@ -9316,24 +9185,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1155, col: 1, offset: 32764},
+			pos:  position{line: 1146, col: 1, offset: 32347},
 			expr: &actionExpr{
-				pos: position{line: 1156, col: 5, offset: 32773},
+				pos: position{line: 1147, col: 5, offset: 32356},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1156, col: 5, offset: 32773},
+					pos: position{line: 1147, col: 5, offset: 32356},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 5, offset: 32773},
+							pos:  position{line: 1147, col: 5, offset: 32356},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1156, col: 14, offset: 32782},
+							pos:        position{line: 1147, col: 14, offset: 32365},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 18, offset: 32786},
+							pos:  position{line: 1147, col: 18, offset: 32369},
 							name: "FullTime",
 						},
 					},
@@ -9342,30 +9211,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1160, col: 1, offset: 32906},
+			pos:  position{line: 1151, col: 1, offset: 32489},
 			expr: &seqExpr{
-				pos: position{line: 1160, col: 12, offset: 32917},
+				pos: position{line: 1151, col: 12, offset: 32500},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 12, offset: 32917},
+						pos:  position{line: 1151, col: 12, offset: 32500},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1160, col: 15, offset: 32920},
+						pos:        position{line: 1151, col: 15, offset: 32503},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 19, offset: 32924},
+						pos:  position{line: 1151, col: 19, offset: 32507},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1160, col: 22, offset: 32927},
+						pos:        position{line: 1151, col: 22, offset: 32510},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 26, offset: 32931},
+						pos:  position{line: 1151, col: 26, offset: 32514},
 						name: "D2",
 					},
 				},
@@ -9373,33 +9242,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1162, col: 1, offset: 32935},
+			pos:  position{line: 1153, col: 1, offset: 32518},
 			expr: &seqExpr{
-				pos: position{line: 1162, col: 6, offset: 32940},
+				pos: position{line: 1153, col: 6, offset: 32523},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1162, col: 6, offset: 32940},
+						pos:        position{line: 1153, col: 6, offset: 32523},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1162, col: 11, offset: 32945},
+						pos:        position{line: 1153, col: 11, offset: 32528},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1162, col: 16, offset: 32950},
+						pos:        position{line: 1153, col: 16, offset: 32533},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1162, col: 21, offset: 32955},
+						pos:        position{line: 1153, col: 21, offset: 32538},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9410,19 +9279,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1163, col: 1, offset: 32961},
+			pos:  position{line: 1154, col: 1, offset: 32544},
 			expr: &seqExpr{
-				pos: position{line: 1163, col: 6, offset: 32966},
+				pos: position{line: 1154, col: 6, offset: 32549},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1163, col: 6, offset: 32966},
+						pos:        position{line: 1154, col: 6, offset: 32549},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1163, col: 11, offset: 32971},
+						pos:        position{line: 1154, col: 11, offset: 32554},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9433,16 +9302,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1165, col: 1, offset: 32978},
+			pos:  position{line: 1156, col: 1, offset: 32561},
 			expr: &seqExpr{
-				pos: position{line: 1165, col: 12, offset: 32989},
+				pos: position{line: 1156, col: 12, offset: 32572},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 12, offset: 32989},
+						pos:  position{line: 1156, col: 12, offset: 32572},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 24, offset: 33001},
+						pos:  position{line: 1156, col: 24, offset: 32584},
 						name: "TimeOffset",
 					},
 				},
@@ -9450,46 +9319,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1167, col: 1, offset: 33013},
+			pos:  position{line: 1158, col: 1, offset: 32596},
 			expr: &seqExpr{
-				pos: position{line: 1167, col: 15, offset: 33027},
+				pos: position{line: 1158, col: 15, offset: 32610},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 15, offset: 33027},
+						pos:  position{line: 1158, col: 15, offset: 32610},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1167, col: 18, offset: 33030},
+						pos:        position{line: 1158, col: 18, offset: 32613},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 22, offset: 33034},
+						pos:  position{line: 1158, col: 22, offset: 32617},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1167, col: 25, offset: 33037},
+						pos:        position{line: 1158, col: 25, offset: 32620},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 29, offset: 33041},
+						pos:  position{line: 1158, col: 29, offset: 32624},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1167, col: 32, offset: 33044},
+						pos: position{line: 1158, col: 32, offset: 32627},
 						expr: &seqExpr{
-							pos: position{line: 1167, col: 33, offset: 33045},
+							pos: position{line: 1158, col: 33, offset: 32628},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1167, col: 33, offset: 33045},
+									pos:        position{line: 1158, col: 33, offset: 32628},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1167, col: 37, offset: 33049},
+									pos: position{line: 1158, col: 37, offset: 32632},
 									expr: &charClassMatcher{
-										pos:        position{line: 1167, col: 37, offset: 33049},
+										pos:        position{line: 1158, col: 37, offset: 32632},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9504,60 +9373,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1169, col: 1, offset: 33059},
+			pos:  position{line: 1160, col: 1, offset: 32642},
 			expr: &choiceExpr{
-				pos: position{line: 1170, col: 5, offset: 33074},
+				pos: position{line: 1161, col: 5, offset: 32657},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1170, col: 5, offset: 33074},
+						pos:        position{line: 1161, col: 5, offset: 32657},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1171, col: 5, offset: 33082},
+						pos: position{line: 1162, col: 5, offset: 32665},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1171, col: 6, offset: 33083},
+								pos: position{line: 1162, col: 6, offset: 32666},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1171, col: 6, offset: 33083},
+										pos:        position{line: 1162, col: 6, offset: 32666},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1171, col: 12, offset: 33089},
+										pos:        position{line: 1162, col: 12, offset: 32672},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1171, col: 17, offset: 33094},
+								pos:  position{line: 1162, col: 17, offset: 32677},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1171, col: 20, offset: 33097},
+								pos:        position{line: 1162, col: 20, offset: 32680},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1171, col: 24, offset: 33101},
+								pos:  position{line: 1162, col: 24, offset: 32684},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1171, col: 27, offset: 33104},
+								pos: position{line: 1162, col: 27, offset: 32687},
 								expr: &seqExpr{
-									pos: position{line: 1171, col: 28, offset: 33105},
+									pos: position{line: 1162, col: 28, offset: 32688},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1171, col: 28, offset: 33105},
+											pos:        position{line: 1162, col: 28, offset: 32688},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1171, col: 32, offset: 33109},
+											pos: position{line: 1162, col: 32, offset: 32692},
 											expr: &charClassMatcher{
-												pos:        position{line: 1171, col: 32, offset: 33109},
+												pos:        position{line: 1162, col: 32, offset: 32692},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9574,32 +9443,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1173, col: 1, offset: 33119},
+			pos:  position{line: 1164, col: 1, offset: 32702},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 5, offset: 33132},
+				pos: position{line: 1165, col: 5, offset: 32715},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1174, col: 5, offset: 33132},
+					pos: position{line: 1165, col: 5, offset: 32715},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1174, col: 5, offset: 33132},
+							pos: position{line: 1165, col: 5, offset: 32715},
 							expr: &litMatcher{
-								pos:        position{line: 1174, col: 5, offset: 33132},
+								pos:        position{line: 1165, col: 5, offset: 32715},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1174, col: 10, offset: 33137},
+							pos: position{line: 1165, col: 10, offset: 32720},
 							expr: &seqExpr{
-								pos: position{line: 1174, col: 11, offset: 33138},
+								pos: position{line: 1165, col: 11, offset: 32721},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1174, col: 11, offset: 33138},
+										pos:  position{line: 1165, col: 11, offset: 32721},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1174, col: 19, offset: 33146},
+										pos:  position{line: 1165, col: 19, offset: 32729},
 										name: "TimeUnit",
 									},
 								},
@@ -9611,26 +9480,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1178, col: 1, offset: 33272},
+			pos:  position{line: 1169, col: 1, offset: 32855},
 			expr: &seqExpr{
-				pos: position{line: 1178, col: 11, offset: 33282},
+				pos: position{line: 1169, col: 11, offset: 32865},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1178, col: 11, offset: 33282},
+						pos:  position{line: 1169, col: 11, offset: 32865},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1178, col: 16, offset: 33287},
+						pos: position{line: 1169, col: 16, offset: 32870},
 						expr: &seqExpr{
-							pos: position{line: 1178, col: 17, offset: 33288},
+							pos: position{line: 1169, col: 17, offset: 32871},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1178, col: 17, offset: 33288},
+									pos:        position{line: 1169, col: 17, offset: 32871},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1178, col: 21, offset: 33292},
+									pos:  position{line: 1169, col: 21, offset: 32875},
 									name: "UInt",
 								},
 							},
@@ -9641,52 +9510,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1180, col: 1, offset: 33300},
+			pos:  position{line: 1171, col: 1, offset: 32883},
 			expr: &choiceExpr{
-				pos: position{line: 1181, col: 5, offset: 33313},
+				pos: position{line: 1172, col: 5, offset: 32896},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1181, col: 5, offset: 33313},
+						pos:        position{line: 1172, col: 5, offset: 32896},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1182, col: 5, offset: 33322},
+						pos:        position{line: 1173, col: 5, offset: 32905},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1183, col: 5, offset: 33331},
+						pos:        position{line: 1174, col: 5, offset: 32914},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1184, col: 5, offset: 33340},
+						pos:        position{line: 1175, col: 5, offset: 32923},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1185, col: 5, offset: 33348},
+						pos:        position{line: 1176, col: 5, offset: 32931},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1186, col: 5, offset: 33356},
+						pos:        position{line: 1177, col: 5, offset: 32939},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1187, col: 5, offset: 33364},
+						pos:        position{line: 1178, col: 5, offset: 32947},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1188, col: 5, offset: 33372},
+						pos:        position{line: 1179, col: 5, offset: 32955},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1189, col: 5, offset: 33380},
+						pos:        position{line: 1180, col: 5, offset: 32963},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9695,42 +9564,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1191, col: 1, offset: 33385},
+			pos:  position{line: 1182, col: 1, offset: 32968},
 			expr: &actionExpr{
-				pos: position{line: 1192, col: 5, offset: 33392},
+				pos: position{line: 1183, col: 5, offset: 32975},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1192, col: 5, offset: 33392},
+					pos: position{line: 1183, col: 5, offset: 32975},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 5, offset: 33392},
+							pos:  position{line: 1183, col: 5, offset: 32975},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1192, col: 10, offset: 33397},
+							pos:        position{line: 1183, col: 10, offset: 32980},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 14, offset: 33401},
+							pos:  position{line: 1183, col: 14, offset: 32984},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1192, col: 19, offset: 33406},
+							pos:        position{line: 1183, col: 19, offset: 32989},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 23, offset: 33410},
+							pos:  position{line: 1183, col: 23, offset: 32993},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1192, col: 28, offset: 33415},
+							pos:        position{line: 1183, col: 28, offset: 32998},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 32, offset: 33419},
+							pos:  position{line: 1183, col: 32, offset: 33002},
 							name: "UInt",
 						},
 					},
@@ -9739,42 +9608,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1194, col: 1, offset: 33456},
+			pos:  position{line: 1185, col: 1, offset: 33039},
 			expr: &actionExpr{
-				pos: position{line: 1195, col: 5, offset: 33464},
+				pos: position{line: 1186, col: 5, offset: 33047},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1195, col: 5, offset: 33464},
+					pos: position{line: 1186, col: 5, offset: 33047},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1195, col: 5, offset: 33464},
+							pos: position{line: 1186, col: 5, offset: 33047},
 							expr: &seqExpr{
-								pos: position{line: 1195, col: 8, offset: 33467},
+								pos: position{line: 1186, col: 8, offset: 33050},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1195, col: 8, offset: 33467},
+										pos:  position{line: 1186, col: 8, offset: 33050},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1195, col: 12, offset: 33471},
+										pos:        position{line: 1186, col: 12, offset: 33054},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1195, col: 16, offset: 33475},
+										pos:  position{line: 1186, col: 16, offset: 33058},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1195, col: 20, offset: 33479},
+										pos: position{line: 1186, col: 20, offset: 33062},
 										expr: &choiceExpr{
-											pos: position{line: 1195, col: 22, offset: 33481},
+											pos: position{line: 1186, col: 22, offset: 33064},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1195, col: 22, offset: 33481},
+													pos:  position{line: 1186, col: 22, offset: 33064},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1195, col: 33, offset: 33492},
+													pos:        position{line: 1186, col: 33, offset: 33075},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9785,10 +9654,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1195, col: 39, offset: 33498},
+							pos:   position{line: 1186, col: 39, offset: 33081},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1195, col: 41, offset: 33500},
+								pos:  position{line: 1186, col: 41, offset: 33083},
 								name: "IP6Variations",
 							},
 						},
@@ -9798,32 +9667,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1199, col: 1, offset: 33664},
+			pos:  position{line: 1190, col: 1, offset: 33247},
 			expr: &choiceExpr{
-				pos: position{line: 1200, col: 5, offset: 33682},
+				pos: position{line: 1191, col: 5, offset: 33265},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1200, col: 5, offset: 33682},
+						pos: position{line: 1191, col: 5, offset: 33265},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1200, col: 5, offset: 33682},
+							pos: position{line: 1191, col: 5, offset: 33265},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1200, col: 5, offset: 33682},
+									pos:   position{line: 1191, col: 5, offset: 33265},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1200, col: 7, offset: 33684},
+										pos: position{line: 1191, col: 7, offset: 33267},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1200, col: 7, offset: 33684},
+											pos:  position{line: 1191, col: 7, offset: 33267},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1200, col: 17, offset: 33694},
+									pos:   position{line: 1191, col: 17, offset: 33277},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1200, col: 19, offset: 33696},
+										pos:  position{line: 1191, col: 19, offset: 33279},
 										name: "IP6Tail",
 									},
 								},
@@ -9831,51 +9700,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1203, col: 5, offset: 33760},
+						pos: position{line: 1194, col: 5, offset: 33343},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1203, col: 5, offset: 33760},
+							pos: position{line: 1194, col: 5, offset: 33343},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1203, col: 5, offset: 33760},
+									pos:   position{line: 1194, col: 5, offset: 33343},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1203, col: 7, offset: 33762},
+										pos:  position{line: 1194, col: 7, offset: 33345},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 11, offset: 33766},
+									pos:   position{line: 1194, col: 11, offset: 33349},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1203, col: 13, offset: 33768},
+										pos: position{line: 1194, col: 13, offset: 33351},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1203, col: 13, offset: 33768},
+											pos:  position{line: 1194, col: 13, offset: 33351},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1203, col: 23, offset: 33778},
+									pos:        position{line: 1194, col: 23, offset: 33361},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 28, offset: 33783},
+									pos:   position{line: 1194, col: 28, offset: 33366},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1203, col: 30, offset: 33785},
+										pos: position{line: 1194, col: 30, offset: 33368},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1203, col: 30, offset: 33785},
+											pos:  position{line: 1194, col: 30, offset: 33368},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 40, offset: 33795},
+									pos:   position{line: 1194, col: 40, offset: 33378},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1203, col: 42, offset: 33797},
+										pos:  position{line: 1194, col: 42, offset: 33380},
 										name: "IP6Tail",
 									},
 								},
@@ -9883,32 +9752,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1206, col: 5, offset: 33896},
+						pos: position{line: 1197, col: 5, offset: 33479},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1206, col: 5, offset: 33896},
+							pos: position{line: 1197, col: 5, offset: 33479},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1206, col: 5, offset: 33896},
+									pos:        position{line: 1197, col: 5, offset: 33479},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1206, col: 10, offset: 33901},
+									pos:   position{line: 1197, col: 10, offset: 33484},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1206, col: 12, offset: 33903},
+										pos: position{line: 1197, col: 12, offset: 33486},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1206, col: 12, offset: 33903},
+											pos:  position{line: 1197, col: 12, offset: 33486},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1206, col: 22, offset: 33913},
+									pos:   position{line: 1197, col: 22, offset: 33496},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1206, col: 24, offset: 33915},
+										pos:  position{line: 1197, col: 24, offset: 33498},
 										name: "IP6Tail",
 									},
 								},
@@ -9916,32 +9785,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1209, col: 5, offset: 33986},
+						pos: position{line: 1200, col: 5, offset: 33569},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1209, col: 5, offset: 33986},
+							pos: position{line: 1200, col: 5, offset: 33569},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1209, col: 5, offset: 33986},
+									pos:   position{line: 1200, col: 5, offset: 33569},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1209, col: 7, offset: 33988},
+										pos:  position{line: 1200, col: 7, offset: 33571},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1209, col: 11, offset: 33992},
+									pos:   position{line: 1200, col: 11, offset: 33575},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1209, col: 13, offset: 33994},
+										pos: position{line: 1200, col: 13, offset: 33577},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1209, col: 13, offset: 33994},
+											pos:  position{line: 1200, col: 13, offset: 33577},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1209, col: 23, offset: 34004},
+									pos:        position{line: 1200, col: 23, offset: 33587},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -9949,10 +9818,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1212, col: 5, offset: 34072},
+						pos: position{line: 1203, col: 5, offset: 33655},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1212, col: 5, offset: 34072},
+							pos:        position{line: 1203, col: 5, offset: 33655},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -9962,16 +9831,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1216, col: 1, offset: 34109},
+			pos:  position{line: 1207, col: 1, offset: 33692},
 			expr: &choiceExpr{
-				pos: position{line: 1217, col: 5, offset: 34121},
+				pos: position{line: 1208, col: 5, offset: 33704},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 5, offset: 34121},
+						pos:  position{line: 1208, col: 5, offset: 33704},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1218, col: 5, offset: 34128},
+						pos:  position{line: 1209, col: 5, offset: 33711},
 						name: "Hex",
 					},
 				},
@@ -9979,23 +9848,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1220, col: 1, offset: 34133},
+			pos:  position{line: 1211, col: 1, offset: 33716},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 12, offset: 34144},
+				pos: position{line: 1211, col: 12, offset: 33727},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 12, offset: 34144},
+					pos: position{line: 1211, col: 12, offset: 33727},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1220, col: 12, offset: 34144},
+							pos:        position{line: 1211, col: 12, offset: 33727},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1220, col: 16, offset: 34148},
+							pos:   position{line: 1211, col: 16, offset: 33731},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 18, offset: 34150},
+								pos:  position{line: 1211, col: 18, offset: 33733},
 								name: "Hex",
 							},
 						},
@@ -10005,23 +9874,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1222, col: 1, offset: 34188},
+			pos:  position{line: 1213, col: 1, offset: 33771},
 			expr: &actionExpr{
-				pos: position{line: 1222, col: 12, offset: 34199},
+				pos: position{line: 1213, col: 12, offset: 33782},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1222, col: 12, offset: 34199},
+					pos: position{line: 1213, col: 12, offset: 33782},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1222, col: 12, offset: 34199},
+							pos:   position{line: 1213, col: 12, offset: 33782},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1222, col: 14, offset: 34201},
+								pos:  position{line: 1213, col: 14, offset: 33784},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1222, col: 18, offset: 34205},
+							pos:        position{line: 1213, col: 18, offset: 33788},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -10031,31 +9900,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1224, col: 1, offset: 34243},
+			pos:  position{line: 1215, col: 1, offset: 33826},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 34254},
+				pos: position{line: 1216, col: 5, offset: 33837},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 34254},
+					pos: position{line: 1216, col: 5, offset: 33837},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1225, col: 5, offset: 34254},
+							pos:   position{line: 1216, col: 5, offset: 33837},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 7, offset: 34256},
+								pos:  position{line: 1216, col: 7, offset: 33839},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1225, col: 10, offset: 34259},
+							pos:        position{line: 1216, col: 10, offset: 33842},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 14, offset: 34263},
+							pos:   position{line: 1216, col: 14, offset: 33846},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 16, offset: 34265},
+								pos:  position{line: 1216, col: 16, offset: 33848},
 								name: "UInt",
 							},
 						},
@@ -10065,31 +9934,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1229, col: 1, offset: 34338},
+			pos:  position{line: 1220, col: 1, offset: 33921},
 			expr: &actionExpr{
-				pos: position{line: 1230, col: 5, offset: 34349},
+				pos: position{line: 1221, col: 5, offset: 33932},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1230, col: 5, offset: 34349},
+					pos: position{line: 1221, col: 5, offset: 33932},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1230, col: 5, offset: 34349},
+							pos:   position{line: 1221, col: 5, offset: 33932},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1230, col: 7, offset: 34351},
+								pos:  position{line: 1221, col: 7, offset: 33934},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1230, col: 11, offset: 34355},
+							pos:        position{line: 1221, col: 11, offset: 33938},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1230, col: 15, offset: 34359},
+							pos:   position{line: 1221, col: 15, offset: 33942},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1230, col: 17, offset: 34361},
+								pos:  position{line: 1221, col: 17, offset: 33944},
 								name: "UInt",
 							},
 						},
@@ -10099,15 +9968,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1234, col: 1, offset: 34424},
+			pos:  position{line: 1225, col: 1, offset: 34007},
 			expr: &actionExpr{
-				pos: position{line: 1235, col: 4, offset: 34432},
+				pos: position{line: 1226, col: 4, offset: 34015},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1235, col: 4, offset: 34432},
+					pos:   position{line: 1226, col: 4, offset: 34015},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1235, col: 6, offset: 34434},
+						pos:  position{line: 1226, col: 6, offset: 34017},
 						name: "UIntString",
 					},
 				},
@@ -10115,16 +9984,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1237, col: 1, offset: 34474},
+			pos:  position{line: 1228, col: 1, offset: 34057},
 			expr: &choiceExpr{
-				pos: position{line: 1238, col: 5, offset: 34488},
+				pos: position{line: 1229, col: 5, offset: 34071},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1238, col: 5, offset: 34488},
+						pos:  position{line: 1229, col: 5, offset: 34071},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1239, col: 5, offset: 34503},
+						pos:  position{line: 1230, col: 5, offset: 34086},
 						name: "MinusIntString",
 					},
 				},
@@ -10132,14 +10001,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1241, col: 1, offset: 34519},
+			pos:  position{line: 1232, col: 1, offset: 34102},
 			expr: &actionExpr{
-				pos: position{line: 1241, col: 14, offset: 34532},
+				pos: position{line: 1232, col: 14, offset: 34115},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1241, col: 14, offset: 34532},
+					pos: position{line: 1232, col: 14, offset: 34115},
 					expr: &charClassMatcher{
-						pos:        position{line: 1241, col: 14, offset: 34532},
+						pos:        position{line: 1232, col: 14, offset: 34115},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10150,20 +10019,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1243, col: 1, offset: 34571},
+			pos:  position{line: 1234, col: 1, offset: 34154},
 			expr: &actionExpr{
-				pos: position{line: 1244, col: 5, offset: 34590},
+				pos: position{line: 1235, col: 5, offset: 34173},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1244, col: 5, offset: 34590},
+					pos: position{line: 1235, col: 5, offset: 34173},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1244, col: 5, offset: 34590},
+							pos:        position{line: 1235, col: 5, offset: 34173},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 9, offset: 34594},
+							pos:  position{line: 1235, col: 9, offset: 34177},
 							name: "UIntString",
 						},
 					},
@@ -10172,28 +10041,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1246, col: 1, offset: 34637},
+			pos:  position{line: 1237, col: 1, offset: 34220},
 			expr: &choiceExpr{
-				pos: position{line: 1247, col: 5, offset: 34653},
+				pos: position{line: 1238, col: 5, offset: 34236},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1247, col: 5, offset: 34653},
+						pos: position{line: 1238, col: 5, offset: 34236},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1247, col: 5, offset: 34653},
+							pos: position{line: 1238, col: 5, offset: 34236},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1247, col: 5, offset: 34653},
+									pos: position{line: 1238, col: 5, offset: 34236},
 									expr: &litMatcher{
-										pos:        position{line: 1247, col: 5, offset: 34653},
+										pos:        position{line: 1238, col: 5, offset: 34236},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1247, col: 10, offset: 34658},
+									pos: position{line: 1238, col: 10, offset: 34241},
 									expr: &charClassMatcher{
-										pos:        position{line: 1247, col: 10, offset: 34658},
+										pos:        position{line: 1238, col: 10, offset: 34241},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10201,14 +10070,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1247, col: 17, offset: 34665},
+									pos:        position{line: 1238, col: 17, offset: 34248},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1247, col: 21, offset: 34669},
+									pos: position{line: 1238, col: 21, offset: 34252},
 									expr: &charClassMatcher{
-										pos:        position{line: 1247, col: 21, offset: 34669},
+										pos:        position{line: 1238, col: 21, offset: 34252},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10216,9 +10085,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1247, col: 28, offset: 34676},
+									pos: position{line: 1238, col: 28, offset: 34259},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1247, col: 28, offset: 34676},
+										pos:  position{line: 1238, col: 28, offset: 34259},
 										name: "ExponentPart",
 									},
 								},
@@ -10226,28 +10095,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1250, col: 5, offset: 34735},
+						pos: position{line: 1241, col: 5, offset: 34318},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1250, col: 5, offset: 34735},
+							pos: position{line: 1241, col: 5, offset: 34318},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1250, col: 5, offset: 34735},
+									pos: position{line: 1241, col: 5, offset: 34318},
 									expr: &litMatcher{
-										pos:        position{line: 1250, col: 5, offset: 34735},
+										pos:        position{line: 1241, col: 5, offset: 34318},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1250, col: 10, offset: 34740},
+									pos:        position{line: 1241, col: 10, offset: 34323},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1250, col: 14, offset: 34744},
+									pos: position{line: 1241, col: 14, offset: 34327},
 									expr: &charClassMatcher{
-										pos:        position{line: 1250, col: 14, offset: 34744},
+										pos:        position{line: 1241, col: 14, offset: 34327},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10255,9 +10124,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1250, col: 21, offset: 34751},
+									pos: position{line: 1241, col: 21, offset: 34334},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1250, col: 21, offset: 34751},
+										pos:  position{line: 1241, col: 21, offset: 34334},
 										name: "ExponentPart",
 									},
 								},
@@ -10265,17 +10134,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1253, col: 5, offset: 34810},
+						pos: position{line: 1244, col: 5, offset: 34393},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1253, col: 7, offset: 34812},
+							pos: position{line: 1244, col: 7, offset: 34395},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1253, col: 7, offset: 34812},
+									pos:  position{line: 1244, col: 7, offset: 34395},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1253, col: 13, offset: 34818},
+									pos:  position{line: 1244, col: 13, offset: 34401},
 									name: "Infinity",
 								},
 							},
@@ -10286,19 +10155,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1256, col: 1, offset: 34862},
+			pos:  position{line: 1247, col: 1, offset: 34445},
 			expr: &seqExpr{
-				pos: position{line: 1256, col: 16, offset: 34877},
+				pos: position{line: 1247, col: 16, offset: 34460},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1256, col: 16, offset: 34877},
+						pos:        position{line: 1247, col: 16, offset: 34460},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1256, col: 21, offset: 34882},
+						pos: position{line: 1247, col: 21, offset: 34465},
 						expr: &charClassMatcher{
-							pos:        position{line: 1256, col: 21, offset: 34882},
+							pos:        position{line: 1247, col: 21, offset: 34465},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10306,7 +10175,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1256, col: 27, offset: 34888},
+						pos:  position{line: 1247, col: 27, offset: 34471},
 						name: "UIntString",
 					},
 				},
@@ -10314,31 +10183,31 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1258, col: 1, offset: 34900},
+			pos:  position{line: 1249, col: 1, offset: 34483},
 			expr: &litMatcher{
-				pos:        position{line: 1258, col: 7, offset: 34906},
+				pos:        position{line: 1249, col: 7, offset: 34489},
 				val:        "NaN",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1260, col: 1, offset: 34913},
+			pos:  position{line: 1251, col: 1, offset: 34496},
 			expr: &seqExpr{
-				pos: position{line: 1260, col: 12, offset: 34924},
+				pos: position{line: 1251, col: 12, offset: 34507},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 1260, col: 12, offset: 34924},
+						pos: position{line: 1251, col: 12, offset: 34507},
 						expr: &choiceExpr{
-							pos: position{line: 1260, col: 13, offset: 34925},
+							pos: position{line: 1251, col: 13, offset: 34508},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1260, col: 13, offset: 34925},
+									pos:        position{line: 1251, col: 13, offset: 34508},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1260, col: 19, offset: 34931},
+									pos:        position{line: 1251, col: 19, offset: 34514},
 									val:        "+",
 									ignoreCase: false,
 								},
@@ -10346,7 +10215,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1260, col: 25, offset: 34937},
+						pos:        position{line: 1251, col: 25, offset: 34520},
 						val:        "Inf",
 						ignoreCase: false,
 					},
@@ -10355,14 +10224,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1262, col: 1, offset: 34944},
+			pos:  position{line: 1253, col: 1, offset: 34527},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 7, offset: 34950},
+				pos: position{line: 1253, col: 7, offset: 34533},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1262, col: 7, offset: 34950},
+					pos: position{line: 1253, col: 7, offset: 34533},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1262, col: 7, offset: 34950},
+						pos:  position{line: 1253, col: 7, offset: 34533},
 						name: "HexDigit",
 					},
 				},
@@ -10370,9 +10239,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1264, col: 1, offset: 34992},
+			pos:  position{line: 1255, col: 1, offset: 34575},
 			expr: &charClassMatcher{
-				pos:        position{line: 1264, col: 12, offset: 35003},
+				pos:        position{line: 1255, col: 12, offset: 34586},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10381,34 +10250,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1266, col: 1, offset: 35016},
+			pos:  position{line: 1257, col: 1, offset: 34599},
 			expr: &choiceExpr{
-				pos: position{line: 1267, col: 5, offset: 35033},
+				pos: position{line: 1258, col: 5, offset: 34616},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 35033},
+						pos: position{line: 1258, col: 5, offset: 34616},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1267, col: 5, offset: 35033},
+							pos: position{line: 1258, col: 5, offset: 34616},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1267, col: 5, offset: 35033},
+									pos:        position{line: 1258, col: 5, offset: 34616},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 9, offset: 35037},
+									pos:   position{line: 1258, col: 9, offset: 34620},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1267, col: 11, offset: 35039},
+										pos: position{line: 1258, col: 11, offset: 34622},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1267, col: 11, offset: 35039},
+											pos:  position{line: 1258, col: 11, offset: 34622},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1267, col: 29, offset: 35057},
+									pos:        position{line: 1258, col: 29, offset: 34640},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10416,29 +10285,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1268, col: 5, offset: 35094},
+						pos: position{line: 1259, col: 5, offset: 34677},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1268, col: 5, offset: 35094},
+							pos: position{line: 1259, col: 5, offset: 34677},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1268, col: 5, offset: 35094},
+									pos:        position{line: 1259, col: 5, offset: 34677},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1268, col: 9, offset: 35098},
+									pos:   position{line: 1259, col: 9, offset: 34681},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1268, col: 11, offset: 35100},
+										pos: position{line: 1259, col: 11, offset: 34683},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1268, col: 11, offset: 35100},
+											pos:  position{line: 1259, col: 11, offset: 34683},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1268, col: 29, offset: 35118},
+									pos:        position{line: 1259, col: 29, offset: 34701},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10450,55 +10319,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1270, col: 1, offset: 35152},
+			pos:  position{line: 1261, col: 1, offset: 34735},
 			expr: &choiceExpr{
-				pos: position{line: 1271, col: 5, offset: 35173},
+				pos: position{line: 1262, col: 5, offset: 34756},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1271, col: 5, offset: 35173},
+						pos: position{line: 1262, col: 5, offset: 34756},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1271, col: 5, offset: 35173},
+							pos: position{line: 1262, col: 5, offset: 34756},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1271, col: 5, offset: 35173},
+									pos: position{line: 1262, col: 5, offset: 34756},
 									expr: &choiceExpr{
-										pos: position{line: 1271, col: 7, offset: 35175},
+										pos: position{line: 1262, col: 7, offset: 34758},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1271, col: 7, offset: 35175},
+												pos:        position{line: 1262, col: 7, offset: 34758},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1271, col: 13, offset: 35181},
+												pos:  position{line: 1262, col: 13, offset: 34764},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1271, col: 26, offset: 35194,
+									line: 1262, col: 26, offset: 34777,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1272, col: 5, offset: 35231},
+						pos: position{line: 1263, col: 5, offset: 34814},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1272, col: 5, offset: 35231},
+							pos: position{line: 1263, col: 5, offset: 34814},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1272, col: 5, offset: 35231},
+									pos:        position{line: 1263, col: 5, offset: 34814},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1272, col: 10, offset: 35236},
+									pos:   position{line: 1263, col: 10, offset: 34819},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1272, col: 12, offset: 35238},
+										pos:  position{line: 1263, col: 12, offset: 34821},
 										name: "EscapeSequence",
 									},
 								},
@@ -10510,28 +10379,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1274, col: 1, offset: 35272},
+			pos:  position{line: 1265, col: 1, offset: 34855},
 			expr: &actionExpr{
-				pos: position{line: 1275, col: 5, offset: 35284},
+				pos: position{line: 1266, col: 5, offset: 34867},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1275, col: 5, offset: 35284},
+					pos: position{line: 1266, col: 5, offset: 34867},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1275, col: 5, offset: 35284},
+							pos:   position{line: 1266, col: 5, offset: 34867},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1275, col: 10, offset: 35289},
+								pos:  position{line: 1266, col: 10, offset: 34872},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1275, col: 23, offset: 35302},
+							pos:   position{line: 1266, col: 23, offset: 34885},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1275, col: 28, offset: 35307},
+								pos: position{line: 1266, col: 28, offset: 34890},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1275, col: 28, offset: 35307},
+									pos:  position{line: 1266, col: 28, offset: 34890},
 									name: "KeyWordRest",
 								},
 							},
@@ -10542,16 +10411,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1277, col: 1, offset: 35369},
+			pos:  position{line: 1268, col: 1, offset: 34952},
 			expr: &choiceExpr{
-				pos: position{line: 1278, col: 5, offset: 35386},
+				pos: position{line: 1269, col: 5, offset: 34969},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 35386},
+						pos:  position{line: 1269, col: 5, offset: 34969},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 5, offset: 35403},
+						pos:  position{line: 1270, col: 5, offset: 34986},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10559,12 +10428,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1281, col: 1, offset: 35415},
+			pos:  position{line: 1272, col: 1, offset: 34998},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 16, offset: 35430},
+				pos: position{line: 1272, col: 16, offset: 35013},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1281, col: 16, offset: 35430},
+					pos:        position{line: 1272, col: 16, offset: 35013},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10575,16 +10444,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1283, col: 1, offset: 35479},
+			pos:  position{line: 1274, col: 1, offset: 35062},
 			expr: &choiceExpr{
-				pos: position{line: 1284, col: 5, offset: 35495},
+				pos: position{line: 1275, col: 5, offset: 35078},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1284, col: 5, offset: 35495},
+						pos:  position{line: 1275, col: 5, offset: 35078},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1285, col: 5, offset: 35512},
+						pos:        position{line: 1276, col: 5, offset: 35095},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10595,30 +10464,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1287, col: 1, offset: 35519},
+			pos:  position{line: 1278, col: 1, offset: 35102},
 			expr: &actionExpr{
-				pos: position{line: 1287, col: 14, offset: 35532},
+				pos: position{line: 1278, col: 14, offset: 35115},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1287, col: 14, offset: 35532},
+					pos: position{line: 1278, col: 14, offset: 35115},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1287, col: 14, offset: 35532},
+							pos:        position{line: 1278, col: 14, offset: 35115},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1287, col: 19, offset: 35537},
+							pos:   position{line: 1278, col: 19, offset: 35120},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1287, col: 22, offset: 35540},
+								pos: position{line: 1278, col: 22, offset: 35123},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1287, col: 22, offset: 35540},
+										pos:  position{line: 1278, col: 22, offset: 35123},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1287, col: 38, offset: 35556},
+										pos:  position{line: 1278, col: 38, offset: 35139},
 										name: "EscapeSequence",
 									},
 								},
@@ -10630,42 +10499,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1289, col: 1, offset: 35592},
+			pos:  position{line: 1280, col: 1, offset: 35175},
 			expr: &actionExpr{
-				pos: position{line: 1290, col: 5, offset: 35608},
+				pos: position{line: 1281, col: 5, offset: 35191},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1290, col: 5, offset: 35608},
+					pos: position{line: 1281, col: 5, offset: 35191},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1290, col: 5, offset: 35608},
+							pos: position{line: 1281, col: 5, offset: 35191},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1290, col: 6, offset: 35609},
+								pos:  position{line: 1281, col: 6, offset: 35192},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1290, col: 22, offset: 35625},
+							pos: position{line: 1281, col: 22, offset: 35208},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1290, col: 23, offset: 35626},
+								pos:  position{line: 1281, col: 23, offset: 35209},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1290, col: 35, offset: 35638},
+							pos:   position{line: 1281, col: 35, offset: 35221},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1290, col: 40, offset: 35643},
+								pos:  position{line: 1281, col: 40, offset: 35226},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1290, col: 50, offset: 35653},
+							pos:   position{line: 1281, col: 50, offset: 35236},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1290, col: 55, offset: 35658},
+								pos: position{line: 1281, col: 55, offset: 35241},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1290, col: 55, offset: 35658},
+									pos:  position{line: 1281, col: 55, offset: 35241},
 									name: "GlobRest",
 								},
 							},
@@ -10676,20 +10545,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1294, col: 1, offset: 35727},
+			pos:  position{line: 1285, col: 1, offset: 35310},
 			expr: &seqExpr{
-				pos: position{line: 1294, col: 19, offset: 35745},
+				pos: position{line: 1285, col: 19, offset: 35328},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1294, col: 19, offset: 35745},
+						pos: position{line: 1285, col: 19, offset: 35328},
 						expr: &litMatcher{
-							pos:        position{line: 1294, col: 19, offset: 35745},
+							pos:        position{line: 1285, col: 19, offset: 35328},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1294, col: 24, offset: 35750},
+						pos:  position{line: 1285, col: 24, offset: 35333},
 						name: "KeyWordStart",
 					},
 				},
@@ -10697,19 +10566,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1295, col: 1, offset: 35763},
+			pos:  position{line: 1286, col: 1, offset: 35346},
 			expr: &seqExpr{
-				pos: position{line: 1295, col: 15, offset: 35777},
+				pos: position{line: 1286, col: 15, offset: 35360},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1295, col: 15, offset: 35777},
+						pos: position{line: 1286, col: 15, offset: 35360},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1295, col: 15, offset: 35777},
+							pos:  position{line: 1286, col: 15, offset: 35360},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1295, col: 28, offset: 35790},
+						pos:        position{line: 1286, col: 28, offset: 35373},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10718,23 +10587,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1297, col: 1, offset: 35795},
+			pos:  position{line: 1288, col: 1, offset: 35378},
 			expr: &choiceExpr{
-				pos: position{line: 1298, col: 5, offset: 35809},
+				pos: position{line: 1289, col: 5, offset: 35392},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1298, col: 5, offset: 35809},
+						pos:  position{line: 1289, col: 5, offset: 35392},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1299, col: 5, offset: 35826},
+						pos:  position{line: 1290, col: 5, offset: 35409},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1300, col: 5, offset: 35838},
+						pos: position{line: 1291, col: 5, offset: 35421},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1300, col: 5, offset: 35838},
+							pos:        position{line: 1291, col: 5, offset: 35421},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10744,16 +10613,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1302, col: 1, offset: 35862},
+			pos:  position{line: 1293, col: 1, offset: 35445},
 			expr: &choiceExpr{
-				pos: position{line: 1303, col: 5, offset: 35875},
+				pos: position{line: 1294, col: 5, offset: 35458},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1303, col: 5, offset: 35875},
+						pos:  position{line: 1294, col: 5, offset: 35458},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1304, col: 5, offset: 35889},
+						pos:        position{line: 1295, col: 5, offset: 35472},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10764,30 +10633,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1306, col: 1, offset: 35896},
+			pos:  position{line: 1297, col: 1, offset: 35479},
 			expr: &actionExpr{
-				pos: position{line: 1306, col: 11, offset: 35906},
+				pos: position{line: 1297, col: 11, offset: 35489},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1306, col: 11, offset: 35906},
+					pos: position{line: 1297, col: 11, offset: 35489},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1306, col: 11, offset: 35906},
+							pos:        position{line: 1297, col: 11, offset: 35489},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1306, col: 16, offset: 35911},
+							pos:   position{line: 1297, col: 16, offset: 35494},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1306, col: 19, offset: 35914},
+								pos: position{line: 1297, col: 19, offset: 35497},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1306, col: 19, offset: 35914},
+										pos:  position{line: 1297, col: 19, offset: 35497},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1306, col: 32, offset: 35927},
+										pos:  position{line: 1297, col: 32, offset: 35510},
 										name: "EscapeSequence",
 									},
 								},
@@ -10799,30 +10668,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1308, col: 1, offset: 35963},
+			pos:  position{line: 1299, col: 1, offset: 35546},
 			expr: &choiceExpr{
-				pos: position{line: 1309, col: 5, offset: 35978},
+				pos: position{line: 1300, col: 5, offset: 35561},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 35978},
+						pos: position{line: 1300, col: 5, offset: 35561},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1309, col: 5, offset: 35978},
+							pos:        position{line: 1300, col: 5, offset: 35561},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 36006},
+						pos: position{line: 1301, col: 5, offset: 35589},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1310, col: 5, offset: 36006},
+							pos:        position{line: 1301, col: 5, offset: 35589},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1311, col: 5, offset: 36036},
+						pos:        position{line: 1302, col: 5, offset: 35619},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10833,55 +10702,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1314, col: 1, offset: 36043},
+			pos:  position{line: 1305, col: 1, offset: 35626},
 			expr: &choiceExpr{
-				pos: position{line: 1315, col: 5, offset: 36064},
+				pos: position{line: 1306, col: 5, offset: 35647},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1315, col: 5, offset: 36064},
+						pos: position{line: 1306, col: 5, offset: 35647},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1315, col: 5, offset: 36064},
+							pos: position{line: 1306, col: 5, offset: 35647},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1315, col: 5, offset: 36064},
+									pos: position{line: 1306, col: 5, offset: 35647},
 									expr: &choiceExpr{
-										pos: position{line: 1315, col: 7, offset: 36066},
+										pos: position{line: 1306, col: 7, offset: 35649},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1315, col: 7, offset: 36066},
+												pos:        position{line: 1306, col: 7, offset: 35649},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1315, col: 13, offset: 36072},
+												pos:  position{line: 1306, col: 13, offset: 35655},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1315, col: 26, offset: 36085,
+									line: 1306, col: 26, offset: 35668,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 36122},
+						pos: position{line: 1307, col: 5, offset: 35705},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 5, offset: 36122},
+							pos: position{line: 1307, col: 5, offset: 35705},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1316, col: 5, offset: 36122},
+									pos:        position{line: 1307, col: 5, offset: 35705},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1316, col: 10, offset: 36127},
+									pos:   position{line: 1307, col: 10, offset: 35710},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1316, col: 12, offset: 36129},
+										pos:  position{line: 1307, col: 12, offset: 35712},
 										name: "EscapeSequence",
 									},
 								},
@@ -10893,16 +10762,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1318, col: 1, offset: 36163},
+			pos:  position{line: 1309, col: 1, offset: 35746},
 			expr: &choiceExpr{
-				pos: position{line: 1319, col: 5, offset: 36182},
+				pos: position{line: 1310, col: 5, offset: 35765},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1319, col: 5, offset: 36182},
+						pos:  position{line: 1310, col: 5, offset: 35765},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 5, offset: 36203},
+						pos:  position{line: 1311, col: 5, offset: 35786},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10910,79 +10779,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1322, col: 1, offset: 36218},
+			pos:  position{line: 1313, col: 1, offset: 35801},
 			expr: &choiceExpr{
-				pos: position{line: 1323, col: 5, offset: 36239},
+				pos: position{line: 1314, col: 5, offset: 35822},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1323, col: 5, offset: 36239},
+						pos:        position{line: 1314, col: 5, offset: 35822},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1324, col: 5, offset: 36247},
+						pos: position{line: 1315, col: 5, offset: 35830},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1324, col: 5, offset: 36247},
+							pos:        position{line: 1315, col: 5, offset: 35830},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1325, col: 5, offset: 36287},
+						pos:        position{line: 1316, col: 5, offset: 35870},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1326, col: 5, offset: 36296},
+						pos: position{line: 1317, col: 5, offset: 35879},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1326, col: 5, offset: 36296},
+							pos:        position{line: 1317, col: 5, offset: 35879},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1327, col: 5, offset: 36325},
+						pos: position{line: 1318, col: 5, offset: 35908},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1327, col: 5, offset: 36325},
+							pos:        position{line: 1318, col: 5, offset: 35908},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1328, col: 5, offset: 36354},
+						pos: position{line: 1319, col: 5, offset: 35937},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1328, col: 5, offset: 36354},
+							pos:        position{line: 1319, col: 5, offset: 35937},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 36383},
+						pos: position{line: 1320, col: 5, offset: 35966},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1329, col: 5, offset: 36383},
+							pos:        position{line: 1320, col: 5, offset: 35966},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1330, col: 5, offset: 36412},
+						pos: position{line: 1321, col: 5, offset: 35995},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1330, col: 5, offset: 36412},
+							pos:        position{line: 1321, col: 5, offset: 35995},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1331, col: 5, offset: 36441},
+						pos: position{line: 1322, col: 5, offset: 36024},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1331, col: 5, offset: 36441},
+							pos:        position{line: 1322, col: 5, offset: 36024},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -10992,30 +10861,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1333, col: 1, offset: 36467},
+			pos:  position{line: 1324, col: 1, offset: 36050},
 			expr: &choiceExpr{
-				pos: position{line: 1334, col: 5, offset: 36485},
+				pos: position{line: 1325, col: 5, offset: 36068},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1334, col: 5, offset: 36485},
+						pos: position{line: 1325, col: 5, offset: 36068},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1334, col: 5, offset: 36485},
+							pos:        position{line: 1325, col: 5, offset: 36068},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1335, col: 5, offset: 36513},
+						pos: position{line: 1326, col: 5, offset: 36096},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1335, col: 5, offset: 36513},
+							pos:        position{line: 1326, col: 5, offset: 36096},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1336, col: 5, offset: 36541},
+						pos:        position{line: 1327, col: 5, offset: 36124},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11026,41 +10895,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1338, col: 1, offset: 36547},
+			pos:  position{line: 1329, col: 1, offset: 36130},
 			expr: &choiceExpr{
-				pos: position{line: 1339, col: 5, offset: 36565},
+				pos: position{line: 1330, col: 5, offset: 36148},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1339, col: 5, offset: 36565},
+						pos: position{line: 1330, col: 5, offset: 36148},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1339, col: 5, offset: 36565},
+							pos: position{line: 1330, col: 5, offset: 36148},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1339, col: 5, offset: 36565},
+									pos:        position{line: 1330, col: 5, offset: 36148},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1339, col: 9, offset: 36569},
+									pos:   position{line: 1330, col: 9, offset: 36152},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1339, col: 16, offset: 36576},
+										pos: position{line: 1330, col: 16, offset: 36159},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1339, col: 16, offset: 36576},
+												pos:  position{line: 1330, col: 16, offset: 36159},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1339, col: 25, offset: 36585},
+												pos:  position{line: 1330, col: 25, offset: 36168},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1339, col: 34, offset: 36594},
+												pos:  position{line: 1330, col: 34, offset: 36177},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1339, col: 43, offset: 36603},
+												pos:  position{line: 1330, col: 43, offset: 36186},
 												name: "HexDigit",
 											},
 										},
@@ -11070,63 +10939,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 36666},
+						pos: position{line: 1333, col: 5, offset: 36249},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1342, col: 5, offset: 36666},
+							pos: position{line: 1333, col: 5, offset: 36249},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1342, col: 5, offset: 36666},
+									pos:        position{line: 1333, col: 5, offset: 36249},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1342, col: 9, offset: 36670},
+									pos:        position{line: 1333, col: 9, offset: 36253},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1342, col: 13, offset: 36674},
+									pos:   position{line: 1333, col: 13, offset: 36257},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1342, col: 20, offset: 36681},
+										pos: position{line: 1333, col: 20, offset: 36264},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1342, col: 20, offset: 36681},
+												pos:  position{line: 1333, col: 20, offset: 36264},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 29, offset: 36690},
+												pos: position{line: 1333, col: 29, offset: 36273},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 29, offset: 36690},
+													pos:  position{line: 1333, col: 29, offset: 36273},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 39, offset: 36700},
+												pos: position{line: 1333, col: 39, offset: 36283},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 39, offset: 36700},
+													pos:  position{line: 1333, col: 39, offset: 36283},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 49, offset: 36710},
+												pos: position{line: 1333, col: 49, offset: 36293},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 49, offset: 36710},
+													pos:  position{line: 1333, col: 49, offset: 36293},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 59, offset: 36720},
+												pos: position{line: 1333, col: 59, offset: 36303},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 59, offset: 36720},
+													pos:  position{line: 1333, col: 59, offset: 36303},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 69, offset: 36730},
+												pos: position{line: 1333, col: 69, offset: 36313},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 69, offset: 36730},
+													pos:  position{line: 1333, col: 69, offset: 36313},
 													name: "HexDigit",
 												},
 											},
@@ -11134,7 +11003,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1342, col: 80, offset: 36741},
+									pos:        position{line: 1333, col: 80, offset: 36324},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11146,35 +11015,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1346, col: 1, offset: 36795},
+			pos:  position{line: 1337, col: 1, offset: 36378},
 			expr: &actionExpr{
-				pos: position{line: 1347, col: 5, offset: 36813},
+				pos: position{line: 1338, col: 5, offset: 36396},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1347, col: 5, offset: 36813},
+					pos: position{line: 1338, col: 5, offset: 36396},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1347, col: 5, offset: 36813},
+							pos:        position{line: 1338, col: 5, offset: 36396},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1347, col: 9, offset: 36817},
+							pos:   position{line: 1338, col: 9, offset: 36400},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1347, col: 14, offset: 36822},
+								pos:  position{line: 1338, col: 14, offset: 36405},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1347, col: 25, offset: 36833},
+							pos:        position{line: 1338, col: 25, offset: 36416},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1347, col: 29, offset: 36837},
+							pos: position{line: 1338, col: 29, offset: 36420},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1347, col: 30, offset: 36838},
+								pos:  position{line: 1338, col: 30, offset: 36421},
 								name: "KeyWordStart",
 							},
 						},
@@ -11184,32 +11053,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1349, col: 1, offset: 36873},
+			pos:  position{line: 1340, col: 1, offset: 36456},
 			expr: &actionExpr{
-				pos: position{line: 1350, col: 5, offset: 36888},
+				pos: position{line: 1341, col: 5, offset: 36471},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1350, col: 5, offset: 36888},
+					pos: position{line: 1341, col: 5, offset: 36471},
 					expr: &choiceExpr{
-						pos: position{line: 1350, col: 6, offset: 36889},
+						pos: position{line: 1341, col: 6, offset: 36472},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1350, col: 6, offset: 36889},
+								pos:        position{line: 1341, col: 6, offset: 36472},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1350, col: 15, offset: 36898},
+								pos: position{line: 1341, col: 15, offset: 36481},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1350, col: 15, offset: 36898},
+										pos:        position{line: 1341, col: 15, offset: 36481},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1350, col: 20, offset: 36903,
+										line: 1341, col: 20, offset: 36486,
 									},
 								},
 							},
@@ -11220,9 +11089,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1352, col: 1, offset: 36939},
+			pos:  position{line: 1343, col: 1, offset: 36522},
 			expr: &charClassMatcher{
-				pos:        position{line: 1353, col: 5, offset: 36955},
+				pos:        position{line: 1344, col: 5, offset: 36538},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11232,42 +11101,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1355, col: 1, offset: 36970},
+			pos:  position{line: 1346, col: 1, offset: 36553},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1355, col: 6, offset: 36975},
+				pos: position{line: 1346, col: 6, offset: 36558},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1355, col: 6, offset: 36975},
+					pos:  position{line: 1346, col: 6, offset: 36558},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1357, col: 1, offset: 36986},
+			pos:  position{line: 1348, col: 1, offset: 36569},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1357, col: 6, offset: 36991},
+				pos: position{line: 1348, col: 6, offset: 36574},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1357, col: 6, offset: 36991},
+					pos:  position{line: 1348, col: 6, offset: 36574},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1359, col: 1, offset: 37002},
+			pos:  position{line: 1350, col: 1, offset: 36585},
 			expr: &choiceExpr{
-				pos: position{line: 1360, col: 5, offset: 37015},
+				pos: position{line: 1351, col: 5, offset: 36598},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1360, col: 5, offset: 37015},
+						pos:  position{line: 1351, col: 5, offset: 36598},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1361, col: 5, offset: 37030},
+						pos:  position{line: 1352, col: 5, offset: 36613},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 5, offset: 37049},
+						pos:  position{line: 1353, col: 5, offset: 36632},
 						name: "Comment",
 					},
 				},
@@ -11275,45 +11144,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1364, col: 1, offset: 37058},
+			pos:  position{line: 1355, col: 1, offset: 36641},
 			expr: &anyMatcher{
-				line: 1365, col: 5, offset: 37078,
+				line: 1356, col: 5, offset: 36661,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1367, col: 1, offset: 37081},
+			pos:         position{line: 1358, col: 1, offset: 36664},
 			expr: &choiceExpr{
-				pos: position{line: 1368, col: 5, offset: 37109},
+				pos: position{line: 1359, col: 5, offset: 36692},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1368, col: 5, offset: 37109},
+						pos:        position{line: 1359, col: 5, offset: 36692},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1369, col: 5, offset: 37118},
+						pos:        position{line: 1360, col: 5, offset: 36701},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1370, col: 5, offset: 37127},
+						pos:        position{line: 1361, col: 5, offset: 36710},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1371, col: 5, offset: 37136},
+						pos:        position{line: 1362, col: 5, offset: 36719},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1372, col: 5, offset: 37144},
+						pos:        position{line: 1363, col: 5, offset: 36727},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1373, col: 5, offset: 37157},
+						pos:        position{line: 1364, col: 5, offset: 36740},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11322,9 +11191,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1375, col: 1, offset: 37167},
+			pos:  position{line: 1366, col: 1, offset: 36750},
 			expr: &charClassMatcher{
-				pos:        position{line: 1376, col: 5, offset: 37186},
+				pos:        position{line: 1367, col: 5, offset: 36769},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11334,45 +11203,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1382, col: 1, offset: 37516},
+			pos:         position{line: 1373, col: 1, offset: 37099},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1385, col: 5, offset: 37587},
+				pos:  position{line: 1376, col: 5, offset: 37170},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1387, col: 1, offset: 37606},
+			pos:  position{line: 1378, col: 1, offset: 37189},
 			expr: &seqExpr{
-				pos: position{line: 1388, col: 5, offset: 37627},
+				pos: position{line: 1379, col: 5, offset: 37210},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1388, col: 5, offset: 37627},
+						pos:        position{line: 1379, col: 5, offset: 37210},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1388, col: 10, offset: 37632},
+						pos: position{line: 1379, col: 10, offset: 37215},
 						expr: &seqExpr{
-							pos: position{line: 1388, col: 11, offset: 37633},
+							pos: position{line: 1379, col: 11, offset: 37216},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1388, col: 11, offset: 37633},
+									pos: position{line: 1379, col: 11, offset: 37216},
 									expr: &litMatcher{
-										pos:        position{line: 1388, col: 12, offset: 37634},
+										pos:        position{line: 1379, col: 12, offset: 37217},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1388, col: 17, offset: 37639},
+									pos:  position{line: 1379, col: 17, offset: 37222},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1388, col: 35, offset: 37657},
+						pos:        position{line: 1379, col: 35, offset: 37240},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11381,29 +11250,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1390, col: 1, offset: 37663},
+			pos:  position{line: 1381, col: 1, offset: 37246},
 			expr: &seqExpr{
-				pos: position{line: 1391, col: 5, offset: 37685},
+				pos: position{line: 1382, col: 5, offset: 37268},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1391, col: 5, offset: 37685},
+						pos:        position{line: 1382, col: 5, offset: 37268},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1391, col: 10, offset: 37690},
+						pos: position{line: 1382, col: 10, offset: 37273},
 						expr: &seqExpr{
-							pos: position{line: 1391, col: 11, offset: 37691},
+							pos: position{line: 1382, col: 11, offset: 37274},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1391, col: 11, offset: 37691},
+									pos: position{line: 1382, col: 11, offset: 37274},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1391, col: 12, offset: 37692},
+										pos:  position{line: 1382, col: 12, offset: 37275},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1391, col: 27, offset: 37707},
+									pos:  position{line: 1382, col: 27, offset: 37290},
 									name: "SourceCharacter",
 								},
 							},
@@ -11414,19 +11283,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1393, col: 1, offset: 37726},
+			pos:  position{line: 1384, col: 1, offset: 37309},
 			expr: &seqExpr{
-				pos: position{line: 1393, col: 7, offset: 37732},
+				pos: position{line: 1384, col: 7, offset: 37315},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1393, col: 7, offset: 37732},
+						pos: position{line: 1384, col: 7, offset: 37315},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1393, col: 7, offset: 37732},
+							pos:  position{line: 1384, col: 7, offset: 37315},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1393, col: 19, offset: 37744},
+						pos:  position{line: 1384, col: 19, offset: 37327},
 						name: "LineTerminator",
 					},
 				},
@@ -11434,16 +11303,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1395, col: 1, offset: 37760},
+			pos:  position{line: 1386, col: 1, offset: 37343},
 			expr: &choiceExpr{
-				pos: position{line: 1395, col: 7, offset: 37766},
+				pos: position{line: 1386, col: 7, offset: 37349},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1395, col: 7, offset: 37766},
+						pos:  position{line: 1386, col: 7, offset: 37349},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1395, col: 11, offset: 37770},
+						pos:  position{line: 1386, col: 11, offset: 37353},
 						name: "EOF",
 					},
 				},
@@ -11451,11 +11320,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1397, col: 1, offset: 37775},
+			pos:  position{line: 1388, col: 1, offset: 37358},
 			expr: &notExpr{
-				pos: position{line: 1397, col: 7, offset: 37781},
+				pos: position{line: 1388, col: 7, offset: 37364},
 				expr: &anyMatcher{
-					line: 1397, col: 8, offset: 37782,
+					line: 1388, col: 8, offset: 37365,
 				},
 			},
 		},
@@ -12757,79 +12626,37 @@ func (p *parser) callonMergeProc1() (interface{}, error) {
 	return p.cur.onMergeProc1(stack["expr"])
 }
 
-func (c *current) onOverProc2(over interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Let", "locals": nil, "over": over}, nil
+func (c *current) onOverProc2(exprs, locals, scope interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Let", "locals": locals, "over": map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope}}, nil
 
 }
 
 func (p *parser) callonOverProc2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOverProc2(stack["over"])
+	return p.cur.onOverProc2(stack["exprs"], stack["locals"], stack["scope"])
 }
 
-func (c *current) onOverProc5(exprs interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": nil, "as": ""}, nil
+func (c *current) onOverProc16(exprs, scope interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope}, nil
 
 }
 
-func (p *parser) callonOverProc5() (interface{}, error) {
+func (p *parser) callonOverProc16() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOverProc5(stack["exprs"])
+	return p.cur.onOverProc16(stack["exprs"], stack["scope"])
 }
 
-func (c *current) onScopedOver1(exprs, as, scope interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope, "as": as}, nil
+func (c *current) onOverProc25(exprs interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": nil}, nil
 
 }
 
-func (p *parser) callonScopedOver1() (interface{}, error) {
+func (p *parser) callonOverProc25() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onScopedOver1(stack["exprs"], stack["as"], stack["scope"])
-}
-
-func (c *current) onOverWith1(exprs, locals, scope interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Let", "locals": locals, "over": map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope, "as": ""}}, nil
-
-}
-
-func (p *parser) callonOverWith1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOverWith1(stack["exprs"], stack["locals"], stack["scope"])
-}
-
-func (c *current) onAs2(id interface{}) (interface{}, error) {
-	return id, nil
-}
-
-func (p *parser) callonAs2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onAs2(stack["id"])
-}
-
-func (c *current) onAs9() (interface{}, error) {
-	return "", nil
-}
-
-func (p *parser) callonAs9() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onAs9()
-}
-
-func (c *current) onLetProc2(locals, over interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Let", "locals": locals, "over": over}, nil
-
-}
-
-func (p *parser) callonLetProc2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onLetProc2(stack["locals"], stack["over"])
+	return p.cur.onOverProc25(stack["exprs"])
 }
 
 func (c *current) onScope1(seq interface{}) (interface{}, error) {
@@ -14259,7 +14086,6 @@ func (p *parser) callonTemplateSingleQuotedChar7() (interface{}, error) {
 }
 
 func (c *current) onTemplateExpr1(e interface{}) (interface{}, error) {
-
 	return map[string]interface{}{
 
 		"kind": "Cast",

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -167,6 +167,7 @@ function peg$parse(input, options) {
               
             "expr":{"kind":"TypeValue","value":{"kind":"TypeDef","name":id,"type":typ}}}
           
+
           },
       peg$c14 = "fork",
       peg$c15 = peg$literalExpectation("fork", false),
@@ -585,42 +586,31 @@ function peg$parse(input, options) {
       peg$c251 = function(expr) {
       	  return {"kind":"Merge", "expr":expr}
           },
-      peg$c252 = function(over) {
-            return {"kind":"Let", "locals":null, "over":over}
+      peg$c252 = "over",
+      peg$c253 = peg$literalExpectation("over", false),
+      peg$c254 = function(exprs, locals, scope) {
+            return {"kind":"Let", "locals":locals, "over":{"kind":"Over", "exprs":exprs, "scope":scope}}
           },
-      peg$c253 = "over",
-      peg$c254 = peg$literalExpectation("over", false),
-      peg$c255 = function(exprs) {
-            return {"kind":"Over", "exprs":exprs, "scope":null, "as":""}
+      peg$c255 = function(exprs, scope) {
+            return {"kind":"Over", "exprs":exprs, "scope":scope}
           },
-      peg$c256 = function(exprs, as, scope) {
-            return {"kind":"Over", "exprs":exprs, "scope":scope, "as":as}
+      peg$c256 = function(exprs) {
+            return {"kind":"Over", "exprs":exprs, "scope":null}
           },
-      peg$c257 = function(exprs, locals, scope) {
-            return {"kind":"Let", "locals":locals, "over":{"kind":"Over", "exprs":exprs, "scope":scope, "as":""}}
-          },
-      peg$c258 = "as",
-      peg$c259 = peg$literalExpectation("as", false),
-      peg$c260 = function() { return "" },
-      peg$c261 = "let",
-      peg$c262 = peg$literalExpectation("let", false),
-      peg$c263 = function(locals, over) {
-            return {"kind":"Let", "locals":locals, "over":over}
-          },
-      peg$c264 = function(seq) { return seq },
-      peg$c265 = function(first, a) { return a },
-      peg$c266 = function(id) {
+      peg$c257 = function(seq) { return seq },
+      peg$c258 = function(first, a) { return a },
+      peg$c259 = function(id) {
             return {"name":id, "expr":{"kind":"ID","name":id}}
           },
-      peg$c267 = "yield",
-      peg$c268 = peg$literalExpectation("yield", false),
-      peg$c269 = function(exprs) {
+      peg$c260 = "yield",
+      peg$c261 = peg$literalExpectation("yield", false),
+      peg$c262 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c270 = function(typ) { return typ},
-      peg$c271 = function(lhs) { return lhs },
-      peg$c272 = function(first, lval) { return lval },
-      peg$c273 = function(first, rest) {
+      peg$c263 = function(typ) { return typ},
+      peg$c264 = function(lhs) { return lhs },
+      peg$c265 = function(first, lval) { return lval },
+      peg$c266 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -629,119 +619,119 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c274 = function(first, rest) {
+      peg$c267 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c275 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c276 = "?",
-      peg$c277 = peg$literalExpectation("?", false),
-      peg$c278 = function(condition, thenClause, elseClause) {
+      peg$c268 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c269 = "?",
+      peg$c270 = peg$literalExpectation("?", false),
+      peg$c271 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c279 = function(first, op, expr) { return [op, expr] },
-      peg$c280 = function(first, rest) {
+      peg$c272 = function(first, op, expr) { return [op, expr] },
+      peg$c273 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c281 = function(lhs, op, rhs) {
+      peg$c274 = function(lhs, op, rhs) {
               return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c282 = function(lhs, rhs) {
+      peg$c275 = function(lhs, rhs) {
               return {"kind": "BinaryExpr", "op": "~", "lhs": lhs, "rhs": rhs}
           },
-      peg$c283 = "+",
-      peg$c284 = peg$literalExpectation("+", false),
-      peg$c285 = "-",
-      peg$c286 = peg$literalExpectation("-", false),
-      peg$c287 = "/",
-      peg$c288 = peg$literalExpectation("/", false),
-      peg$c289 = "%",
-      peg$c290 = peg$literalExpectation("%", false),
-      peg$c291 = function(e) {
+      peg$c276 = "+",
+      peg$c277 = peg$literalExpectation("+", false),
+      peg$c278 = "-",
+      peg$c279 = peg$literalExpectation("-", false),
+      peg$c280 = "/",
+      peg$c281 = peg$literalExpectation("/", false),
+      peg$c282 = "%",
+      peg$c283 = peg$literalExpectation("%", false),
+      peg$c284 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c292 = function(e) {
+      peg$c285 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c293 = "not",
-      peg$c294 = peg$literalExpectation("not", false),
-      peg$c295 = "select",
-      peg$c296 = peg$literalExpectation("select", false),
-      peg$c297 = function(typ, expr) {
+      peg$c286 = "not",
+      peg$c287 = peg$literalExpectation("not", false),
+      peg$c288 = "select",
+      peg$c289 = peg$literalExpectation("select", false),
+      peg$c290 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c298 = function(fn, args, where) {
+      peg$c291 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c299 = "grep",
-      peg$c300 = peg$literalExpectation("grep", false),
-      peg$c301 = function(pattern) {
+      peg$c292 = "grep",
+      peg$c293 = peg$literalExpectation("grep", false),
+      peg$c294 = function(pattern) {
             return {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
           },
-      peg$c302 = function(pattern, expr) {
+      peg$c295 = function(pattern, expr) {
             return {"kind": "Grep", "pattern": pattern, "expr": expr}
           },
-      peg$c303 = function(s) {
+      peg$c296 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c304 = function(first, e) { return e },
-      peg$c305 = "]",
-      peg$c306 = peg$literalExpectation("]", false),
-      peg$c307 = function(from, to) {
+      peg$c297 = function(first, e) { return e },
+      peg$c298 = "]",
+      peg$c299 = peg$literalExpectation("]", false),
+      peg$c300 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c308 = function(to) {
+      peg$c301 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c309 = function(from) {
+      peg$c302 = function(from) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c310 = function(expr) { return ["[", expr] },
-      peg$c311 = function(id) { return [".", id] },
-      peg$c312 = "}",
-      peg$c313 = peg$literalExpectation("}", false),
-      peg$c314 = function(elems) {
+      peg$c303 = function(expr) { return ["[", expr] },
+      peg$c304 = function(id) { return [".", id] },
+      peg$c305 = "}",
+      peg$c306 = peg$literalExpectation("}", false),
+      peg$c307 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c315 = function(elem) { return elem },
-      peg$c316 = "...",
-      peg$c317 = peg$literalExpectation("...", false),
-      peg$c318 = function(expr) {
+      peg$c308 = function(elem) { return elem },
+      peg$c309 = "...",
+      peg$c310 = peg$literalExpectation("...", false),
+      peg$c311 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c319 = function(name, value) {
+      peg$c312 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c320 = function(exprs) {
+      peg$c313 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c321 = "|[",
-      peg$c322 = peg$literalExpectation("|[", false),
-      peg$c323 = "]|",
-      peg$c324 = peg$literalExpectation("]|", false),
-      peg$c325 = function(exprs) {
+      peg$c314 = "|[",
+      peg$c315 = peg$literalExpectation("|[", false),
+      peg$c316 = "]|",
+      peg$c317 = peg$literalExpectation("]|", false),
+      peg$c318 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c326 = "|{",
-      peg$c327 = peg$literalExpectation("|{", false),
-      peg$c328 = "}|",
-      peg$c329 = peg$literalExpectation("}|", false),
-      peg$c330 = function(exprs) {
+      peg$c319 = "|{",
+      peg$c320 = peg$literalExpectation("|{", false),
+      peg$c321 = "}|",
+      peg$c322 = peg$literalExpectation("}|", false),
+      peg$c323 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c331 = function(e) { return e },
-      peg$c332 = function(key, value) {
+      peg$c324 = function(e) { return e },
+      peg$c325 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c333 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c326 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -763,13 +753,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c334 = function(assignments) { return assignments },
-      peg$c335 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c336 = function(table, alias) {
+      peg$c327 = function(assignments) { return assignments },
+      peg$c328 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c329 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c337 = function(first, join) { return join },
-      peg$c338 = function(style, table, alias, leftKey, rightKey) {
+      peg$c330 = function(first, join) { return join },
+      peg$c331 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -782,117 +772,122 @@ function peg$parse(input, options) {
               
             "alias": alias}
           
+
+
+
+
           },
-      peg$c339 = function(style) { return style },
-      peg$c340 = function(keys, order) {
+      peg$c332 = function(style) { return style },
+      peg$c333 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c341 = function(dir) { return dir },
-      peg$c342 = function(count) { return count },
-      peg$c343 = peg$literalExpectation("select", true),
-      peg$c344 = function() { return "select" },
-      peg$c345 = peg$literalExpectation("as", true),
-      peg$c346 = function() { return "as" },
-      peg$c347 = peg$literalExpectation("from", true),
-      peg$c348 = function() { return "from" },
-      peg$c349 = peg$literalExpectation("join", true),
-      peg$c350 = function() { return "join" },
-      peg$c351 = peg$literalExpectation("where", true),
-      peg$c352 = function() { return "where" },
-      peg$c353 = "group",
-      peg$c354 = peg$literalExpectation("group", true),
-      peg$c355 = function() { return "group" },
-      peg$c356 = "by",
-      peg$c357 = peg$literalExpectation("by", true),
-      peg$c358 = function() { return "by" },
-      peg$c359 = "having",
-      peg$c360 = peg$literalExpectation("having", true),
-      peg$c361 = function() { return "having" },
-      peg$c362 = peg$literalExpectation("order", true),
-      peg$c363 = function() { return "order" },
-      peg$c364 = "on",
-      peg$c365 = peg$literalExpectation("on", true),
-      peg$c366 = function() { return "on" },
-      peg$c367 = "limit",
-      peg$c368 = peg$literalExpectation("limit", true),
-      peg$c369 = function() { return "limit" },
-      peg$c370 = peg$literalExpectation("asc", true),
-      peg$c371 = peg$literalExpectation("desc", true),
-      peg$c372 = peg$literalExpectation("anti", true),
-      peg$c373 = peg$literalExpectation("left", true),
-      peg$c374 = peg$literalExpectation("right", true),
-      peg$c375 = peg$literalExpectation("inner", true),
-      peg$c376 = function(v) {
+      peg$c334 = function(dir) { return dir },
+      peg$c335 = function(count) { return count },
+      peg$c336 = peg$literalExpectation("select", true),
+      peg$c337 = function() { return "select" },
+      peg$c338 = "as",
+      peg$c339 = peg$literalExpectation("as", true),
+      peg$c340 = function() { return "as" },
+      peg$c341 = peg$literalExpectation("from", true),
+      peg$c342 = function() { return "from" },
+      peg$c343 = peg$literalExpectation("join", true),
+      peg$c344 = function() { return "join" },
+      peg$c345 = peg$literalExpectation("where", true),
+      peg$c346 = function() { return "where" },
+      peg$c347 = "group",
+      peg$c348 = peg$literalExpectation("group", true),
+      peg$c349 = function() { return "group" },
+      peg$c350 = "by",
+      peg$c351 = peg$literalExpectation("by", true),
+      peg$c352 = function() { return "by" },
+      peg$c353 = "having",
+      peg$c354 = peg$literalExpectation("having", true),
+      peg$c355 = function() { return "having" },
+      peg$c356 = peg$literalExpectation("order", true),
+      peg$c357 = function() { return "order" },
+      peg$c358 = "on",
+      peg$c359 = peg$literalExpectation("on", true),
+      peg$c360 = function() { return "on" },
+      peg$c361 = "limit",
+      peg$c362 = peg$literalExpectation("limit", true),
+      peg$c363 = function() { return "limit" },
+      peg$c364 = peg$literalExpectation("asc", true),
+      peg$c365 = peg$literalExpectation("desc", true),
+      peg$c366 = peg$literalExpectation("anti", true),
+      peg$c367 = peg$literalExpectation("left", true),
+      peg$c368 = peg$literalExpectation("right", true),
+      peg$c369 = peg$literalExpectation("inner", true),
+      peg$c370 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c377 = function(v) {
+      peg$c371 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c378 = function(v) {
+      peg$c372 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c379 = function(v) {
+      peg$c373 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c380 = "true",
-      peg$c381 = peg$literalExpectation("true", false),
-      peg$c382 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c383 = "false",
-      peg$c384 = peg$literalExpectation("false", false),
-      peg$c385 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c386 = "null",
-      peg$c387 = peg$literalExpectation("null", false),
-      peg$c388 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c389 = "0x",
-      peg$c390 = peg$literalExpectation("0x", false),
-      peg$c391 = function() {
+      peg$c374 = "true",
+      peg$c375 = peg$literalExpectation("true", false),
+      peg$c376 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c377 = "false",
+      peg$c378 = peg$literalExpectation("false", false),
+      peg$c379 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c380 = "null",
+      peg$c381 = peg$literalExpectation("null", false),
+      peg$c382 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c383 = "0x",
+      peg$c384 = peg$literalExpectation("0x", false),
+      peg$c385 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c392 = function(typ) {
+      peg$c386 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c393 = function(name) { return name },
-      peg$c394 = function(name, typ) {
+      peg$c387 = function(name) { return name },
+      peg$c388 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c395 = function(name) {
+      peg$c389 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c396 = function(u) { return u },
-      peg$c397 = function(types) {
+      peg$c390 = function(u) { return u },
+      peg$c391 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c398 = function(typ) { return typ },
-      peg$c399 = function(fields) {
+      peg$c392 = function(typ) { return typ },
+      peg$c393 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c400 = function(typ) {
+      peg$c394 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c401 = function(typ) {
+      peg$c395 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c402 = function(keyType, valType) {
+      peg$c396 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c403 = function(v) {
+      peg$c397 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c404 = "\"",
-      peg$c405 = peg$literalExpectation("\"", false),
-      peg$c406 = "'",
-      peg$c407 = peg$literalExpectation("'", false),
-      peg$c408 = function(v) {
+      peg$c398 = "\"",
+      peg$c399 = peg$literalExpectation("\"", false),
+      peg$c400 = "'",
+      peg$c401 = peg$literalExpectation("'", false),
+      peg$c402 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c409 = "\\",
-      peg$c410 = peg$literalExpectation("\\", false),
-      peg$c411 = "${",
-      peg$c412 = peg$literalExpectation("${", false),
-      peg$c413 = function(e) { 
+      peg$c403 = "\\",
+      peg$c404 = peg$literalExpectation("\\", false),
+      peg$c405 = "${",
+      peg$c406 = peg$literalExpectation("${", false),
+      peg$c407 = function(e) {
             return {
               
             "kind": "Cast",
@@ -905,197 +900,201 @@ function peg$parse(input, options) {
                 
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
+
+
+
+
           },
-      peg$c414 = "uint8",
-      peg$c415 = peg$literalExpectation("uint8", false),
-      peg$c416 = "uint16",
-      peg$c417 = peg$literalExpectation("uint16", false),
-      peg$c418 = "uint32",
-      peg$c419 = peg$literalExpectation("uint32", false),
-      peg$c420 = "uint64",
-      peg$c421 = peg$literalExpectation("uint64", false),
-      peg$c422 = "int8",
-      peg$c423 = peg$literalExpectation("int8", false),
-      peg$c424 = "int16",
-      peg$c425 = peg$literalExpectation("int16", false),
-      peg$c426 = "int32",
-      peg$c427 = peg$literalExpectation("int32", false),
-      peg$c428 = "int64",
-      peg$c429 = peg$literalExpectation("int64", false),
-      peg$c430 = "float32",
-      peg$c431 = peg$literalExpectation("float32", false),
-      peg$c432 = "float64",
-      peg$c433 = peg$literalExpectation("float64", false),
-      peg$c434 = "bool",
-      peg$c435 = peg$literalExpectation("bool", false),
-      peg$c436 = "string",
-      peg$c437 = peg$literalExpectation("string", false),
-      peg$c438 = "duration",
-      peg$c439 = peg$literalExpectation("duration", false),
-      peg$c440 = "time",
-      peg$c441 = peg$literalExpectation("time", false),
-      peg$c442 = "bytes",
-      peg$c443 = peg$literalExpectation("bytes", false),
-      peg$c444 = "ip",
-      peg$c445 = peg$literalExpectation("ip", false),
-      peg$c446 = "net",
-      peg$c447 = peg$literalExpectation("net", false),
-      peg$c448 = function() {
+      peg$c408 = "uint8",
+      peg$c409 = peg$literalExpectation("uint8", false),
+      peg$c410 = "uint16",
+      peg$c411 = peg$literalExpectation("uint16", false),
+      peg$c412 = "uint32",
+      peg$c413 = peg$literalExpectation("uint32", false),
+      peg$c414 = "uint64",
+      peg$c415 = peg$literalExpectation("uint64", false),
+      peg$c416 = "int8",
+      peg$c417 = peg$literalExpectation("int8", false),
+      peg$c418 = "int16",
+      peg$c419 = peg$literalExpectation("int16", false),
+      peg$c420 = "int32",
+      peg$c421 = peg$literalExpectation("int32", false),
+      peg$c422 = "int64",
+      peg$c423 = peg$literalExpectation("int64", false),
+      peg$c424 = "float32",
+      peg$c425 = peg$literalExpectation("float32", false),
+      peg$c426 = "float64",
+      peg$c427 = peg$literalExpectation("float64", false),
+      peg$c428 = "bool",
+      peg$c429 = peg$literalExpectation("bool", false),
+      peg$c430 = "string",
+      peg$c431 = peg$literalExpectation("string", false),
+      peg$c432 = "duration",
+      peg$c433 = peg$literalExpectation("duration", false),
+      peg$c434 = "time",
+      peg$c435 = peg$literalExpectation("time", false),
+      peg$c436 = "bytes",
+      peg$c437 = peg$literalExpectation("bytes", false),
+      peg$c438 = "ip",
+      peg$c439 = peg$literalExpectation("ip", false),
+      peg$c440 = "net",
+      peg$c441 = peg$literalExpectation("net", false),
+      peg$c442 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c449 = function(name, typ) {
+      peg$c443 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c450 = "and",
-      peg$c451 = peg$literalExpectation("and", false),
-      peg$c452 = "AND",
-      peg$c453 = peg$literalExpectation("AND", false),
-      peg$c454 = function() { return "and" },
-      peg$c455 = "or",
-      peg$c456 = peg$literalExpectation("or", false),
-      peg$c457 = "OR",
-      peg$c458 = peg$literalExpectation("OR", false),
-      peg$c459 = function() { return "or" },
-      peg$c460 = function() { return "in" },
-      peg$c461 = "NOT",
-      peg$c462 = peg$literalExpectation("NOT", false),
-      peg$c463 = function() { return "not" },
-      peg$c464 = peg$literalExpectation("by", false),
-      peg$c465 = /^[A-Za-z_$]/,
-      peg$c466 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c467 = /^[0-9]/,
-      peg$c468 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c469 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c470 = "$",
-      peg$c471 = peg$literalExpectation("$", false),
-      peg$c472 = "T",
-      peg$c473 = peg$literalExpectation("T", false),
-      peg$c474 = function() {
+      peg$c444 = "and",
+      peg$c445 = peg$literalExpectation("and", false),
+      peg$c446 = "AND",
+      peg$c447 = peg$literalExpectation("AND", false),
+      peg$c448 = function() { return "and" },
+      peg$c449 = "or",
+      peg$c450 = peg$literalExpectation("or", false),
+      peg$c451 = "OR",
+      peg$c452 = peg$literalExpectation("OR", false),
+      peg$c453 = function() { return "or" },
+      peg$c454 = function() { return "in" },
+      peg$c455 = "NOT",
+      peg$c456 = peg$literalExpectation("NOT", false),
+      peg$c457 = function() { return "not" },
+      peg$c458 = peg$literalExpectation("by", false),
+      peg$c459 = /^[A-Za-z_$]/,
+      peg$c460 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c461 = /^[0-9]/,
+      peg$c462 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c463 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c464 = "$",
+      peg$c465 = peg$literalExpectation("$", false),
+      peg$c466 = "T",
+      peg$c467 = peg$literalExpectation("T", false),
+      peg$c468 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c475 = "Z",
-      peg$c476 = peg$literalExpectation("Z", false),
-      peg$c477 = function() {
+      peg$c469 = "Z",
+      peg$c470 = peg$literalExpectation("Z", false),
+      peg$c471 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c478 = "ns",
-      peg$c479 = peg$literalExpectation("ns", false),
-      peg$c480 = "us",
-      peg$c481 = peg$literalExpectation("us", false),
-      peg$c482 = "ms",
-      peg$c483 = peg$literalExpectation("ms", false),
-      peg$c484 = "s",
-      peg$c485 = peg$literalExpectation("s", false),
-      peg$c486 = "m",
-      peg$c487 = peg$literalExpectation("m", false),
-      peg$c488 = "h",
-      peg$c489 = peg$literalExpectation("h", false),
-      peg$c490 = "d",
-      peg$c491 = peg$literalExpectation("d", false),
-      peg$c492 = "w",
-      peg$c493 = peg$literalExpectation("w", false),
-      peg$c494 = "y",
-      peg$c495 = peg$literalExpectation("y", false),
-      peg$c496 = function(a, b) {
+      peg$c472 = "ns",
+      peg$c473 = peg$literalExpectation("ns", false),
+      peg$c474 = "us",
+      peg$c475 = peg$literalExpectation("us", false),
+      peg$c476 = "ms",
+      peg$c477 = peg$literalExpectation("ms", false),
+      peg$c478 = "s",
+      peg$c479 = peg$literalExpectation("s", false),
+      peg$c480 = "m",
+      peg$c481 = peg$literalExpectation("m", false),
+      peg$c482 = "h",
+      peg$c483 = peg$literalExpectation("h", false),
+      peg$c484 = "d",
+      peg$c485 = peg$literalExpectation("d", false),
+      peg$c486 = "w",
+      peg$c487 = peg$literalExpectation("w", false),
+      peg$c488 = "y",
+      peg$c489 = peg$literalExpectation("y", false),
+      peg$c490 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c497 = "::",
-      peg$c498 = peg$literalExpectation("::", false),
-      peg$c499 = function(a, b, d, e) {
+      peg$c491 = "::",
+      peg$c492 = peg$literalExpectation("::", false),
+      peg$c493 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c500 = function(a, b) {
+      peg$c494 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c501 = function(a, b) {
+      peg$c495 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c502 = function() {
+      peg$c496 = function() {
             return "::"
           },
-      peg$c503 = function(v) { return ":" + v },
-      peg$c504 = function(v) { return v + ":" },
-      peg$c505 = function(a, m) {
+      peg$c497 = function(v) { return ":" + v },
+      peg$c498 = function(v) { return v + ":" },
+      peg$c499 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c506 = function(a, m) {
+      peg$c500 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c507 = function(s) { return parseInt(s) },
-      peg$c508 = function() {
+      peg$c501 = function(s) { return parseInt(s) },
+      peg$c502 = function() {
             return text()
           },
-      peg$c509 = "e",
-      peg$c510 = peg$literalExpectation("e", true),
-      peg$c511 = /^[+\-]/,
-      peg$c512 = peg$classExpectation(["+", "-"], false, false),
-      peg$c513 = "NaN",
-      peg$c514 = peg$literalExpectation("NaN", false),
-      peg$c515 = "Inf",
-      peg$c516 = peg$literalExpectation("Inf", false),
-      peg$c517 = /^[0-9a-fA-F]/,
-      peg$c518 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c519 = function(v) { return joinChars(v) },
-      peg$c520 = peg$anyExpectation(),
-      peg$c521 = function(head, tail) { return head + joinChars(tail) },
-      peg$c522 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c523 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c524 = function(head, tail) {
+      peg$c503 = "e",
+      peg$c504 = peg$literalExpectation("e", true),
+      peg$c505 = /^[+\-]/,
+      peg$c506 = peg$classExpectation(["+", "-"], false, false),
+      peg$c507 = "NaN",
+      peg$c508 = peg$literalExpectation("NaN", false),
+      peg$c509 = "Inf",
+      peg$c510 = peg$literalExpectation("Inf", false),
+      peg$c511 = /^[0-9a-fA-F]/,
+      peg$c512 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c513 = function(v) { return joinChars(v) },
+      peg$c514 = peg$anyExpectation(),
+      peg$c515 = function(head, tail) { return head + joinChars(tail) },
+      peg$c516 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c517 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c518 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c525 = function() { return "*"},
-      peg$c526 = function() { return "=" },
-      peg$c527 = function() { return "\\*" },
-      peg$c528 = "b",
-      peg$c529 = peg$literalExpectation("b", false),
-      peg$c530 = function() { return "\b" },
-      peg$c531 = "f",
-      peg$c532 = peg$literalExpectation("f", false),
-      peg$c533 = function() { return "\f" },
-      peg$c534 = "n",
-      peg$c535 = peg$literalExpectation("n", false),
-      peg$c536 = function() { return "\n" },
-      peg$c537 = "r",
-      peg$c538 = peg$literalExpectation("r", false),
-      peg$c539 = function() { return "\r" },
-      peg$c540 = "t",
-      peg$c541 = peg$literalExpectation("t", false),
-      peg$c542 = function() { return "\t" },
-      peg$c543 = "v",
-      peg$c544 = peg$literalExpectation("v", false),
-      peg$c545 = function() { return "\v" },
-      peg$c546 = function() { return "*" },
-      peg$c547 = "u",
-      peg$c548 = peg$literalExpectation("u", false),
-      peg$c549 = function(chars) {
+      peg$c519 = function() { return "*"},
+      peg$c520 = function() { return "=" },
+      peg$c521 = function() { return "\\*" },
+      peg$c522 = "b",
+      peg$c523 = peg$literalExpectation("b", false),
+      peg$c524 = function() { return "\b" },
+      peg$c525 = "f",
+      peg$c526 = peg$literalExpectation("f", false),
+      peg$c527 = function() { return "\f" },
+      peg$c528 = "n",
+      peg$c529 = peg$literalExpectation("n", false),
+      peg$c530 = function() { return "\n" },
+      peg$c531 = "r",
+      peg$c532 = peg$literalExpectation("r", false),
+      peg$c533 = function() { return "\r" },
+      peg$c534 = "t",
+      peg$c535 = peg$literalExpectation("t", false),
+      peg$c536 = function() { return "\t" },
+      peg$c537 = "v",
+      peg$c538 = peg$literalExpectation("v", false),
+      peg$c539 = function() { return "\v" },
+      peg$c540 = function() { return "*" },
+      peg$c541 = "u",
+      peg$c542 = peg$literalExpectation("u", false),
+      peg$c543 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c550 = /^[^\/\\]/,
-      peg$c551 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c552 = /^[\0-\x1F\\]/,
-      peg$c553 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c554 = peg$otherExpectation("whitespace"),
-      peg$c555 = "\t",
-      peg$c556 = peg$literalExpectation("\t", false),
-      peg$c557 = "\x0B",
-      peg$c558 = peg$literalExpectation("\x0B", false),
-      peg$c559 = "\f",
-      peg$c560 = peg$literalExpectation("\f", false),
-      peg$c561 = " ",
-      peg$c562 = peg$literalExpectation(" ", false),
-      peg$c563 = "\xA0",
-      peg$c564 = peg$literalExpectation("\xA0", false),
-      peg$c565 = "\uFEFF",
-      peg$c566 = peg$literalExpectation("\uFEFF", false),
-      peg$c567 = /^[\n\r\u2028\u2029]/,
-      peg$c568 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c569 = peg$otherExpectation("comment"),
-      peg$c570 = "/*",
-      peg$c571 = peg$literalExpectation("/*", false),
-      peg$c572 = "*/",
-      peg$c573 = peg$literalExpectation("*/", false),
-      peg$c574 = "//",
-      peg$c575 = peg$literalExpectation("//", false),
+      peg$c544 = /^[^\/\\]/,
+      peg$c545 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c546 = /^[\0-\x1F\\]/,
+      peg$c547 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c548 = peg$otherExpectation("whitespace"),
+      peg$c549 = "\t",
+      peg$c550 = peg$literalExpectation("\t", false),
+      peg$c551 = "\x0B",
+      peg$c552 = peg$literalExpectation("\x0B", false),
+      peg$c553 = "\f",
+      peg$c554 = peg$literalExpectation("\f", false),
+      peg$c555 = " ",
+      peg$c556 = peg$literalExpectation(" ", false),
+      peg$c557 = "\xA0",
+      peg$c558 = peg$literalExpectation("\xA0", false),
+      peg$c559 = "\uFEFF",
+      peg$c560 = peg$literalExpectation("\uFEFF", false),
+      peg$c561 = /^[\n\r\u2028\u2029]/,
+      peg$c562 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c563 = peg$otherExpectation("comment"),
+      peg$c564 = "/*",
+      peg$c565 = peg$literalExpectation("/*", false),
+      peg$c566 = "*/",
+      peg$c567 = peg$literalExpectation("*/", false),
+      peg$c568 = "//",
+      peg$c569 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -3800,14 +3799,11 @@ function peg$parse(input, options) {
                                     if (s0 === peg$FAILED) {
                                       s0 = peg$parseExplodeProc();
                                       if (s0 === peg$FAILED) {
-                                        s0 = peg$parseLetProc();
+                                        s0 = peg$parseMergeProc();
                                         if (s0 === peg$FAILED) {
-                                          s0 = peg$parseMergeProc();
+                                          s0 = peg$parseOverProc();
                                           if (s0 === peg$FAILED) {
-                                            s0 = peg$parseOverProc();
-                                            if (s0 === peg$FAILED) {
-                                              s0 = peg$parseYieldProc();
-                                            }
+                                            s0 = peg$parseYieldProc();
                                           }
                                         }
                                       }
@@ -6010,112 +6006,15 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOverProc() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseScopedOver();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c252(s1);
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c253) {
-        s1 = peg$c253;
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c254); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseExprs();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c255(s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseScopedOver() {
-    var s0, s1, s2, s3, s4, s5, s6;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c253) {
-      s1 = peg$c253;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseExprs();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseAs();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parse__();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseScope();
-              if (s6 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c256(s3, s4, s6);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseOverWith() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c253) {
-      s1 = peg$c253;
+    if (input.substr(peg$currPos, 4) === peg$c252) {
+      s1 = peg$c252;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6141,7 +6040,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseScope();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c257(s3, s7, s9);
+                      s1 = peg$c254(s3, s7, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6179,83 +6078,31 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-
-    return s0;
-  }
-
-  function peg$parseAs() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse_();
-    if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c258) {
-        s2 = peg$c258;
-        peg$currPos += 2;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c259); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseIdentifierName();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c212(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c260();
+      if (input.substr(peg$currPos, 4) === peg$c252) {
+        s1 = peg$c252;
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c253); }
       }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseLetProc() {
-    var s0, s1, s2, s3, s4, s5;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c261) {
-      s1 = peg$c261;
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c262); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseLetAssignments();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseScopedOver();
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c263(s3, s5);
-              s0 = s1;
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseExprs();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseScope();
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c255(s3, s5);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -6272,12 +6119,36 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseOverWith();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 4) === peg$c252) {
+          s1 = peg$c252;
+          peg$currPos += 4;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c253); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parse_();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parseExprs();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c256(s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
     }
 
     return s0;
@@ -6320,7 +6191,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c264(s5);
+                  s1 = peg$c257(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6377,7 +6248,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLetAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c265(s1, s7);
+              s4 = peg$c258(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6413,7 +6284,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLetAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c265(s1, s7);
+                s4 = peg$c258(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6496,7 +6367,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIdentifierName();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1);
+        s1 = peg$c259(s1);
       }
       s0 = s1;
     }
@@ -6508,12 +6379,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c267) {
-      s1 = peg$c267;
+    if (input.substr(peg$currPos, 5) === peg$c260) {
+      s1 = peg$c260;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c261); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6521,7 +6392,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c269(s3);
+          s1 = peg$c262(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6552,7 +6423,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c270(s4);
+            s1 = peg$c263(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6587,7 +6458,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c271(s4);
+            s1 = peg$c264(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6632,7 +6503,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s7);
+              s4 = peg$c265(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6668,7 +6539,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s7);
+                s4 = peg$c265(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6781,7 +6652,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6818,7 +6689,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c265(s1, s7);
+              s4 = peg$c258(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6854,7 +6725,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c265(s1, s7);
+                s4 = peg$c258(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6875,7 +6746,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6910,7 +6781,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c275(s1, s5);
+              s1 = peg$c268(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6953,11 +6824,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c276;
+          s3 = peg$c269;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6979,7 +6850,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c278(s1, s5, s9);
+                      s1 = peg$c271(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7041,7 +6912,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c279(s1, s5, s7);
+              s4 = peg$c272(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7071,7 +6942,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c279(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7092,7 +6963,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7123,7 +6994,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c279(s1, s5, s7);
+              s4 = peg$c272(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7153,7 +7024,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c279(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7174,7 +7045,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7203,7 +7074,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAdditiveExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c281(s1, s3, s5);
+              s1 = peg$c274(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7244,7 +7115,7 @@ function peg$parse(input, options) {
               s5 = peg$parseRegexp();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c282(s1, s5);
+                s1 = peg$c275(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7291,7 +7162,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c279(s1, s5, s7);
+              s4 = peg$c272(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7321,7 +7192,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c279(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7342,7 +7213,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7361,19 +7232,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c283;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c285;
+        s1 = peg$c278;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c286); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7402,7 +7273,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c279(s1, s5, s7);
+              s4 = peg$c272(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7432,7 +7303,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c279(s1, s5, s7);
+                s4 = peg$c272(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7453,7 +7324,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7480,19 +7351,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c287;
+        s1 = peg$c280;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c281); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c289;
+          s1 = peg$c282;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c290); }
+          if (peg$silentFails === 0) { peg$fail(peg$c283); }
         }
       }
     }
@@ -7522,7 +7393,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c291(s3);
+          s1 = peg$c284(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7559,11 +7430,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c285;
+        s2 = peg$c278;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c286); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7571,7 +7442,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c292(s4);
+            s1 = peg$c285(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7690,20 +7561,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c293) {
-      s0 = peg$c293;
+    if (input.substr(peg$currPos, 3) === peg$c286) {
+      s0 = peg$c286;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c287); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c295) {
-        s0 = peg$c295;
+      if (input.substr(peg$currPos, 6) === peg$c288) {
+        s0 = peg$c288;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c296); }
+        if (peg$silentFails === 0) { peg$fail(peg$c289); }
       }
     }
 
@@ -7741,7 +7612,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c297(s1, s5);
+                  s1 = peg$c290(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7824,7 +7695,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c298(s2, s6, s9);
+                        s1 = peg$c291(s2, s6, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7871,12 +7742,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c299) {
-      s1 = peg$c299;
+    if (input.substr(peg$currPos, 4) === peg$c292) {
+      s1 = peg$c292;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
+      if (peg$silentFails === 0) { peg$fail(peg$c293); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7904,7 +7775,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c301(s5);
+                  s1 = peg$c294(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7936,12 +7807,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c299) {
-        s1 = peg$c299;
+      if (input.substr(peg$currPos, 4) === peg$c292) {
+        s1 = peg$c292;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c300); }
+        if (peg$silentFails === 0) { peg$fail(peg$c293); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7983,7 +7854,7 @@ function peg$parse(input, options) {
                           }
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c302(s5, s9);
+                            s1 = peg$c295(s5, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -8045,7 +7916,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c303(s1);
+          s1 = peg$c296(s1);
         }
         s0 = s1;
       }
@@ -8094,7 +7965,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c304(s1, s7);
+              s4 = peg$c297(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8130,7 +8001,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c304(s1, s7);
+                s4 = peg$c297(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8237,15 +8108,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c305;
+                  s7 = peg$c298;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c307(s2, s6);
+                  s1 = peg$c300(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8300,15 +8171,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c305;
+                  s6 = peg$c298;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c308(s5);
+                  s1 = peg$c301(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8359,15 +8230,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c305;
+                    s6 = peg$c298;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c299); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c309(s2);
+                    s1 = peg$c302(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8406,15 +8277,15 @@ function peg$parse(input, options) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c305;
+                s3 = peg$c298;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                if (peg$silentFails === 0) { peg$fail(peg$c299); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c310(s2);
+                s1 = peg$c303(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8441,7 +8312,7 @@ function peg$parse(input, options) {
               s2 = peg$parseIdentifier();
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c311(s2);
+                s1 = peg$c304(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8546,15 +8417,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c312;
+              s5 = peg$c305;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314(s3);
+              s1 = peg$c307(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8594,7 +8465,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8636,7 +8507,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c315(s4);
+            s1 = peg$c308(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8676,12 +8547,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c316) {
-      s1 = peg$c316;
+    if (input.substr(peg$currPos, 3) === peg$c309) {
+      s1 = peg$c309;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c310); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8689,7 +8560,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c318(s3);
+          s1 = peg$c311(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8728,7 +8599,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319(s1, s5);
+              s1 = peg$c312(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8773,15 +8644,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c305;
+              s5 = peg$c298;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c299); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s3);
+              s1 = peg$c313(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8811,12 +8682,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c321) {
-      s1 = peg$c321;
+    if (input.substr(peg$currPos, 2) === peg$c314) {
+      s1 = peg$c314;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8825,16 +8696,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c323) {
-              s5 = peg$c323;
+            if (input.substr(peg$currPos, 2) === peg$c316) {
+              s5 = peg$c316;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c324); }
+              if (peg$silentFails === 0) { peg$fail(peg$c317); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c325(s3);
+              s1 = peg$c318(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8864,12 +8735,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c326) {
-      s1 = peg$c326;
+    if (input.substr(peg$currPos, 2) === peg$c319) {
+      s1 = peg$c319;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8878,16 +8749,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c328) {
-              s5 = peg$c328;
+            if (input.substr(peg$currPos, 2) === peg$c321) {
+              s5 = peg$c321;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c329); }
+              if (peg$silentFails === 0) { peg$fail(peg$c322); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s3);
+              s1 = peg$c323(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8927,7 +8798,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8969,7 +8840,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c331(s4);
+            s1 = peg$c324(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9012,7 +8883,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c332(s1, s5);
+              s1 = peg$c325(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9077,7 +8948,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c333(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c326(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9155,7 +9026,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334(s3);
+            s1 = peg$c327(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9189,7 +9060,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c335(s1, s5);
+              s1 = peg$c328(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9336,7 +9207,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c336(s4, s5);
+              s1 = peg$c329(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9491,7 +9362,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c337(s1, s4);
+        s4 = peg$c330(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9500,7 +9371,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c337(s1, s4);
+          s4 = peg$c330(s1, s4);
         }
         s3 = s4;
       }
@@ -9562,7 +9433,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c338(s1, s5, s6, s10, s14);
+                                s1 = peg$c331(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9642,7 +9513,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c339(s2);
+        s1 = peg$c332(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9801,7 +9672,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c340(s6, s7);
+                  s1 = peg$c333(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9847,7 +9718,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c341(s2);
+        s1 = peg$c334(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9883,7 +9754,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c342(s4);
+            s1 = peg$c335(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9918,16 +9789,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c295) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c288) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c336); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c344();
+      s1 = peg$c337();
     }
     s0 = s1;
 
@@ -9938,16 +9809,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c258) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c338) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+      if (peg$silentFails === 0) { peg$fail(peg$c339); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c346();
+      s1 = peg$c340();
     }
     s0 = s1;
 
@@ -9963,11 +9834,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -9983,11 +9854,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -10003,6 +9874,46 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c346();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseGROUP() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c347) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c349();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseBY() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c350) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c351); }
     }
     if (s1 !== peg$FAILED) {
@@ -10014,13 +9925,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseGROUP() {
+  function peg$parseHAVING() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c353) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c353) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c354); }
@@ -10028,46 +9939,6 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
       s1 = peg$c355();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseBY() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c356) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c358();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseHAVING() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c359) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10083,11 +9954,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c362); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c363();
+      s1 = peg$c357();
     }
     s0 = s1;
 
@@ -10098,16 +9969,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c364) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c358) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c359); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c366();
+      s1 = peg$c360();
     }
     s0 = s1;
 
@@ -10118,16 +9989,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c367) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c361) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c362); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c369();
+      s1 = peg$c363();
     }
     s0 = s1;
 
@@ -10143,7 +10014,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10163,7 +10034,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10183,7 +10054,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10203,7 +10074,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10223,7 +10094,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10243,7 +10114,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c375); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10345,7 +10216,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c370(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10360,7 +10231,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c370(s1);
       }
       s0 = s1;
     }
@@ -10386,7 +10257,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s1);
+        s1 = peg$c371(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10401,7 +10272,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s1);
+        s1 = peg$c371(s1);
       }
       s0 = s1;
     }
@@ -10416,7 +10287,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c378(s1);
+      s1 = peg$c372(s1);
     }
     s0 = s1;
 
@@ -10430,7 +10301,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c379(s1);
+      s1 = peg$c373(s1);
     }
     s0 = s1;
 
@@ -10438,6 +10309,41 @@ function peg$parse(input, options) {
   }
 
   function peg$parseBooleanLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4) === peg$c374) {
+      s1 = peg$c374;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c375); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c376();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c377) {
+        s1 = peg$c377;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c378); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c379();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseNullLiteral() {
     var s0, s1;
 
     s0 = peg$currPos;
@@ -10453,41 +10359,6 @@ function peg$parse(input, options) {
       s1 = peg$c382();
     }
     s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c383) {
-        s1 = peg$c383;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c384); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c385();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseNullLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c386) {
-      s1 = peg$c386;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c388();
-    }
-    s0 = s1;
 
     return s0;
   }
@@ -10496,12 +10367,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c389) {
-      s1 = peg$c389;
+    if (input.substr(peg$currPos, 2) === peg$c383) {
+      s1 = peg$c383;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c384); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10512,7 +10383,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391();
+        s1 = peg$c385();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10549,7 +10420,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c392(s2);
+          s1 = peg$c386(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10576,7 +10447,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c392(s1);
+        s1 = peg$c386(s1);
       }
       s0 = s1;
     }
@@ -10616,7 +10487,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c393(s1);
+        s1 = peg$c387(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10645,7 +10516,7 @@ function peg$parse(input, options) {
               s5 = peg$parseType();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c394(s1, s5);
+                s1 = peg$c388(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10672,7 +10543,7 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c395(s1);
+          s1 = peg$c389(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10698,7 +10569,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c396(s3);
+                  s1 = peg$c390(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10730,7 +10601,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c397(s1);
+      s1 = peg$c391(s1);
     }
     s0 = s1;
 
@@ -10755,7 +10626,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10788,7 +10659,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c398(s4);
+            s1 = peg$c392(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10829,15 +10700,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c312;
+              s5 = peg$c305;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c399(s3);
+              s1 = peg$c393(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10876,15 +10747,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c305;
+                s5 = peg$c298;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c306); }
+                if (peg$silentFails === 0) { peg$fail(peg$c299); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c400(s3);
+                s1 = peg$c394(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10908,12 +10779,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c321) {
-          s1 = peg$c321;
+        if (input.substr(peg$currPos, 2) === peg$c314) {
+          s1 = peg$c314;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c322); }
+          if (peg$silentFails === 0) { peg$fail(peg$c315); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10922,16 +10793,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c323) {
-                  s5 = peg$c323;
+                if (input.substr(peg$currPos, 2) === peg$c316) {
+                  s5 = peg$c316;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c317); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c401(s3);
+                  s1 = peg$c395(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10955,12 +10826,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c326) {
-            s1 = peg$c326;
+          if (input.substr(peg$currPos, 2) === peg$c319) {
+            s1 = peg$c319;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c320); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10983,16 +10854,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c328) {
-                            s9 = peg$c328;
+                          if (input.substr(peg$currPos, 2) === peg$c321) {
+                            s9 = peg$c321;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c329); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c322); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c402(s3, s7);
+                            s1 = peg$c396(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11044,7 +10915,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c403(s1);
+      s1 = peg$c397(s1);
     }
     s0 = s1;
 
@@ -11056,11 +10927,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c404;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11071,11 +10942,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c404;
+          s3 = peg$c398;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c405); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11096,11 +10967,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c406;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11111,11 +10982,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c406;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c407); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11156,7 +11027,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c408(s1);
+        s1 = peg$c402(s1);
       }
       s0 = s1;
     }
@@ -11169,19 +11040,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c409;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c411) {
-        s2 = peg$c411;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11199,12 +11070,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c411) {
-        s2 = peg$c411;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11250,7 +11121,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c408(s1);
+        s1 = peg$c402(s1);
       }
       s0 = s1;
     }
@@ -11263,19 +11134,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c409;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c411) {
-        s2 = peg$c411;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11293,12 +11164,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c411) {
-        s2 = peg$c411;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11330,12 +11201,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c411) {
-      s1 = peg$c411;
+    if (input.substr(peg$currPos, 2) === peg$c405) {
+      s1 = peg$c405;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c412); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11345,15 +11216,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c312;
+              s5 = peg$c305;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c413(s3);
+              s1 = peg$c407(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11383,140 +11254,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c414) {
-      s1 = peg$c414;
+    if (input.substr(peg$currPos, 5) === peg$c408) {
+      s1 = peg$c408;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c415); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c416) {
-        s1 = peg$c416;
+      if (input.substr(peg$currPos, 6) === peg$c410) {
+        s1 = peg$c410;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c417); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c418) {
-          s1 = peg$c418;
+        if (input.substr(peg$currPos, 6) === peg$c412) {
+          s1 = peg$c412;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c419); }
+          if (peg$silentFails === 0) { peg$fail(peg$c413); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c420) {
-            s1 = peg$c420;
+          if (input.substr(peg$currPos, 6) === peg$c414) {
+            s1 = peg$c414;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c415); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c422) {
-              s1 = peg$c422;
+            if (input.substr(peg$currPos, 4) === peg$c416) {
+              s1 = peg$c416;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c423); }
+              if (peg$silentFails === 0) { peg$fail(peg$c417); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c424) {
-                s1 = peg$c424;
+              if (input.substr(peg$currPos, 5) === peg$c418) {
+                s1 = peg$c418;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                if (peg$silentFails === 0) { peg$fail(peg$c419); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c426) {
-                  s1 = peg$c426;
+                if (input.substr(peg$currPos, 5) === peg$c420) {
+                  s1 = peg$c420;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c427); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c421); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c428) {
-                    s1 = peg$c428;
+                  if (input.substr(peg$currPos, 5) === peg$c422) {
+                    s1 = peg$c422;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c423); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c430) {
-                      s1 = peg$c430;
+                    if (input.substr(peg$currPos, 7) === peg$c424) {
+                      s1 = peg$c424;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c431); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c432) {
-                        s1 = peg$c432;
+                      if (input.substr(peg$currPos, 7) === peg$c426) {
+                        s1 = peg$c426;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c433); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c427); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c434) {
-                          s1 = peg$c434;
+                        if (input.substr(peg$currPos, 4) === peg$c428) {
+                          s1 = peg$c428;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c435); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c429); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c436) {
-                            s1 = peg$c436;
+                          if (input.substr(peg$currPos, 6) === peg$c430) {
+                            s1 = peg$c430;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c437); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c431); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c438) {
-                              s1 = peg$c438;
+                            if (input.substr(peg$currPos, 8) === peg$c432) {
+                              s1 = peg$c432;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c439); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c433); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c440) {
-                                s1 = peg$c440;
+                              if (input.substr(peg$currPos, 4) === peg$c434) {
+                                s1 = peg$c434;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c441); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c435); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c442) {
-                                  s1 = peg$c442;
+                                if (input.substr(peg$currPos, 5) === peg$c436) {
+                                  s1 = peg$c436;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c443); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c437); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c444) {
-                                    s1 = peg$c444;
+                                  if (input.substr(peg$currPos, 2) === peg$c438) {
+                                    s1 = peg$c438;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c445); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c439); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c446) {
-                                      s1 = peg$c446;
+                                    if (input.substr(peg$currPos, 3) === peg$c440) {
+                                      s1 = peg$c440;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c447); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c441); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c11) {
@@ -11527,12 +11398,12 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c12); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c386) {
-                                          s1 = peg$c386;
+                                        if (input.substr(peg$currPos, 4) === peg$c380) {
+                                          s1 = peg$c380;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c387); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c381); }
                                         }
                                       }
                                     }
@@ -11554,7 +11425,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c448();
+      s1 = peg$c442();
     }
     s0 = s1;
 
@@ -11575,7 +11446,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11617,7 +11488,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c398(s4);
+            s1 = peg$c392(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11660,7 +11531,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c449(s1, s5);
+              s1 = peg$c443(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11701,20 +11572,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c450) {
-      s1 = peg$c450;
+    if (input.substr(peg$currPos, 3) === peg$c444) {
+      s1 = peg$c444;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c451); }
+      if (peg$silentFails === 0) { peg$fail(peg$c445); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c452) {
-        s1 = peg$c452;
+      if (input.substr(peg$currPos, 3) === peg$c446) {
+        s1 = peg$c446;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c453); }
+        if (peg$silentFails === 0) { peg$fail(peg$c447); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11730,7 +11601,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c454();
+        s1 = peg$c448();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11748,20 +11619,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c455) {
-      s1 = peg$c455;
+    if (input.substr(peg$currPos, 2) === peg$c449) {
+      s1 = peg$c449;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c456); }
+      if (peg$silentFails === 0) { peg$fail(peg$c450); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c457) {
-        s1 = peg$c457;
+      if (input.substr(peg$currPos, 2) === peg$c451) {
+        s1 = peg$c451;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c458); }
+        if (peg$silentFails === 0) { peg$fail(peg$c452); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11777,7 +11648,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c459();
+        s1 = peg$c453();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11815,7 +11686,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c460();
+        s1 = peg$c454();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11833,20 +11704,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c293) {
-      s1 = peg$c293;
+    if (input.substr(peg$currPos, 3) === peg$c286) {
+      s1 = peg$c286;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c287); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c461) {
-        s1 = peg$c461;
+      if (input.substr(peg$currPos, 3) === peg$c455) {
+        s1 = peg$c455;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c462); }
+        if (peg$silentFails === 0) { peg$fail(peg$c456); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11862,7 +11733,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c463();
+        s1 = peg$c457();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11880,12 +11751,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c356) {
-      s1 = peg$c356;
+    if (input.substr(peg$currPos, 2) === peg$c350) {
+      s1 = peg$c350;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c458); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11900,7 +11771,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c358();
+        s1 = peg$c352();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11917,12 +11788,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c465.test(input.charAt(peg$currPos))) {
+    if (peg$c459.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c460); }
     }
 
     return s0;
@@ -11933,12 +11804,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
     }
 
@@ -11952,7 +11823,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c469(s1);
+      s1 = peg$c463(s1);
     }
     s0 = s1;
 
@@ -12024,11 +11895,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c470;
+        s1 = peg$c464;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c465); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12038,11 +11909,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c409;
+          s1 = peg$c403;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c410); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12150,17 +12021,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c472;
+        s2 = peg$c466;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c473); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c474();
+          s1 = peg$c468();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12185,21 +12056,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c285;
+        s2 = peg$c278;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c286); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c285;
+            s4 = peg$c278;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c286); }
+            if (peg$silentFails === 0) { peg$fail(peg$c279); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12234,36 +12105,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c467.test(input.charAt(peg$currPos))) {
+    if (peg$c461.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c467.test(input.charAt(peg$currPos))) {
+        if (peg$c461.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c468); }
+          if (peg$silentFails === 0) { peg$fail(peg$c462); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c467.test(input.charAt(peg$currPos))) {
+          if (peg$c461.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c468); }
+            if (peg$silentFails === 0) { peg$fail(peg$c462); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12292,20 +12163,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c467.test(input.charAt(peg$currPos))) {
+    if (peg$c461.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12380,22 +12251,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c467.test(input.charAt(peg$currPos))) {
+                if (peg$c461.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c462); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c467.test(input.charAt(peg$currPos))) {
+                    if (peg$c461.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c462); }
                     }
                   }
                 } else {
@@ -12450,28 +12321,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c475;
+      s0 = peg$c469;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c476); }
+      if (peg$silentFails === 0) { peg$fail(peg$c470); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c283;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c285;
+          s1 = peg$c278;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c279); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12497,22 +12368,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c467.test(input.charAt(peg$currPos))) {
+                if (peg$c461.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c462); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c467.test(input.charAt(peg$currPos))) {
+                    if (peg$c461.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c462); }
                     }
                   }
                 } else {
@@ -12565,11 +12436,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c285;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12615,7 +12486,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c477();
+        s1 = peg$c471();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12677,76 +12548,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c478) {
-      s0 = peg$c478;
+    if (input.substr(peg$currPos, 2) === peg$c472) {
+      s0 = peg$c472;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c479); }
+      if (peg$silentFails === 0) { peg$fail(peg$c473); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c480) {
-        s0 = peg$c480;
+      if (input.substr(peg$currPos, 2) === peg$c474) {
+        s0 = peg$c474;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c481); }
+        if (peg$silentFails === 0) { peg$fail(peg$c475); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c482) {
-          s0 = peg$c482;
+        if (input.substr(peg$currPos, 2) === peg$c476) {
+          s0 = peg$c476;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c483); }
+          if (peg$silentFails === 0) { peg$fail(peg$c477); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c484;
+            s0 = peg$c478;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c485); }
+            if (peg$silentFails === 0) { peg$fail(peg$c479); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c486;
+              s0 = peg$c480;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c487); }
+              if (peg$silentFails === 0) { peg$fail(peg$c481); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c488;
+                s0 = peg$c482;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c489); }
+                if (peg$silentFails === 0) { peg$fail(peg$c483); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c490;
+                  s0 = peg$c484;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c491); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c485); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c492;
+                    s0 = peg$c486;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c487); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c494;
+                      s0 = peg$c488;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c495); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c489); }
                     }
                   }
                 }
@@ -12931,7 +12802,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c496(s1, s2);
+        s1 = peg$c490(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12952,12 +12823,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c497) {
-            s3 = peg$c497;
+          if (input.substr(peg$currPos, 2) === peg$c491) {
+            s3 = peg$c491;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c498); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12970,7 +12841,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c499(s1, s2, s4, s5);
+                s1 = peg$c493(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12994,12 +12865,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c497) {
-          s1 = peg$c497;
+        if (input.substr(peg$currPos, 2) === peg$c491) {
+          s1 = peg$c491;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c498); }
+          if (peg$silentFails === 0) { peg$fail(peg$c492); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13012,7 +12883,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c500(s2, s3);
+              s1 = peg$c494(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13037,16 +12908,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c497) {
-                s3 = peg$c497;
+              if (input.substr(peg$currPos, 2) === peg$c491) {
+                s3 = peg$c491;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c498); }
+                if (peg$silentFails === 0) { peg$fail(peg$c492); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c501(s1, s2);
+                s1 = peg$c495(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13062,16 +12933,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c497) {
-              s1 = peg$c497;
+            if (input.substr(peg$currPos, 2) === peg$c491) {
+              s1 = peg$c491;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c498); }
+              if (peg$silentFails === 0) { peg$fail(peg$c492); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c502();
+              s1 = peg$c496();
             }
             s0 = s1;
           }
@@ -13108,7 +12979,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c503(s2);
+        s1 = peg$c497(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13137,7 +13008,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c504(s1);
+        s1 = peg$c498(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13158,17 +13029,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c287;
+        s2 = peg$c280;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c281); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c505(s1, s3);
+          s1 = peg$c499(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13193,17 +13064,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c287;
+        s2 = peg$c280;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c281); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c506(s1, s3);
+          s1 = peg$c500(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13228,7 +13099,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c507(s1);
+      s1 = peg$c501(s1);
     }
     s0 = s1;
 
@@ -13251,22 +13122,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c467.test(input.charAt(peg$currPos))) {
+    if (peg$c461.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c468); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c467.test(input.charAt(peg$currPos))) {
+        if (peg$c461.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c468); }
+          if (peg$silentFails === 0) { peg$fail(peg$c462); }
         }
       }
     } else {
@@ -13286,11 +13157,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c285;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13315,33 +13186,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c285;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c467.test(input.charAt(peg$currPos))) {
+          if (peg$c461.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c468); }
+            if (peg$silentFails === 0) { peg$fail(peg$c462); }
           }
         }
       } else {
@@ -13357,21 +13228,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c467.test(input.charAt(peg$currPos))) {
+          if (peg$c461.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c468); }
+            if (peg$silentFails === 0) { peg$fail(peg$c462); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c467.test(input.charAt(peg$currPos))) {
+            if (peg$c461.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c468); }
+              if (peg$silentFails === 0) { peg$fail(peg$c462); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13381,7 +13252,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c508();
+              s1 = peg$c502();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13406,11 +13277,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c285;
+        s1 = peg$c278;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c286); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13425,22 +13296,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c467.test(input.charAt(peg$currPos))) {
+          if (peg$c461.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c468); }
+            if (peg$silentFails === 0) { peg$fail(peg$c462); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c467.test(input.charAt(peg$currPos))) {
+              if (peg$c461.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c468); }
+                if (peg$silentFails === 0) { peg$fail(peg$c462); }
               }
             }
           } else {
@@ -13453,7 +13324,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c508();
+              s1 = peg$c502();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13492,20 +13363,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c509) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c503) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c510); }
+      if (peg$silentFails === 0) { peg$fail(peg$c504); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c511.test(input.charAt(peg$currPos))) {
+      if (peg$c505.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c512); }
+        if (peg$silentFails === 0) { peg$fail(peg$c506); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13534,12 +13405,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c513) {
-      s0 = peg$c513;
+    if (input.substr(peg$currPos, 3) === peg$c507) {
+      s0 = peg$c507;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c508); }
     }
 
     return s0;
@@ -13550,31 +13421,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c285;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c283;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c515) {
-        s2 = peg$c515;
+      if (input.substr(peg$currPos, 3) === peg$c509) {
+        s2 = peg$c509;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c510); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13617,12 +13488,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c517.test(input.charAt(peg$currPos))) {
+    if (peg$c511.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c518); }
+      if (peg$silentFails === 0) { peg$fail(peg$c512); }
     }
 
     return s0;
@@ -13633,11 +13504,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c404;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13648,15 +13519,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c404;
+          s3 = peg$c398;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c405); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c519(s2);
+          s1 = peg$c513(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13673,11 +13544,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c406;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13688,15 +13559,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c406;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c407); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c519(s2);
+            s1 = peg$c513(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13722,11 +13593,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c404;
+      s2 = peg$c398;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13744,7 +13615,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c520); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13761,11 +13632,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c409;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c410); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13800,7 +13671,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c521(s1, s2);
+        s1 = peg$c515(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13829,12 +13700,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c522.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c523); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13850,12 +13721,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
     }
 
@@ -13867,11 +13738,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c409;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13930,7 +13801,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c524(s3, s4);
+            s1 = peg$c518(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14041,7 +13912,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c525();
+          s1 = peg$c519();
         }
         s0 = s1;
       }
@@ -14055,12 +13926,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c467.test(input.charAt(peg$currPos))) {
+      if (peg$c461.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
     }
 
@@ -14072,11 +13943,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c409;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14112,7 +13983,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c526();
+      s1 = peg$c520();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14126,16 +13997,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c527();
+        s1 = peg$c521();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c511.test(input.charAt(peg$currPos))) {
+        if (peg$c505.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c512); }
+          if (peg$silentFails === 0) { peg$fail(peg$c506); }
         }
       }
     }
@@ -14150,11 +14021,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c406;
+      s2 = peg$c400;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c407); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14172,7 +14043,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c520); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14189,11 +14060,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c409;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c410); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14229,20 +14100,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c406;
+      s0 = peg$c400;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c407); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c404;
+        s1 = peg$c398;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c399); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14251,94 +14122,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c409;
+          s0 = peg$c403;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c410); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c528;
+            s1 = peg$c522;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c529); }
+            if (peg$silentFails === 0) { peg$fail(peg$c523); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c530();
+            s1 = peg$c524();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c531;
+              s1 = peg$c525;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c532); }
+              if (peg$silentFails === 0) { peg$fail(peg$c526); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c533();
+              s1 = peg$c527();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c534;
+                s1 = peg$c528;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c535); }
+                if (peg$silentFails === 0) { peg$fail(peg$c529); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c536();
+                s1 = peg$c530();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c537;
+                  s1 = peg$c531;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c538); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c532); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c539();
+                  s1 = peg$c533();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c540;
+                    s1 = peg$c534;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c541); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c535); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c542();
+                    s1 = peg$c536();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c543;
+                      s1 = peg$c537;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c544); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c538); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c545();
+                      s1 = peg$c539();
                     }
                     s0 = s1;
                   }
@@ -14366,7 +14237,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c526();
+      s1 = peg$c520();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14380,16 +14251,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c546();
+        s1 = peg$c540();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c511.test(input.charAt(peg$currPos))) {
+        if (peg$c505.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c512); }
+          if (peg$silentFails === 0) { peg$fail(peg$c506); }
         }
       }
     }
@@ -14402,11 +14273,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c547;
+      s1 = peg$c541;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c548); }
+      if (peg$silentFails === 0) { peg$fail(peg$c542); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14438,7 +14309,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c549(s2);
+        s1 = peg$c543(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14451,11 +14322,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c547;
+        s1 = peg$c541;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c548); }
+        if (peg$silentFails === 0) { peg$fail(peg$c542); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14522,15 +14393,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c312;
+              s4 = peg$c305;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c549(s3);
+              s1 = peg$c543(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14558,21 +14429,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c287;
+      s1 = peg$c280;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c288); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c287;
+          s3 = peg$c280;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c288); }
+          if (peg$silentFails === 0) { peg$fail(peg$c281); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14614,21 +14485,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c550.test(input.charAt(peg$currPos))) {
+    if (peg$c544.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c551); }
+      if (peg$silentFails === 0) { peg$fail(peg$c545); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c409;
+        s3 = peg$c403;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c410); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14636,7 +14507,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c520); }
+          if (peg$silentFails === 0) { peg$fail(peg$c514); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14653,21 +14524,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c550.test(input.charAt(peg$currPos))) {
+        if (peg$c544.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c551); }
+          if (peg$silentFails === 0) { peg$fail(peg$c545); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c409;
+            s3 = peg$c403;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c410); }
+            if (peg$silentFails === 0) { peg$fail(peg$c404); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14675,7 +14546,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c520); }
+              if (peg$silentFails === 0) { peg$fail(peg$c514); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14705,12 +14576,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c552.test(input.charAt(peg$currPos))) {
+    if (peg$c546.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c553); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
 
     return s0;
@@ -14768,7 +14639,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c520); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
 
     return s0;
@@ -14779,51 +14650,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c555;
+      s0 = peg$c549;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c556); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c557;
+        s0 = peg$c551;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c558); }
+        if (peg$silentFails === 0) { peg$fail(peg$c552); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c559;
+          s0 = peg$c553;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c560); }
+          if (peg$silentFails === 0) { peg$fail(peg$c554); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c561;
+            s0 = peg$c555;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c562); }
+            if (peg$silentFails === 0) { peg$fail(peg$c556); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c563;
+              s0 = peg$c557;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c564); }
+              if (peg$silentFails === 0) { peg$fail(peg$c558); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c565;
+                s0 = peg$c559;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c566); }
+                if (peg$silentFails === 0) { peg$fail(peg$c560); }
               }
             }
           }
@@ -14833,7 +14704,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c554); }
+      if (peg$silentFails === 0) { peg$fail(peg$c548); }
     }
 
     return s0;
@@ -14842,12 +14713,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c567.test(input.charAt(peg$currPos))) {
+    if (peg$c561.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c568); }
+      if (peg$silentFails === 0) { peg$fail(peg$c562); }
     }
 
     return s0;
@@ -14861,7 +14732,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c569); }
+      if (peg$silentFails === 0) { peg$fail(peg$c563); }
     }
 
     return s0;
@@ -14871,24 +14742,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c570) {
-      s1 = peg$c570;
+    if (input.substr(peg$currPos, 2) === peg$c564) {
+      s1 = peg$c564;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c571); }
+      if (peg$silentFails === 0) { peg$fail(peg$c565); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c572) {
-        s5 = peg$c572;
+      if (input.substr(peg$currPos, 2) === peg$c566) {
+        s5 = peg$c566;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c573); }
+        if (peg$silentFails === 0) { peg$fail(peg$c567); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -14915,12 +14786,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c572) {
-          s5 = peg$c572;
+        if (input.substr(peg$currPos, 2) === peg$c566) {
+          s5 = peg$c566;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c573); }
+          if (peg$silentFails === 0) { peg$fail(peg$c567); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -14944,12 +14815,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c572) {
-          s3 = peg$c572;
+        if (input.substr(peg$currPos, 2) === peg$c566) {
+          s3 = peg$c566;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c573); }
+          if (peg$silentFails === 0) { peg$fail(peg$c567); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -14974,12 +14845,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c574) {
-      s1 = peg$c574;
+    if (input.substr(peg$currPos, 2) === peg$c568) {
+      s1 = peg$c568;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c575); }
+      if (peg$silentFails === 0) { peg$fail(peg$c569); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15097,7 +14968,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c520); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -290,7 +290,6 @@ Operator
   / FromProc
   / PassProc
   / ExplodeProc
-  / LetProc
   / MergeProc
   / OverProc
   / YieldProc
@@ -554,32 +553,15 @@ MergeProc
     }
 
 OverProc
-  = over:ScopedOver {
-      RETURN(MAP("kind":"Let", "locals":NULL, "over":over))
+  = "over" _ exprs:Exprs _ "with" _ locals:LetAssignments __ scope:Scope {
+      RETURN(MAP("kind":"Let", "locals":locals, "over":MAP("kind":"Over", "exprs":exprs, "scope":scope)))
+    }
+  / "over" _ exprs:Exprs __ scope:Scope {
+      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":scope))
     }
   / "over" _ exprs:Exprs {
-      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":NULL, "as":""))
+      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":NULL))
     }
-
-ScopedOver
-  = "over" _ exprs:Exprs as:As __ scope:Scope {
-      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":scope, "as":as))
-    }
-
-OverWith
-  = "over" _ exprs:Exprs _ "with" _ locals:LetAssignments __ scope:Scope {
-      RETURN(MAP("kind":"Let", "locals":locals, "over":MAP("kind":"Over", "exprs":exprs, "scope":scope, "as":"")))
-    }
-
-As
-  = _ "as" _ id:IdentifierName { RETURN(id) }
-  / "" { RETURN("") }
-
-LetProc
-  = "let" _ locals:LetAssignments __ over:ScopedOver {
-      RETURN(MAP("kind":"Let", "locals":locals, "over":over))
-    }
-  / OverWith
 
 Scope = "=>" __ "(" __ seq:Sequential __ ")" { RETURN(seq) }
 
@@ -1081,7 +1063,7 @@ TemplateSingleQuotedChar
   / !( "${" ) v:SingleQuotedChar { RETURN(v) }
 
 TemplateExpr
-  = "${" __ e:Expr __ "}" { 
+  = "${" __ e:Expr __ "}" {
       RETURN(MAP(
         "kind": "Cast",
         "expr": e,

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -529,27 +529,6 @@ func semProc(ctx context.Context, scope *Scope, p ast.Proc, adaptor op.DataAdapt
 		if err != nil {
 			return nil, err
 		}
-		if as := p.Over.As; as != "" {
-			// If there is an "as" clause, then we bind the name
-			// to the sub-scope "this" and we bind "this" to the
-			// outer-scope "this".  Nested scopes are elegantly
-			// handle by this approach because the closest "as" name
-			// resolves to the real this and the next closest
-			// "as" name resolves to "this" in the scope above, which is
-			// where it was bound.
-			if err := scope.DefineAs(as); err != nil {
-				return nil, err
-			}
-			if err := scope.DefineVar("this"); err != nil {
-				return nil, err
-			}
-			// We append "this" to locals so it will be eval'd
-			// but we don't put it in the scope.
-			locals = append(locals, dag.Def{
-				Name: "this",
-				Expr: &dag.This{Kind: "This"},
-			})
-		}
 		over, err := semOver(ctx, scope, p.Over, adaptor, head)
 		if err != nil {
 			return nil, err

--- a/compiler/ztests/scoped-this.yaml
+++ b/compiler/ztests/scoped-this.yaml
@@ -1,7 +1,7 @@
 zed: |
-  over ids as id => (
-    ids:=collect(string(id))
-    | yield {name:this.name,ids:join(ids,',')}
+  over ids with name => (
+    ids:=collect(string(this))
+    | yield {name,ids:join(ids,',')}
   )
 
 input: |

--- a/runtime/expr/ztests/record-spread-over.yaml
+++ b/runtime/expr/ztests/record-spread-over.yaml
@@ -1,5 +1,5 @@
 zed: |
-  let that=this over tweet_ids => (
+  over tweet_ids with that=this => (
     ids:=collect(string(this))
     | yield {...that,tweet_ids:join(ids,',')}
   )

--- a/runtime/op/traverse/ztests/nested.yaml
+++ b/runtime/op/traverse/ztests/nested.yaml
@@ -1,7 +1,7 @@
 zed: |
-  let TOP=top over outer => (
+  over outer with TOP=top => (
     yield {msg:"OUTER", TOP:TOP, inner:inner, b:b}
-    | let BOTTOM=b over inner => (
+    | over inner with BOTTOM=b => (
       yield {top:TOP, bottom:BOTTOM, elem:this}
     )
   )

--- a/runtime/op/traverse/ztests/over-record.yaml
+++ b/runtime/op/traverse/ztests/over-record.yaml
@@ -1,5 +1,5 @@
 zed: |
-  let d=date over this => (
+  over this with d=date => (
     key[0] != 'date'
     | yield {date: d, sym: key[0], price: value}
   )

--- a/runtime/op/traverse/ztests/scope-groupby-key.yaml
+++ b/runtime/op/traverse/ztests/scope-groupby-key.yaml
@@ -1,4 +1,4 @@
-zed: let s=s over x => (sum(this) by s)
+zed: over x with s => (sum(this) by s)
 
 input: |
   {s:"a",x:[1,2]}

--- a/runtime/op/traverse/ztests/scope-lets.yaml
+++ b/runtime/op/traverse/ztests/scope-lets.yaml
@@ -1,5 +1,5 @@
 zed: |
-  let v=c, w=a over b => (
+  over b with v=c, w=a => (
     yield {x:w,y:this,z:v}
   )
 

--- a/runtime/op/traverse/ztests/scope.yaml
+++ b/runtime/op/traverse/ztests/scope.yaml
@@ -1,5 +1,5 @@
 zed: |
-  let w=a over b => (
+  over b with w=a => (
     yield {x:w,y:this}
   )
 


### PR DESCRIPTION
This commit removes some experimental language features that
were deprecated by the the finalized over-with syntax.