### PR TITLE
simplfiy lake/api for external use

### DIFF
--- a/cli/lake.go
+++ b/cli/lake.go
@@ -64,7 +64,7 @@ func (l *LakeFlags) Open(ctx context.Context) (api.Interface, error) {
 		}
 		return api.NewRemoteWithConnection(conn), nil
 	}
-	return api.OpenLocalLake(ctx, uri)
+	return api.OpenLocalLakeWithURI(ctx, uri)
 }
 
 func (l *LakeFlags) AuthStore() *auth0.Store {

--- a/cli/lake.go
+++ b/cli/lake.go
@@ -42,7 +42,7 @@ func (l *LakeFlags) Connection() (*client.Connection, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !api.IsLakeService(uri) {
+	if !api.IsLakeService(uri.String()) {
 		return nil, errors.New("cannot open connection on local lake")
 	}
 	conn := client.NewConnectionTo(uri.String())
@@ -57,14 +57,14 @@ func (l *LakeFlags) Open(ctx context.Context) (api.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	if api.IsLakeService(uri) {
+	if api.IsLakeService(uri.String()) {
 		conn, err := l.Connection()
 		if err != nil {
 			return nil, err
 		}
-		return api.NewRemoteWithConnection(conn), nil
+		return api.NewRemoteLake(conn), nil
 	}
-	return api.OpenLocalLakeWithURI(ctx, uri)
+	return api.OpenLocalLake(ctx, uri.String())
 }
 
 func (l *LakeFlags) AuthStore() *auth0.Store {

--- a/cmd/zed/init/command.go
+++ b/cmd/zed/init/command.go
@@ -10,7 +10,6 @@ import (
 	"github.com/brimdata/zed/cmd/zed/root"
 	"github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/pkg/charm"
-	"github.com/brimdata/zed/pkg/storage"
 )
 
 var Cmd = &charm.Spec{
@@ -51,14 +50,10 @@ func (c *Command) Run(args []string) error {
 	if path == "" {
 		return errors.New("single lake path argument required")
 	}
-	lakePath, err := storage.ParseURI(path)
-	if err != nil {
-		return err
-	}
-	if api.IsLakeService(lakePath) {
+	if api.IsLakeService(path) {
 		return fmt.Errorf("init command not valid on remote lake")
 	}
-	if _, err := api.CreateLocalLake(ctx, lakePath); err != nil {
+	if _, err := api.CreateLocalLake(ctx, path); err != nil {
 		return err
 	}
 	if !c.lakeFlags.Quiet {

--- a/cmd/zed/serve/command.go
+++ b/cmd/zed/serve/command.go
@@ -79,7 +79,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	if api.IsLakeService(uri) {
+	if api.IsLakeService(uri.String()) {
 		return errors.New("serve command available for local lakes only")
 	}
 	c.conf.Root = uri

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/api"
+	"github.com/brimdata/zed/api/client"
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/lake/pools"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
-	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
@@ -41,18 +42,14 @@ type Interface interface {
 }
 
 func OpenLake(ctx context.Context, u string) (Interface, error) {
-	uri, err := storage.ParseURI(u)
-	if err != nil {
-		return nil, err
+	if IsLakeService(u) {
+		return NewRemoteLake(client.NewConnectionTo(u)), nil
 	}
-	if IsLakeService(uri) {
-		return OpenRemoteLakeWithURI(ctx, uri)
-	}
-	return OpenLocalLakeWithURI(ctx, uri)
+	return OpenLocalLake(ctx, u)
 }
 
-func IsLakeService(u *storage.URI) bool {
-	return u.Scheme == "http" || u.Scheme == "https"
+func IsLakeService(u string) bool {
+	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
 }
 
 func ScanIndexRules(ctx context.Context, api Interface) (zio.ReadCloser, error) {

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -40,6 +40,17 @@ type Interface interface {
 	UpdateIndex(ctx context.Context, names []string, pool ksuid.KSUID, branchName string) (ksuid.KSUID, error)
 }
 
+func OpenLake(ctx context.Context, u string) (Interface, error) {
+	uri, err := storage.ParseURI(u)
+	if err != nil {
+		return nil, err
+	}
+	if IsLakeService(uri) {
+		return OpenRemoteLakeWithURI(ctx, uri)
+	}
+	return OpenLocalLakeWithURI(ctx, uri)
+}
+
 func IsLakeService(u *storage.URI) bool {
 	return u.Scheme == "http" || u.Scheme == "https"
 }

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -31,12 +31,8 @@ func OpenLocalLake(ctx context.Context, lakePath string) (Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	return OpenLocalLakeWithURI(ctx, uri)
-}
-
-func OpenLocalLakeWithURI(ctx context.Context, lakePath *storage.URI) (Interface, error) {
 	engine := storage.NewLocalEngine()
-	root, err := lake.Open(ctx, engine, lakePath)
+	root, err := lake.Open(ctx, engine, uri)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +42,13 @@ func OpenLocalLakeWithURI(ctx context.Context, lakePath *storage.URI) (Interface
 	}, nil
 }
 
-func CreateLocalLake(ctx context.Context, lakePath *storage.URI) (Interface, error) {
+func CreateLocalLake(ctx context.Context, lakePath string) (Interface, error) {
+	uri, err := storage.ParseURI(lakePath)
+	if err != nil {
+		return nil, err
+	}
 	engine := storage.NewLocalEngine()
-	root, err := lake.Create(ctx, engine, lakePath)
+	root, err := lake.Create(ctx, engine, uri)
 	if err != nil {
 		return nil, err
 	}

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -19,38 +19,46 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
-type LocalSession struct {
+type local struct {
 	root   *lake.Root
 	engine storage.Engine
 }
 
-var _ Interface = (*LocalSession)(nil)
+var _ Interface = (*local)(nil)
 
-func OpenLocalLake(ctx context.Context, lakePath *storage.URI) (*LocalSession, error) {
+func OpenLocalLake(ctx context.Context, lakePath string) (*local, error) {
+	uri, err := storage.ParseURI(lakePath)
+	if err != nil {
+		return nil, err
+	}
+	return OpenLocalLakeWithURI(ctx, uri)
+}
+
+func OpenLocalLakeWithURI(ctx context.Context, lakePath *storage.URI) (*local, error) {
 	engine := storage.NewLocalEngine()
 	root, err := lake.Open(ctx, engine, lakePath)
 	if err != nil {
 		return nil, err
 	}
-	return &LocalSession{
+	return &local{
 		root:   root,
 		engine: engine,
 	}, nil
 }
 
-func CreateLocalLake(ctx context.Context, lakePath *storage.URI) (*LocalSession, error) {
+func CreateLocalLake(ctx context.Context, lakePath *storage.URI) (*local, error) {
 	engine := storage.NewLocalEngine()
 	root, err := lake.Create(ctx, engine, lakePath)
 	if err != nil {
 		return nil, err
 	}
-	return &LocalSession{
+	return &local{
 		root:   root,
 		engine: engine,
 	}, nil
 }
 
-func (l *LocalSession) CreatePool(ctx context.Context, name string, layout order.Layout, seekStride int, thresh int64) (ksuid.KSUID, error) {
+func (l *local) CreatePool(ctx context.Context, name string, layout order.Layout, seekStride int, thresh int64) (ksuid.KSUID, error) {
 	if name == "" {
 		return ksuid.Nil, errors.New("no pool name provided")
 	}
@@ -61,40 +69,40 @@ func (l *LocalSession) CreatePool(ctx context.Context, name string, layout order
 	return pool.ID, nil
 }
 
-func (l *LocalSession) RemovePool(ctx context.Context, id ksuid.KSUID) error {
+func (l *local) RemovePool(ctx context.Context, id ksuid.KSUID) error {
 	return l.root.RemovePool(ctx, id)
 
 }
 
-func (l *LocalSession) RenamePool(ctx context.Context, id ksuid.KSUID, name string) error {
+func (l *local) RenamePool(ctx context.Context, id ksuid.KSUID, name string) error {
 	if name == "" {
 		return errors.New("no pool name provided")
 	}
 	return l.root.RenamePool(ctx, id, name)
 }
 
-func (l *LocalSession) CreateBranch(ctx context.Context, poolID ksuid.KSUID, name string, parent ksuid.KSUID) error {
+func (l *local) CreateBranch(ctx context.Context, poolID ksuid.KSUID, name string, parent ksuid.KSUID) error {
 	_, err := l.root.CreateBranch(ctx, poolID, name, parent)
 	return err
 }
 
-func (l *LocalSession) RemoveBranch(ctx context.Context, poolID ksuid.KSUID, branchName string) error {
+func (l *local) RemoveBranch(ctx context.Context, poolID ksuid.KSUID, branchName string) error {
 	return l.root.RemoveBranch(ctx, poolID, branchName)
 }
 
-func (l *LocalSession) MergeBranch(ctx context.Context, poolID ksuid.KSUID, childBranch, parentBranch string, message api.CommitMessage) (ksuid.KSUID, error) {
+func (l *local) MergeBranch(ctx context.Context, poolID ksuid.KSUID, childBranch, parentBranch string, message api.CommitMessage) (ksuid.KSUID, error) {
 	return l.root.MergeBranch(ctx, poolID, childBranch, parentBranch, message.Author, message.Body)
 }
 
-func (l *LocalSession) AddIndexRules(ctx context.Context, rules []index.Rule) error {
+func (l *local) AddIndexRules(ctx context.Context, rules []index.Rule) error {
 	return l.root.AddIndexRules(ctx, rules)
 }
 
-func (l *LocalSession) DeleteIndexRules(ctx context.Context, ids []ksuid.KSUID) ([]index.Rule, error) {
+func (l *local) DeleteIndexRules(ctx context.Context, ids []ksuid.KSUID) ([]index.Rule, error) {
 	return l.root.DeleteIndexRules(ctx, ids)
 }
 
-func (l *LocalSession) Query(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zio.ReadCloser, error) {
+func (l *local) Query(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zio.ReadCloser, error) {
 	q, err := l.QueryWithControl(ctx, head, src, srcfiles...)
 	if err != nil {
 		return nil, err
@@ -102,7 +110,7 @@ func (l *LocalSession) Query(ctx context.Context, head *lakeparse.Commitish, src
 	return zio.NewReadCloser(zbuf.NoControl(q), q), nil
 }
 
-func (l *LocalSession) QueryWithControl(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ProgressReadCloser, error) {
+func (l *local) QueryWithControl(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ProgressReadCloser, error) {
 	flowgraph, err := compiler.ParseProc(src, srcfiles...)
 	if err != nil {
 		return nil, err
@@ -117,18 +125,18 @@ func (l *LocalSession) QueryWithControl(ctx context.Context, head *lakeparse.Com
 	return q.AsProgressReadCloser(), nil
 }
 
-func (l *LocalSession) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error) {
+func (l *local) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error) {
 	if poolName == "" {
 		return ksuid.Nil, errors.New("no pool name provided")
 	}
 	return l.root.PoolID(ctx, poolName)
 }
 
-func (l *LocalSession) CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {
+func (l *local) CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {
 	return l.root.CommitObject(ctx, poolID, branchName)
 }
 
-func (l *LocalSession) lookupBranch(ctx context.Context, poolID ksuid.KSUID, branchName string) (*lake.Pool, *lake.Branch, error) {
+func (l *local) lookupBranch(ctx context.Context, poolID ksuid.KSUID, branchName string) (*lake.Pool, *lake.Branch, error) {
 	pool, err := l.root.OpenPool(ctx, poolID)
 	if err != nil {
 		return nil, nil, err
@@ -140,7 +148,7 @@ func (l *LocalSession) lookupBranch(ctx context.Context, poolID ksuid.KSUID, bra
 	return pool, branch, nil
 }
 
-func (l *LocalSession) Load(ctx context.Context, ztcx *zed.Context, poolID ksuid.KSUID, branchName string, r zio.Reader, message api.CommitMessage) (ksuid.KSUID, error) {
+func (l *local) Load(ctx context.Context, ztcx *zed.Context, poolID ksuid.KSUID, branchName string, r zio.Reader, message api.CommitMessage) (ksuid.KSUID, error) {
 	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
 	if err != nil {
 		return ksuid.Nil, err
@@ -148,7 +156,7 @@ func (l *LocalSession) Load(ctx context.Context, ztcx *zed.Context, poolID ksuid
 	return branch.Load(ctx, ztcx, r, message.Author, message.Body, message.Meta)
 }
 
-func (l *LocalSession) Delete(ctx context.Context, poolID ksuid.KSUID, branchName string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
+func (l *local) Delete(ctx context.Context, poolID ksuid.KSUID, branchName string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
 	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
 	if err != nil {
 		return ksuid.Nil, err
@@ -160,7 +168,7 @@ func (l *LocalSession) Delete(ctx context.Context, poolID ksuid.KSUID, branchNam
 	return commitID, nil
 }
 
-func (l *LocalSession) DeleteByPredicate(ctx context.Context, poolID ksuid.KSUID, branchName, src string, commit api.CommitMessage) (ksuid.KSUID, error) {
+func (l *local) DeleteByPredicate(ctx context.Context, poolID ksuid.KSUID, branchName, src string, commit api.CommitMessage) (ksuid.KSUID, error) {
 	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
 	if err != nil {
 		return ksuid.Nil, err
@@ -168,11 +176,11 @@ func (l *LocalSession) DeleteByPredicate(ctx context.Context, poolID ksuid.KSUID
 	return branch.DeleteByPredicate(ctx, l.root, src, commit.Author, commit.Body, commit.Meta)
 }
 
-func (l *LocalSession) Revert(ctx context.Context, poolID ksuid.KSUID, branchName string, commitID ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
+func (l *local) Revert(ctx context.Context, poolID ksuid.KSUID, branchName string, commitID ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
 	return l.root.Revert(ctx, poolID, branchName, commitID, message.Author, message.Body)
 }
 
-func (l *LocalSession) ApplyIndexRules(ctx context.Context, name string, poolID ksuid.KSUID, branchName string, inTags []ksuid.KSUID) (ksuid.KSUID, error) {
+func (l *local) ApplyIndexRules(ctx context.Context, name string, poolID ksuid.KSUID, branchName string, inTags []ksuid.KSUID) (ksuid.KSUID, error) {
 	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
 	if err != nil {
 		return ksuid.Nil, err
@@ -192,7 +200,7 @@ func (l *LocalSession) ApplyIndexRules(ctx context.Context, name string, poolID 
 	return commit, nil
 }
 
-func (l *LocalSession) UpdateIndex(ctx context.Context, names []string, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {
+func (l *local) UpdateIndex(ctx context.Context, names []string, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {
 	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
 	if err != nil {
 		return ksuid.Nil, err

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -26,7 +26,7 @@ type local struct {
 
 var _ Interface = (*local)(nil)
 
-func OpenLocalLake(ctx context.Context, lakePath string) (*local, error) {
+func OpenLocalLake(ctx context.Context, lakePath string) (Interface, error) {
 	uri, err := storage.ParseURI(lakePath)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func OpenLocalLake(ctx context.Context, lakePath string) (*local, error) {
 	return OpenLocalLakeWithURI(ctx, uri)
 }
 
-func OpenLocalLakeWithURI(ctx context.Context, lakePath *storage.URI) (*local, error) {
+func OpenLocalLakeWithURI(ctx context.Context, lakePath *storage.URI) (Interface, error) {
 	engine := storage.NewLocalEngine()
 	root, err := lake.Open(ctx, engine, lakePath)
 	if err != nil {
@@ -46,7 +46,7 @@ func OpenLocalLakeWithURI(ctx context.Context, lakePath *storage.URI) (*local, e
 	}, nil
 }
 
-func CreateLocalLake(ctx context.Context, lakePath *storage.URI) (*local, error) {
+func CreateLocalLake(ctx context.Context, lakePath *storage.URI) (Interface, error) {
 	engine := storage.NewLocalEngine()
 	root, err := lake.Create(ctx, engine, lakePath)
 	if err != nil {

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -12,7 +12,6 @@ import (
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
-	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/zngio"
@@ -25,17 +24,7 @@ type remote struct {
 
 var _ Interface = (*remote)(nil)
 
-func OpenRemoteLake(ctx context.Context, url string) (Interface, error) {
-	return &remote{
-		conn: client.NewConnectionTo(url),
-	}, nil
-}
-
-func OpenRemoteLakeWithURI(ctx context.Context, uri *storage.URI) (Interface, error) {
-	return OpenRemoteLake(ctx, uri.String())
-}
-
-func NewRemoteWithConnection(conn *client.Connection) *remote {
+func NewRemoteLake(conn *client.Connection) Interface {
 	return &remote{conn}
 }
 

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -25,13 +25,13 @@ type remote struct {
 
 var _ Interface = (*remote)(nil)
 
-func OpenRemoteLake(ctx context.Context, url string) (*remote, error) {
+func OpenRemoteLake(ctx context.Context, url string) (Interface, error) {
 	return &remote{
 		conn: client.NewConnectionTo(url),
 	}, nil
 }
 
-func OpenRemoteLakeWithURI(ctx context.Context, uri *storage.URI) (*remote, error) {
+func OpenRemoteLakeWithURI(ctx context.Context, uri *storage.URI) (Interface, error) {
 	return OpenRemoteLake(ctx, uri.String())
 }
 

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -33,14 +33,14 @@ func (c *testClient) TestPoolStats(id ksuid.KSUID) lake.PoolStats {
 }
 
 func (c *testClient) TestPoolGet(id ksuid.KSUID) (config pools.Config) {
-	remote := lakeapi.NewRemoteWithConnection(c.Connection)
+	remote := lakeapi.NewRemoteLake(c.Connection)
 	pool, err := lakeapi.LookupPoolByID(context.Background(), remote, id)
 	require.NoError(c, err)
 	return *pool
 }
 
 func (c *testClient) TestBranchGet(id ksuid.KSUID) (config lake.BranchMeta) {
-	remote := lakeapi.NewRemoteWithConnection(c.Connection)
+	remote := lakeapi.NewRemoteLake(c.Connection)
 	branch, err := lakeapi.LookupBranchByID(context.Background(), remote, id)
 	require.NoError(c, err)
 	return *branch


### PR DESCRIPTION
This commit simplifies package lake/api by not exporting
the implementations and making it easier to open a lake
with either a string URL or parsed storage.URI.  We added
the OpenLake method which figures out if a local or remote
instance should be used based on the URI.