### PR TITLE
zson.Unmarshal: Improve handling of null values

### DIFF
--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -855,6 +855,8 @@ func (u *UnmarshalZNGContext) decodeMap(zv zed.Value, mapVal reflect.Value) erro
 		return errors.New("not a map")
 	}
 	if zv.Bytes == nil {
+		// XXX The inner types of the null should be checked.
+		mapVal.Set(reflect.Zero(mapVal.Type()))
 		return nil
 	}
 	if mapVal.IsNil() {
@@ -908,6 +910,7 @@ func (u *UnmarshalZNGContext) decodeArray(zv zed.Value, arrVal reflect.Value) er
 	typ := zed.TypeUnder(zv.Type)
 	if typ == zed.TypeBytes && arrVal.Type().Elem().Kind() == reflect.Uint8 {
 		if zv.Bytes == nil {
+			arrVal.Set(reflect.Zero(arrVal.Type()))
 			return nil
 		}
 		if arrVal.Kind() == reflect.Array {
@@ -922,6 +925,8 @@ func (u *UnmarshalZNGContext) decodeArray(zv zed.Value, arrVal reflect.Value) er
 		return errors.New("not an array")
 	}
 	if zv.Bytes == nil {
+		// XXX The inner type of the null should be checked.
+		arrVal.Set(reflect.Zero(arrVal.Type()))
 		return nil
 	}
 	i := 0

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -202,6 +202,45 @@ func TestUnmarshalRecord(t *testing.T) {
 	require.Equal(t, *v1.T1f1, *v3.T4f1)
 }
 
+func TestUnmarshalNull(t *testing.T) {
+	t.Run("slice", func(t *testing.T) {
+		slice := []int{1}
+		require.NoError(t, zson.UnmarshalZNG(*zed.Null, &slice))
+		assert.Nil(t, slice)
+		slice = []int{1}
+		assert.EqualError(t, zson.UnmarshalZNG(*zed.NullInt64, &slice), "not an array")
+	})
+	t.Run("primitive", func(t *testing.T) {
+		integer := -1
+		require.NoError(t, zson.UnmarshalZNG(*zed.Null, &integer))
+		assert.Equal(t, integer, 0)
+		intptr := &integer
+		require.NoError(t, zson.UnmarshalZNG(*zed.Null, &intptr))
+		assert.Nil(t, intptr)
+		assert.EqualError(t, zson.UnmarshalZNG(*zed.NullIP, &intptr), "incompatible type translation: zng type ip go type int go kind int")
+	})
+	t.Run("map", func(t *testing.T) {
+		m := map[string]string{"key": "value"}
+		require.NoError(t, zson.UnmarshalZNG(*zed.Null, &m))
+		assert.Nil(t, m)
+		val := zson.MustParseValue(zed.NewContext(), "null({foo:int64})")
+		require.EqualError(t, zson.UnmarshalZNG(*val, &m), "not a map")
+	})
+	t.Run("struct", func(t *testing.T) {
+		type testobj struct {
+			Val int
+		}
+		var obj struct {
+			Test *testobj `zed:"test"`
+		}
+		val := zson.MustParseValue(zed.NewContext(), "{test: null({Val:int64})}")
+		require.NoError(t, zson.UnmarshalZNG(*val, &obj))
+		require.Nil(t, obj.Test)
+		val = zson.MustParseValue(zed.NewContext(), "{test: null(ip)}")
+		require.EqualError(t, zson.UnmarshalZNG(*val, &obj), "cannot unmarshal Zed type \"ip\" into Go struct")
+	})
+}
+
 func TestUnmarshalSlice(t *testing.T) {
 	type T1 struct {
 		T1f1 []bool

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -209,6 +209,14 @@ func TestUnmarshalNull(t *testing.T) {
 		assert.Nil(t, slice)
 		slice = []int{1}
 		assert.EqualError(t, zson.UnmarshalZNG(*zed.NullInt64, &slice), "not an array")
+		slice = []int{1}
+		v := zson.MustParseValue(zed.NewContext(), "null([int64])")
+		require.NoError(t, zson.UnmarshalZNG(*v, &slice))
+		assert.Nil(t, slice)
+		v = zson.MustParseValue(zed.NewContext(), "null(bytes)")
+		buf := []byte("testing")
+		require.NoError(t, zson.UnmarshalZNG(*v, &buf))
+		assert.Nil(t, buf)
 	})
 	t.Run("primitive", func(t *testing.T) {
 		integer := -1
@@ -225,6 +233,10 @@ func TestUnmarshalNull(t *testing.T) {
 		assert.Nil(t, m)
 		val := zson.MustParseValue(zed.NewContext(), "null({foo:int64})")
 		require.EqualError(t, zson.UnmarshalZNG(*val, &m), "not a map")
+		m = map[string]string{"key": "value"}
+		val = zson.MustParseValue(zed.NewContext(), "null(|{string:string}|)")
+		require.NoError(t, zson.UnmarshalZNG(*val, &m))
+		assert.Nil(t, m)
 	})
 	t.Run("struct", func(t *testing.T) {
 		type testobj struct {

--- a/zson/zson.go
+++ b/zson/zson.go
@@ -81,6 +81,14 @@ func ParseValue(zctx *zed.Context, zson string) (*zed.Value, error) {
 	return Build(zcode.NewBuilder(), val)
 }
 
+func MustParseValue(zctx *zed.Context, zson string) *zed.Value {
+	val, err := ParseValue(zctx, zson)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 func ParseValueFromAST(zctx *zed.Context, ast astzed.Value) (*zed.Value, error) {
 	val, err := NewAnalyzer().ConvertValue(zctx, ast)
 	if err != nil {


### PR DESCRIPTION
This pr fixes a couple issues when unmarshaling null zed values:
- zson.Unmarshal was panicing when trying to unmarshal a "null" value
   into an array.
- Typed null values (e.g. "null(int64)") were not getting typed check if
   the go value was a pointer.
- Ensure nested pointers are getting properly traversed.