### PR TITLE
Correct switch synopsis

### DIFF
--- a/docs/zq/operators/switch.md
+++ b/docs/zq/operators/switch.md
@@ -5,19 +5,19 @@
 ### Synopsis
 
 ```
-switch <expr> {
+switch <expr> (
   case <const> => <leg>
   case <const> => <leg>
   ...
   [ default => <leg> ]
-}
+)
 
-switch {
+switch (
   case <bool-expr> => <leg>
   case <bool-expr> => <leg>
   ...
   [ default => <leg> ]
-}
+)
 ```
 ### Description
 


### PR DESCRIPTION
Language expects parenthesis not curly braces.