### PR TITLE
streamline Zed lake format spec as work in progress

### DIFF
--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -696,6 +696,8 @@ that is stored in the commit journal for reference.  These values may
 be specified as options to the `load` command, and are also available in the
 API for automation.
 
+> Note that the branchlog meta-query source is not yet implemented.
+
 ### 2.10 Merge
 
 Data is merged from one branch into another with the `merge` command, e.g.,


### PR DESCRIPTION
This commit simplifies the Zed lake format spec and
clarifies that it needs to be updated.  We also
added some philosophy and framing in the introduction.

The text we removed was really just design notes regarding
pending work and we pasted that into issue #3804 as a
placeholder to create and prioritize relevant issues.
