### PR TITLE
move Zeek time handling to zio/zeekio from pkg/nano

### DIFF
--- a/zio/zeekio/builder.go
+++ b/zio/zeekio/builder.go
@@ -142,13 +142,13 @@ func (b *builder) appendPrimitive(typ zed.Type, val []byte) error {
 		}
 		b.buf = zed.AppendUint(b.buf[:0], v)
 	case zed.IDDuration:
-		v, err := nano.Parse(val) // zeek-style fractional ts
+		v, err := parseTime(val)
 		if err != nil {
 			return err
 		}
 		b.buf = zed.AppendDuration(b.buf[:0], nano.Duration(v))
 	case zed.IDTime:
-		v, err := nano.Parse(val)
+		v, err := parseTime(val)
 		if err != nil {
 			return err
 		}

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -29,11 +29,7 @@ func formatAny(zv zed.Value, inContainer bool) string {
 	case *zed.TypeOfBytes:
 		return base64.StdEncoding.EncodeToString(zv.Bytes)
 	case *zed.TypeOfDuration:
-		// This format of a fractional second is used by Zeek in logs.
-		// It uses enough precision to fully represent the 64-bit ns
-		// accuracy of a nano Duration. Such values cannot be represented by
-		// float64's without loss of the least significant digits of ns.
-		return nano.Ts(zed.DecodeDuration(zv.Bytes)).StringFloat()
+		return formatTime(nano.Ts(zed.DecodeDuration(zv.Bytes)), -1)
 	case *zed.TypeEnum:
 		return formatAny(zed.Value{zed.TypeUint64, zv.Bytes}, false)
 	case *zed.TypeOfFloat32:
@@ -59,11 +55,7 @@ func formatAny(zv zed.Value, inContainer bool) string {
 	case *zed.TypeOfString:
 		return formatString(t, zv.Bytes, inContainer)
 	case *zed.TypeOfTime:
-		// This format of a fractional second is used by Zeek in logs.
-		// It uses enough precision to fully represent the 64-bit ns
-		// accuracy of a nano.Ts.  Such values cannot be representd by
-		// float64's without loss of the least significant digits of ns.
-		return zed.DecodeTime(zv.Bytes).StringFloat()
+		return formatTime(zed.DecodeTime(zv.Bytes), -1)
 	case *zed.TypeOfType:
 		return zson.String(zv)
 	case *zed.TypeUnion:

--- a/zio/zeekio/parser_test.go
+++ b/zio/zeekio/parser_test.go
@@ -93,7 +93,7 @@ func TestLegacyZeekValid(t *testing.T) {
 	record, err = sendLegacyValues(parser, valsWithTs)
 	require.NoError(t, err)
 
-	expectedTs, err := nano.Parse([]byte(timestamp))
+	expectedTs, err := parseTime([]byte(timestamp))
 	require.NoError(t, err)
 	x := record.Deref("ts").AsTime()
 	assert.Equal(t, expectedTs, x, "Timestamp is correct")

--- a/zio/zeekio/time.go
+++ b/zio/zeekio/time.go
@@ -1,0 +1,94 @@
+package zeekio
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/brimdata/zed/pkg/byteconv"
+	"github.com/brimdata/zed/pkg/nano"
+)
+
+// formatTime formats ts as a Zeek time value.  A Zeek time value is a
+// floating-point number representing seconds since (or before, for negative
+// values) the Unix epoch.  Since a float64 lacks sufficient precision to
+// represent an arbitrary nano.Ts value, formatTime and parseTime do extra work
+// to preserve precision that would be lost by using strconv.FormatFloat and
+// ParseFloat.
+func formatTime(ts nano.Ts, precision int) string {
+	sec, ns := ts.Split()
+	var negative bool
+	if sec < 0 {
+		sec = sec * -1
+		negative = true
+	}
+	if ns < 0 {
+		ns = ns * -1
+		negative = true
+	}
+	var dst []byte
+	if negative {
+		dst = append(dst, '-')
+	}
+	dst = strconv.AppendInt(dst, sec, 10)
+	if ns > 0 || precision > 0 {
+		n := len(dst)
+		dst = strconv.AppendFloat(dst, float64(ns)/1e9, 'f', precision, 64)
+		// Remove the first '0'.  This is a little hacky but the alternative
+		// is implementing this ourselves.  Something to avoid given
+		// https://golang.org/src/math/big/ftoa.go?s=2522:2583#L53.
+		dst = append(dst[:n], dst[n+1:]...)
+	}
+	return string(dst)
+}
+
+// parseTime interprets b as a Zeek time value and returns the corresponding
+// value.  See formatTime for details.
+func parseTime(b []byte) (nano.Ts, error) {
+	if ts, ok := parseTimeDecimal(b); ok {
+		return ts, nil
+	}
+	// Slow path for scientific notation.
+	if f, err := byteconv.ParseFloat64(b); err == nil {
+		sec := math.Round(f)
+		ns := f - sec
+		return nano.Ts(int64(sec)*1e9 + int64(ns*1e9)), nil
+	}
+	return 0, fmt.Errorf("invalid time format: %q", b)
+}
+
+func parseTimeDecimal(b []byte) (nano.Ts, bool) {
+	var v, scale, sign int64
+	sign = 1
+	scale = 1000000000
+	k := 0
+	n := len(b)
+	if n == 0 {
+		return 0, false
+	}
+	if b[0] == '-' {
+		if n == 1 {
+			return 0, false
+		}
+		sign, k = -1, 1
+	}
+	for ; k < n; k++ {
+		c := b[k]
+		if c != '.' && (c < '0' || c > '9') {
+			return 0, false
+		}
+		if c == '.' {
+			for k++; k < n; k++ {
+				c = b[k]
+				if c < '0' || c > '9' {
+					return 0, false
+				}
+				v = v*10 + int64(c-'0')
+				scale /= 10
+			}
+			break
+		}
+		v = v*10 + int64(c-'0')
+	}
+	return nano.Ts(sign * v * scale), true
+}

--- a/zio/zeekio/time_test.go
+++ b/zio/zeekio/time_test.go
@@ -1,0 +1,42 @@
+package zeekio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brimdata/zed/pkg/nano"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatTime(t *testing.T) {
+	assert.Equal(t, "-60.000000001", formatTime(-nano.Ts(time.Minute+1), -1))
+	assert.Equal(t, "-60.00000001", formatTime(-nano.Ts(time.Minute+10), -1))
+	assert.Equal(t, "-60", formatTime(-nano.Ts(time.Minute), -1))
+	assert.Equal(t, "-0.1", formatTime(-nano.Ts(time.Millisecond*100), -1))
+	assert.Equal(t, "-60.000000", formatTime(-nano.Ts(time.Minute), 6))
+	assert.Equal(t, "60.001000000", formatTime(nano.Ts(time.Minute+time.Millisecond), 9))
+}
+
+func TestParseTime(t *testing.T) {
+	cases := []struct {
+		input      string
+		expectedTs nano.Ts
+	}{
+		{"0", 0},
+		{"1425565514.419939", 1425565514419939000},
+		{"001425565514.419939", 1425565514419939000},
+		{"-1425565514.419939", -1425565514419939000},
+		{"1e9", 1e9 * 1e9},
+		{"1.123e8", 1.123e8 * 1e9},
+		{"1.123e-5", nano.Ts(1.123e-5 * 1e9)},
+	}
+	for _, c := range cases {
+		ts, err := parseTime([]byte(c.input))
+		assert.NoError(t, err, "input: %q", c.input)
+		assert.Exactly(t, c.expectedTs, ts, "input: %q", c.input)
+	}
+	for _, input := range []string{"", " ", "a"} {
+		_, err := parseTime([]byte(input))
+		assert.Error(t, err, "input: %q", input)
+	}
+}

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -125,7 +125,7 @@ func ZeekStrings(r *zed.Value) ([]string, error) {
 			if isHighPrecision(ts) {
 				precision = 9
 			}
-			field = string(ts.AppendFloat(nil, precision))
+			field = formatTime(ts, precision)
 		} else {
 			field = formatAny(zed.Value{col.Type, val}, false)
 		}


### PR DESCRIPTION
There's no good reason for pkg/nano to know about Zeek's floating-point
time format.