### PR TITLE
rework some parser rules to reduce backtracking

### DIFF
--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -137,201 +137,197 @@ function peg$parse(input, options) {
       peg$c1 = function(consts, first, rest) {
             return {"kind": "Sequential", "ops": [first, ... rest], "consts":consts}
           },
-      peg$c2 = function(consts, op) {
-            return {"kind": "Sequential", "ops": [op], "consts":consts}
-          },
-      peg$c3 = function(p) { return p },
-      peg$c4 = function() { return [] },
-      peg$c5 = function(v) { return v },
-      peg$c6 = "const",
-      peg$c7 = peg$literalExpectation("const", false),
-      peg$c8 = "=",
-      peg$c9 = peg$literalExpectation("=", false),
-      peg$c10 = function(id, expr) {
+      peg$c2 = function(p) { return p },
+      peg$c3 = function() { return [] },
+      peg$c4 = function(v) { return v },
+      peg$c5 = "const",
+      peg$c6 = peg$literalExpectation("const", false),
+      peg$c7 = "=",
+      peg$c8 = peg$literalExpectation("=", false),
+      peg$c9 = function(id, expr) {
             return {"name":id, "expr":expr}
           },
-      peg$c11 = "type",
-      peg$c12 = peg$literalExpectation("type", false),
-      peg$c13 = function(id, typ) {
+      peg$c10 = "type",
+      peg$c11 = peg$literalExpectation("type", false),
+      peg$c12 = function(id, typ) {
             return {
               
             "name":id,
               
             "expr":{"kind":"TypeValue","value":{"kind":"TypeDef","name":id,"type":typ}}}
           
-
           },
-      peg$c14 = "fork",
-      peg$c15 = peg$literalExpectation("fork", false),
-      peg$c16 = "(",
-      peg$c17 = peg$literalExpectation("(", false),
-      peg$c18 = ")",
-      peg$c19 = peg$literalExpectation(")", false),
-      peg$c20 = function(ops) {
+      peg$c13 = "fork",
+      peg$c14 = peg$literalExpectation("fork", false),
+      peg$c15 = "(",
+      peg$c16 = peg$literalExpectation("(", false),
+      peg$c17 = ")",
+      peg$c18 = peg$literalExpectation(")", false),
+      peg$c19 = function(ops) {
             return {"kind": "Parallel", "ops": ops}
           },
-      peg$c21 = "switch",
-      peg$c22 = peg$literalExpectation("switch", false),
-      peg$c23 = function(expr, cases) {
+      peg$c20 = "switch",
+      peg$c21 = peg$literalExpectation("switch", false),
+      peg$c22 = function(expr, cases) {
             return {"kind": "Switch", "expr": expr, "cases": cases}
           },
-      peg$c24 = function(cases) {
+      peg$c23 = function(cases) {
             return {"kind": "Switch", "expr": null, "cases": cases}
           },
-      peg$c25 = "from",
-      peg$c26 = peg$literalExpectation("from", false),
-      peg$c27 = function(trunks) {
+      peg$c24 = "from",
+      peg$c25 = peg$literalExpectation("from", false),
+      peg$c26 = function(trunks) {
             return {"kind": "From", "trunks": trunks}
           },
-      peg$c28 = function(a) { return a },
-      peg$c29 = "search",
-      peg$c30 = peg$literalExpectation("search", false),
-      peg$c31 = function(expr) {
+      peg$c27 = function(a) { return a },
+      peg$c28 = "search",
+      peg$c29 = peg$literalExpectation("search", false),
+      peg$c30 = function(expr) {
             return {"kind": "Search", "expr": expr}
+          },
+      peg$c31 = function(expr) {
+            return {"kind": "OpExpr", "expr": expr}
           },
       peg$c32 = function(expr) {
             return {"kind": "OpExpr", "expr": expr}
-          },
-      peg$c33 = function(expr) {
-            return {"kind": "OpExpr", "expr": expr}
         },
-      peg$c34 = "=>",
-      peg$c35 = peg$literalExpectation("=>", false),
-      peg$c36 = "|",
-      peg$c37 = peg$literalExpectation("|", false),
-      peg$c38 = "{",
-      peg$c39 = peg$literalExpectation("{", false),
-      peg$c40 = "[",
-      peg$c41 = peg$literalExpectation("[", false),
-      peg$c42 = function(s) { return s },
-      peg$c43 = function(expr, op) {
+      peg$c33 = "=>",
+      peg$c34 = peg$literalExpectation("=>", false),
+      peg$c35 = "|",
+      peg$c36 = peg$literalExpectation("|", false),
+      peg$c37 = "{",
+      peg$c38 = peg$literalExpectation("{", false),
+      peg$c39 = "[",
+      peg$c40 = peg$literalExpectation("[", false),
+      peg$c41 = function(s) { return s },
+      peg$c42 = function(expr, op) {
             return {"expr": expr, "op": op}
           },
-      peg$c44 = "case",
-      peg$c45 = peg$literalExpectation("case", false),
-      peg$c46 = function(expr) { return expr },
-      peg$c47 = "default",
-      peg$c48 = peg$literalExpectation("default", false),
-      peg$c49 = function() { return null },
-      peg$c50 = function(source, seq) {
+      peg$c43 = "case",
+      peg$c44 = peg$literalExpectation("case", false),
+      peg$c45 = function(expr) { return expr },
+      peg$c46 = "default",
+      peg$c47 = peg$literalExpectation("default", false),
+      peg$c48 = function() { return null },
+      peg$c49 = function(source, seq) {
             return {"kind": "Trunk", "source": source, "seq": seq}
           },
-      peg$c51 = function(source) {
+      peg$c50 = function(source) {
             return {"kind": "Trunk", "source": source, "seq": null}
           },
-      peg$c52 = function(src) { return src },
-      peg$c53 = ":",
-      peg$c54 = peg$literalExpectation(":", false),
-      peg$c55 = "~",
-      peg$c56 = peg$literalExpectation("~", false),
-      peg$c57 = "==",
-      peg$c58 = peg$literalExpectation("==", false),
-      peg$c59 = "!=",
-      peg$c60 = peg$literalExpectation("!=", false),
-      peg$c61 = "in",
-      peg$c62 = peg$literalExpectation("in", false),
-      peg$c63 = "<=",
-      peg$c64 = peg$literalExpectation("<=", false),
-      peg$c65 = "<",
-      peg$c66 = peg$literalExpectation("<", false),
-      peg$c67 = ">=",
-      peg$c68 = peg$literalExpectation(">=", false),
-      peg$c69 = ">",
-      peg$c70 = peg$literalExpectation(">", false),
-      peg$c71 = function() { return text() },
-      peg$c72 = function(first, rest) {
+      peg$c51 = function(src) { return src },
+      peg$c52 = ":",
+      peg$c53 = peg$literalExpectation(":", false),
+      peg$c54 = "~",
+      peg$c55 = peg$literalExpectation("~", false),
+      peg$c56 = "==",
+      peg$c57 = peg$literalExpectation("==", false),
+      peg$c58 = "!=",
+      peg$c59 = peg$literalExpectation("!=", false),
+      peg$c60 = "in",
+      peg$c61 = peg$literalExpectation("in", false),
+      peg$c62 = "<=",
+      peg$c63 = peg$literalExpectation("<=", false),
+      peg$c64 = "<",
+      peg$c65 = peg$literalExpectation("<", false),
+      peg$c66 = ">=",
+      peg$c67 = peg$literalExpectation(">=", false),
+      peg$c68 = ">",
+      peg$c69 = peg$literalExpectation(">", false),
+      peg$c70 = function() { return text() },
+      peg$c71 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c73 = function(t) { return ["or", t] },
-      peg$c74 = function(first, expr) { return ["and", expr] },
-      peg$c75 = function(first, rest) {
+      peg$c72 = function(t) { return ["or", t] },
+      peg$c73 = function(first, expr) { return ["and", expr] },
+      peg$c74 = function(first, rest) {
             return makeBinaryExprChain(first,rest)
           },
-      peg$c76 = "!",
-      peg$c77 = peg$literalExpectation("!", false),
-      peg$c78 = function(e) {
+      peg$c75 = "!",
+      peg$c76 = peg$literalExpectation("!", false),
+      peg$c77 = function(e) {
             return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c79 = function(v) {
+      peg$c78 = function(v) {
             return {"kind": "Term", "text": text(), "value": v}
           },
-      peg$c80 = "*",
-      peg$c81 = peg$literalExpectation("*", false),
-      peg$c82 = function() {
+      peg$c79 = "*",
+      peg$c80 = peg$literalExpectation("*", false),
+      peg$c81 = function() {
             return {"kind": "Primitive", "type": "bool", "text": "true"}
           },
-      peg$c83 = function(lhs, op, rhs) {
+      peg$c82 = function(lhs, op, rhs) {
             return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c84 = function(first, rest) {
+      peg$c83 = function(first, rest) {
                return makeBinaryExprChain(first, rest)
            },
-      peg$c85 = function(v) {
+      peg$c84 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": v}
           },
-      peg$c86 = function(pattern) {
+      peg$c85 = function(pattern) {
             return {"kind": "Glob", "pattern": pattern}
         },
-      peg$c87 = function(pattern) {
+      peg$c86 = function(pattern) {
             return {"kind": "Regexp", "pattern": pattern}
         },
-      peg$c88 = function(keys, limit) {
+      peg$c87 = function(keys, limit) {
             return {"kind": "Summarize", "keys": keys, "aggs": null, "limit": limit}
           },
-      peg$c89 = function(aggs, keys, limit) {
+      peg$c88 = function(aggs, keys, limit) {
             let p = {"kind": "Summarize", "keys": null, "aggs": aggs, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
             }
             return p
           },
-      peg$c90 = "summarize",
-      peg$c91 = peg$literalExpectation("summarize", false),
-      peg$c92 = function(columns) { return columns },
-      peg$c93 = "with",
-      peg$c94 = peg$literalExpectation("with", false),
-      peg$c95 = "-limit",
-      peg$c96 = peg$literalExpectation("-limit", false),
-      peg$c97 = function(limit) { return limit },
-      peg$c98 = "",
-      peg$c99 = function() { return 0 },
-      peg$c100 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c101 = ",",
-      peg$c102 = peg$literalExpectation(",", false),
-      peg$c103 = function(first, expr) { return expr },
-      peg$c104 = function(first, rest) {
+      peg$c89 = "summarize",
+      peg$c90 = peg$literalExpectation("summarize", false),
+      peg$c91 = function(columns) { return columns },
+      peg$c92 = "with",
+      peg$c93 = peg$literalExpectation("with", false),
+      peg$c94 = "-limit",
+      peg$c95 = peg$literalExpectation("-limit", false),
+      peg$c96 = function(limit) { return limit },
+      peg$c97 = "",
+      peg$c98 = function() { return 0 },
+      peg$c99 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c100 = ",",
+      peg$c101 = peg$literalExpectation(",", false),
+      peg$c102 = function(first, expr) { return expr },
+      peg$c103 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c105 = ":=",
-      peg$c106 = peg$literalExpectation(":=", false),
-      peg$c107 = function(lval, agg) {
+      peg$c104 = ":=",
+      peg$c105 = peg$literalExpectation(":=", false),
+      peg$c106 = function(lval, agg) {
             return {"kind": "Assignment", "lhs": lval, "rhs": agg}
           },
-      peg$c108 = function(agg) {
+      peg$c107 = function(agg) {
             return {"kind": "Assignment", "lhs": null, "rhs": agg}
           },
-      peg$c109 = ".",
-      peg$c110 = peg$literalExpectation(".", false),
-      peg$c111 = function(op, expr, where) {
+      peg$c108 = ".",
+      peg$c109 = peg$literalExpectation(".", false),
+      peg$c110 = function(op, expr, where) {
             let r = {"kind": "Agg", "name": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c112 = "where",
-      peg$c113 = peg$literalExpectation("where", false),
-      peg$c114 = function(first, rest) {
+      peg$c111 = "where",
+      peg$c112 = peg$literalExpectation("where", false),
+      peg$c113 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c115 = "sort",
-      peg$c116 = peg$literalExpectation("sort", false),
-      peg$c117 = function(args, l) { return l },
-      peg$c118 = function(args, list) {
+      peg$c114 = "sort",
+      peg$c115 = peg$literalExpectation("sort", false),
+      peg$c116 = function(args, l) { return l },
+      peg$c117 = function(args, list) {
             let argm = args;
             let op = {"kind": "Sort", "args": list, "order": "asc", "nullsfirst": false};
             if ( "r" in argm) {
@@ -344,24 +340,24 @@ function peg$parse(input, options) {
             }
             return op
           },
-      peg$c119 = function(args) { return makeArgMap(args) },
-      peg$c120 = "-r",
-      peg$c121 = peg$literalExpectation("-r", false),
-      peg$c122 = function() { return {"name": "r", "value": null} },
-      peg$c123 = "-nulls",
-      peg$c124 = peg$literalExpectation("-nulls", false),
-      peg$c125 = "first",
-      peg$c126 = peg$literalExpectation("first", false),
-      peg$c127 = "last",
-      peg$c128 = peg$literalExpectation("last", false),
-      peg$c129 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c130 = "top",
-      peg$c131 = peg$literalExpectation("top", false),
-      peg$c132 = function(n) { return n},
-      peg$c133 = "-flush",
-      peg$c134 = peg$literalExpectation("-flush", false),
-      peg$c135 = function(limit, flush, f) { return f },
-      peg$c136 = function(limit, flush, fields) {
+      peg$c118 = function(args) { return makeArgMap(args) },
+      peg$c119 = "-r",
+      peg$c120 = peg$literalExpectation("-r", false),
+      peg$c121 = function() { return {"name": "r", "value": null} },
+      peg$c122 = "-nulls",
+      peg$c123 = peg$literalExpectation("-nulls", false),
+      peg$c124 = "first",
+      peg$c125 = peg$literalExpectation("first", false),
+      peg$c126 = "last",
+      peg$c127 = peg$literalExpectation("last", false),
+      peg$c128 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c129 = "top",
+      peg$c130 = peg$literalExpectation("top", false),
+      peg$c131 = function(n) { return n},
+      peg$c132 = "-flush",
+      peg$c133 = peg$literalExpectation("-flush", false),
+      peg$c134 = function(limit, flush, f) { return f },
+      peg$c135 = function(limit, flush, fields) {
             let op = {"kind": "Top", "limit": 0, "args": null, "flush": false};
             if (limit) {
               op["limit"] = limit;
@@ -374,89 +370,89 @@ function peg$parse(input, options) {
             }
             return op
           },
-      peg$c137 = "cut",
-      peg$c138 = peg$literalExpectation("cut", false),
-      peg$c139 = function(args) {
+      peg$c136 = "cut",
+      peg$c137 = peg$literalExpectation("cut", false),
+      peg$c138 = function(args) {
             return {"kind": "Cut", "args": args}
           },
-      peg$c140 = "drop",
-      peg$c141 = peg$literalExpectation("drop", false),
-      peg$c142 = function(args) {
+      peg$c139 = "drop",
+      peg$c140 = peg$literalExpectation("drop", false),
+      peg$c141 = function(args) {
             return {"kind": "Drop", "args": args}
           },
-      peg$c143 = "head",
-      peg$c144 = peg$literalExpectation("head", false),
-      peg$c145 = function(count) { return {"kind": "Head", "count": count} },
-      peg$c146 = function() { return {"kind": "Head", "count": 1} },
-      peg$c147 = "tail",
-      peg$c148 = peg$literalExpectation("tail", false),
-      peg$c149 = function(count) { return {"kind": "Tail", "count": count} },
-      peg$c150 = function() { return {"kind": "Tail", "count": 1} },
-      peg$c151 = function(expr) {
+      peg$c142 = "head",
+      peg$c143 = peg$literalExpectation("head", false),
+      peg$c144 = function(count) { return {"kind": "Head", "count": count} },
+      peg$c145 = function() { return {"kind": "Head", "count": 1} },
+      peg$c146 = "tail",
+      peg$c147 = peg$literalExpectation("tail", false),
+      peg$c148 = function(count) { return {"kind": "Tail", "count": count} },
+      peg$c149 = function() { return {"kind": "Tail", "count": 1} },
+      peg$c150 = function(expr) {
             return {"kind": "Where", "expr": expr}
           },
-      peg$c152 = "uniq",
-      peg$c153 = peg$literalExpectation("uniq", false),
-      peg$c154 = "-c",
-      peg$c155 = peg$literalExpectation("-c", false),
-      peg$c156 = function() {
+      peg$c151 = "uniq",
+      peg$c152 = peg$literalExpectation("uniq", false),
+      peg$c153 = "-c",
+      peg$c154 = peg$literalExpectation("-c", false),
+      peg$c155 = function() {
             return {"kind": "Uniq", "cflag": true}
           },
-      peg$c157 = function() {
+      peg$c156 = function() {
             return {"kind": "Uniq", "cflag": false}
           },
-      peg$c158 = "put",
-      peg$c159 = peg$literalExpectation("put", false),
-      peg$c160 = function(args) {
+      peg$c157 = "put",
+      peg$c158 = peg$literalExpectation("put", false),
+      peg$c159 = function(args) {
             return {"kind": "Put", "args": args}
           },
-      peg$c161 = "rename",
-      peg$c162 = peg$literalExpectation("rename", false),
-      peg$c163 = function(first, cl) { return cl },
-      peg$c164 = function(first, rest) {
+      peg$c160 = "rename",
+      peg$c161 = peg$literalExpectation("rename", false),
+      peg$c162 = function(first, cl) { return cl },
+      peg$c163 = function(first, rest) {
             return {"kind": "Rename", "args": [first, ... rest]}
           },
-      peg$c165 = "fuse",
-      peg$c166 = peg$literalExpectation("fuse", false),
-      peg$c167 = function() {
+      peg$c164 = "fuse",
+      peg$c165 = peg$literalExpectation("fuse", false),
+      peg$c166 = function() {
             return {"kind": "Fuse"}
           },
-      peg$c168 = "shape",
-      peg$c169 = peg$literalExpectation("shape", false),
-      peg$c170 = function() {
+      peg$c167 = "shape",
+      peg$c168 = peg$literalExpectation("shape", false),
+      peg$c169 = function() {
             return {"kind": "Shape"}
           },
-      peg$c171 = "join",
-      peg$c172 = peg$literalExpectation("join", false),
-      peg$c173 = function(style, leftKey, rightKey, columns) {
+      peg$c170 = "join",
+      peg$c171 = peg$literalExpectation("join", false),
+      peg$c172 = function(style, leftKey, rightKey, columns) {
             let op = {"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": null};
             if (columns) {
               op["args"] = columns[1];
             }
             return op
           },
-      peg$c174 = function(style, key, columns) {
+      peg$c173 = function(style, key, columns) {
             let op = {"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": null};
             if (columns) {
               op["args"] = columns[1];
             }
             return op
           },
-      peg$c175 = "anti",
-      peg$c176 = peg$literalExpectation("anti", false),
-      peg$c177 = function() { return "anti" },
-      peg$c178 = "inner",
-      peg$c179 = peg$literalExpectation("inner", false),
-      peg$c180 = function() { return "inner" },
-      peg$c181 = "left",
-      peg$c182 = peg$literalExpectation("left", false),
-      peg$c183 = function() { return "left" },
-      peg$c184 = "right",
-      peg$c185 = peg$literalExpectation("right", false),
-      peg$c186 = function() { return "right" },
-      peg$c187 = "sample",
-      peg$c188 = peg$literalExpectation("sample", false),
-      peg$c189 = function(e) {
+      peg$c174 = "anti",
+      peg$c175 = peg$literalExpectation("anti", false),
+      peg$c176 = function() { return "anti" },
+      peg$c177 = "inner",
+      peg$c178 = peg$literalExpectation("inner", false),
+      peg$c179 = function() { return "inner" },
+      peg$c180 = "left",
+      peg$c181 = peg$literalExpectation("left", false),
+      peg$c182 = function() { return "left" },
+      peg$c183 = "right",
+      peg$c184 = peg$literalExpectation("right", false),
+      peg$c185 = function() { return "right" },
+      peg$c186 = "sample",
+      peg$c187 = peg$literalExpectation("sample", false),
+      peg$c188 = function(e) {
             return {"kind": "Sequential", "consts": [], "ops": [
               
             {"kind": "Summarize",
@@ -492,116 +488,116 @@ function peg$parse(input, options) {
             {"kind": "ID", "name": "sample"}]}]}
           
           },
-      peg$c190 = function(a) {
+      peg$c189 = function(a) {
           return {"kind": "OpAssignment", "assignments": a}
         },
-      peg$c191 = function(lval) { return lval},
-      peg$c192 = function() { return {"kind":"ID", "name":"this"} },
-      peg$c193 = function(source) {
+      peg$c190 = function(lval) { return lval},
+      peg$c191 = function() { return {"kind":"ID", "name":"this"} },
+      peg$c192 = function(source) {
             return {"kind":"From", "trunks": [{"kind": "Trunk","source": source}]}
           },
-      peg$c194 = "file",
-      peg$c195 = peg$literalExpectation("file", false),
-      peg$c196 = function(path, format, layout) {
+      peg$c193 = "file",
+      peg$c194 = peg$literalExpectation("file", false),
+      peg$c195 = function(path, format, layout) {
             return {"kind": "File", "path": path, "format": format, "layout": layout }
           },
-      peg$c197 = function(body) { return body },
-      peg$c198 = "pool",
-      peg$c199 = peg$literalExpectation("pool", false),
-      peg$c200 = function(spec, at, over, order) {
+      peg$c196 = function(body) { return body },
+      peg$c197 = "pool",
+      peg$c198 = peg$literalExpectation("pool", false),
+      peg$c199 = function(spec, at, over, order) {
             return {"kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order}
           },
-      peg$c201 = "get",
-      peg$c202 = peg$literalExpectation("get", false),
-      peg$c203 = function(url, format, layout) {
+      peg$c200 = "get",
+      peg$c201 = peg$literalExpectation("get", false),
+      peg$c202 = function(url, format, layout) {
             return {"kind": "HTTP", "url": url, "format": format, "layout": layout }
           },
-      peg$c204 = "http:",
-      peg$c205 = peg$literalExpectation("http:", false),
-      peg$c206 = "https:",
-      peg$c207 = peg$literalExpectation("https:", false),
-      peg$c208 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
-      peg$c209 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
-      peg$c210 = "at",
-      peg$c211 = peg$literalExpectation("at", false),
-      peg$c212 = function(id) { return id },
-      peg$c213 = /^[0-9a-zA-Z]/,
-      peg$c214 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
-      peg$c215 = "range",
-      peg$c216 = peg$literalExpectation("range", false),
-      peg$c217 = "to",
-      peg$c218 = peg$literalExpectation("to", false),
-      peg$c219 = function(lower, upper) {
+      peg$c203 = "http:",
+      peg$c204 = peg$literalExpectation("http:", false),
+      peg$c205 = "https:",
+      peg$c206 = peg$literalExpectation("https:", false),
+      peg$c207 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
+      peg$c208 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
+      peg$c209 = "at",
+      peg$c210 = peg$literalExpectation("at", false),
+      peg$c211 = function(id) { return id },
+      peg$c212 = /^[0-9a-zA-Z]/,
+      peg$c213 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
+      peg$c214 = "range",
+      peg$c215 = peg$literalExpectation("range", false),
+      peg$c216 = "to",
+      peg$c217 = peg$literalExpectation("to", false),
+      peg$c218 = function(lower, upper) {
             return {"kind":"Range","lower": lower, "upper": upper}
           },
-      peg$c220 = function(pool, commit, meta) {
+      peg$c219 = function(pool, commit, meta) {
             return {"pool": pool, "commit": commit, "meta": meta}
           },
-      peg$c221 = function(meta) {
+      peg$c220 = function(meta) {
             return {"pool": null, "commit": null, "meta": meta}
           },
-      peg$c222 = "@",
-      peg$c223 = peg$literalExpectation("@", false),
-      peg$c224 = function(commit) { return commit },
-      peg$c225 = function(meta) { return meta },
-      peg$c226 = function() {  return text() },
-      peg$c227 = "order",
-      peg$c228 = peg$literalExpectation("order", false),
-      peg$c229 = function(keys, order) {
+      peg$c221 = "@",
+      peg$c222 = peg$literalExpectation("@", false),
+      peg$c223 = function(commit) { return commit },
+      peg$c224 = function(meta) { return meta },
+      peg$c225 = function() {  return text() },
+      peg$c226 = "order",
+      peg$c227 = peg$literalExpectation("order", false),
+      peg$c228 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c230 = "format",
-      peg$c231 = peg$literalExpectation("format", false),
-      peg$c232 = function(val) { return val },
-      peg$c233 = ":asc",
-      peg$c234 = peg$literalExpectation(":asc", false),
-      peg$c235 = function() { return "asc" },
-      peg$c236 = ":desc",
-      peg$c237 = peg$literalExpectation(":desc", false),
-      peg$c238 = function() { return "desc" },
-      peg$c239 = "asc",
-      peg$c240 = peg$literalExpectation("asc", false),
-      peg$c241 = "desc",
-      peg$c242 = peg$literalExpectation("desc", false),
-      peg$c243 = "pass",
-      peg$c244 = peg$literalExpectation("pass", false),
-      peg$c245 = function() {
+      peg$c229 = "format",
+      peg$c230 = peg$literalExpectation("format", false),
+      peg$c231 = function(val) { return val },
+      peg$c232 = ":asc",
+      peg$c233 = peg$literalExpectation(":asc", false),
+      peg$c234 = function() { return "asc" },
+      peg$c235 = ":desc",
+      peg$c236 = peg$literalExpectation(":desc", false),
+      peg$c237 = function() { return "desc" },
+      peg$c238 = "asc",
+      peg$c239 = peg$literalExpectation("asc", false),
+      peg$c240 = "desc",
+      peg$c241 = peg$literalExpectation("desc", false),
+      peg$c242 = "pass",
+      peg$c243 = peg$literalExpectation("pass", false),
+      peg$c244 = function() {
             return {"kind":"Pass"}
           },
-      peg$c246 = "explode",
-      peg$c247 = peg$literalExpectation("explode", false),
-      peg$c248 = function(args, typ, as) {
+      peg$c245 = "explode",
+      peg$c246 = peg$literalExpectation("explode", false),
+      peg$c247 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c249 = "merge",
-      peg$c250 = peg$literalExpectation("merge", false),
-      peg$c251 = function(expr) {
+      peg$c248 = "merge",
+      peg$c249 = peg$literalExpectation("merge", false),
+      peg$c250 = function(expr) {
       	  return {"kind":"Merge", "expr":expr}
           },
-      peg$c252 = "over",
-      peg$c253 = peg$literalExpectation("over", false),
-      peg$c254 = function(exprs, locals, scope) {
-            return {"kind":"Let", "locals":locals, "over":{"kind":"Over", "exprs":exprs, "scope":scope}}
+      peg$c251 = "over",
+      peg$c252 = peg$literalExpectation("over", false),
+      peg$c253 = function(exprs, l) { return l },
+      peg$c254 = function(exprs, locals, s) { return s },
+      peg$c255 = function(exprs, locals, scope) {
+            let over = {"kind": "Over", "exprs": exprs, "scope": scope};
+            if (locals) {
+              return {"kind": "Let", "locals": locals, "over": over}
+            }
+            return over
           },
-      peg$c255 = function(exprs, scope) {
-            return {"kind":"Over", "exprs":exprs, "scope":scope}
-          },
-      peg$c256 = function(exprs) {
-            return {"kind":"Over", "exprs":exprs, "scope":null}
-          },
-      peg$c257 = function(seq) { return seq },
-      peg$c258 = function(first, a) { return a },
-      peg$c259 = function(id) {
+      peg$c256 = function(seq) { return seq },
+      peg$c257 = function(first, a) { return a },
+      peg$c258 = function(id) {
             return {"name":id, "expr":{"kind":"ID","name":id}}
           },
-      peg$c260 = "yield",
-      peg$c261 = peg$literalExpectation("yield", false),
-      peg$c262 = function(exprs) {
+      peg$c259 = "yield",
+      peg$c260 = peg$literalExpectation("yield", false),
+      peg$c261 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c263 = function(typ) { return typ},
-      peg$c264 = function(lhs) { return lhs },
-      peg$c266 = function(first, rest) {
+      peg$c262 = function(typ) { return typ},
+      peg$c263 = function(lhs) { return lhs },
+      peg$c265 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -610,125 +606,119 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c267 = function(first, rest) {
+      peg$c266 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c268 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c269 = "?",
-      peg$c270 = peg$literalExpectation("?", false),
-      peg$c271 = function(condition, thenClause, elseClause) {
+      peg$c267 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c268 = "?",
+      peg$c269 = peg$literalExpectation("?", false),
+      peg$c270 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c272 = function(first, op, expr) { return [op, expr] },
-      peg$c273 = function(first, rest) {
+      peg$c271 = function(first, op, expr) { return [op, expr] },
+      peg$c272 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c274 = function(lhs, op, rhs) {
-              return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
+      peg$c273 = function(lhs) { return text() },
+      peg$c274 = function(lhs, opAndRHS) {
+            if (!opAndRHS) {
+              return lhs
+            }
+            let op = opAndRHS[1];
+            let rhs = opAndRHS[3];
+            return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c275 = function(lhs, rhs) {
-              return {"kind": "BinaryExpr", "op": "~", "lhs": lhs, "rhs": rhs}
-          },
-      peg$c276 = "+",
-      peg$c277 = peg$literalExpectation("+", false),
-      peg$c278 = "-",
-      peg$c279 = peg$literalExpectation("-", false),
-      peg$c280 = "/",
-      peg$c281 = peg$literalExpectation("/", false),
-      peg$c282 = "%",
-      peg$c283 = peg$literalExpectation("%", false),
-      peg$c284 = function(e) {
+      peg$c275 = "+",
+      peg$c276 = peg$literalExpectation("+", false),
+      peg$c277 = "-",
+      peg$c278 = peg$literalExpectation("-", false),
+      peg$c279 = "/",
+      peg$c280 = peg$literalExpectation("/", false),
+      peg$c281 = "%",
+      peg$c282 = peg$literalExpectation("%", false),
+      peg$c283 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c285 = function(e) {
+      peg$c284 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c286 = "not",
-      peg$c287 = peg$literalExpectation("not", false),
-      peg$c288 = "select",
-      peg$c289 = peg$literalExpectation("select", false),
-      peg$c290 = function(typ, expr) {
+      peg$c285 = "not",
+      peg$c286 = peg$literalExpectation("not", false),
+      peg$c287 = "select",
+      peg$c288 = peg$literalExpectation("select", false),
+      peg$c289 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c291 = function(fn, args, where) {
+      peg$c290 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c292 = "grep",
-      peg$c293 = peg$literalExpectation("grep", false),
-      peg$c294 = function(pattern) {
+      peg$c291 = "grep",
+      peg$c292 = peg$literalExpectation("grep", false),
+      peg$c293 = function(pattern) {
             return {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
           },
-      peg$c295 = function(pattern, expr) {
+      peg$c294 = function(pattern, expr) {
             return {"kind": "Grep", "pattern": pattern, "expr": expr}
           },
-      peg$c296 = function(s) {
+      peg$c295 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c297 = function(first, e) { return e },
-      peg$c298 = "]",
-      peg$c299 = peg$literalExpectation("]", false),
-      peg$c300 = function(from, to) {
+      peg$c296 = function(first, e) { return e },
+      peg$c297 = "]",
+      peg$c298 = peg$literalExpectation("]", false),
+      peg$c299 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c301 = function(to) {
+      peg$c300 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c302 = function(from) {
-            return ["[", {"kind": "BinaryExpr", "op":":",
-                                  
-            "lhs":from, "rhs": null}]
-          
-          },
-      peg$c303 = function(expr) { return ["[", expr] },
-      peg$c304 = function(id) { return [".", id] },
-      peg$c305 = function(exprs, locals, scope) {
+      peg$c301 = function(expr) { return ["[", expr] },
+      peg$c302 = function(id) { return [".", id] },
+      peg$c303 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c306 = function(exprs, scope) {
-            return {"kind": "OverExpr", "locals":null, "exprs": exprs, "scope": scope}
-          },
-      peg$c307 = "}",
-      peg$c308 = peg$literalExpectation("}", false),
-      peg$c309 = function(elems) {
+      peg$c304 = "}",
+      peg$c305 = peg$literalExpectation("}", false),
+      peg$c306 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c310 = function(elem) { return elem },
-      peg$c311 = "...",
-      peg$c312 = peg$literalExpectation("...", false),
-      peg$c313 = function(expr) {
+      peg$c307 = function(elem) { return elem },
+      peg$c308 = "...",
+      peg$c309 = peg$literalExpectation("...", false),
+      peg$c310 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c314 = function(name, value) {
+      peg$c311 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c315 = function(exprs) {
+      peg$c312 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c316 = "|[",
-      peg$c317 = peg$literalExpectation("|[", false),
-      peg$c318 = "]|",
-      peg$c319 = peg$literalExpectation("]|", false),
-      peg$c320 = function(exprs) {
+      peg$c313 = "|[",
+      peg$c314 = peg$literalExpectation("|[", false),
+      peg$c315 = "]|",
+      peg$c316 = peg$literalExpectation("]|", false),
+      peg$c317 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c321 = "|{",
-      peg$c322 = peg$literalExpectation("|{", false),
-      peg$c323 = "}|",
-      peg$c324 = peg$literalExpectation("}|", false),
-      peg$c325 = function(exprs) {
+      peg$c318 = "|{",
+      peg$c319 = peg$literalExpectation("|{", false),
+      peg$c320 = "}|",
+      peg$c321 = peg$literalExpectation("}|", false),
+      peg$c322 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c326 = function(e) { return e },
-      peg$c327 = function(key, value) {
+      peg$c323 = function(e) { return e },
+      peg$c324 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c328 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c325 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -750,13 +740,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c329 = function(assignments) { return assignments },
-      peg$c330 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c331 = function(table, alias) {
+      peg$c326 = function(assignments) { return assignments },
+      peg$c327 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c328 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c332 = function(first, join) { return join },
-      peg$c333 = function(style, table, alias, leftKey, rightKey) {
+      peg$c329 = function(first, join) { return join },
+      peg$c330 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -769,122 +759,118 @@ function peg$parse(input, options) {
               
             "alias": alias}
           
-
-
-
-
           },
-      peg$c334 = function(style) { return style },
-      peg$c335 = function(keys, order) {
+      peg$c331 = function(style) { return style },
+      peg$c332 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c336 = function(dir) { return dir },
-      peg$c337 = function(count) { return count },
-      peg$c338 = peg$literalExpectation("select", true),
-      peg$c339 = function() { return "select" },
-      peg$c340 = "as",
-      peg$c341 = peg$literalExpectation("as", true),
-      peg$c342 = function() { return "as" },
-      peg$c343 = peg$literalExpectation("from", true),
-      peg$c344 = function() { return "from" },
-      peg$c345 = peg$literalExpectation("join", true),
-      peg$c346 = function() { return "join" },
-      peg$c347 = peg$literalExpectation("where", true),
-      peg$c348 = function() { return "where" },
-      peg$c349 = "group",
-      peg$c350 = peg$literalExpectation("group", true),
-      peg$c351 = function() { return "group" },
-      peg$c352 = "by",
-      peg$c353 = peg$literalExpectation("by", true),
-      peg$c354 = function() { return "by" },
-      peg$c355 = "having",
-      peg$c356 = peg$literalExpectation("having", true),
-      peg$c357 = function() { return "having" },
-      peg$c358 = peg$literalExpectation("order", true),
-      peg$c359 = function() { return "order" },
-      peg$c360 = "on",
-      peg$c361 = peg$literalExpectation("on", true),
-      peg$c362 = function() { return "on" },
-      peg$c363 = "limit",
-      peg$c364 = peg$literalExpectation("limit", true),
-      peg$c365 = function() { return "limit" },
-      peg$c366 = peg$literalExpectation("asc", true),
-      peg$c367 = peg$literalExpectation("desc", true),
-      peg$c368 = peg$literalExpectation("anti", true),
-      peg$c369 = peg$literalExpectation("left", true),
-      peg$c370 = peg$literalExpectation("right", true),
-      peg$c371 = peg$literalExpectation("inner", true),
-      peg$c372 = function(v) {
+      peg$c333 = function(dir) { return dir },
+      peg$c334 = function(count) { return count },
+      peg$c335 = peg$literalExpectation("select", true),
+      peg$c336 = function() { return "select" },
+      peg$c337 = "as",
+      peg$c338 = peg$literalExpectation("as", true),
+      peg$c339 = function() { return "as" },
+      peg$c340 = peg$literalExpectation("from", true),
+      peg$c341 = function() { return "from" },
+      peg$c342 = peg$literalExpectation("join", true),
+      peg$c343 = function() { return "join" },
+      peg$c344 = peg$literalExpectation("where", true),
+      peg$c345 = function() { return "where" },
+      peg$c346 = "group",
+      peg$c347 = peg$literalExpectation("group", true),
+      peg$c348 = function() { return "group" },
+      peg$c349 = "by",
+      peg$c350 = peg$literalExpectation("by", true),
+      peg$c351 = function() { return "by" },
+      peg$c352 = "having",
+      peg$c353 = peg$literalExpectation("having", true),
+      peg$c354 = function() { return "having" },
+      peg$c355 = peg$literalExpectation("order", true),
+      peg$c356 = function() { return "order" },
+      peg$c357 = "on",
+      peg$c358 = peg$literalExpectation("on", true),
+      peg$c359 = function() { return "on" },
+      peg$c360 = "limit",
+      peg$c361 = peg$literalExpectation("limit", true),
+      peg$c362 = function() { return "limit" },
+      peg$c363 = peg$literalExpectation("asc", true),
+      peg$c364 = peg$literalExpectation("desc", true),
+      peg$c365 = peg$literalExpectation("anti", true),
+      peg$c366 = peg$literalExpectation("left", true),
+      peg$c367 = peg$literalExpectation("right", true),
+      peg$c368 = peg$literalExpectation("inner", true),
+      peg$c369 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c373 = function(v) {
+      peg$c370 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c374 = function(v) {
+      peg$c371 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c375 = function(v) {
+      peg$c372 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c376 = "true",
-      peg$c377 = peg$literalExpectation("true", false),
-      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c379 = "false",
-      peg$c380 = peg$literalExpectation("false", false),
-      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c382 = "null",
-      peg$c383 = peg$literalExpectation("null", false),
-      peg$c384 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c385 = "0x",
-      peg$c386 = peg$literalExpectation("0x", false),
-      peg$c387 = function() {
+      peg$c373 = "true",
+      peg$c374 = peg$literalExpectation("true", false),
+      peg$c375 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c376 = "false",
+      peg$c377 = peg$literalExpectation("false", false),
+      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c379 = "null",
+      peg$c380 = peg$literalExpectation("null", false),
+      peg$c381 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c382 = "0x",
+      peg$c383 = peg$literalExpectation("0x", false),
+      peg$c384 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c388 = function(typ) {
+      peg$c385 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c389 = function(name) { return name },
-      peg$c390 = function(name, typ) {
+      peg$c386 = function(name) { return name },
+      peg$c387 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c391 = function(name) {
+      peg$c388 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c392 = function(u) { return u },
-      peg$c393 = function(types) {
+      peg$c389 = function(u) { return u },
+      peg$c390 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c394 = function(typ) { return typ },
-      peg$c395 = function(fields) {
+      peg$c391 = function(typ) { return typ },
+      peg$c392 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c396 = function(typ) {
+      peg$c393 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c397 = function(typ) {
+      peg$c394 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c398 = function(keyType, valType) {
+      peg$c395 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c399 = function(v) {
+      peg$c396 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c400 = "\"",
-      peg$c401 = peg$literalExpectation("\"", false),
-      peg$c402 = "'",
-      peg$c403 = peg$literalExpectation("'", false),
-      peg$c404 = function(v) {
+      peg$c397 = "\"",
+      peg$c398 = peg$literalExpectation("\"", false),
+      peg$c399 = "'",
+      peg$c400 = peg$literalExpectation("'", false),
+      peg$c401 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c405 = "\\",
-      peg$c406 = peg$literalExpectation("\\", false),
-      peg$c407 = "${",
-      peg$c408 = peg$literalExpectation("${", false),
-      peg$c409 = function(e) {
+      peg$c402 = "\\",
+      peg$c403 = peg$literalExpectation("\\", false),
+      peg$c404 = "${",
+      peg$c405 = peg$literalExpectation("${", false),
+      peg$c406 = function(e) {
             return {
               
             "kind": "Cast",
@@ -897,196 +883,192 @@ function peg$parse(input, options) {
                 
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
-
-
-
-
           },
-      peg$c410 = "uint8",
-      peg$c411 = peg$literalExpectation("uint8", false),
-      peg$c412 = "uint16",
-      peg$c413 = peg$literalExpectation("uint16", false),
-      peg$c414 = "uint32",
-      peg$c415 = peg$literalExpectation("uint32", false),
-      peg$c416 = "uint64",
-      peg$c417 = peg$literalExpectation("uint64", false),
-      peg$c418 = "int8",
-      peg$c419 = peg$literalExpectation("int8", false),
-      peg$c420 = "int16",
-      peg$c421 = peg$literalExpectation("int16", false),
-      peg$c422 = "int32",
-      peg$c423 = peg$literalExpectation("int32", false),
-      peg$c424 = "int64",
-      peg$c425 = peg$literalExpectation("int64", false),
-      peg$c426 = "float32",
-      peg$c427 = peg$literalExpectation("float32", false),
-      peg$c428 = "float64",
-      peg$c429 = peg$literalExpectation("float64", false),
-      peg$c430 = "bool",
-      peg$c431 = peg$literalExpectation("bool", false),
-      peg$c432 = "string",
-      peg$c433 = peg$literalExpectation("string", false),
-      peg$c434 = "duration",
-      peg$c435 = peg$literalExpectation("duration", false),
-      peg$c436 = "time",
-      peg$c437 = peg$literalExpectation("time", false),
-      peg$c438 = "bytes",
-      peg$c439 = peg$literalExpectation("bytes", false),
-      peg$c440 = "ip",
-      peg$c441 = peg$literalExpectation("ip", false),
-      peg$c442 = "net",
-      peg$c443 = peg$literalExpectation("net", false),
-      peg$c444 = function() {
+      peg$c407 = "uint8",
+      peg$c408 = peg$literalExpectation("uint8", false),
+      peg$c409 = "uint16",
+      peg$c410 = peg$literalExpectation("uint16", false),
+      peg$c411 = "uint32",
+      peg$c412 = peg$literalExpectation("uint32", false),
+      peg$c413 = "uint64",
+      peg$c414 = peg$literalExpectation("uint64", false),
+      peg$c415 = "int8",
+      peg$c416 = peg$literalExpectation("int8", false),
+      peg$c417 = "int16",
+      peg$c418 = peg$literalExpectation("int16", false),
+      peg$c419 = "int32",
+      peg$c420 = peg$literalExpectation("int32", false),
+      peg$c421 = "int64",
+      peg$c422 = peg$literalExpectation("int64", false),
+      peg$c423 = "float32",
+      peg$c424 = peg$literalExpectation("float32", false),
+      peg$c425 = "float64",
+      peg$c426 = peg$literalExpectation("float64", false),
+      peg$c427 = "bool",
+      peg$c428 = peg$literalExpectation("bool", false),
+      peg$c429 = "string",
+      peg$c430 = peg$literalExpectation("string", false),
+      peg$c431 = "duration",
+      peg$c432 = peg$literalExpectation("duration", false),
+      peg$c433 = "time",
+      peg$c434 = peg$literalExpectation("time", false),
+      peg$c435 = "bytes",
+      peg$c436 = peg$literalExpectation("bytes", false),
+      peg$c437 = "ip",
+      peg$c438 = peg$literalExpectation("ip", false),
+      peg$c439 = "net",
+      peg$c440 = peg$literalExpectation("net", false),
+      peg$c441 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c445 = function(name, typ) {
+      peg$c442 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c446 = "and",
-      peg$c447 = peg$literalExpectation("and", false),
-      peg$c448 = "AND",
-      peg$c449 = peg$literalExpectation("AND", false),
-      peg$c450 = function() { return "and" },
-      peg$c451 = "or",
-      peg$c452 = peg$literalExpectation("or", false),
-      peg$c453 = "OR",
-      peg$c454 = peg$literalExpectation("OR", false),
-      peg$c455 = function() { return "or" },
-      peg$c457 = "NOT",
-      peg$c458 = peg$literalExpectation("NOT", false),
-      peg$c459 = function() { return "not" },
-      peg$c460 = peg$literalExpectation("by", false),
-      peg$c461 = /^[A-Za-z_$]/,
-      peg$c462 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c463 = /^[0-9]/,
-      peg$c464 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c465 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c466 = "$",
-      peg$c467 = peg$literalExpectation("$", false),
-      peg$c468 = "T",
-      peg$c469 = peg$literalExpectation("T", false),
-      peg$c470 = function() {
+      peg$c443 = "and",
+      peg$c444 = peg$literalExpectation("and", false),
+      peg$c445 = "AND",
+      peg$c446 = peg$literalExpectation("AND", false),
+      peg$c447 = function() { return "and" },
+      peg$c448 = "or",
+      peg$c449 = peg$literalExpectation("or", false),
+      peg$c450 = "OR",
+      peg$c451 = peg$literalExpectation("OR", false),
+      peg$c452 = function() { return "or" },
+      peg$c454 = "NOT",
+      peg$c455 = peg$literalExpectation("NOT", false),
+      peg$c456 = function() { return "not" },
+      peg$c457 = peg$literalExpectation("by", false),
+      peg$c458 = /^[A-Za-z_$]/,
+      peg$c459 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c460 = /^[0-9]/,
+      peg$c461 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c462 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c463 = "$",
+      peg$c464 = peg$literalExpectation("$", false),
+      peg$c465 = "T",
+      peg$c466 = peg$literalExpectation("T", false),
+      peg$c467 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c471 = "Z",
-      peg$c472 = peg$literalExpectation("Z", false),
-      peg$c473 = function() {
+      peg$c468 = "Z",
+      peg$c469 = peg$literalExpectation("Z", false),
+      peg$c470 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c474 = "ns",
-      peg$c475 = peg$literalExpectation("ns", false),
-      peg$c476 = "us",
-      peg$c477 = peg$literalExpectation("us", false),
-      peg$c478 = "ms",
-      peg$c479 = peg$literalExpectation("ms", false),
-      peg$c480 = "s",
-      peg$c481 = peg$literalExpectation("s", false),
-      peg$c482 = "m",
-      peg$c483 = peg$literalExpectation("m", false),
-      peg$c484 = "h",
-      peg$c485 = peg$literalExpectation("h", false),
-      peg$c486 = "d",
-      peg$c487 = peg$literalExpectation("d", false),
-      peg$c488 = "w",
-      peg$c489 = peg$literalExpectation("w", false),
-      peg$c490 = "y",
-      peg$c491 = peg$literalExpectation("y", false),
-      peg$c492 = function(a, b) {
+      peg$c471 = "ns",
+      peg$c472 = peg$literalExpectation("ns", false),
+      peg$c473 = "us",
+      peg$c474 = peg$literalExpectation("us", false),
+      peg$c475 = "ms",
+      peg$c476 = peg$literalExpectation("ms", false),
+      peg$c477 = "s",
+      peg$c478 = peg$literalExpectation("s", false),
+      peg$c479 = "m",
+      peg$c480 = peg$literalExpectation("m", false),
+      peg$c481 = "h",
+      peg$c482 = peg$literalExpectation("h", false),
+      peg$c483 = "d",
+      peg$c484 = peg$literalExpectation("d", false),
+      peg$c485 = "w",
+      peg$c486 = peg$literalExpectation("w", false),
+      peg$c487 = "y",
+      peg$c488 = peg$literalExpectation("y", false),
+      peg$c489 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c493 = "::",
-      peg$c494 = peg$literalExpectation("::", false),
-      peg$c495 = function(a, b, d, e) {
+      peg$c490 = "::",
+      peg$c491 = peg$literalExpectation("::", false),
+      peg$c492 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c496 = function(a, b) {
+      peg$c493 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c497 = function(a, b) {
+      peg$c494 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c498 = function() {
+      peg$c495 = function() {
             return "::"
           },
-      peg$c499 = function(v) { return ":" + v },
-      peg$c500 = function(v) { return v + ":" },
-      peg$c501 = function(a, m) {
+      peg$c496 = function(v) { return ":" + v },
+      peg$c497 = function(v) { return v + ":" },
+      peg$c498 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c502 = function(a, m) {
+      peg$c499 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c503 = function(s) { return parseInt(s) },
-      peg$c504 = function() {
+      peg$c500 = function(s) { return parseInt(s) },
+      peg$c501 = function() {
             return text()
           },
-      peg$c505 = "e",
-      peg$c506 = peg$literalExpectation("e", true),
-      peg$c507 = /^[+\-]/,
-      peg$c508 = peg$classExpectation(["+", "-"], false, false),
-      peg$c509 = "NaN",
-      peg$c510 = peg$literalExpectation("NaN", false),
-      peg$c511 = "Inf",
-      peg$c512 = peg$literalExpectation("Inf", false),
-      peg$c513 = /^[0-9a-fA-F]/,
-      peg$c514 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c515 = function(v) { return joinChars(v) },
-      peg$c516 = peg$anyExpectation(),
-      peg$c517 = function(head, tail) { return head + joinChars(tail) },
-      peg$c518 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c519 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c520 = function(head, tail) {
+      peg$c502 = "e",
+      peg$c503 = peg$literalExpectation("e", true),
+      peg$c504 = /^[+\-]/,
+      peg$c505 = peg$classExpectation(["+", "-"], false, false),
+      peg$c506 = "NaN",
+      peg$c507 = peg$literalExpectation("NaN", false),
+      peg$c508 = "Inf",
+      peg$c509 = peg$literalExpectation("Inf", false),
+      peg$c510 = /^[0-9a-fA-F]/,
+      peg$c511 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c512 = function(v) { return joinChars(v) },
+      peg$c513 = peg$anyExpectation(),
+      peg$c514 = function(head, tail) { return head + joinChars(tail) },
+      peg$c515 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c516 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c517 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c521 = function() { return "*"},
-      peg$c522 = function() { return "=" },
-      peg$c523 = function() { return "\\*" },
-      peg$c524 = "b",
-      peg$c525 = peg$literalExpectation("b", false),
-      peg$c526 = function() { return "\b" },
-      peg$c527 = "f",
-      peg$c528 = peg$literalExpectation("f", false),
-      peg$c529 = function() { return "\f" },
-      peg$c530 = "n",
-      peg$c531 = peg$literalExpectation("n", false),
-      peg$c532 = function() { return "\n" },
-      peg$c533 = "r",
-      peg$c534 = peg$literalExpectation("r", false),
-      peg$c535 = function() { return "\r" },
-      peg$c536 = "t",
-      peg$c537 = peg$literalExpectation("t", false),
-      peg$c538 = function() { return "\t" },
-      peg$c539 = "v",
-      peg$c540 = peg$literalExpectation("v", false),
-      peg$c541 = function() { return "\v" },
-      peg$c542 = function() { return "*" },
-      peg$c543 = "u",
-      peg$c544 = peg$literalExpectation("u", false),
-      peg$c545 = function(chars) {
+      peg$c518 = function() { return "*"},
+      peg$c519 = function() { return "=" },
+      peg$c520 = function() { return "\\*" },
+      peg$c521 = "b",
+      peg$c522 = peg$literalExpectation("b", false),
+      peg$c523 = function() { return "\b" },
+      peg$c524 = "f",
+      peg$c525 = peg$literalExpectation("f", false),
+      peg$c526 = function() { return "\f" },
+      peg$c527 = "n",
+      peg$c528 = peg$literalExpectation("n", false),
+      peg$c529 = function() { return "\n" },
+      peg$c530 = "r",
+      peg$c531 = peg$literalExpectation("r", false),
+      peg$c532 = function() { return "\r" },
+      peg$c533 = "t",
+      peg$c534 = peg$literalExpectation("t", false),
+      peg$c535 = function() { return "\t" },
+      peg$c536 = "v",
+      peg$c537 = peg$literalExpectation("v", false),
+      peg$c538 = function() { return "\v" },
+      peg$c539 = function() { return "*" },
+      peg$c540 = "u",
+      peg$c541 = peg$literalExpectation("u", false),
+      peg$c542 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c546 = /^[^\/\\]/,
-      peg$c547 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c548 = /^[\0-\x1F\\]/,
-      peg$c549 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c550 = peg$otherExpectation("whitespace"),
-      peg$c551 = "\t",
-      peg$c552 = peg$literalExpectation("\t", false),
-      peg$c553 = "\x0B",
-      peg$c554 = peg$literalExpectation("\x0B", false),
-      peg$c555 = "\f",
-      peg$c556 = peg$literalExpectation("\f", false),
-      peg$c557 = " ",
-      peg$c558 = peg$literalExpectation(" ", false),
-      peg$c559 = "\xA0",
-      peg$c560 = peg$literalExpectation("\xA0", false),
-      peg$c561 = "\uFEFF",
-      peg$c562 = peg$literalExpectation("\uFEFF", false),
-      peg$c563 = /^[\n\r\u2028\u2029]/,
-      peg$c564 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c565 = peg$otherExpectation("comment"),
-      peg$c570 = "//",
-      peg$c571 = peg$literalExpectation("//", false),
+      peg$c543 = /^[^\/\\]/,
+      peg$c544 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c545 = /^[\0-\x1F\\]/,
+      peg$c546 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c547 = peg$otherExpectation("whitespace"),
+      peg$c548 = "\t",
+      peg$c549 = peg$literalExpectation("\t", false),
+      peg$c550 = "\x0B",
+      peg$c551 = peg$literalExpectation("\x0B", false),
+      peg$c552 = "\f",
+      peg$c553 = peg$literalExpectation("\f", false),
+      peg$c554 = " ",
+      peg$c555 = peg$literalExpectation(" ", false),
+      peg$c556 = "\xA0",
+      peg$c557 = peg$literalExpectation("\xA0", false),
+      peg$c558 = "\uFEFF",
+      peg$c559 = peg$literalExpectation("\uFEFF", false),
+      peg$c560 = /^[\n\r\u2028\u2029]/,
+      peg$c561 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c562 = peg$otherExpectation("comment"),
+      peg$c567 = "//",
+      peg$c568 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1247,13 +1229,9 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = [];
           s5 = peg$parseSequentialTail();
-          if (s5 !== peg$FAILED) {
-            while (s5 !== peg$FAILED) {
-              s4.push(s5);
-              s5 = peg$parseSequentialTail();
-            }
-          } else {
-            s4 = peg$FAILED;
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$parseSequentialTail();
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -1275,30 +1253,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseConsts();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseOperation();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c2(s1, s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
 
     return s0;
   }
@@ -1316,7 +1270,7 @@ function peg$parse(input, options) {
           s4 = peg$parseOperation();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c3(s4);
+            s1 = peg$c2(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1356,7 +1310,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4();
+        s1 = peg$c3();
       }
       s0 = s1;
     }
@@ -1373,7 +1327,7 @@ function peg$parse(input, options) {
       s2 = peg$parseConstDef();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s2);
+        s1 = peg$c4(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1391,12 +1345,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c6) {
-      s1 = peg$c6;
+    if (input.substr(peg$currPos, 5) === peg$c5) {
+      s1 = peg$c5;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c7); }
+      if (peg$silentFails === 0) { peg$fail(peg$c6); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1406,11 +1360,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s5 = peg$c8;
+              s5 = peg$c7;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c9); }
+              if (peg$silentFails === 0) { peg$fail(peg$c8); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -1418,7 +1372,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseConditionalExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c10(s3, s7);
+                  s1 = peg$c9(s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1450,12 +1404,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c11) {
-        s1 = peg$c11;
+      if (input.substr(peg$currPos, 4) === peg$c10) {
+        s1 = peg$c10;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+        if (peg$silentFails === 0) { peg$fail(peg$c11); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1465,11 +1419,11 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 61) {
-                s5 = peg$c8;
+                s5 = peg$c7;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c9); }
+                if (peg$silentFails === 0) { peg$fail(peg$c8); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse__();
@@ -1477,7 +1431,7 @@ function peg$parse(input, options) {
                   s7 = peg$parseType();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c13(s3, s7);
+                    s1 = peg$c12(s3, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1516,22 +1470,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c14) {
-      s1 = peg$c14;
+    if (input.substr(peg$currPos, 4) === peg$c13) {
+      s1 = peg$c13;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c15); }
+      if (peg$silentFails === 0) { peg$fail(peg$c14); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -1548,15 +1502,15 @@ function peg$parse(input, options) {
             s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s6 = peg$c18;
+                s6 = peg$c17;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                if (peg$silentFails === 0) { peg$fail(peg$c18); }
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c20(s4);
+                s1 = peg$c19(s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1584,12 +1538,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c21) {
-        s1 = peg$c21;
+      if (input.substr(peg$currPos, 6) === peg$c20) {
+        s1 = peg$c20;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c22); }
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1599,11 +1553,11 @@ function peg$parse(input, options) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s5 = peg$c16;
+                s5 = peg$c15;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = [];
@@ -1620,15 +1574,15 @@ function peg$parse(input, options) {
                   s7 = peg$parse__();
                   if (s7 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s8 = peg$c18;
+                      s8 = peg$c17;
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c18); }
                     }
                     if (s8 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c23(s3, s6);
+                      s1 = peg$c22(s3, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1664,22 +1618,22 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 6) === peg$c21) {
-          s1 = peg$c21;
+        if (input.substr(peg$currPos, 6) === peg$c20) {
+          s1 = peg$c20;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c22); }
+          if (peg$silentFails === 0) { peg$fail(peg$c21); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s3 = peg$c16;
+              s3 = peg$c15;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+              if (peg$silentFails === 0) { peg$fail(peg$c16); }
             }
             if (s3 !== peg$FAILED) {
               s4 = [];
@@ -1696,15 +1650,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s6 = peg$c18;
+                    s6 = peg$c17;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c24(s4);
+                    s1 = peg$c23(s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1732,22 +1686,22 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 4) === peg$c25) {
-            s1 = peg$c25;
+          if (input.substr(peg$currPos, 4) === peg$c24) {
+            s1 = peg$c24;
             peg$currPos += 4;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c26); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s3 = peg$c16;
+                s3 = peg$c15;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = [];
@@ -1764,15 +1718,15 @@ function peg$parse(input, options) {
                   s5 = peg$parse__();
                   if (s5 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s6 = peg$c18;
+                      s6 = peg$c17;
                       peg$currPos++;
                     } else {
                       s6 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c18); }
                     }
                     if (s6 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c27(s4);
+                      s1 = peg$c26(s4);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1816,7 +1770,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c28(s1);
+                  s1 = peg$c27(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1867,7 +1821,7 @@ function peg$parse(input, options) {
                     }
                     if (s3 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c28(s2);
+                      s1 = peg$c27(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1883,12 +1837,12 @@ function peg$parse(input, options) {
                 }
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 6) === peg$c29) {
-                    s1 = peg$c29;
+                  if (input.substr(peg$currPos, 6) === peg$c28) {
+                    s1 = peg$c28;
                     peg$currPos += 6;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c30); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c29); }
                   }
                   if (s1 !== peg$FAILED) {
                     s2 = peg$parse_();
@@ -1896,7 +1850,7 @@ function peg$parse(input, options) {
                       s3 = peg$parseSearchBoolean();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c31(s3);
+                        s1 = peg$c30(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1915,7 +1869,7 @@ function peg$parse(input, options) {
                     s1 = peg$parseSearchBoolean();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c32(s1);
+                      s1 = peg$c31(s1);
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
@@ -1923,7 +1877,7 @@ function peg$parse(input, options) {
                       s1 = peg$parseCast();
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c33(s1);
+                        s1 = peg$c32(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
@@ -1931,7 +1885,7 @@ function peg$parse(input, options) {
                         s1 = peg$parseConditionalExpr();
                         if (s1 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c32(s1);
+                          s1 = peg$c31(s1);
                         }
                         s0 = s1;
                       }
@@ -1958,20 +1912,20 @@ function peg$parse(input, options) {
       if (s2 === peg$FAILED) {
         s2 = peg$parseSearchKeywordGuard();
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c34) {
-            s2 = peg$c34;
+          if (input.substr(peg$currPos, 2) === peg$c33) {
+            s2 = peg$c33;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s2 = peg$c18;
+              s2 = peg$c17;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c19); }
+              if (peg$silentFails === 0) { peg$fail(peg$c18); }
             }
             if (s2 === peg$FAILED) {
               s2 = peg$parseEOF();
@@ -1999,29 +1953,29 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 124) {
-      s1 = peg$c36;
+      s1 = peg$c35;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c37); }
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s3 = peg$c38;
+        s3 = peg$c37;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        if (peg$silentFails === 0) { peg$fail(peg$c38); }
       }
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s3 = peg$c40;
+          s3 = peg$c39;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c40); }
         }
       }
       peg$silentFails--;
@@ -2052,12 +2006,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c34) {
-        s2 = peg$c34;
+      if (input.substr(peg$currPos, 2) === peg$c33) {
+        s2 = peg$c33;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c34); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2065,7 +2019,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequential();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c42(s4);
+            s1 = peg$c41(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2097,12 +2051,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c34) {
-            s4 = peg$c34;
+          if (input.substr(peg$currPos, 2) === peg$c33) {
+            s4 = peg$c33;
             peg$currPos += 2;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -2110,7 +2064,7 @@ function peg$parse(input, options) {
               s6 = peg$parseSequential();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c43(s2, s6);
+                s1 = peg$c42(s2, s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2144,12 +2098,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c44) {
-      s1 = peg$c44;
+    if (input.substr(peg$currPos, 4) === peg$c43) {
+      s1 = peg$c43;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c45); }
+      if (peg$silentFails === 0) { peg$fail(peg$c44); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2157,7 +2111,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c46(s3);
+          s1 = peg$c45(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2173,16 +2127,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c47) {
-        s1 = peg$c47;
+      if (input.substr(peg$currPos, 7) === peg$c46) {
+        s1 = peg$c46;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c48); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c49();
+        s1 = peg$c48();
       }
       s0 = s1;
     }
@@ -2203,7 +2157,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequential();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c50(s2, s4);
+            s1 = peg$c49(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2228,7 +2182,7 @@ function peg$parse(input, options) {
         s2 = peg$parseFromSource();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c51(s2);
+          s1 = peg$c50(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2251,16 +2205,16 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c34) {
-          s3 = peg$c34;
+        if (input.substr(peg$currPos, 2) === peg$c33) {
+          s3 = peg$c33;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c34); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c52(s1);
+          s1 = peg$c51(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2304,12 +2258,12 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c34) {
-        s4 = peg$c34;
+      if (input.substr(peg$currPos, 2) === peg$c33) {
+        s4 = peg$c33;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c34); }
       }
       peg$silentFails--;
       if (s4 === peg$FAILED) {
@@ -2337,35 +2291,35 @@ function peg$parse(input, options) {
           s2 = peg$parseMultiplicativeOperator();
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s2 = peg$c53;
+              s2 = peg$c52;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c54); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s2 = peg$c16;
+                s2 = peg$c15;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
               }
               if (s2 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s2 = peg$c40;
+                  s2 = peg$c39;
                   peg$currPos++;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c41); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c40); }
                 }
                 if (s2 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 126) {
-                    s2 = peg$c55;
+                    s2 = peg$c54;
                     peg$currPos++;
                   } else {
                     s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c56); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c55); }
                   }
                 }
               }
@@ -2392,29 +2346,29 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c57) {
-      s1 = peg$c57;
+    if (input.substr(peg$currPos, 2) === peg$c56) {
+      s1 = peg$c56;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c59) {
-        s1 = peg$c59;
+      if (input.substr(peg$currPos, 2) === peg$c58) {
+        s1 = peg$c58;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+        if (peg$silentFails === 0) { peg$fail(peg$c59); }
       }
       if (s1 === peg$FAILED) {
         s1 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c61) {
-          s2 = peg$c61;
+        if (input.substr(peg$currPos, 2) === peg$c60) {
+          s2 = peg$c60;
           peg$currPos += 2;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -2439,36 +2393,36 @@ function peg$parse(input, options) {
           s1 = peg$FAILED;
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c63) {
-            s1 = peg$c63;
+          if (input.substr(peg$currPos, 2) === peg$c62) {
+            s1 = peg$c62;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c64); }
+            if (peg$silentFails === 0) { peg$fail(peg$c63); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c65;
+              s1 = peg$c64;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c66); }
+              if (peg$silentFails === 0) { peg$fail(peg$c65); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c67) {
-                s1 = peg$c67;
+              if (input.substr(peg$currPos, 2) === peg$c66) {
+                s1 = peg$c66;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c68); }
+                if (peg$silentFails === 0) { peg$fail(peg$c67); }
               }
               if (s1 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 62) {
-                  s1 = peg$c69;
+                  s1 = peg$c68;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c70); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c69); }
                 }
               }
             }
@@ -2478,7 +2432,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -2499,7 +2453,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s1, s2);
+        s1 = peg$c71(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2526,7 +2480,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchAnd();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c73(s4);
+            s1 = peg$c72(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2594,7 +2548,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchFactor();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c74(s1, s7);
+              s4 = peg$c73(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2653,7 +2607,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchFactor();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c74(s1, s7);
+                s4 = peg$c73(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2674,7 +2628,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c75(s1, s2);
+        s1 = peg$c74(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2749,11 +2703,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c76;
+        s2 = peg$c75;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        if (peg$silentFails === 0) { peg$fail(peg$c76); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2773,7 +2727,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s2);
+        s1 = peg$c77(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2786,11 +2740,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c16;
+        s1 = peg$c15;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c16); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -2800,15 +2754,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s5 = peg$c18;
+                s5 = peg$c17;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                if (peg$silentFails === 0) { peg$fail(peg$c18); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c46(s3);
+                s1 = peg$c45(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2850,31 +2804,43 @@ function peg$parse(input, options) {
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
           peg$silentFails++;
-          s3 = peg$currPos;
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseGlob();
-            if (s5 !== peg$FAILED) {
-              s4 = [s4, s5];
-              s3 = s4;
+          s3 = peg$parseExprGuard();
+          peg$silentFails--;
+          if (s3 === peg$FAILED) {
+            s2 = void 0;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+          if (s2 === peg$FAILED) {
+            s2 = peg$currPos;
+            peg$silentFails++;
+            s3 = peg$currPos;
+            s4 = peg$parse_();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseGlob();
+              if (s5 !== peg$FAILED) {
+                s4 = [s4, s5];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
             } else {
               peg$currPos = s3;
               s3 = peg$FAILED;
             }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-          peg$silentFails--;
-          if (s3 !== peg$FAILED) {
-            peg$currPos = s2;
-            s2 = void 0;
-          } else {
-            s2 = peg$FAILED;
+            peg$silentFails--;
+            if (s3 !== peg$FAILED) {
+              peg$currPos = s2;
+              s2 = void 0;
+            } else {
+              s2 = peg$FAILED;
+            }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c79(s1);
+            s1 = peg$c78(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2886,7 +2852,13 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseSearchValue();
+          if (input.charCodeAt(peg$currPos) === 42) {
+            s1 = peg$c79;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          }
           if (s1 !== peg$FAILED) {
             s2 = peg$currPos;
             peg$silentFails++;
@@ -2900,7 +2872,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c79(s1);
+              s1 = peg$c81();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2911,40 +2883,7 @@ function peg$parse(input, options) {
             s0 = peg$FAILED;
           }
           if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.charCodeAt(peg$currPos) === 42) {
-              s1 = peg$c80;
-              peg$currPos++;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c81); }
-            }
-            if (s1 !== peg$FAILED) {
-              s2 = peg$currPos;
-              peg$silentFails++;
-              s3 = peg$parseExprGuard();
-              peg$silentFails--;
-              if (s3 === peg$FAILED) {
-                s2 = void 0;
-              } else {
-                peg$currPos = s2;
-                s2 = peg$FAILED;
-              }
-              if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c82();
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-              s0 = peg$parseSearchPredicate();
-            }
+            s0 = peg$parseSearchPredicate();
           }
         }
       }
@@ -2968,7 +2907,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAdditiveExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c83(s1, s3, s5);
+              s1 = peg$c82(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3002,7 +2941,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c84(s1, s2);
+          s1 = peg$c83(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3037,7 +2976,7 @@ function peg$parse(input, options) {
         s2 = peg$parseKeyWord();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c85(s2);
+          s1 = peg$c84(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3059,7 +2998,7 @@ function peg$parse(input, options) {
     s1 = peg$parseGlobPattern();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c86(s1);
+      s1 = peg$c85(s1);
     }
     s0 = s1;
 
@@ -3073,7 +3012,7 @@ function peg$parse(input, options) {
     s1 = peg$parseRegexpPattern();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c87(s1);
+      s1 = peg$c86(s1);
     }
     s0 = s1;
 
@@ -3094,7 +3033,7 @@ function peg$parse(input, options) {
         s3 = peg$parseLimitArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c88(s2, s3);
+          s1 = peg$c87(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3139,7 +3078,7 @@ function peg$parse(input, options) {
             s4 = peg$parseLimitArg();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c89(s2, s3, s4);
+              s1 = peg$c88(s2, s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3166,12 +3105,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c90) {
-      s1 = peg$c90;
+    if (input.substr(peg$currPos, 9) === peg$c89) {
+      s1 = peg$c89;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c91); }
+      if (peg$silentFails === 0) { peg$fail(peg$c90); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3201,7 +3140,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c92(s3);
+          s1 = peg$c91(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3225,22 +3164,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c93) {
-        s2 = peg$c93;
+      if (input.substr(peg$currPos, 4) === peg$c92) {
+        s2 = peg$c92;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c95) {
-            s4 = peg$c95;
+          if (input.substr(peg$currPos, 6) === peg$c94) {
+            s4 = peg$c94;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c96); }
+            if (peg$silentFails === 0) { peg$fail(peg$c95); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3248,7 +3187,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c97(s6);
+                s1 = peg$c96(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3276,10 +3215,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c99();
+        s1 = peg$c98();
       }
       s0 = s1;
     }
@@ -3296,7 +3235,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c100(s1);
+        s1 = peg$c99(s1);
       }
       s0 = s1;
     }
@@ -3315,11 +3254,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3327,7 +3266,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c103(s1, s7);
+              s4 = peg$c102(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3351,11 +3290,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3363,7 +3302,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c103(s1, s7);
+                s4 = peg$c102(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3384,7 +3323,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3406,12 +3345,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c105) {
-          s3 = peg$c105;
+        if (input.substr(peg$currPos, 2) === peg$c104) {
+          s3 = peg$c104;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c106); }
+          if (peg$silentFails === 0) { peg$fail(peg$c105); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3419,7 +3358,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAgg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c107(s1, s5);
+              s1 = peg$c106(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3446,7 +3385,7 @@ function peg$parse(input, options) {
       s1 = peg$parseAgg();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108(s1);
+        s1 = peg$c107(s1);
       }
       s0 = s1;
     }
@@ -3474,11 +3413,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c16;
+            s4 = peg$c15;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -3491,11 +3430,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c18;
+                    s8 = peg$c17;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$currPos;
@@ -3504,11 +3443,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c109;
+                        s12 = peg$c108;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c109); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3535,7 +3474,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c111(s2, s6, s10);
+                        s1 = peg$c110(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3601,12 +3540,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c112) {
-        s2 = peg$c112;
+      if (input.substr(peg$currPos, 5) === peg$c111) {
+        s2 = peg$c111;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+        if (peg$silentFails === 0) { peg$fail(peg$c112); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3614,7 +3553,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLogicalOrExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s4);
+            s1 = peg$c45(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3647,11 +3586,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3682,11 +3621,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3714,7 +3653,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3800,12 +3739,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c115) {
-      s1 = peg$c115;
+    if (input.substr(peg$currPos, 4) === peg$c114) {
+      s1 = peg$c114;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c116); }
+      if (peg$silentFails === 0) { peg$fail(peg$c115); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3827,7 +3766,7 @@ function peg$parse(input, options) {
             s6 = peg$parseExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c117(s3, s6);
+              s5 = peg$c116(s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3842,7 +3781,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c118(s3, s4);
+            s1 = peg$c117(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3875,7 +3814,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c28(s4);
+        s3 = peg$c27(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3893,7 +3832,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c28(s4);
+          s3 = peg$c27(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3906,7 +3845,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c119(s1);
+      s1 = peg$c118(s1);
     }
     s0 = s1;
 
@@ -3917,55 +3856,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c120) {
-      s1 = peg$c120;
+    if (input.substr(peg$currPos, 2) === peg$c119) {
+      s1 = peg$c119;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c120); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c122();
+      s1 = peg$c121();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c123) {
-        s1 = peg$c123;
+      if (input.substr(peg$currPos, 6) === peg$c122) {
+        s1 = peg$c122;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c124); }
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c125) {
-            s4 = peg$c125;
+          if (input.substr(peg$currPos, 5) === peg$c124) {
+            s4 = peg$c124;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c126); }
+            if (peg$silentFails === 0) { peg$fail(peg$c125); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c127) {
-              s4 = peg$c127;
+            if (input.substr(peg$currPos, 4) === peg$c126) {
+              s4 = peg$c126;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c128); }
+              if (peg$silentFails === 0) { peg$fail(peg$c127); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c71();
+            s4 = peg$c70();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c129(s3);
+            s1 = peg$c128(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3988,12 +3927,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c130) {
-      s1 = peg$c130;
+    if (input.substr(peg$currPos, 3) === peg$c129) {
+      s1 = peg$c129;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c131); }
+      if (peg$silentFails === 0) { peg$fail(peg$c130); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4013,7 +3952,7 @@ function peg$parse(input, options) {
           s5 = peg$parseUInt();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c132(s5);
+            s4 = peg$c131(s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -4030,12 +3969,12 @@ function peg$parse(input, options) {
           s4 = peg$currPos;
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c133) {
-              s6 = peg$c133;
+            if (input.substr(peg$currPos, 6) === peg$c132) {
+              s6 = peg$c132;
               peg$currPos += 6;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c134); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -4058,7 +3997,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFieldExprs();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c135(s3, s4, s7);
+                s6 = peg$c134(s3, s4, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -4073,7 +4012,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c136(s3, s4, s5);
+              s1 = peg$c135(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4103,12 +4042,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c137) {
-      s1 = peg$c137;
+    if (input.substr(peg$currPos, 3) === peg$c136) {
+      s1 = peg$c136;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c138); }
+      if (peg$silentFails === 0) { peg$fail(peg$c137); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4116,7 +4055,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c139(s3);
+          s1 = peg$c138(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4138,12 +4077,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c140) {
-      s1 = peg$c140;
+    if (input.substr(peg$currPos, 4) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4151,7 +4090,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s3);
+          s1 = peg$c141(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4173,12 +4112,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c143) {
-      s1 = peg$c143;
+    if (input.substr(peg$currPos, 4) === peg$c142) {
+      s1 = peg$c142;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c144); }
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4186,7 +4125,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c145(s3);
+          s1 = peg$c144(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4202,16 +4141,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c143) {
-        s1 = peg$c143;
+      if (input.substr(peg$currPos, 4) === peg$c142) {
+        s1 = peg$c142;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c144); }
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c146();
+        s1 = peg$c145();
       }
       s0 = s1;
     }
@@ -4223,12 +4162,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c147) {
-      s1 = peg$c147;
+    if (input.substr(peg$currPos, 4) === peg$c146) {
+      s1 = peg$c146;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c147); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4236,7 +4175,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c149(s3);
+          s1 = peg$c148(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4252,16 +4191,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c147) {
-        s1 = peg$c147;
+      if (input.substr(peg$currPos, 4) === peg$c146) {
+        s1 = peg$c146;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+        if (peg$silentFails === 0) { peg$fail(peg$c147); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c150();
+        s1 = peg$c149();
       }
       s0 = s1;
     }
@@ -4273,12 +4212,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c112) {
-      s1 = peg$c112;
+    if (input.substr(peg$currPos, 5) === peg$c111) {
+      s1 = peg$c111;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c113); }
+      if (peg$silentFails === 0) { peg$fail(peg$c112); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4286,7 +4225,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c151(s3);
+          s1 = peg$c150(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4308,26 +4247,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c152) {
-      s1 = peg$c152;
+    if (input.substr(peg$currPos, 4) === peg$c151) {
+      s1 = peg$c151;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c153); }
+      if (peg$silentFails === 0) { peg$fail(peg$c152); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c154) {
-          s3 = peg$c154;
+        if (input.substr(peg$currPos, 2) === peg$c153) {
+          s3 = peg$c153;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c154); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c156();
+          s1 = peg$c155();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4343,16 +4282,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c152) {
-        s1 = peg$c152;
+      if (input.substr(peg$currPos, 4) === peg$c151) {
+        s1 = peg$c151;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c153); }
+        if (peg$silentFails === 0) { peg$fail(peg$c152); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c157();
+        s1 = peg$c156();
       }
       s0 = s1;
     }
@@ -4364,12 +4303,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c158) {
-      s1 = peg$c158;
+    if (input.substr(peg$currPos, 3) === peg$c157) {
+      s1 = peg$c157;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
+      if (peg$silentFails === 0) { peg$fail(peg$c158); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4377,7 +4316,7 @@ function peg$parse(input, options) {
         s3 = peg$parseAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c160(s3);
+          s1 = peg$c159(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4399,12 +4338,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c161) {
-      s1 = peg$c161;
+    if (input.substr(peg$currPos, 6) === peg$c160) {
+      s1 = peg$c160;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c162); }
+      if (peg$silentFails === 0) { peg$fail(peg$c161); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4416,11 +4355,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c101;
+              s7 = peg$c100;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c102); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -4428,7 +4367,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c163(s3, s9);
+                  s6 = peg$c162(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4452,11 +4391,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c101;
+                s7 = peg$c100;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -4464,7 +4403,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c163(s3, s9);
+                    s6 = peg$c162(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4485,7 +4424,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c164(s3, s4);
+            s1 = peg$c163(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4511,12 +4450,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c165) {
-      s1 = peg$c165;
+    if (input.substr(peg$currPos, 4) === peg$c164) {
+      s1 = peg$c164;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c166); }
+      if (peg$silentFails === 0) { peg$fail(peg$c165); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4525,11 +4464,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c16;
+          s5 = peg$c15;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4562,7 +4501,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c167();
+          s1 = peg$c166();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4584,12 +4523,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c168) {
-      s1 = peg$c168;
+    if (input.substr(peg$currPos, 5) === peg$c167) {
+      s1 = peg$c167;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c168); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4598,11 +4537,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c16;
+          s5 = peg$c15;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4635,7 +4574,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c170();
+          s1 = peg$c169();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4659,12 +4598,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseJoinStyle();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c171) {
-        s2 = peg$c171;
+      if (input.substr(peg$currPos, 4) === peg$c170) {
+        s2 = peg$c170;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c172); }
+        if (peg$silentFails === 0) { peg$fail(peg$c171); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4678,11 +4617,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 61) {
-                    s8 = peg$c8;
+                    s8 = peg$c7;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c9); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$parse__();
@@ -4709,7 +4648,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c173(s1, s6, s10, s11);
+                          s1 = peg$c172(s1, s6, s10, s11);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -4759,12 +4698,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parseJoinStyle();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c171) {
-          s2 = peg$c171;
+        if (input.substr(peg$currPos, 4) === peg$c170) {
+          s2 = peg$c170;
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c172); }
+          if (peg$silentFails === 0) { peg$fail(peg$c171); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4795,7 +4734,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c174(s1, s6, s7);
+                    s1 = peg$c173(s1, s6, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4834,18 +4773,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c175) {
-      s1 = peg$c175;
+    if (input.substr(peg$currPos, 4) === peg$c174) {
+      s1 = peg$c174;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c176); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c177();
+        s1 = peg$c176();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4857,18 +4796,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c178) {
-        s1 = peg$c178;
+      if (input.substr(peg$currPos, 5) === peg$c177) {
+        s1 = peg$c177;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c180();
+          s1 = peg$c179();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4880,18 +4819,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c181) {
-          s1 = peg$c181;
+        if (input.substr(peg$currPos, 4) === peg$c180) {
+          s1 = peg$c180;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c182); }
+          if (peg$silentFails === 0) { peg$fail(peg$c181); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c183();
+            s1 = peg$c182();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4903,18 +4842,18 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c184) {
-            s1 = peg$c184;
+          if (input.substr(peg$currPos, 5) === peg$c183) {
+            s1 = peg$c183;
             peg$currPos += 5;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c185); }
+            if (peg$silentFails === 0) { peg$fail(peg$c184); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c186();
+              s1 = peg$c185();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4926,10 +4865,10 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$c98;
+            s1 = peg$c97;
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c180();
+              s1 = peg$c179();
             }
             s0 = s1;
           }
@@ -4947,25 +4886,25 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c16;
+        s1 = peg$c15;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c16); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c18;
+            s3 = peg$c17;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c19); }
+            if (peg$silentFails === 0) { peg$fail(peg$c18); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s2);
+            s1 = peg$c45(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4988,12 +4927,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c187) {
-      s1 = peg$c187;
+    if (input.substr(peg$currPos, 6) === peg$c186) {
+      s1 = peg$c186;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+      if (peg$silentFails === 0) { peg$fail(peg$c187); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -5010,7 +4949,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSampleExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c189(s3);
+          s1 = peg$c188(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5035,7 +4974,7 @@ function peg$parse(input, options) {
     s1 = peg$parseAssignments();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c190(s1);
+      s1 = peg$c189(s1);
     }
     s0 = s1;
 
@@ -5051,7 +4990,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c191(s2);
+        s1 = peg$c190(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5063,10 +5002,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c192();
+        s1 = peg$c191();
       }
       s0 = s1;
     }
@@ -5081,7 +5020,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFromAny();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c193(s1);
+      s1 = peg$c192(s1);
     }
     s0 = s1;
 
@@ -5106,12 +5045,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c194) {
-      s1 = peg$c194;
+    if (input.substr(peg$currPos, 4) === peg$c193) {
+      s1 = peg$c193;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5129,7 +5068,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c196(s3, s4, s5);
+              s1 = peg$c195(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5159,12 +5098,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c25) {
-      s1 = peg$c25;
+    if (input.substr(peg$currPos, 4) === peg$c24) {
+      s1 = peg$c24;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c26); }
+      if (peg$silentFails === 0) { peg$fail(peg$c25); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5172,7 +5111,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePoolBody();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c197(s3);
+          s1 = peg$c196(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5194,12 +5133,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c198) {
-      s1 = peg$c198;
+    if (input.substr(peg$currPos, 4) === peg$c197) {
+      s1 = peg$c197;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c199); }
+      if (peg$silentFails === 0) { peg$fail(peg$c198); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5207,7 +5146,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePoolBody();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c197(s3);
+          s1 = peg$c196(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5247,7 +5186,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c200(s1, s2, s3, s4);
+            s1 = peg$c199(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5273,12 +5212,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c201) {
-      s1 = peg$c201;
+    if (input.substr(peg$currPos, 3) === peg$c200) {
+      s1 = peg$c200;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c202); }
+      if (peg$silentFails === 0) { peg$fail(peg$c201); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5296,7 +5235,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c203(s3, s4, s5);
+              s1 = peg$c202(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5326,27 +5265,27 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c204) {
-      s1 = peg$c204;
+    if (input.substr(peg$currPos, 5) === peg$c203) {
+      s1 = peg$c203;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c205); }
+      if (peg$silentFails === 0) { peg$fail(peg$c204); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c206) {
-        s1 = peg$c206;
+      if (input.substr(peg$currPos, 6) === peg$c205) {
+        s1 = peg$c205;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c207); }
+        if (peg$silentFails === 0) { peg$fail(peg$c206); }
       }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePath();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5367,28 +5306,28 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c5(s1);
+      s1 = peg$c4(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c208.test(input.charAt(peg$currPos))) {
+      if (peg$c207.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c209); }
+        if (peg$silentFails === 0) { peg$fail(peg$c208); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c208.test(input.charAt(peg$currPos))) {
+          if (peg$c207.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c209); }
+            if (peg$silentFails === 0) { peg$fail(peg$c208); }
           }
         }
       } else {
@@ -5396,7 +5335,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
       }
       s0 = s1;
     }
@@ -5410,12 +5349,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c210) {
-        s2 = peg$c210;
+      if (input.substr(peg$currPos, 2) === peg$c209) {
+        s2 = peg$c209;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c211); }
+        if (peg$silentFails === 0) { peg$fail(peg$c210); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5423,7 +5362,7 @@ function peg$parse(input, options) {
           s4 = peg$parseKSUID();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c212(s4);
+            s1 = peg$c211(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5450,22 +5389,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c213.test(input.charAt(peg$currPos))) {
+    if (peg$c212.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+      if (peg$silentFails === 0) { peg$fail(peg$c213); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c213.test(input.charAt(peg$currPos))) {
+        if (peg$c212.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+          if (peg$silentFails === 0) { peg$fail(peg$c213); }
         }
       }
     } else {
@@ -5473,7 +5412,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -5486,12 +5425,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c215) {
-        s2 = peg$c215;
+      if (input.substr(peg$currPos, 5) === peg$c214) {
+        s2 = peg$c214;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c216); }
+        if (peg$silentFails === 0) { peg$fail(peg$c215); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5500,12 +5439,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c217) {
-                s6 = peg$c217;
+              if (input.substr(peg$currPos, 2) === peg$c216) {
+                s6 = peg$c216;
                 peg$currPos += 2;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c218); }
+                if (peg$silentFails === 0) { peg$fail(peg$c217); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parse_();
@@ -5513,7 +5452,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseLiteral();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c219(s4, s8);
+                    s1 = peg$c218(s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5568,7 +5507,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c220(s1, s2, s3);
+          s1 = peg$c219(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5587,7 +5526,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePoolMeta();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c221(s1);
+        s1 = peg$c220(s1);
       }
       s0 = s1;
     }
@@ -5600,17 +5539,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 64) {
-      s1 = peg$c222;
+      s1 = peg$c221;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c223); }
+      if (peg$silentFails === 0) { peg$fail(peg$c222); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePoolName();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224(s2);
+        s1 = peg$c223(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5629,17 +5568,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c53;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePoolIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c225(s2);
+        s1 = peg$c224(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5674,11 +5613,11 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierStart();
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c109;
+        s1 = peg$c108;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -5686,11 +5625,11 @@ function peg$parse(input, options) {
       s3 = peg$parseIdentifierRest();
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c109;
+          s3 = peg$c108;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
       }
       while (s3 !== peg$FAILED) {
@@ -5698,17 +5637,17 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierRest();
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c109;
+            s3 = peg$c108;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c226();
+        s1 = peg$c225();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5728,12 +5667,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c227) {
-        s2 = peg$c227;
+      if (input.substr(peg$currPos, 5) === peg$c226) {
+        s2 = peg$c226;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c228); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5743,7 +5682,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c229(s4, s5);
+              s1 = peg$c228(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5775,12 +5714,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c230) {
-        s2 = peg$c230;
+      if (input.substr(peg$currPos, 6) === peg$c229) {
+        s2 = peg$c229;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c231); }
+        if (peg$silentFails === 0) { peg$fail(peg$c230); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5788,7 +5727,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c232(s4);
+            s1 = peg$c231(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5814,38 +5753,38 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c233) {
-      s1 = peg$c233;
+    if (input.substr(peg$currPos, 4) === peg$c232) {
+      s1 = peg$c232;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c235();
+      s1 = peg$c234();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c236) {
-        s1 = peg$c236;
+      if (input.substr(peg$currPos, 5) === peg$c235) {
+        s1 = peg$c235;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c237); }
+        if (peg$silentFails === 0) { peg$fail(peg$c236); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c238();
+        s1 = peg$c237();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c98;
+        s1 = peg$c97;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c235();
+          s1 = peg$c234();
         }
         s0 = s1;
       }
@@ -5860,26 +5799,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c227) {
-        s2 = peg$c227;
+      if (input.substr(peg$currPos, 5) === peg$c226) {
+        s2 = peg$c226;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c228); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c239) {
-            s4 = peg$c239;
+          if (input.substr(peg$currPos, 3) === peg$c238) {
+            s4 = peg$c238;
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c235();
+            s1 = peg$c234();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5901,26 +5840,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c227) {
-          s2 = peg$c227;
+        if (input.substr(peg$currPos, 5) === peg$c226) {
+          s2 = peg$c226;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+          if (peg$silentFails === 0) { peg$fail(peg$c227); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c241) {
-              s4 = peg$c241;
+            if (input.substr(peg$currPos, 4) === peg$c240) {
+              s4 = peg$c240;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c242); }
+              if (peg$silentFails === 0) { peg$fail(peg$c241); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c238();
+              s1 = peg$c237();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5947,12 +5886,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c243) {
-      s1 = peg$c243;
+    if (input.substr(peg$currPos, 4) === peg$c242) {
+      s1 = peg$c242;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c243); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -5967,7 +5906,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245();
+        s1 = peg$c244();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5985,12 +5924,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7) === peg$c246) {
-      s1 = peg$c246;
+    if (input.substr(peg$currPos, 7) === peg$c245) {
+      s1 = peg$c245;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6005,7 +5944,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c248(s3, s4, s5);
+              s1 = peg$c247(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6035,12 +5974,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c249) {
-      s1 = peg$c249;
+    if (input.substr(peg$currPos, 5) === peg$c248) {
+      s1 = peg$c248;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c250); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6048,7 +5987,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c251(s3);
+          s1 = peg$c250(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6067,58 +6006,82 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOverOp() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c251) {
+      s1 = peg$c251;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c252); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c93) {
-              s5 = peg$c93;
+          s4 = peg$currPos;
+          s5 = peg$parse_();
+          if (s5 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 4) === peg$c92) {
+              s6 = peg$c92;
               peg$currPos += 4;
             } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c94); }
+              s6 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c93); }
             }
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse_();
-              if (s6 !== peg$FAILED) {
-                s7 = peg$parseLetAssignments();
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
-                  if (s8 !== peg$FAILED) {
-                    s9 = peg$parseScope();
-                    if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c254(s3, s7, s9);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parse_();
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parseLetAssignments();
+                if (s8 !== peg$FAILED) {
+                  peg$savedPos = s4;
+                  s5 = peg$c253(s3, s8);
+                  s4 = s5;
                 } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
+                  peg$currPos = s4;
+                  s4 = peg$FAILED;
                 }
               } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
+                peg$currPos = s4;
+                s4 = peg$FAILED;
               }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+          if (s4 === peg$FAILED) {
+            s4 = null;
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$currPos;
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseScope();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s5;
+                s6 = peg$c254(s3, s4, s7);
+                s5 = s6;
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c255(s3, s4, s5);
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -6139,78 +6102,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c252) {
-        s1 = peg$c252;
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c253); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseExprs();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parseScope();
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c255(s3, s5);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c252) {
-          s1 = peg$c252;
-          peg$currPos += 4;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c253); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse_();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parseExprs();
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c256(s3);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      }
-    }
 
     return s0;
   }
@@ -6219,22 +6110,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c34) {
-      s1 = peg$c34;
+    if (input.substr(peg$currPos, 2) === peg$c33) {
+      s1 = peg$c33;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c35); }
+      if (peg$silentFails === 0) { peg$fail(peg$c34); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6244,15 +6135,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c18;
+                  s7 = peg$c17;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c257(s5);
+                  s1 = peg$c256(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6297,11 +6188,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6309,7 +6200,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLetAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c258(s1, s7);
+              s4 = peg$c257(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6333,11 +6224,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6345,7 +6236,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLetAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c258(s1, s7);
+                s4 = peg$c257(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6366,7 +6257,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6389,11 +6280,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c8;
+          s3 = peg$c7;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c9); }
+          if (peg$silentFails === 0) { peg$fail(peg$c8); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6401,7 +6292,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c10(s1, s5);
+              s1 = peg$c9(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6428,7 +6319,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIdentifierName();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c259(s1);
+        s1 = peg$c258(s1);
       }
       s0 = s1;
     }
@@ -6440,12 +6331,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c260) {
-      s1 = peg$c260;
+    if (input.substr(peg$currPos, 5) === peg$c259) {
+      s1 = peg$c259;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c261); }
+      if (peg$silentFails === 0) { peg$fail(peg$c260); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6453,7 +6344,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c262(s3);
+          s1 = peg$c261(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6484,7 +6375,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c263(s4);
+            s1 = peg$c262(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6519,7 +6410,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c264(s4);
+            s1 = peg$c263(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6552,11 +6443,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6587,11 +6478,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6599,6 +6490,100 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 s4 = [s4, s5, s6, s7];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c265(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssignments() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseAssignment();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c100;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseAssignment();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c257(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c100;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseAssignment();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c257(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6633,100 +6618,6 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseAssignments() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseAssignment();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseAssignment();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c258(s1, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseAssignment();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c258(s1, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parseAssignment() {
     var s0, s1, s2, s3, s4, s5;
 
@@ -6735,12 +6626,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c105) {
-          s3 = peg$c105;
+        if (input.substr(peg$currPos, 2) === peg$c104) {
+          s3 = peg$c104;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c106); }
+          if (peg$silentFails === 0) { peg$fail(peg$c105); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6748,7 +6639,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c268(s1, s5);
+              s1 = peg$c267(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6791,11 +6682,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c269;
+          s3 = peg$c268;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c269); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6805,11 +6696,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c53;
+                  s7 = peg$c52;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -6817,7 +6708,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c271(s1, s5, s9);
+                      s1 = peg$c270(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6879,7 +6770,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s5, s7);
+              s4 = peg$c271(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6909,7 +6800,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s5, s7);
+                s4 = peg$c271(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6930,7 +6821,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6961,7 +6852,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s5, s7);
+              s4 = peg$c271(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6991,7 +6882,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s5, s7);
+                s4 = peg$c271(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7012,7 +6903,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7027,34 +6918,86 @@ function peg$parse(input, options) {
   }
 
   function peg$parseComparisonExpr() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     s1 = peg$parseAdditiveExpr();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseComparator();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseAdditiveExpr();
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c274(s1, s3, s5);
-              s0 = s1;
+      s2 = peg$currPos;
+      s3 = peg$parse__();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parseComparator();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parse__();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parseAdditiveExpr();
+            if (s6 !== peg$FAILED) {
+              s3 = [s3, s4, s5, s6];
+              s2 = s3;
             } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
+              peg$currPos = s2;
+              s2 = peg$FAILED;
             }
           } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
+            peg$currPos = s2;
+            s2 = peg$FAILED;
           }
         } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
+          peg$currPos = s2;
+          s2 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 === peg$FAILED) {
+        s2 = peg$currPos;
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 126) {
+            s5 = peg$c54;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          }
+          if (s5 !== peg$FAILED) {
+            peg$savedPos = s4;
+            s5 = peg$c273();
+          }
+          s4 = s5;
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse__();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseRegexp();
+              if (s6 !== peg$FAILED) {
+                s3 = [s3, s4, s5, s6];
+                s2 = s3;
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      }
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c274(s1, s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -7062,51 +7005,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseAdditiveExpr();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 126) {
-            s3 = peg$c55;
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c56); }
-          }
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parseRegexp();
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c275(s1, s5);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseAdditiveExpr();
-      }
     }
 
     return s0;
@@ -7129,7 +7027,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s5, s7);
+              s4 = peg$c271(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7159,7 +7057,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s5, s7);
+                s4 = peg$c271(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7180,7 +7078,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7199,24 +7097,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c276;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c278;
+        s1 = peg$c277;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7240,7 +7138,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s5, s7);
+              s4 = peg$c271(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7270,7 +7168,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s5, s7);
+                s4 = peg$c271(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7291,7 +7189,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7310,33 +7208,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c80;
+      s1 = peg$c79;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c81); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c280;
+        s1 = peg$c279;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+        if (peg$silentFails === 0) { peg$fail(peg$c280); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c282;
+          s1 = peg$c281;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+          if (peg$silentFails === 0) { peg$fail(peg$c282); }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7348,11 +7246,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c76;
+      s1 = peg$c75;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c77); }
+      if (peg$silentFails === 0) { peg$fail(peg$c76); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7360,7 +7258,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c284(s3);
+          s1 = peg$c283(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7397,11 +7295,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c278;
+        s2 = peg$c277;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7409,7 +7307,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c285(s4);
+            s1 = peg$c284(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7448,7 +7346,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s1, s2);
+        s1 = peg$c71(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7470,7 +7368,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c72(s1, s2);
+          s1 = peg$c71(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7500,11 +7398,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -7528,20 +7426,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c286) {
-      s0 = peg$c286;
+    if (input.substr(peg$currPos, 3) === peg$c285) {
+      s0 = peg$c285;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c287); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c288) {
-        s0 = peg$c288;
+      if (input.substr(peg$currPos, 6) === peg$c287) {
+        s0 = peg$c287;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c289); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
     }
 
@@ -7557,11 +7455,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7571,15 +7469,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c18;
+                  s7 = peg$c17;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c290(s1, s5);
+                  s1 = peg$c289(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7635,11 +7533,11 @@ function peg$parse(input, options) {
           s3 = peg$parse__();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s4 = peg$c16;
+              s4 = peg$c15;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+              if (peg$silentFails === 0) { peg$fail(peg$c16); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse__();
@@ -7649,11 +7547,11 @@ function peg$parse(input, options) {
                   s7 = peg$parse__();
                   if (s7 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s8 = peg$c18;
+                      s8 = peg$c17;
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c18); }
                     }
                     if (s8 !== peg$FAILED) {
                       s9 = peg$parseWhereClause();
@@ -7662,7 +7560,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c291(s2, s6, s9);
+                        s1 = peg$c290(s2, s6, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7709,22 +7607,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c292) {
-      s1 = peg$c292;
+    if (input.substr(peg$currPos, 4) === peg$c291) {
+      s1 = peg$c291;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c293); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7734,15 +7632,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c18;
+                  s7 = peg$c17;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c294(s5);
+                  s1 = peg$c293(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7774,22 +7672,22 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c292) {
-        s1 = peg$c292;
+      if (input.substr(peg$currPos, 4) === peg$c291) {
+        s1 = peg$c291;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c293); }
+        if (peg$silentFails === 0) { peg$fail(peg$c292); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c16;
+            s3 = peg$c15;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -7799,11 +7697,11 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c101;
+                    s7 = peg$c100;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c101); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse__();
@@ -7813,15 +7711,15 @@ function peg$parse(input, options) {
                         s10 = peg$parse__();
                         if (s10 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 41) {
-                            s11 = peg$c18;
+                            s11 = peg$c17;
                             peg$currPos++;
                           } else {
                             s11 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c18); }
                           }
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c295(s5, s9);
+                            s1 = peg$c294(s5, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7883,7 +7781,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c296(s1);
+          s1 = peg$c295(s1);
         }
         s0 = s1;
       }
@@ -7901,7 +7799,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4();
+        s1 = peg$c3();
       }
       s0 = s1;
     }
@@ -7920,11 +7818,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -7932,7 +7830,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c297(s1, s7);
+              s4 = peg$c296(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7956,11 +7854,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -7968,7 +7866,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c297(s1, s7);
+                s4 = peg$c296(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7989,7 +7887,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8028,7 +7926,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c72(s2, s3);
+          s1 = peg$c71(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8051,11 +7949,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c40;
+      s1 = peg$c39;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c41); }
+      if (peg$silentFails === 0) { peg$fail(peg$c40); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -8063,27 +7961,30 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c53;
+            s4 = peg$c52;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
               s6 = peg$parseAdditiveExpr();
+              if (s6 === peg$FAILED) {
+                s6 = null;
+              }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c298;
+                  s7 = peg$c297;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c300(s2, s6);
+                  s1 = peg$c299(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8116,21 +8017,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c40;
+        s1 = peg$c39;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c41); }
+        if (peg$silentFails === 0) { peg$fail(peg$c40); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c53;
+            s3 = peg$c52;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -8138,15 +8039,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c298;
+                  s6 = peg$c297;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c301(s5);
+                  s1 = peg$c300(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8175,50 +8076,26 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c40;
+          s1 = peg$c39;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c40); }
         }
         if (s1 !== peg$FAILED) {
-          s2 = peg$parseAdditiveExpr();
+          s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parse__();
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s3 = peg$c297;
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c298); }
+            }
             if (s3 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c53;
-                peg$currPos++;
-              } else {
-                s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c54); }
-              }
-              if (s4 !== peg$FAILED) {
-                s5 = peg$parse__();
-                if (s5 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c298;
-                    peg$currPos++;
-                  } else {
-                    s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c299); }
-                  }
-                  if (s6 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c302(s2);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
+              peg$savedPos = s0;
+              s1 = peg$c301(s2);
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -8233,31 +8110,19 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c40;
+          if (input.charCodeAt(peg$currPos) === 46) {
+            s1 = peg$c108;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c41); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
           if (s1 !== peg$FAILED) {
-            s2 = peg$parseConditionalExpr();
+            s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c298;
-                peg$currPos++;
-              } else {
-                s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c299); }
-              }
-              if (s3 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c303(s2);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
+              peg$savedPos = s0;
+              s1 = peg$c302(s2);
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -8265,30 +8130,6 @@ function peg$parse(input, options) {
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c109;
-              peg$currPos++;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c110); }
-            }
-            if (s1 !== peg$FAILED) {
-              s2 = peg$parseIdentifier();
-              if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c304(s2);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
           }
         }
       }
@@ -8312,11 +8153,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 40) {
-                s1 = peg$c16;
+                s1 = peg$c15;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -8326,15 +8167,15 @@ function peg$parse(input, options) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s5 = peg$c18;
+                        s5 = peg$c17;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c18); }
                       }
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c46(s3);
+                        s1 = peg$c45(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -8359,11 +8200,11 @@ function peg$parse(input, options) {
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s1 = peg$c16;
+                  s1 = peg$c15;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse__();
@@ -8373,15 +8214,15 @@ function peg$parse(input, options) {
                       s4 = peg$parse__();
                       if (s4 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 41) {
-                          s5 = peg$c18;
+                          s5 = peg$c17;
                           peg$currPos++;
                         } else {
                           s5 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c18); }
                         }
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c46(s3);
+                          s1 = peg$c45(s3);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -8414,64 +8255,76 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOverExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c251) {
+      s1 = peg$c251;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c252); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c93) {
-              s5 = peg$c93;
+          s4 = peg$currPos;
+          s5 = peg$parse_();
+          if (s5 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 4) === peg$c92) {
+              s6 = peg$c92;
               peg$currPos += 4;
             } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c94); }
+              s6 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c93); }
             }
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parse_();
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parseLetAssignments();
+                if (s8 !== peg$FAILED) {
+                  peg$savedPos = s4;
+                  s5 = peg$c253(s3, s8);
+                  s4 = s5;
+                } else {
+                  peg$currPos = s4;
+                  s4 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s4;
+                s4 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+          if (s4 === peg$FAILED) {
+            s4 = null;
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse_();
+              if (input.charCodeAt(peg$currPos) === 124) {
+                s6 = peg$c35;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c36); }
+              }
               if (s6 !== peg$FAILED) {
-                s7 = peg$parseLetAssignments();
+                s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
+                  s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 124) {
-                      s9 = peg$c36;
-                      peg$currPos++;
-                    } else {
-                      s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c37); }
-                    }
-                    if (s9 !== peg$FAILED) {
-                      s10 = peg$parse__();
-                      if (s10 !== peg$FAILED) {
-                        s11 = peg$parseSequential();
-                        if (s11 !== peg$FAILED) {
-                          peg$savedPos = s0;
-                          s1 = peg$c305(s3, s7, s11);
-                          s0 = s1;
-                        } else {
-                          peg$currPos = s0;
-                          s0 = peg$FAILED;
-                        }
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
+                    peg$savedPos = s0;
+                    s1 = peg$c303(s3, s4, s8);
+                    s0 = s1;
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -8504,66 +8357,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c252) {
-        s1 = peg$c252;
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c253); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseExprs();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 124) {
-                s5 = peg$c36;
-                peg$currPos++;
-              } else {
-                s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c37); }
-              }
-              if (s5 !== peg$FAILED) {
-                s6 = peg$parse__();
-                if (s6 !== peg$FAILED) {
-                  s7 = peg$parseSequential();
-                  if (s7 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c306(s3, s7);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
 
     return s0;
   }
@@ -8573,11 +8366,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c38;
+      s1 = peg$c37;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c38); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8587,15 +8380,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c307;
+              s5 = peg$c304;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c308); }
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c309(s3);
+              s1 = peg$c306(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8635,7 +8428,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8650,7 +8443,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4();
+        s1 = peg$c3();
       }
       s0 = s1;
     }
@@ -8665,11 +8458,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c101;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8677,7 +8470,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c310(s4);
+            s1 = peg$c307(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8717,12 +8510,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c311) {
-      s1 = peg$c311;
+    if (input.substr(peg$currPos, 3) === peg$c308) {
+      s1 = peg$c308;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c312); }
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8730,7 +8523,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c313(s3);
+          s1 = peg$c310(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8757,11 +8550,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c53;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8769,7 +8562,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314(s1, s5);
+              s1 = peg$c311(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8800,11 +8593,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c40;
+      s1 = peg$c39;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c41); }
+      if (peg$silentFails === 0) { peg$fail(peg$c40); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8814,15 +8607,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c298;
+              s5 = peg$c297;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c299); }
+              if (peg$silentFails === 0) { peg$fail(peg$c298); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s3);
+              s1 = peg$c312(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8852,12 +8645,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c316) {
-      s1 = peg$c316;
+    if (input.substr(peg$currPos, 2) === peg$c313) {
+      s1 = peg$c313;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8866,16 +8659,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c318) {
-              s5 = peg$c318;
+            if (input.substr(peg$currPos, 2) === peg$c315) {
+              s5 = peg$c315;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c319); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s3);
+              s1 = peg$c317(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8905,12 +8698,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c321) {
-      s1 = peg$c321;
+    if (input.substr(peg$currPos, 2) === peg$c318) {
+      s1 = peg$c318;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8919,16 +8712,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c323) {
-              s5 = peg$c323;
+            if (input.substr(peg$currPos, 2) === peg$c320) {
+              s5 = peg$c320;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c324); }
+              if (peg$silentFails === 0) { peg$fail(peg$c321); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c325(s3);
+              s1 = peg$c322(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8968,7 +8761,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8983,7 +8776,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4();
+        s1 = peg$c3();
       }
       s0 = s1;
     }
@@ -8998,11 +8791,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c101;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -9010,7 +8803,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s4);
+            s1 = peg$c323(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9041,11 +8834,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c53;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -9053,7 +8846,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c327(s1, s5);
+              s1 = peg$c324(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9118,7 +8911,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c328(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c325(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9165,15 +8958,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 42) {
-          s3 = peg$c80;
+          s3 = peg$c79;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c49();
+          s1 = peg$c48();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9196,7 +8989,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c329(s3);
+            s1 = peg$c326(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9230,7 +9023,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s1, s5);
+              s1 = peg$c327(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9257,7 +9050,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c100(s1);
+        s1 = peg$c99(s1);
       }
       s0 = s1;
     }
@@ -9276,11 +9069,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -9288,7 +9081,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSQLAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c103(s1, s7);
+              s4 = peg$c102(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9312,11 +9105,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -9324,7 +9117,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSQLAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c103(s1, s7);
+                s4 = peg$c102(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9345,7 +9138,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9377,7 +9170,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331(s4, s5);
+              s1 = peg$c328(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9408,15 +9201,15 @@ function peg$parse(input, options) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 42) {
-              s4 = peg$c80;
+              s4 = peg$c79;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c81); }
+              if (peg$silentFails === 0) { peg$fail(peg$c80); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c49();
+              s1 = peg$c48();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9452,7 +9245,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c212(s4);
+            s1 = peg$c211(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9502,7 +9295,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDerefExpr();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c212(s3);
+            s1 = peg$c211(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9532,7 +9325,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c332(s1, s4);
+        s4 = peg$c329(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9541,13 +9334,13 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c332(s1, s4);
+          s4 = peg$c329(s1, s4);
         }
         s3 = s4;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9591,11 +9384,11 @@ function peg$parse(input, options) {
                         s11 = peg$parse__();
                         if (s11 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 61) {
-                            s12 = peg$c8;
+                            s12 = peg$c7;
                             peg$currPos++;
                           } else {
                             s12 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c9); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c8); }
                           }
                           if (s12 !== peg$FAILED) {
                             s13 = peg$parse__();
@@ -9603,7 +9396,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c333(s1, s5, s6, s10, s14);
+                                s1 = peg$c330(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9683,7 +9476,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c334(s2);
+        s1 = peg$c331(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9695,10 +9488,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c180();
+        s1 = peg$c179();
       }
       s0 = s1;
     }
@@ -9719,7 +9512,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLogicalOrExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s4);
+            s1 = peg$c45(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9758,7 +9551,7 @@ function peg$parse(input, options) {
               s6 = peg$parseFieldExprs();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c92(s6);
+                s1 = peg$c91(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9801,7 +9594,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLogicalOrExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s4);
+            s1 = peg$c45(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9842,7 +9635,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c335(s6, s7);
+                  s1 = peg$c332(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9888,7 +9681,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c336(s2);
+        s1 = peg$c333(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9900,10 +9693,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c235();
+        s1 = peg$c234();
       }
       s0 = s1;
     }
@@ -9924,7 +9717,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c337(s4);
+            s1 = peg$c334(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9944,10 +9737,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c99();
+        s1 = peg$c98();
       }
       s0 = s1;
     }
@@ -9959,9 +9752,29 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c288) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c287) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c336();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseAS() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c337) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c338); }
@@ -9975,40 +9788,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseAS() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c340) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c342();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
   function peg$parseFROM() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c25) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c24) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c344();
+      s1 = peg$c341();
     }
     s0 = s1;
 
@@ -10019,16 +9812,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c171) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c170) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c346();
+      s1 = peg$c343();
     }
     s0 = s1;
 
@@ -10039,7 +9832,27 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c112) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c111) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c345();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseGROUP() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
@@ -10055,13 +9868,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseGROUP() {
+  function peg$parseBY() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c349) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c350); }
@@ -10075,13 +9888,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseBY() {
+  function peg$parseHAVING() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c352) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c352) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c353); }
@@ -10095,33 +9908,33 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseHAVING() {
+  function peg$parseORDER() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c355) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c226) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c357();
+      s1 = peg$c356();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseORDER() {
+  function peg$parseON() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c227) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c357) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c358); }
@@ -10135,13 +9948,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseON() {
+  function peg$parseLIMIT() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c360) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c360) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c361); }
@@ -10155,40 +9968,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLIMIT() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c363) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c365();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
   function peg$parseASC() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c239) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c238) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c235();
+      s1 = peg$c234();
     }
     s0 = s1;
 
@@ -10199,16 +9992,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c238();
+      s1 = peg$c237();
     }
     s0 = s1;
 
@@ -10219,16 +10012,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c175) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c177();
+      s1 = peg$c176();
     }
     s0 = s1;
 
@@ -10239,16 +10032,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c181) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c183();
+      s1 = peg$c182();
     }
     s0 = s1;
 
@@ -10259,16 +10052,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c184) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c183) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c186();
+      s1 = peg$c185();
     }
     s0 = s1;
 
@@ -10279,16 +10072,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c178) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c177) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c180();
+      s1 = peg$c179();
     }
     s0 = s1;
 
@@ -10386,7 +10179,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c369(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10401,7 +10194,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c369(s1);
       }
       s0 = s1;
     }
@@ -10427,7 +10220,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s1);
+        s1 = peg$c370(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10442,7 +10235,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s1);
+        s1 = peg$c370(s1);
       }
       s0 = s1;
     }
@@ -10457,7 +10250,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374(s1);
+      s1 = peg$c371(s1);
     }
     s0 = s1;
 
@@ -10471,7 +10264,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c375(s1);
+      s1 = peg$c372(s1);
     }
     s0 = s1;
 
@@ -10482,30 +10275,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c376) {
-      s1 = peg$c376;
+    if (input.substr(peg$currPos, 4) === peg$c373) {
+      s1 = peg$c373;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c377); }
+      if (peg$silentFails === 0) { peg$fail(peg$c374); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c378();
+      s1 = peg$c375();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c379) {
-        s1 = peg$c379;
+      if (input.substr(peg$currPos, 5) === peg$c376) {
+        s1 = peg$c376;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c380); }
+        if (peg$silentFails === 0) { peg$fail(peg$c377); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c381();
+        s1 = peg$c378();
       }
       s0 = s1;
     }
@@ -10517,16 +10310,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c382) {
-      s1 = peg$c382;
+    if (input.substr(peg$currPos, 4) === peg$c379) {
+      s1 = peg$c379;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c383); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c384();
+      s1 = peg$c381();
     }
     s0 = s1;
 
@@ -10537,12 +10330,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c385) {
-      s1 = peg$c385;
+    if (input.substr(peg$currPos, 2) === peg$c382) {
+      s1 = peg$c382;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10553,7 +10346,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c387();
+        s1 = peg$c384();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10572,25 +10365,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 60) {
-      s1 = peg$c65;
+      s1 = peg$c64;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      if (peg$silentFails === 0) { peg$fail(peg$c65); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseType();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 62) {
-          s3 = peg$c69;
+          s3 = peg$c68;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c69); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c388(s2);
+          s1 = peg$c385(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10617,7 +10410,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c388(s1);
+        s1 = peg$c385(s1);
       }
       s0 = s1;
     }
@@ -10657,7 +10450,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c389(s1);
+        s1 = peg$c386(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10674,11 +10467,11 @@ function peg$parse(input, options) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 61) {
-            s3 = peg$c8;
+            s3 = peg$c7;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c9); }
+            if (peg$silentFails === 0) { peg$fail(peg$c8); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -10686,7 +10479,7 @@ function peg$parse(input, options) {
               s5 = peg$parseType();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c390(s1, s5);
+                s1 = peg$c387(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10713,17 +10506,17 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s1);
+          s1 = peg$c388(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c16;
+            s1 = peg$c15;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10731,15 +10524,15 @@ function peg$parse(input, options) {
               s3 = peg$parseTypeUnion();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s4 = peg$c18;
+                  s4 = peg$c17;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c392(s3);
+                  s1 = peg$c389(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10771,7 +10564,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c393(s1);
+      s1 = peg$c390(s1);
     }
     s0 = s1;
 
@@ -10796,7 +10589,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10817,11 +10610,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c101;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -10829,7 +10622,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c394(s4);
+            s1 = peg$c391(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10856,11 +10649,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c38;
+      s1 = peg$c37;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c38); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -10870,15 +10663,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c307;
+              s5 = peg$c304;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c308); }
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c395(s3);
+              s1 = peg$c392(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10903,11 +10696,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c40;
+        s1 = peg$c39;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c41); }
+        if (peg$silentFails === 0) { peg$fail(peg$c40); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -10917,15 +10710,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c298;
+                s5 = peg$c297;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                if (peg$silentFails === 0) { peg$fail(peg$c298); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c396(s3);
+                s1 = peg$c393(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10949,12 +10742,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c316) {
-          s1 = peg$c316;
+        if (input.substr(peg$currPos, 2) === peg$c313) {
+          s1 = peg$c313;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c317); }
+          if (peg$silentFails === 0) { peg$fail(peg$c314); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10963,16 +10756,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c318) {
-                  s5 = peg$c318;
+                if (input.substr(peg$currPos, 2) === peg$c315) {
+                  s5 = peg$c315;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c316); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c397(s3);
+                  s1 = peg$c394(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10996,12 +10789,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c321) {
-            s1 = peg$c321;
+          if (input.substr(peg$currPos, 2) === peg$c318) {
+            s1 = peg$c318;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c322); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11011,11 +10804,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 58) {
-                    s5 = peg$c53;
+                    s5 = peg$c52;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c53); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -11024,16 +10817,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c323) {
-                            s9 = peg$c323;
+                          if (input.substr(peg$currPos, 2) === peg$c320) {
+                            s9 = peg$c320;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c321); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c398(s3, s7);
+                            s1 = peg$c395(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11085,7 +10878,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c399(s1);
+      s1 = peg$c396(s1);
     }
     s0 = s1;
 
@@ -11097,11 +10890,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c397;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11112,15 +10905,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c397;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c398); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c5(s2);
+          s1 = peg$c4(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11137,11 +10930,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c402;
+        s1 = peg$c399;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c400); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11152,15 +10945,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c402;
+            s3 = peg$c399;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c400); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c5(s2);
+            s1 = peg$c4(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11197,7 +10990,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c404(s1);
+        s1 = peg$c401(s1);
       }
       s0 = s1;
     }
@@ -11210,23 +11003,23 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s2 = peg$c404;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s2);
+        s1 = peg$c4(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11240,12 +11033,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s2 = peg$c404;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11258,7 +11051,7 @@ function peg$parse(input, options) {
         s2 = peg$parseDoubleQuotedChar();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c5(s2);
+          s1 = peg$c4(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11291,7 +11084,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c404(s1);
+        s1 = peg$c401(s1);
       }
       s0 = s1;
     }
@@ -11304,23 +11097,23 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s2 = peg$c404;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s2);
+        s1 = peg$c4(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11334,12 +11127,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s2 = peg$c404;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11352,7 +11145,7 @@ function peg$parse(input, options) {
         s2 = peg$parseSingleQuotedChar();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c5(s2);
+          s1 = peg$c4(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11371,12 +11164,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c407) {
-      s1 = peg$c407;
+    if (input.substr(peg$currPos, 2) === peg$c404) {
+      s1 = peg$c404;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c405); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11386,15 +11179,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c307;
+              s5 = peg$c304;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c308); }
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c409(s3);
+              s1 = peg$c406(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11424,156 +11217,156 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c410) {
-      s1 = peg$c410;
+    if (input.substr(peg$currPos, 5) === peg$c407) {
+      s1 = peg$c407;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c412) {
-        s1 = peg$c412;
+      if (input.substr(peg$currPos, 6) === peg$c409) {
+        s1 = peg$c409;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c414) {
-          s1 = peg$c414;
+        if (input.substr(peg$currPos, 6) === peg$c411) {
+          s1 = peg$c411;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c415); }
+          if (peg$silentFails === 0) { peg$fail(peg$c412); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c416) {
-            s1 = peg$c416;
+          if (input.substr(peg$currPos, 6) === peg$c413) {
+            s1 = peg$c413;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c417); }
+            if (peg$silentFails === 0) { peg$fail(peg$c414); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c418) {
-              s1 = peg$c418;
+            if (input.substr(peg$currPos, 4) === peg$c415) {
+              s1 = peg$c415;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c419); }
+              if (peg$silentFails === 0) { peg$fail(peg$c416); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c420) {
-                s1 = peg$c420;
+              if (input.substr(peg$currPos, 5) === peg$c417) {
+                s1 = peg$c417;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                if (peg$silentFails === 0) { peg$fail(peg$c418); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c422) {
-                  s1 = peg$c422;
+                if (input.substr(peg$currPos, 5) === peg$c419) {
+                  s1 = peg$c419;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c420); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c424) {
-                    s1 = peg$c424;
+                  if (input.substr(peg$currPos, 5) === peg$c421) {
+                    s1 = peg$c421;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c422); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c426) {
-                      s1 = peg$c426;
+                    if (input.substr(peg$currPos, 7) === peg$c423) {
+                      s1 = peg$c423;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c427); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c424); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c428) {
-                        s1 = peg$c428;
+                      if (input.substr(peg$currPos, 7) === peg$c425) {
+                        s1 = peg$c425;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c426); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c430) {
-                          s1 = peg$c430;
+                        if (input.substr(peg$currPos, 4) === peg$c427) {
+                          s1 = peg$c427;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c428); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c432) {
-                            s1 = peg$c432;
+                          if (input.substr(peg$currPos, 6) === peg$c429) {
+                            s1 = peg$c429;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c433); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c430); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c434) {
-                              s1 = peg$c434;
+                            if (input.substr(peg$currPos, 8) === peg$c431) {
+                              s1 = peg$c431;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c435); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c432); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c436) {
-                                s1 = peg$c436;
+                              if (input.substr(peg$currPos, 4) === peg$c433) {
+                                s1 = peg$c433;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c437); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c434); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c438) {
-                                  s1 = peg$c438;
+                                if (input.substr(peg$currPos, 5) === peg$c435) {
+                                  s1 = peg$c435;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c439); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c436); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c440) {
-                                    s1 = peg$c440;
+                                  if (input.substr(peg$currPos, 2) === peg$c437) {
+                                    s1 = peg$c437;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c441); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c438); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c442) {
-                                      s1 = peg$c442;
+                                    if (input.substr(peg$currPos, 3) === peg$c439) {
+                                      s1 = peg$c439;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c440); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 4) === peg$c11) {
-                                        s1 = peg$c11;
+                                      if (input.substr(peg$currPos, 4) === peg$c10) {
+                                        s1 = peg$c10;
                                         peg$currPos += 4;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c382) {
-                                          s1 = peg$c382;
+                                        if (input.substr(peg$currPos, 4) === peg$c379) {
+                                          s1 = peg$c379;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c383); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c380); }
                                         }
                                       }
                                     }
@@ -11595,7 +11388,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c444();
+      s1 = peg$c441();
     }
     s0 = s1;
 
@@ -11616,7 +11409,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11628,10 +11421,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c49();
+        s1 = peg$c48();
       }
       s0 = s1;
     }
@@ -11646,11 +11439,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c101;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -11658,7 +11451,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c394(s4);
+            s1 = peg$c391(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11689,11 +11482,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c53;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -11701,7 +11494,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c445(s1, s5);
+              s1 = peg$c442(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11742,20 +11535,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c446) {
-      s1 = peg$c446;
+    if (input.substr(peg$currPos, 3) === peg$c443) {
+      s1 = peg$c443;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c447); }
+      if (peg$silentFails === 0) { peg$fail(peg$c444); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c448) {
-        s1 = peg$c448;
+      if (input.substr(peg$currPos, 3) === peg$c445) {
+        s1 = peg$c445;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c449); }
+        if (peg$silentFails === 0) { peg$fail(peg$c446); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11771,7 +11564,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c450();
+        s1 = peg$c447();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11789,20 +11582,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c451) {
-      s1 = peg$c451;
+    if (input.substr(peg$currPos, 2) === peg$c448) {
+      s1 = peg$c448;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c452); }
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c453) {
-        s1 = peg$c453;
+      if (input.substr(peg$currPos, 2) === peg$c450) {
+        s1 = peg$c450;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c454); }
+        if (peg$silentFails === 0) { peg$fail(peg$c451); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11818,7 +11611,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c455();
+        s1 = peg$c452();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11836,20 +11629,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c286) {
-      s1 = peg$c286;
+    if (input.substr(peg$currPos, 3) === peg$c285) {
+      s1 = peg$c285;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c287); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c457) {
-        s1 = peg$c457;
+      if (input.substr(peg$currPos, 3) === peg$c454) {
+        s1 = peg$c454;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c458); }
+        if (peg$silentFails === 0) { peg$fail(peg$c455); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11865,7 +11658,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c459();
+        s1 = peg$c456();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11883,12 +11676,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c352) {
-      s1 = peg$c352;
+    if (input.substr(peg$currPos, 2) === peg$c349) {
+      s1 = peg$c349;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c460); }
+      if (peg$silentFails === 0) { peg$fail(peg$c457); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11903,7 +11696,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354();
+        s1 = peg$c351();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11920,12 +11713,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c461.test(input.charAt(peg$currPos))) {
+    if (peg$c458.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c462); }
+      if (peg$silentFails === 0) { peg$fail(peg$c459); }
     }
 
     return s0;
@@ -11936,12 +11729,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
     }
 
@@ -11955,7 +11748,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c465(s1);
+      s1 = peg$c462(s1);
     }
     s0 = s1;
 
@@ -12010,7 +11803,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c226();
+          s1 = peg$c225();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12027,31 +11820,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c466;
+        s1 = peg$c463;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c405;
+          s1 = peg$c402;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c212(s2);
+            s1 = peg$c211(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -12063,16 +11856,16 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 4) === peg$c11) {
-            s1 = peg$c11;
+          if (input.substr(peg$currPos, 4) === peg$c10) {
+            s1 = peg$c10;
             peg$currPos += 4;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c12); }
+            if (peg$silentFails === 0) { peg$fail(peg$c11); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c71();
+            s1 = peg$c70();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -12085,11 +11878,11 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s5 = peg$c16;
+                  s5 = peg$c15;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
                 }
                 if (s5 !== peg$FAILED) {
                   s4 = [s4, s5];
@@ -12111,7 +11904,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c212(s1);
+                s1 = peg$c211(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12153,17 +11946,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c468;
+        s2 = peg$c465;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c469); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c470();
+          s1 = peg$c467();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12188,21 +11981,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c278;
+        s2 = peg$c277;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c278;
+            s4 = peg$c277;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c279); }
+            if (peg$silentFails === 0) { peg$fail(peg$c278); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12237,36 +12030,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c463.test(input.charAt(peg$currPos))) {
+    if (peg$c460.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c463.test(input.charAt(peg$currPos))) {
+        if (peg$c460.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c464); }
+          if (peg$silentFails === 0) { peg$fail(peg$c461); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c463.test(input.charAt(peg$currPos))) {
+          if (peg$c460.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c464); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12295,20 +12088,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c463.test(input.charAt(peg$currPos))) {
+    if (peg$c460.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12354,51 +12147,51 @@ function peg$parse(input, options) {
     s1 = peg$parseD2();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c53;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c53;
+            s4 = peg$c52;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
             if (s5 !== peg$FAILED) {
               s6 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c109;
+                s7 = peg$c108;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c110); }
+                if (peg$silentFails === 0) { peg$fail(peg$c109); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c463.test(input.charAt(peg$currPos))) {
+                if (peg$c460.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c463.test(input.charAt(peg$currPos))) {
+                    if (peg$c460.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c461); }
                     }
                   }
                 } else {
@@ -12453,69 +12246,69 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c471;
+      s0 = peg$c468;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c469); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c276;
+        s1 = peg$c275;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c278;
+          s1 = peg$c277;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c279); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseD2();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c53;
+            s3 = peg$c52;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parseD2();
             if (s4 !== peg$FAILED) {
               s5 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c109;
+                s6 = peg$c108;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c110); }
+                if (peg$silentFails === 0) { peg$fail(peg$c109); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c463.test(input.charAt(peg$currPos))) {
+                if (peg$c460.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c463.test(input.charAt(peg$currPos))) {
+                    if (peg$c460.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c461); }
                     }
                   }
                 } else {
@@ -12568,11 +12361,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c278;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12618,7 +12411,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c473();
+        s1 = peg$c470();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12640,11 +12433,11 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c109;
+        s3 = peg$c108;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseUInt();
@@ -12680,76 +12473,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c474) {
-      s0 = peg$c474;
+    if (input.substr(peg$currPos, 2) === peg$c471) {
+      s0 = peg$c471;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c472); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c476) {
-        s0 = peg$c476;
+      if (input.substr(peg$currPos, 2) === peg$c473) {
+        s0 = peg$c473;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c477); }
+        if (peg$silentFails === 0) { peg$fail(peg$c474); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c478) {
-          s0 = peg$c478;
+        if (input.substr(peg$currPos, 2) === peg$c475) {
+          s0 = peg$c475;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c479); }
+          if (peg$silentFails === 0) { peg$fail(peg$c476); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c480;
+            s0 = peg$c477;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c481); }
+            if (peg$silentFails === 0) { peg$fail(peg$c478); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c482;
+              s0 = peg$c479;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c483); }
+              if (peg$silentFails === 0) { peg$fail(peg$c480); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c484;
+                s0 = peg$c481;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c485); }
+                if (peg$silentFails === 0) { peg$fail(peg$c482); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c486;
+                  s0 = peg$c483;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c487); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c484); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c488;
+                    s0 = peg$c485;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c489); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c486); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c490;
+                      s0 = peg$c487;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c491); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c488); }
                     }
                   }
                 }
@@ -12770,37 +12563,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c109;
+        s2 = peg$c108;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c109;
+            s4 = peg$c108;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c109;
+                s6 = peg$c108;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c110); }
+                if (peg$silentFails === 0) { peg$fail(peg$c109); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c71();
+                  s1 = peg$c70();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -12844,11 +12637,11 @@ function peg$parse(input, options) {
     s3 = peg$parseHex();
     if (s3 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s4 = peg$c53;
+        s4 = peg$c52;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parseHex();
@@ -12858,11 +12651,11 @@ function peg$parse(input, options) {
           s7 = peg$parseHexDigit();
           if (s7 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s7 = peg$c53;
+              s7 = peg$c52;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c54); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
           }
           peg$silentFails--;
@@ -12902,7 +12695,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Variations();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s2);
+        s1 = peg$c4(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12934,7 +12727,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c492(s1, s2);
+        s1 = peg$c489(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12955,12 +12748,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c493) {
-            s3 = peg$c493;
+          if (input.substr(peg$currPos, 2) === peg$c490) {
+            s3 = peg$c490;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c494); }
+            if (peg$silentFails === 0) { peg$fail(peg$c491); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12973,7 +12766,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c495(s1, s2, s4, s5);
+                s1 = peg$c492(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12997,12 +12790,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c493) {
-          s1 = peg$c493;
+        if (input.substr(peg$currPos, 2) === peg$c490) {
+          s1 = peg$c490;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c494); }
+          if (peg$silentFails === 0) { peg$fail(peg$c491); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13015,7 +12808,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c496(s2, s3);
+              s1 = peg$c493(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13040,16 +12833,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c493) {
-                s3 = peg$c493;
+              if (input.substr(peg$currPos, 2) === peg$c490) {
+                s3 = peg$c490;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c494); }
+                if (peg$silentFails === 0) { peg$fail(peg$c491); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c497(s1, s2);
+                s1 = peg$c494(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13065,16 +12858,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c493) {
-              s1 = peg$c493;
+            if (input.substr(peg$currPos, 2) === peg$c490) {
+              s1 = peg$c490;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c494); }
+              if (peg$silentFails === 0) { peg$fail(peg$c491); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c498();
+              s1 = peg$c495();
             }
             s0 = s1;
           }
@@ -13101,17 +12894,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c53;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c499(s2);
+        s1 = peg$c496(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13132,15 +12925,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c53;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c500(s1);
+        s1 = peg$c497(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13161,17 +12954,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c280;
+        s2 = peg$c279;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+        if (peg$silentFails === 0) { peg$fail(peg$c280); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c501(s1, s3);
+          s1 = peg$c498(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13196,17 +12989,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c280;
+        s2 = peg$c279;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+        if (peg$silentFails === 0) { peg$fail(peg$c280); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c502(s1, s3);
+          s1 = peg$c499(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13231,7 +13024,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c503(s1);
+      s1 = peg$c500(s1);
     }
     s0 = s1;
 
@@ -13254,22 +13047,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c463.test(input.charAt(peg$currPos))) {
+    if (peg$c460.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c463.test(input.charAt(peg$currPos))) {
+        if (peg$c460.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c464); }
+          if (peg$silentFails === 0) { peg$fail(peg$c461); }
         }
       }
     } else {
@@ -13277,7 +13070,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13289,17 +13082,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c278;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13318,33 +13111,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c278;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c463.test(input.charAt(peg$currPos))) {
+          if (peg$c460.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c464); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
         }
       } else {
@@ -13352,29 +13145,29 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c109;
+          s3 = peg$c108;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c463.test(input.charAt(peg$currPos))) {
+          if (peg$c460.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c464); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c463.test(input.charAt(peg$currPos))) {
+            if (peg$c460.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c464); }
+              if (peg$silentFails === 0) { peg$fail(peg$c461); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13384,7 +13177,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c504();
+              s1 = peg$c501();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13409,41 +13202,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c278;
+        s1 = peg$c277;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c109;
+          s2 = peg$c108;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c463.test(input.charAt(peg$currPos))) {
+          if (peg$c460.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c464); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c463.test(input.charAt(peg$currPos))) {
+              if (peg$c460.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                if (peg$silentFails === 0) { peg$fail(peg$c461); }
               }
             }
           } else {
@@ -13456,7 +13249,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c504();
+              s1 = peg$c501();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13482,7 +13275,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c71();
+          s1 = peg$c70();
         }
         s0 = s1;
       }
@@ -13495,20 +13288,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c505) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c502) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c506); }
+      if (peg$silentFails === 0) { peg$fail(peg$c503); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c507.test(input.charAt(peg$currPos))) {
+      if (peg$c504.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c508); }
+        if (peg$silentFails === 0) { peg$fail(peg$c505); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13537,12 +13330,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c509) {
-      s0 = peg$c509;
+    if (input.substr(peg$currPos, 3) === peg$c506) {
+      s0 = peg$c506;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c510); }
+      if (peg$silentFails === 0) { peg$fail(peg$c507); }
     }
 
     return s0;
@@ -13553,31 +13346,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c278;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c276;
+        s1 = peg$c275;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c511) {
-        s2 = peg$c511;
+      if (input.substr(peg$currPos, 3) === peg$c508) {
+        s2 = peg$c508;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c512); }
+        if (peg$silentFails === 0) { peg$fail(peg$c509); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13610,7 +13403,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13620,12 +13413,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c513.test(input.charAt(peg$currPos))) {
+    if (peg$c510.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
 
     return s0;
@@ -13636,11 +13429,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c397;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13651,15 +13444,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c397;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c398); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c515(s2);
+          s1 = peg$c512(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13676,11 +13469,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c402;
+        s1 = peg$c399;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c400); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13691,15 +13484,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c402;
+            s3 = peg$c399;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c400); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c515(s2);
+            s1 = peg$c512(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13725,11 +13518,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c400;
+      s2 = peg$c397;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13747,11 +13540,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c513); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13764,17 +13557,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c405;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c42(s2);
+          s1 = peg$c41(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13803,7 +13596,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c517(s1, s2);
+        s1 = peg$c514(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13832,16 +13625,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c518.test(input.charAt(peg$currPos))) {
+    if (peg$c515.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c516); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13853,12 +13646,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
     }
 
@@ -13870,11 +13663,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13883,7 +13676,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s2);
+        s1 = peg$c41(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13933,7 +13726,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c520(s3, s4);
+            s1 = peg$c517(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13961,20 +13754,20 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     if (input.charCodeAt(peg$currPos) === 42) {
-      s2 = peg$c80;
+      s2 = peg$c79;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c81); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c80;
+        s2 = peg$c79;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -14006,11 +13799,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c80;
+        s2 = peg$c79;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -14036,15 +13829,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c80;
+          s1 = peg$c79;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c521();
+          s1 = peg$c518();
         }
         s0 = s1;
       }
@@ -14058,12 +13851,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
     }
 
@@ -14075,11 +13868,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14088,7 +13881,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s2);
+        s1 = peg$c41(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14107,38 +13900,38 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c8;
+      s1 = peg$c7;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      if (peg$silentFails === 0) { peg$fail(peg$c8); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c522();
+      s1 = peg$c519();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c80;
+        s1 = peg$c79;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c523();
+        s1 = peg$c520();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c507.test(input.charAt(peg$currPos))) {
+        if (peg$c504.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c508); }
+          if (peg$silentFails === 0) { peg$fail(peg$c505); }
         }
       }
     }
@@ -14153,11 +13946,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c402;
+      s2 = peg$c399;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c400); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14175,11 +13968,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c513); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14192,17 +13985,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c405;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c42(s2);
+          s1 = peg$c41(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14232,116 +14025,116 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c402;
+      s0 = peg$c399;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c400); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c400;
+        s1 = peg$c397;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c401); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c405;
+          s0 = peg$c402;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c524;
+            s1 = peg$c521;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c525); }
+            if (peg$silentFails === 0) { peg$fail(peg$c522); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c526();
+            s1 = peg$c523();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c527;
+              s1 = peg$c524;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c528); }
+              if (peg$silentFails === 0) { peg$fail(peg$c525); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c529();
+              s1 = peg$c526();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c530;
+                s1 = peg$c527;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c531); }
+                if (peg$silentFails === 0) { peg$fail(peg$c528); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c532();
+                s1 = peg$c529();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c533;
+                  s1 = peg$c530;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c534); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c531); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c535();
+                  s1 = peg$c532();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c536;
+                    s1 = peg$c533;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c537); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c534); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c538();
+                    s1 = peg$c535();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c539;
+                      s1 = peg$c536;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c540); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c537); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c541();
+                      s1 = peg$c538();
                     }
                     s0 = s1;
                   }
@@ -14361,38 +14154,38 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c8;
+      s1 = peg$c7;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      if (peg$silentFails === 0) { peg$fail(peg$c8); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c522();
+      s1 = peg$c519();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c80;
+        s1 = peg$c79;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c542();
+        s1 = peg$c539();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c507.test(input.charAt(peg$currPos))) {
+        if (peg$c504.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c508); }
+          if (peg$silentFails === 0) { peg$fail(peg$c505); }
         }
       }
     }
@@ -14405,11 +14198,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c543;
+      s1 = peg$c540;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c544); }
+      if (peg$silentFails === 0) { peg$fail(peg$c541); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14441,7 +14234,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c545(s2);
+        s1 = peg$c542(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14454,19 +14247,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c543;
+        s1 = peg$c540;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c544); }
+        if (peg$silentFails === 0) { peg$fail(peg$c541); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c38;
+          s2 = peg$c37;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c39); }
+          if (peg$silentFails === 0) { peg$fail(peg$c38); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -14525,15 +14318,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c307;
+              s4 = peg$c304;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c308); }
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c545(s3);
+              s1 = peg$c542(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14561,21 +14354,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c280;
+      s1 = peg$c279;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+      if (peg$silentFails === 0) { peg$fail(peg$c280); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c280;
+          s3 = peg$c279;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14590,7 +14383,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c197(s2);
+            s1 = peg$c196(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14617,21 +14410,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c546.test(input.charAt(peg$currPos))) {
+    if (peg$c543.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c544); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c405;
+        s3 = peg$c402;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14639,7 +14432,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c516); }
+          if (peg$silentFails === 0) { peg$fail(peg$c513); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14656,21 +14449,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c546.test(input.charAt(peg$currPos))) {
+        if (peg$c543.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c547); }
+          if (peg$silentFails === 0) { peg$fail(peg$c544); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c405;
+            s3 = peg$c402;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c406); }
+            if (peg$silentFails === 0) { peg$fail(peg$c403); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14678,7 +14471,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c516); }
+              if (peg$silentFails === 0) { peg$fail(peg$c513); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14698,7 +14491,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -14708,12 +14501,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c548.test(input.charAt(peg$currPos))) {
+    if (peg$c545.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c549); }
+      if (peg$silentFails === 0) { peg$fail(peg$c546); }
     }
 
     return s0;
@@ -14771,7 +14564,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c516); }
+      if (peg$silentFails === 0) { peg$fail(peg$c513); }
     }
 
     return s0;
@@ -14782,51 +14575,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c551;
+      s0 = peg$c548;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c552); }
+      if (peg$silentFails === 0) { peg$fail(peg$c549); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c553;
+        s0 = peg$c550;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c554); }
+        if (peg$silentFails === 0) { peg$fail(peg$c551); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c555;
+          s0 = peg$c552;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c556); }
+          if (peg$silentFails === 0) { peg$fail(peg$c553); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c557;
+            s0 = peg$c554;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c558); }
+            if (peg$silentFails === 0) { peg$fail(peg$c555); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c559;
+              s0 = peg$c556;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c560); }
+              if (peg$silentFails === 0) { peg$fail(peg$c557); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c561;
+                s0 = peg$c558;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c562); }
+                if (peg$silentFails === 0) { peg$fail(peg$c559); }
               }
             }
           }
@@ -14835,7 +14628,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c550); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
 
     return s0;
@@ -14844,12 +14637,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c563.test(input.charAt(peg$currPos))) {
+    if (peg$c560.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c564); }
+      if (peg$silentFails === 0) { peg$fail(peg$c561); }
     }
 
     return s0;
@@ -14862,7 +14655,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c565); }
+      if (peg$silentFails === 0) { peg$fail(peg$c562); }
     }
 
     return s0;
@@ -14872,12 +14665,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c570) {
-      s1 = peg$c570;
+    if (input.substr(peg$currPos, 2) === peg$c567) {
+      s1 = peg$c567;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c571); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14957,7 +14750,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c516); }
+      if (peg$silentFails === 0) { peg$fail(peg$c513); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -576,28 +576,26 @@ function peg$parse(input, options) {
           },
       peg$c251 = "over",
       peg$c252 = peg$literalExpectation("over", false),
-      peg$c253 = function(exprs, l) { return l },
-      peg$c254 = function(exprs, locals, s) { return s },
-      peg$c255 = function(exprs, locals, scope) {
+      peg$c253 = function(exprs, locals, scope) {
             let over = {"kind": "Over", "exprs": exprs, "scope": scope};
             if (locals) {
               return {"kind": "Let", "locals": locals, "over": over}
             }
             return over
           },
-      peg$c256 = function(seq) { return seq },
-      peg$c257 = function(first, a) { return a },
-      peg$c258 = function(id) {
+      peg$c254 = function(seq) { return seq },
+      peg$c255 = function(first, a) { return a },
+      peg$c256 = function(id) {
             return {"name":id, "expr":{"kind":"ID","name":id}}
           },
-      peg$c259 = "yield",
-      peg$c260 = peg$literalExpectation("yield", false),
-      peg$c261 = function(exprs) {
+      peg$c257 = "yield",
+      peg$c258 = peg$literalExpectation("yield", false),
+      peg$c259 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c262 = function(typ) { return typ},
-      peg$c263 = function(lhs) { return lhs },
-      peg$c265 = function(first, rest) {
+      peg$c260 = function(typ) { return typ},
+      peg$c261 = function(lhs) { return lhs },
+      peg$c263 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -606,21 +604,21 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c266 = function(first, rest) {
+      peg$c264 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c267 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c268 = "?",
-      peg$c269 = peg$literalExpectation("?", false),
-      peg$c270 = function(condition, thenClause, elseClause) {
+      peg$c265 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c266 = "?",
+      peg$c267 = peg$literalExpectation("?", false),
+      peg$c268 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c271 = function(first, op, expr) { return [op, expr] },
-      peg$c272 = function(first, rest) {
+      peg$c269 = function(first, op, expr) { return [op, expr] },
+      peg$c270 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c273 = function(lhs) { return text() },
-      peg$c274 = function(lhs, opAndRHS) {
+      peg$c271 = function(lhs) { return text() },
+      peg$c272 = function(lhs, opAndRHS) {
             if (!opAndRHS) {
               return lhs
             }
@@ -628,97 +626,97 @@ function peg$parse(input, options) {
             let rhs = opAndRHS[3];
             return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c275 = "+",
-      peg$c276 = peg$literalExpectation("+", false),
-      peg$c277 = "-",
-      peg$c278 = peg$literalExpectation("-", false),
-      peg$c279 = "/",
-      peg$c280 = peg$literalExpectation("/", false),
-      peg$c281 = "%",
-      peg$c282 = peg$literalExpectation("%", false),
-      peg$c283 = function(e) {
+      peg$c273 = "+",
+      peg$c274 = peg$literalExpectation("+", false),
+      peg$c275 = "-",
+      peg$c276 = peg$literalExpectation("-", false),
+      peg$c277 = "/",
+      peg$c278 = peg$literalExpectation("/", false),
+      peg$c279 = "%",
+      peg$c280 = peg$literalExpectation("%", false),
+      peg$c281 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c284 = function(e) {
+      peg$c282 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c285 = "not",
-      peg$c286 = peg$literalExpectation("not", false),
-      peg$c287 = "select",
-      peg$c288 = peg$literalExpectation("select", false),
-      peg$c289 = function(typ, expr) {
+      peg$c283 = "not",
+      peg$c284 = peg$literalExpectation("not", false),
+      peg$c285 = "select",
+      peg$c286 = peg$literalExpectation("select", false),
+      peg$c287 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c290 = function(fn, args, where) {
+      peg$c288 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c291 = "grep",
-      peg$c292 = peg$literalExpectation("grep", false),
-      peg$c293 = function(pattern) {
+      peg$c289 = "grep",
+      peg$c290 = peg$literalExpectation("grep", false),
+      peg$c291 = function(pattern) {
             return {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
           },
-      peg$c294 = function(pattern, expr) {
+      peg$c292 = function(pattern, expr) {
             return {"kind": "Grep", "pattern": pattern, "expr": expr}
           },
-      peg$c295 = function(s) {
+      peg$c293 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c296 = function(first, e) { return e },
-      peg$c297 = "]",
-      peg$c298 = peg$literalExpectation("]", false),
-      peg$c299 = function(from, to) {
+      peg$c294 = function(first, e) { return e },
+      peg$c295 = "]",
+      peg$c296 = peg$literalExpectation("]", false),
+      peg$c297 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c300 = function(to) {
+      peg$c298 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c301 = function(expr) { return ["[", expr] },
-      peg$c302 = function(id) { return [".", id] },
-      peg$c303 = function(exprs, locals, scope) {
+      peg$c299 = function(expr) { return ["[", expr] },
+      peg$c300 = function(id) { return [".", id] },
+      peg$c301 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c304 = "}",
-      peg$c305 = peg$literalExpectation("}", false),
-      peg$c306 = function(elems) {
+      peg$c302 = "}",
+      peg$c303 = peg$literalExpectation("}", false),
+      peg$c304 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c307 = function(elem) { return elem },
-      peg$c308 = "...",
-      peg$c309 = peg$literalExpectation("...", false),
-      peg$c310 = function(expr) {
+      peg$c305 = function(elem) { return elem },
+      peg$c306 = "...",
+      peg$c307 = peg$literalExpectation("...", false),
+      peg$c308 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c311 = function(name, value) {
+      peg$c309 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c312 = function(exprs) {
+      peg$c310 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c313 = "|[",
-      peg$c314 = peg$literalExpectation("|[", false),
-      peg$c315 = "]|",
-      peg$c316 = peg$literalExpectation("]|", false),
-      peg$c317 = function(exprs) {
+      peg$c311 = "|[",
+      peg$c312 = peg$literalExpectation("|[", false),
+      peg$c313 = "]|",
+      peg$c314 = peg$literalExpectation("]|", false),
+      peg$c315 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c318 = "|{",
-      peg$c319 = peg$literalExpectation("|{", false),
-      peg$c320 = "}|",
-      peg$c321 = peg$literalExpectation("}|", false),
-      peg$c322 = function(exprs) {
+      peg$c316 = "|{",
+      peg$c317 = peg$literalExpectation("|{", false),
+      peg$c318 = "}|",
+      peg$c319 = peg$literalExpectation("}|", false),
+      peg$c320 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c323 = function(e) { return e },
-      peg$c324 = function(key, value) {
+      peg$c321 = function(e) { return e },
+      peg$c322 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c325 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c323 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -740,13 +738,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c326 = function(assignments) { return assignments },
-      peg$c327 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c328 = function(table, alias) {
+      peg$c324 = function(assignments) { return assignments },
+      peg$c325 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c326 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c329 = function(first, join) { return join },
-      peg$c330 = function(style, table, alias, leftKey, rightKey) {
+      peg$c327 = function(first, join) { return join },
+      peg$c328 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -760,117 +758,117 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c331 = function(style) { return style },
-      peg$c332 = function(keys, order) {
+      peg$c329 = function(style) { return style },
+      peg$c330 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c333 = function(dir) { return dir },
-      peg$c334 = function(count) { return count },
-      peg$c335 = peg$literalExpectation("select", true),
-      peg$c336 = function() { return "select" },
-      peg$c337 = "as",
-      peg$c338 = peg$literalExpectation("as", true),
-      peg$c339 = function() { return "as" },
-      peg$c340 = peg$literalExpectation("from", true),
-      peg$c341 = function() { return "from" },
-      peg$c342 = peg$literalExpectation("join", true),
-      peg$c343 = function() { return "join" },
-      peg$c344 = peg$literalExpectation("where", true),
-      peg$c345 = function() { return "where" },
-      peg$c346 = "group",
-      peg$c347 = peg$literalExpectation("group", true),
-      peg$c348 = function() { return "group" },
-      peg$c349 = "by",
-      peg$c350 = peg$literalExpectation("by", true),
-      peg$c351 = function() { return "by" },
-      peg$c352 = "having",
-      peg$c353 = peg$literalExpectation("having", true),
-      peg$c354 = function() { return "having" },
-      peg$c355 = peg$literalExpectation("order", true),
-      peg$c356 = function() { return "order" },
-      peg$c357 = "on",
-      peg$c358 = peg$literalExpectation("on", true),
-      peg$c359 = function() { return "on" },
-      peg$c360 = "limit",
-      peg$c361 = peg$literalExpectation("limit", true),
-      peg$c362 = function() { return "limit" },
-      peg$c363 = peg$literalExpectation("asc", true),
-      peg$c364 = peg$literalExpectation("desc", true),
-      peg$c365 = peg$literalExpectation("anti", true),
-      peg$c366 = peg$literalExpectation("left", true),
-      peg$c367 = peg$literalExpectation("right", true),
-      peg$c368 = peg$literalExpectation("inner", true),
-      peg$c369 = function(v) {
+      peg$c331 = function(dir) { return dir },
+      peg$c332 = function(count) { return count },
+      peg$c333 = peg$literalExpectation("select", true),
+      peg$c334 = function() { return "select" },
+      peg$c335 = "as",
+      peg$c336 = peg$literalExpectation("as", true),
+      peg$c337 = function() { return "as" },
+      peg$c338 = peg$literalExpectation("from", true),
+      peg$c339 = function() { return "from" },
+      peg$c340 = peg$literalExpectation("join", true),
+      peg$c341 = function() { return "join" },
+      peg$c342 = peg$literalExpectation("where", true),
+      peg$c343 = function() { return "where" },
+      peg$c344 = "group",
+      peg$c345 = peg$literalExpectation("group", true),
+      peg$c346 = function() { return "group" },
+      peg$c347 = "by",
+      peg$c348 = peg$literalExpectation("by", true),
+      peg$c349 = function() { return "by" },
+      peg$c350 = "having",
+      peg$c351 = peg$literalExpectation("having", true),
+      peg$c352 = function() { return "having" },
+      peg$c353 = peg$literalExpectation("order", true),
+      peg$c354 = function() { return "order" },
+      peg$c355 = "on",
+      peg$c356 = peg$literalExpectation("on", true),
+      peg$c357 = function() { return "on" },
+      peg$c358 = "limit",
+      peg$c359 = peg$literalExpectation("limit", true),
+      peg$c360 = function() { return "limit" },
+      peg$c361 = peg$literalExpectation("asc", true),
+      peg$c362 = peg$literalExpectation("desc", true),
+      peg$c363 = peg$literalExpectation("anti", true),
+      peg$c364 = peg$literalExpectation("left", true),
+      peg$c365 = peg$literalExpectation("right", true),
+      peg$c366 = peg$literalExpectation("inner", true),
+      peg$c367 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c370 = function(v) {
+      peg$c368 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c371 = function(v) {
+      peg$c369 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c372 = function(v) {
+      peg$c370 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c373 = "true",
-      peg$c374 = peg$literalExpectation("true", false),
-      peg$c375 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c376 = "false",
-      peg$c377 = peg$literalExpectation("false", false),
-      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c379 = "null",
-      peg$c380 = peg$literalExpectation("null", false),
-      peg$c381 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c382 = "0x",
-      peg$c383 = peg$literalExpectation("0x", false),
-      peg$c384 = function() {
+      peg$c371 = "true",
+      peg$c372 = peg$literalExpectation("true", false),
+      peg$c373 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c374 = "false",
+      peg$c375 = peg$literalExpectation("false", false),
+      peg$c376 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c377 = "null",
+      peg$c378 = peg$literalExpectation("null", false),
+      peg$c379 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c380 = "0x",
+      peg$c381 = peg$literalExpectation("0x", false),
+      peg$c382 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c385 = function(typ) {
+      peg$c383 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c386 = function(name) { return name },
-      peg$c387 = function(name, typ) {
+      peg$c384 = function(name) { return name },
+      peg$c385 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c388 = function(name) {
+      peg$c386 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c389 = function(u) { return u },
-      peg$c390 = function(types) {
+      peg$c387 = function(u) { return u },
+      peg$c388 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c391 = function(typ) { return typ },
-      peg$c392 = function(fields) {
+      peg$c389 = function(typ) { return typ },
+      peg$c390 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c393 = function(typ) {
+      peg$c391 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c394 = function(typ) {
+      peg$c392 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c395 = function(keyType, valType) {
+      peg$c393 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c396 = function(v) {
+      peg$c394 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c397 = "\"",
-      peg$c398 = peg$literalExpectation("\"", false),
-      peg$c399 = "'",
-      peg$c400 = peg$literalExpectation("'", false),
-      peg$c401 = function(v) {
+      peg$c395 = "\"",
+      peg$c396 = peg$literalExpectation("\"", false),
+      peg$c397 = "'",
+      peg$c398 = peg$literalExpectation("'", false),
+      peg$c399 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c402 = "\\",
-      peg$c403 = peg$literalExpectation("\\", false),
-      peg$c404 = "${",
-      peg$c405 = peg$literalExpectation("${", false),
-      peg$c406 = function(e) {
+      peg$c400 = "\\",
+      peg$c401 = peg$literalExpectation("\\", false),
+      peg$c402 = "${",
+      peg$c403 = peg$literalExpectation("${", false),
+      peg$c404 = function(e) {
             return {
               
             "kind": "Cast",
@@ -884,191 +882,191 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c407 = "uint8",
-      peg$c408 = peg$literalExpectation("uint8", false),
-      peg$c409 = "uint16",
-      peg$c410 = peg$literalExpectation("uint16", false),
-      peg$c411 = "uint32",
-      peg$c412 = peg$literalExpectation("uint32", false),
-      peg$c413 = "uint64",
-      peg$c414 = peg$literalExpectation("uint64", false),
-      peg$c415 = "int8",
-      peg$c416 = peg$literalExpectation("int8", false),
-      peg$c417 = "int16",
-      peg$c418 = peg$literalExpectation("int16", false),
-      peg$c419 = "int32",
-      peg$c420 = peg$literalExpectation("int32", false),
-      peg$c421 = "int64",
-      peg$c422 = peg$literalExpectation("int64", false),
-      peg$c423 = "float32",
-      peg$c424 = peg$literalExpectation("float32", false),
-      peg$c425 = "float64",
-      peg$c426 = peg$literalExpectation("float64", false),
-      peg$c427 = "bool",
-      peg$c428 = peg$literalExpectation("bool", false),
-      peg$c429 = "string",
-      peg$c430 = peg$literalExpectation("string", false),
-      peg$c431 = "duration",
-      peg$c432 = peg$literalExpectation("duration", false),
-      peg$c433 = "time",
-      peg$c434 = peg$literalExpectation("time", false),
-      peg$c435 = "bytes",
-      peg$c436 = peg$literalExpectation("bytes", false),
-      peg$c437 = "ip",
-      peg$c438 = peg$literalExpectation("ip", false),
-      peg$c439 = "net",
-      peg$c440 = peg$literalExpectation("net", false),
-      peg$c441 = function() {
+      peg$c405 = "uint8",
+      peg$c406 = peg$literalExpectation("uint8", false),
+      peg$c407 = "uint16",
+      peg$c408 = peg$literalExpectation("uint16", false),
+      peg$c409 = "uint32",
+      peg$c410 = peg$literalExpectation("uint32", false),
+      peg$c411 = "uint64",
+      peg$c412 = peg$literalExpectation("uint64", false),
+      peg$c413 = "int8",
+      peg$c414 = peg$literalExpectation("int8", false),
+      peg$c415 = "int16",
+      peg$c416 = peg$literalExpectation("int16", false),
+      peg$c417 = "int32",
+      peg$c418 = peg$literalExpectation("int32", false),
+      peg$c419 = "int64",
+      peg$c420 = peg$literalExpectation("int64", false),
+      peg$c421 = "float32",
+      peg$c422 = peg$literalExpectation("float32", false),
+      peg$c423 = "float64",
+      peg$c424 = peg$literalExpectation("float64", false),
+      peg$c425 = "bool",
+      peg$c426 = peg$literalExpectation("bool", false),
+      peg$c427 = "string",
+      peg$c428 = peg$literalExpectation("string", false),
+      peg$c429 = "duration",
+      peg$c430 = peg$literalExpectation("duration", false),
+      peg$c431 = "time",
+      peg$c432 = peg$literalExpectation("time", false),
+      peg$c433 = "bytes",
+      peg$c434 = peg$literalExpectation("bytes", false),
+      peg$c435 = "ip",
+      peg$c436 = peg$literalExpectation("ip", false),
+      peg$c437 = "net",
+      peg$c438 = peg$literalExpectation("net", false),
+      peg$c439 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c442 = function(name, typ) {
+      peg$c440 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c443 = "and",
-      peg$c444 = peg$literalExpectation("and", false),
-      peg$c445 = "AND",
-      peg$c446 = peg$literalExpectation("AND", false),
-      peg$c447 = function() { return "and" },
-      peg$c448 = "or",
-      peg$c449 = peg$literalExpectation("or", false),
-      peg$c450 = "OR",
-      peg$c451 = peg$literalExpectation("OR", false),
-      peg$c452 = function() { return "or" },
-      peg$c454 = "NOT",
-      peg$c455 = peg$literalExpectation("NOT", false),
-      peg$c456 = function() { return "not" },
-      peg$c457 = peg$literalExpectation("by", false),
-      peg$c458 = /^[A-Za-z_$]/,
-      peg$c459 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c460 = /^[0-9]/,
-      peg$c461 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c462 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c463 = "$",
-      peg$c464 = peg$literalExpectation("$", false),
-      peg$c465 = "T",
-      peg$c466 = peg$literalExpectation("T", false),
-      peg$c467 = function() {
+      peg$c441 = "and",
+      peg$c442 = peg$literalExpectation("and", false),
+      peg$c443 = "AND",
+      peg$c444 = peg$literalExpectation("AND", false),
+      peg$c445 = function() { return "and" },
+      peg$c446 = "or",
+      peg$c447 = peg$literalExpectation("or", false),
+      peg$c448 = "OR",
+      peg$c449 = peg$literalExpectation("OR", false),
+      peg$c450 = function() { return "or" },
+      peg$c452 = "NOT",
+      peg$c453 = peg$literalExpectation("NOT", false),
+      peg$c454 = function() { return "not" },
+      peg$c455 = peg$literalExpectation("by", false),
+      peg$c456 = /^[A-Za-z_$]/,
+      peg$c457 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c458 = /^[0-9]/,
+      peg$c459 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c460 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c461 = "$",
+      peg$c462 = peg$literalExpectation("$", false),
+      peg$c463 = "T",
+      peg$c464 = peg$literalExpectation("T", false),
+      peg$c465 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c468 = "Z",
-      peg$c469 = peg$literalExpectation("Z", false),
-      peg$c470 = function() {
+      peg$c466 = "Z",
+      peg$c467 = peg$literalExpectation("Z", false),
+      peg$c468 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c471 = "ns",
-      peg$c472 = peg$literalExpectation("ns", false),
-      peg$c473 = "us",
-      peg$c474 = peg$literalExpectation("us", false),
-      peg$c475 = "ms",
-      peg$c476 = peg$literalExpectation("ms", false),
-      peg$c477 = "s",
-      peg$c478 = peg$literalExpectation("s", false),
-      peg$c479 = "m",
-      peg$c480 = peg$literalExpectation("m", false),
-      peg$c481 = "h",
-      peg$c482 = peg$literalExpectation("h", false),
-      peg$c483 = "d",
-      peg$c484 = peg$literalExpectation("d", false),
-      peg$c485 = "w",
-      peg$c486 = peg$literalExpectation("w", false),
-      peg$c487 = "y",
-      peg$c488 = peg$literalExpectation("y", false),
-      peg$c489 = function(a, b) {
+      peg$c469 = "ns",
+      peg$c470 = peg$literalExpectation("ns", false),
+      peg$c471 = "us",
+      peg$c472 = peg$literalExpectation("us", false),
+      peg$c473 = "ms",
+      peg$c474 = peg$literalExpectation("ms", false),
+      peg$c475 = "s",
+      peg$c476 = peg$literalExpectation("s", false),
+      peg$c477 = "m",
+      peg$c478 = peg$literalExpectation("m", false),
+      peg$c479 = "h",
+      peg$c480 = peg$literalExpectation("h", false),
+      peg$c481 = "d",
+      peg$c482 = peg$literalExpectation("d", false),
+      peg$c483 = "w",
+      peg$c484 = peg$literalExpectation("w", false),
+      peg$c485 = "y",
+      peg$c486 = peg$literalExpectation("y", false),
+      peg$c487 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c490 = "::",
-      peg$c491 = peg$literalExpectation("::", false),
-      peg$c492 = function(a, b, d, e) {
+      peg$c488 = "::",
+      peg$c489 = peg$literalExpectation("::", false),
+      peg$c490 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c493 = function(a, b) {
+      peg$c491 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c494 = function(a, b) {
+      peg$c492 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c495 = function() {
+      peg$c493 = function() {
             return "::"
           },
-      peg$c496 = function(v) { return ":" + v },
-      peg$c497 = function(v) { return v + ":" },
-      peg$c498 = function(a, m) {
+      peg$c494 = function(v) { return ":" + v },
+      peg$c495 = function(v) { return v + ":" },
+      peg$c496 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c499 = function(a, m) {
+      peg$c497 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c500 = function(s) { return parseInt(s) },
-      peg$c501 = function() {
+      peg$c498 = function(s) { return parseInt(s) },
+      peg$c499 = function() {
             return text()
           },
-      peg$c502 = "e",
-      peg$c503 = peg$literalExpectation("e", true),
-      peg$c504 = /^[+\-]/,
-      peg$c505 = peg$classExpectation(["+", "-"], false, false),
-      peg$c506 = "NaN",
-      peg$c507 = peg$literalExpectation("NaN", false),
-      peg$c508 = "Inf",
-      peg$c509 = peg$literalExpectation("Inf", false),
-      peg$c510 = /^[0-9a-fA-F]/,
-      peg$c511 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c512 = function(v) { return joinChars(v) },
-      peg$c513 = peg$anyExpectation(),
-      peg$c514 = function(head, tail) { return head + joinChars(tail) },
-      peg$c515 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c516 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c517 = function(head, tail) {
+      peg$c500 = "e",
+      peg$c501 = peg$literalExpectation("e", true),
+      peg$c502 = /^[+\-]/,
+      peg$c503 = peg$classExpectation(["+", "-"], false, false),
+      peg$c504 = "NaN",
+      peg$c505 = peg$literalExpectation("NaN", false),
+      peg$c506 = "Inf",
+      peg$c507 = peg$literalExpectation("Inf", false),
+      peg$c508 = /^[0-9a-fA-F]/,
+      peg$c509 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c510 = function(v) { return joinChars(v) },
+      peg$c511 = peg$anyExpectation(),
+      peg$c512 = function(head, tail) { return head + joinChars(tail) },
+      peg$c513 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c514 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c515 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c518 = function() { return "*"},
-      peg$c519 = function() { return "=" },
-      peg$c520 = function() { return "\\*" },
-      peg$c521 = "b",
-      peg$c522 = peg$literalExpectation("b", false),
-      peg$c523 = function() { return "\b" },
-      peg$c524 = "f",
-      peg$c525 = peg$literalExpectation("f", false),
-      peg$c526 = function() { return "\f" },
-      peg$c527 = "n",
-      peg$c528 = peg$literalExpectation("n", false),
-      peg$c529 = function() { return "\n" },
-      peg$c530 = "r",
-      peg$c531 = peg$literalExpectation("r", false),
-      peg$c532 = function() { return "\r" },
-      peg$c533 = "t",
-      peg$c534 = peg$literalExpectation("t", false),
-      peg$c535 = function() { return "\t" },
-      peg$c536 = "v",
-      peg$c537 = peg$literalExpectation("v", false),
-      peg$c538 = function() { return "\v" },
-      peg$c539 = function() { return "*" },
-      peg$c540 = "u",
-      peg$c541 = peg$literalExpectation("u", false),
-      peg$c542 = function(chars) {
+      peg$c516 = function() { return "*"},
+      peg$c517 = function() { return "=" },
+      peg$c518 = function() { return "\\*" },
+      peg$c519 = "b",
+      peg$c520 = peg$literalExpectation("b", false),
+      peg$c521 = function() { return "\b" },
+      peg$c522 = "f",
+      peg$c523 = peg$literalExpectation("f", false),
+      peg$c524 = function() { return "\f" },
+      peg$c525 = "n",
+      peg$c526 = peg$literalExpectation("n", false),
+      peg$c527 = function() { return "\n" },
+      peg$c528 = "r",
+      peg$c529 = peg$literalExpectation("r", false),
+      peg$c530 = function() { return "\r" },
+      peg$c531 = "t",
+      peg$c532 = peg$literalExpectation("t", false),
+      peg$c533 = function() { return "\t" },
+      peg$c534 = "v",
+      peg$c535 = peg$literalExpectation("v", false),
+      peg$c536 = function() { return "\v" },
+      peg$c537 = function() { return "*" },
+      peg$c538 = "u",
+      peg$c539 = peg$literalExpectation("u", false),
+      peg$c540 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c543 = /^[^\/\\]/,
-      peg$c544 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c545 = /^[\0-\x1F\\]/,
-      peg$c546 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c547 = peg$otherExpectation("whitespace"),
-      peg$c548 = "\t",
-      peg$c549 = peg$literalExpectation("\t", false),
-      peg$c550 = "\x0B",
-      peg$c551 = peg$literalExpectation("\x0B", false),
-      peg$c552 = "\f",
-      peg$c553 = peg$literalExpectation("\f", false),
-      peg$c554 = " ",
-      peg$c555 = peg$literalExpectation(" ", false),
-      peg$c556 = "\xA0",
-      peg$c557 = peg$literalExpectation("\xA0", false),
-      peg$c558 = "\uFEFF",
-      peg$c559 = peg$literalExpectation("\uFEFF", false),
-      peg$c560 = /^[\n\r\u2028\u2029]/,
-      peg$c561 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c562 = peg$otherExpectation("comment"),
-      peg$c567 = "//",
-      peg$c568 = peg$literalExpectation("//", false),
+      peg$c541 = /^[^\/\\]/,
+      peg$c542 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c543 = /^[\0-\x1F\\]/,
+      peg$c544 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c545 = peg$otherExpectation("whitespace"),
+      peg$c546 = "\t",
+      peg$c547 = peg$literalExpectation("\t", false),
+      peg$c548 = "\x0B",
+      peg$c549 = peg$literalExpectation("\x0B", false),
+      peg$c550 = "\f",
+      peg$c551 = peg$literalExpectation("\f", false),
+      peg$c552 = " ",
+      peg$c553 = peg$literalExpectation(" ", false),
+      peg$c554 = "\xA0",
+      peg$c555 = peg$literalExpectation("\xA0", false),
+      peg$c556 = "\uFEFF",
+      peg$c557 = peg$literalExpectation("\uFEFF", false),
+      peg$c558 = /^[\n\r\u2028\u2029]/,
+      peg$c559 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c560 = peg$otherExpectation("comment"),
+      peg$c565 = "//",
+      peg$c566 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -6006,7 +6004,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOverOp() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+    var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c251) {
@@ -6021,66 +6019,18 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$currPos;
-          s5 = peg$parse_();
-          if (s5 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c92) {
-              s6 = peg$c92;
-              peg$currPos += 4;
-            } else {
-              s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c93); }
-            }
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parse_();
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parseLetAssignments();
-                if (s8 !== peg$FAILED) {
-                  peg$savedPos = s4;
-                  s5 = peg$c253(s3, s8);
-                  s4 = s5;
-                } else {
-                  peg$currPos = s4;
-                  s4 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s4;
-                s4 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s4;
-              s4 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s4;
-            s4 = peg$FAILED;
-          }
+          s4 = peg$parseLocals();
           if (s4 === peg$FAILED) {
             s4 = null;
           }
           if (s4 !== peg$FAILED) {
-            s5 = peg$currPos;
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseScope();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s5;
-                s6 = peg$c254(s3, s4, s7);
-                s5 = s6;
-              } else {
-                peg$currPos = s5;
-                s5 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s5;
-              s5 = peg$FAILED;
-            }
+            s5 = peg$parseScope();
             if (s5 === peg$FAILED) {
               s5 = null;
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c255(s3, s4, s5);
+              s1 = peg$c253(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6107,44 +6057,50 @@ function peg$parse(input, options) {
   }
 
   function peg$parseScope() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c33) {
-      s1 = peg$c33;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c34); }
-    }
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
+      if (input.substr(peg$currPos, 2) === peg$c33) {
+        s2 = peg$c33;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c34); }
+      }
       if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c15;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
-        }
+        s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          if (input.charCodeAt(peg$currPos) === 40) {
+            s4 = peg$c15;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseSequential();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
+              s6 = peg$parseSequential();
               if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c17;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
-                }
+                s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c256(s5);
-                  s0 = s1;
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s8 = peg$c17;
+                    peg$currPos++;
+                  } else {
+                    s8 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                  }
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c254(s6);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -6177,88 +6133,112 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLetAssignments() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseLocals() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    s1 = peg$parseLetAssignment();
+    s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c100;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseLetAssignment();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c257(s1, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+      if (input.substr(peg$currPos, 4) === peg$c92) {
+        s2 = peg$c92;
+        peg$currPos += 4;
       } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c100;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseLetAssignment();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c257(s1, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c103(s1, s2);
-        s0 = s1;
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseLocalsAssignment();
+          if (s4 !== peg$FAILED) {
+            s5 = [];
+            s6 = peg$currPos;
+            s7 = peg$parse__();
+            if (s7 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 44) {
+                s8 = peg$c100;
+                peg$currPos++;
+              } else {
+                s8 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              }
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parse__();
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parseLocalsAssignment();
+                  if (s10 !== peg$FAILED) {
+                    peg$savedPos = s6;
+                    s7 = peg$c255(s4, s10);
+                    s6 = s7;
+                  } else {
+                    peg$currPos = s6;
+                    s6 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s6;
+                  s6 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s6;
+                s6 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s6;
+              s6 = peg$FAILED;
+            }
+            while (s6 !== peg$FAILED) {
+              s5.push(s6);
+              s6 = peg$currPos;
+              s7 = peg$parse__();
+              if (s7 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 44) {
+                  s8 = peg$c100;
+                  peg$currPos++;
+                } else {
+                  s8 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c101); }
+                }
+                if (s8 !== peg$FAILED) {
+                  s9 = peg$parse__();
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parseLocalsAssignment();
+                    if (s10 !== peg$FAILED) {
+                      peg$savedPos = s6;
+                      s7 = peg$c255(s4, s10);
+                      s6 = s7;
+                    } else {
+                      peg$currPos = s6;
+                      s6 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s6;
+                    s6 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s6;
+                  s6 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s6;
+                s6 = peg$FAILED;
+              }
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c103(s4, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -6271,7 +6251,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLetAssignment() {
+  function peg$parseLocalsAssignment() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
@@ -6319,7 +6299,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIdentifierName();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c258(s1);
+        s1 = peg$c256(s1);
       }
       s0 = s1;
     }
@@ -6331,12 +6311,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c259) {
-      s1 = peg$c259;
+    if (input.substr(peg$currPos, 5) === peg$c257) {
+      s1 = peg$c257;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c260); }
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6344,7 +6324,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c261(s3);
+          s1 = peg$c259(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6375,7 +6355,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s4);
+            s1 = peg$c260(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6410,7 +6390,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c263(s4);
+            s1 = peg$c261(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6510,7 +6490,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c263(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6547,7 +6527,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c257(s1, s7);
+              s4 = peg$c255(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6583,7 +6563,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c257(s1, s7);
+                s4 = peg$c255(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6604,7 +6584,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6639,7 +6619,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c267(s1, s5);
+              s1 = peg$c265(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6682,11 +6662,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c268;
+          s3 = peg$c266;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c269); }
+          if (peg$silentFails === 0) { peg$fail(peg$c267); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6708,7 +6688,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c270(s1, s5, s9);
+                      s1 = peg$c268(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6770,7 +6750,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c271(s1, s5, s7);
+              s4 = peg$c269(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6800,7 +6780,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c271(s1, s5, s7);
+                s4 = peg$c269(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6821,7 +6801,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6852,7 +6832,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c271(s1, s5, s7);
+              s4 = peg$c269(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6882,7 +6862,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c271(s1, s5, s7);
+                s4 = peg$c269(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6903,7 +6883,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6964,7 +6944,7 @@ function peg$parse(input, options) {
           }
           if (s5 !== peg$FAILED) {
             peg$savedPos = s4;
-            s5 = peg$c273();
+            s5 = peg$c271();
           }
           s4 = s5;
           if (s4 !== peg$FAILED) {
@@ -6996,7 +6976,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7027,7 +7007,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c271(s1, s5, s7);
+              s4 = peg$c269(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7057,7 +7037,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c271(s1, s5, s7);
+                s4 = peg$c269(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7078,7 +7058,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7097,19 +7077,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c275;
+      s1 = peg$c273;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c277;
+        s1 = peg$c275;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7138,7 +7118,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c271(s1, s5, s7);
+              s4 = peg$c269(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7168,7 +7148,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c271(s1, s5, s7);
+                s4 = peg$c269(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7189,7 +7169,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7216,19 +7196,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c279;
+        s1 = peg$c277;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c281;
+          s1 = peg$c279;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c282); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
       }
     }
@@ -7258,7 +7238,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c283(s3);
+          s1 = peg$c281(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7295,11 +7275,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c277;
+        s2 = peg$c275;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7307,7 +7287,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c284(s4);
+            s1 = peg$c282(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7426,20 +7406,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c285) {
-      s0 = peg$c285;
+    if (input.substr(peg$currPos, 3) === peg$c283) {
+      s0 = peg$c283;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c287) {
-        s0 = peg$c287;
+      if (input.substr(peg$currPos, 6) === peg$c285) {
+        s0 = peg$c285;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
     }
 
@@ -7477,7 +7457,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c289(s1, s5);
+                  s1 = peg$c287(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7560,7 +7540,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c290(s2, s6, s9);
+                        s1 = peg$c288(s2, s6, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7607,12 +7587,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c291) {
-      s1 = peg$c291;
+    if (input.substr(peg$currPos, 4) === peg$c289) {
+      s1 = peg$c289;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c290); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7640,7 +7620,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c293(s5);
+                  s1 = peg$c291(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7672,12 +7652,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c291) {
-        s1 = peg$c291;
+      if (input.substr(peg$currPos, 4) === peg$c289) {
+        s1 = peg$c289;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c292); }
+        if (peg$silentFails === 0) { peg$fail(peg$c290); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7719,7 +7699,7 @@ function peg$parse(input, options) {
                           }
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c294(s5, s9);
+                            s1 = peg$c292(s5, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7781,7 +7761,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c295(s1);
+          s1 = peg$c293(s1);
         }
         s0 = s1;
       }
@@ -7830,7 +7810,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c296(s1, s7);
+              s4 = peg$c294(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7866,7 +7846,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c296(s1, s7);
+                s4 = peg$c294(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7976,15 +7956,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c297;
+                  s7 = peg$c295;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c299(s2, s6);
+                  s1 = peg$c297(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8039,15 +8019,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c297;
+                  s6 = peg$c295;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c300(s5);
+                  s1 = peg$c298(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8086,15 +8066,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c297;
+              s3 = peg$c295;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c298); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c301(s2);
+              s1 = peg$c299(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8121,7 +8101,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c302(s2);
+              s1 = peg$c300(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8270,40 +8250,7 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$currPos;
-          s5 = peg$parse_();
-          if (s5 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c92) {
-              s6 = peg$c92;
-              peg$currPos += 4;
-            } else {
-              s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c93); }
-            }
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parse_();
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parseLetAssignments();
-                if (s8 !== peg$FAILED) {
-                  peg$savedPos = s4;
-                  s5 = peg$c253(s3, s8);
-                  s4 = s5;
-                } else {
-                  peg$currPos = s4;
-                  s4 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s4;
-                s4 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s4;
-              s4 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s4;
-            s4 = peg$FAILED;
-          }
+          s4 = peg$parseLocals();
           if (s4 === peg$FAILED) {
             s4 = null;
           }
@@ -8323,7 +8270,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c303(s3, s4, s8);
+                    s1 = peg$c301(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8380,15 +8327,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c304;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c306(s3);
+              s1 = peg$c304(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8428,7 +8375,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8470,7 +8417,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c307(s4);
+            s1 = peg$c305(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8510,12 +8457,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c308) {
-      s1 = peg$c308;
+    if (input.substr(peg$currPos, 3) === peg$c306) {
+      s1 = peg$c306;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c309); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8523,7 +8470,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c310(s3);
+          s1 = peg$c308(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8562,7 +8509,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s1, s5);
+              s1 = peg$c309(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8607,15 +8554,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c297;
+              s5 = peg$c295;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c298); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c312(s3);
+              s1 = peg$c310(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8645,12 +8592,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c313) {
-      s1 = peg$c313;
+    if (input.substr(peg$currPos, 2) === peg$c311) {
+      s1 = peg$c311;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8659,16 +8606,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c315) {
-              s5 = peg$c315;
+            if (input.substr(peg$currPos, 2) === peg$c313) {
+              s5 = peg$c313;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c316); }
+              if (peg$silentFails === 0) { peg$fail(peg$c314); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c317(s3);
+              s1 = peg$c315(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8698,12 +8645,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c318) {
-      s1 = peg$c318;
+    if (input.substr(peg$currPos, 2) === peg$c316) {
+      s1 = peg$c316;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c319); }
+      if (peg$silentFails === 0) { peg$fail(peg$c317); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8712,16 +8659,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c320) {
-              s5 = peg$c320;
+            if (input.substr(peg$currPos, 2) === peg$c318) {
+              s5 = peg$c318;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c321); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c322(s3);
+              s1 = peg$c320(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8761,7 +8708,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8803,7 +8750,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c323(s4);
+            s1 = peg$c321(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8846,7 +8793,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c324(s1, s5);
+              s1 = peg$c322(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8911,7 +8858,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c325(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c323(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8989,7 +8936,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s3);
+            s1 = peg$c324(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9023,7 +8970,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c327(s1, s5);
+              s1 = peg$c325(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9170,7 +9117,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c328(s4, s5);
+              s1 = peg$c326(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9325,7 +9272,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c329(s1, s4);
+        s4 = peg$c327(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9334,7 +9281,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c329(s1, s4);
+          s4 = peg$c327(s1, s4);
         }
         s3 = s4;
       }
@@ -9396,7 +9343,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c330(s1, s5, s6, s10, s14);
+                                s1 = peg$c328(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9476,7 +9423,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c331(s2);
+        s1 = peg$c329(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9635,7 +9582,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c332(s6, s7);
+                  s1 = peg$c330(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9681,7 +9628,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s2);
+        s1 = peg$c331(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9717,7 +9664,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334(s4);
+            s1 = peg$c332(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9752,16 +9699,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c287) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c285) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c333); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c336();
+      s1 = peg$c334();
     }
     s0 = s1;
 
@@ -9772,16 +9719,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c337) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c335) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c336); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339();
+      s1 = peg$c337();
     }
     s0 = s1;
 
@@ -9797,11 +9744,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341();
+      s1 = peg$c339();
     }
     s0 = s1;
 
@@ -9817,11 +9764,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c343();
+      s1 = peg$c341();
     }
     s0 = s1;
 
@@ -9837,11 +9784,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c345();
+      s1 = peg$c343();
     }
     s0 = s1;
 
@@ -9852,16 +9799,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c344) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -9872,16 +9819,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c349) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c347) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c348); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c349();
     }
     s0 = s1;
 
@@ -9892,16 +9839,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c352) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c350) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c351); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c354();
+      s1 = peg$c352();
     }
     s0 = s1;
 
@@ -9917,11 +9864,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c354();
     }
     s0 = s1;
 
@@ -9932,16 +9879,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c357) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c355) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c359();
+      s1 = peg$c357();
     }
     s0 = s1;
 
@@ -9952,16 +9899,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c360) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c358) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c359); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c360();
     }
     s0 = s1;
 
@@ -9977,7 +9924,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -9997,7 +9944,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c362); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10017,7 +9964,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10037,7 +9984,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10057,7 +10004,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10077,7 +10024,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10179,7 +10126,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c369(s1);
+        s1 = peg$c367(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10194,7 +10141,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c369(s1);
+        s1 = peg$c367(s1);
       }
       s0 = s1;
     }
@@ -10220,7 +10167,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c370(s1);
+        s1 = peg$c368(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10235,7 +10182,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c370(s1);
+        s1 = peg$c368(s1);
       }
       s0 = s1;
     }
@@ -10250,7 +10197,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c371(s1);
+      s1 = peg$c369(s1);
     }
     s0 = s1;
 
@@ -10264,7 +10211,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c372(s1);
+      s1 = peg$c370(s1);
     }
     s0 = s1;
 
@@ -10275,30 +10222,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c373) {
-      s1 = peg$c373;
+    if (input.substr(peg$currPos, 4) === peg$c371) {
+      s1 = peg$c371;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c375();
+      s1 = peg$c373();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c376) {
-        s1 = peg$c376;
+      if (input.substr(peg$currPos, 5) === peg$c374) {
+        s1 = peg$c374;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c377); }
+        if (peg$silentFails === 0) { peg$fail(peg$c375); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c378();
+        s1 = peg$c376();
       }
       s0 = s1;
     }
@@ -10310,16 +10257,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c379) {
-      s1 = peg$c379;
+    if (input.substr(peg$currPos, 4) === peg$c377) {
+      s1 = peg$c377;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c378); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c381();
+      s1 = peg$c379();
     }
     s0 = s1;
 
@@ -10330,12 +10277,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c382) {
-      s1 = peg$c382;
+    if (input.substr(peg$currPos, 2) === peg$c380) {
+      s1 = peg$c380;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c383); }
+      if (peg$silentFails === 0) { peg$fail(peg$c381); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10346,7 +10293,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c384();
+        s1 = peg$c382();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10383,7 +10330,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c385(s2);
+          s1 = peg$c383(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10410,7 +10357,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c385(s1);
+        s1 = peg$c383(s1);
       }
       s0 = s1;
     }
@@ -10450,7 +10397,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c386(s1);
+        s1 = peg$c384(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10479,7 +10426,7 @@ function peg$parse(input, options) {
               s5 = peg$parseType();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c387(s1, s5);
+                s1 = peg$c385(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10506,7 +10453,7 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c388(s1);
+          s1 = peg$c386(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10532,7 +10479,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c389(s3);
+                  s1 = peg$c387(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10564,7 +10511,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c390(s1);
+      s1 = peg$c388(s1);
     }
     s0 = s1;
 
@@ -10589,7 +10536,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10622,7 +10569,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c391(s4);
+            s1 = peg$c389(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10663,15 +10610,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c304;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c392(s3);
+              s1 = peg$c390(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10710,15 +10657,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c297;
+                s5 = peg$c295;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                if (peg$silentFails === 0) { peg$fail(peg$c296); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c393(s3);
+                s1 = peg$c391(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10742,12 +10689,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c313) {
-          s1 = peg$c313;
+        if (input.substr(peg$currPos, 2) === peg$c311) {
+          s1 = peg$c311;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c314); }
+          if (peg$silentFails === 0) { peg$fail(peg$c312); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10756,16 +10703,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c315) {
-                  s5 = peg$c315;
+                if (input.substr(peg$currPos, 2) === peg$c313) {
+                  s5 = peg$c313;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c316); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c314); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c394(s3);
+                  s1 = peg$c392(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10789,12 +10736,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c318) {
-            s1 = peg$c318;
+          if (input.substr(peg$currPos, 2) === peg$c316) {
+            s1 = peg$c316;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c319); }
+            if (peg$silentFails === 0) { peg$fail(peg$c317); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10817,16 +10764,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c320) {
-                            s9 = peg$c320;
+                          if (input.substr(peg$currPos, 2) === peg$c318) {
+                            s9 = peg$c318;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c321); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c319); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c395(s3, s7);
+                            s1 = peg$c393(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10878,7 +10825,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c396(s1);
+      s1 = peg$c394(s1);
     }
     s0 = s1;
 
@@ -10890,11 +10837,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c397;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c398); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10905,11 +10852,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c397;
+          s3 = peg$c395;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c398); }
+          if (peg$silentFails === 0) { peg$fail(peg$c396); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -10930,11 +10877,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c399;
+        s1 = peg$c397;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c400); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -10945,11 +10892,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c399;
+            s3 = peg$c397;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c400); }
+            if (peg$silentFails === 0) { peg$fail(peg$c398); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -10990,7 +10937,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c401(s1);
+        s1 = peg$c399(s1);
       }
       s0 = s1;
     }
@@ -11003,19 +10950,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c402;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c404) {
-        s2 = peg$c404;
+      if (input.substr(peg$currPos, 2) === peg$c402) {
+        s2 = peg$c402;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11033,12 +10980,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c404) {
-        s2 = peg$c404;
+      if (input.substr(peg$currPos, 2) === peg$c402) {
+        s2 = peg$c402;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11084,7 +11031,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c401(s1);
+        s1 = peg$c399(s1);
       }
       s0 = s1;
     }
@@ -11097,19 +11044,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c402;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c404) {
-        s2 = peg$c404;
+      if (input.substr(peg$currPos, 2) === peg$c402) {
+        s2 = peg$c402;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11127,12 +11074,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c404) {
-        s2 = peg$c404;
+      if (input.substr(peg$currPos, 2) === peg$c402) {
+        s2 = peg$c402;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11164,12 +11111,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c404) {
-      s1 = peg$c404;
+    if (input.substr(peg$currPos, 2) === peg$c402) {
+      s1 = peg$c402;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11179,15 +11126,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c304;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c406(s3);
+              s1 = peg$c404(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11217,140 +11164,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c407) {
-      s1 = peg$c407;
+    if (input.substr(peg$currPos, 5) === peg$c405) {
+      s1 = peg$c405;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c409) {
-        s1 = peg$c409;
+      if (input.substr(peg$currPos, 6) === peg$c407) {
+        s1 = peg$c407;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c410); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c411) {
-          s1 = peg$c411;
+        if (input.substr(peg$currPos, 6) === peg$c409) {
+          s1 = peg$c409;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c412); }
+          if (peg$silentFails === 0) { peg$fail(peg$c410); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c413) {
-            s1 = peg$c413;
+          if (input.substr(peg$currPos, 6) === peg$c411) {
+            s1 = peg$c411;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c414); }
+            if (peg$silentFails === 0) { peg$fail(peg$c412); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c415) {
-              s1 = peg$c415;
+            if (input.substr(peg$currPos, 4) === peg$c413) {
+              s1 = peg$c413;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c416); }
+              if (peg$silentFails === 0) { peg$fail(peg$c414); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c417) {
-                s1 = peg$c417;
+              if (input.substr(peg$currPos, 5) === peg$c415) {
+                s1 = peg$c415;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c418); }
+                if (peg$silentFails === 0) { peg$fail(peg$c416); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c419) {
-                  s1 = peg$c419;
+                if (input.substr(peg$currPos, 5) === peg$c417) {
+                  s1 = peg$c417;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c420); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c418); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c421) {
-                    s1 = peg$c421;
+                  if (input.substr(peg$currPos, 5) === peg$c419) {
+                    s1 = peg$c419;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c422); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c420); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c423) {
-                      s1 = peg$c423;
+                    if (input.substr(peg$currPos, 7) === peg$c421) {
+                      s1 = peg$c421;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c424); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c422); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c425) {
-                        s1 = peg$c425;
+                      if (input.substr(peg$currPos, 7) === peg$c423) {
+                        s1 = peg$c423;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c424); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c427) {
-                          s1 = peg$c427;
+                        if (input.substr(peg$currPos, 4) === peg$c425) {
+                          s1 = peg$c425;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c428); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c426); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c429) {
-                            s1 = peg$c429;
+                          if (input.substr(peg$currPos, 6) === peg$c427) {
+                            s1 = peg$c427;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c430); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c428); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c431) {
-                              s1 = peg$c431;
+                            if (input.substr(peg$currPos, 8) === peg$c429) {
+                              s1 = peg$c429;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c432); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c430); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c433) {
-                                s1 = peg$c433;
+                              if (input.substr(peg$currPos, 4) === peg$c431) {
+                                s1 = peg$c431;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c434); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c432); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c435) {
-                                  s1 = peg$c435;
+                                if (input.substr(peg$currPos, 5) === peg$c433) {
+                                  s1 = peg$c433;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c434); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c437) {
-                                    s1 = peg$c437;
+                                  if (input.substr(peg$currPos, 2) === peg$c435) {
+                                    s1 = peg$c435;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c436); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c439) {
-                                      s1 = peg$c439;
+                                    if (input.substr(peg$currPos, 3) === peg$c437) {
+                                      s1 = peg$c437;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c438); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11361,12 +11308,12 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c379) {
-                                          s1 = peg$c379;
+                                        if (input.substr(peg$currPos, 4) === peg$c377) {
+                                          s1 = peg$c377;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c380); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c378); }
                                         }
                                       }
                                     }
@@ -11388,7 +11335,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c441();
+      s1 = peg$c439();
     }
     s0 = s1;
 
@@ -11409,7 +11356,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11451,7 +11398,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c391(s4);
+            s1 = peg$c389(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11494,7 +11441,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c442(s1, s5);
+              s1 = peg$c440(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11535,20 +11482,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c443) {
-      s1 = peg$c443;
+    if (input.substr(peg$currPos, 3) === peg$c441) {
+      s1 = peg$c441;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c444); }
+      if (peg$silentFails === 0) { peg$fail(peg$c442); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c445) {
-        s1 = peg$c445;
+      if (input.substr(peg$currPos, 3) === peg$c443) {
+        s1 = peg$c443;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c446); }
+        if (peg$silentFails === 0) { peg$fail(peg$c444); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11564,7 +11511,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c447();
+        s1 = peg$c445();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11582,20 +11529,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c448) {
-      s1 = peg$c448;
+    if (input.substr(peg$currPos, 2) === peg$c446) {
+      s1 = peg$c446;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c449); }
+      if (peg$silentFails === 0) { peg$fail(peg$c447); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c450) {
-        s1 = peg$c450;
+      if (input.substr(peg$currPos, 2) === peg$c448) {
+        s1 = peg$c448;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c451); }
+        if (peg$silentFails === 0) { peg$fail(peg$c449); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11611,7 +11558,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c452();
+        s1 = peg$c450();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11629,20 +11576,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c285) {
-      s1 = peg$c285;
+    if (input.substr(peg$currPos, 3) === peg$c283) {
+      s1 = peg$c283;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c454) {
-        s1 = peg$c454;
+      if (input.substr(peg$currPos, 3) === peg$c452) {
+        s1 = peg$c452;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c455); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11658,7 +11605,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c456();
+        s1 = peg$c454();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11676,12 +11623,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c349) {
-      s1 = peg$c349;
+    if (input.substr(peg$currPos, 2) === peg$c347) {
+      s1 = peg$c347;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c457); }
+      if (peg$silentFails === 0) { peg$fail(peg$c455); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11696,7 +11643,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351();
+        s1 = peg$c349();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11713,12 +11660,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c458.test(input.charAt(peg$currPos))) {
+    if (peg$c456.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c459); }
+      if (peg$silentFails === 0) { peg$fail(peg$c457); }
     }
 
     return s0;
@@ -11729,12 +11676,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
     }
 
@@ -11748,7 +11695,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c462(s1);
+      s1 = peg$c460(s1);
     }
     s0 = s1;
 
@@ -11820,11 +11767,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c463;
+        s1 = peg$c461;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11834,11 +11781,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c402;
+          s1 = peg$c400;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c403); }
+          if (peg$silentFails === 0) { peg$fail(peg$c401); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -11946,17 +11893,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c465;
+        s2 = peg$c463;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c467();
+          s1 = peg$c465();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11981,21 +11928,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c277;
+        s2 = peg$c275;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c277;
+            s4 = peg$c275;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c278); }
+            if (peg$silentFails === 0) { peg$fail(peg$c276); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12030,36 +11977,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c460.test(input.charAt(peg$currPos))) {
+    if (peg$c458.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c459); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c460.test(input.charAt(peg$currPos))) {
+        if (peg$c458.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c461); }
+          if (peg$silentFails === 0) { peg$fail(peg$c459); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c460.test(input.charAt(peg$currPos))) {
+          if (peg$c458.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c461); }
+            if (peg$silentFails === 0) { peg$fail(peg$c459); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12088,20 +12035,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c460.test(input.charAt(peg$currPos))) {
+    if (peg$c458.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c459); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12176,22 +12123,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c460.test(input.charAt(peg$currPos))) {
+                if (peg$c458.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c459); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c460.test(input.charAt(peg$currPos))) {
+                    if (peg$c458.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c459); }
                     }
                   }
                 } else {
@@ -12246,28 +12193,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c468;
+      s0 = peg$c466;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c469); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c275;
+        s1 = peg$c273;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c276); }
+        if (peg$silentFails === 0) { peg$fail(peg$c274); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c277;
+          s1 = peg$c275;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c278); }
+          if (peg$silentFails === 0) { peg$fail(peg$c276); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12293,22 +12240,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c460.test(input.charAt(peg$currPos))) {
+                if (peg$c458.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c459); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c460.test(input.charAt(peg$currPos))) {
+                    if (peg$c458.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c459); }
                     }
                   }
                 } else {
@@ -12361,11 +12308,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c277;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12411,7 +12358,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c470();
+        s1 = peg$c468();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12473,76 +12420,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c471) {
-      s0 = peg$c471;
+    if (input.substr(peg$currPos, 2) === peg$c469) {
+      s0 = peg$c469;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c470); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c473) {
-        s0 = peg$c473;
+      if (input.substr(peg$currPos, 2) === peg$c471) {
+        s0 = peg$c471;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c474); }
+        if (peg$silentFails === 0) { peg$fail(peg$c472); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c475) {
-          s0 = peg$c475;
+        if (input.substr(peg$currPos, 2) === peg$c473) {
+          s0 = peg$c473;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c476); }
+          if (peg$silentFails === 0) { peg$fail(peg$c474); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c477;
+            s0 = peg$c475;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c478); }
+            if (peg$silentFails === 0) { peg$fail(peg$c476); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c479;
+              s0 = peg$c477;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c480); }
+              if (peg$silentFails === 0) { peg$fail(peg$c478); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c481;
+                s0 = peg$c479;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c482); }
+                if (peg$silentFails === 0) { peg$fail(peg$c480); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c483;
+                  s0 = peg$c481;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c484); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c482); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c485;
+                    s0 = peg$c483;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c486); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c484); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c487;
+                      s0 = peg$c485;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c488); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c486); }
                     }
                   }
                 }
@@ -12727,7 +12674,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c489(s1, s2);
+        s1 = peg$c487(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12748,12 +12695,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c490) {
-            s3 = peg$c490;
+          if (input.substr(peg$currPos, 2) === peg$c488) {
+            s3 = peg$c488;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c491); }
+            if (peg$silentFails === 0) { peg$fail(peg$c489); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12766,7 +12713,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c492(s1, s2, s4, s5);
+                s1 = peg$c490(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12790,12 +12737,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c490) {
-          s1 = peg$c490;
+        if (input.substr(peg$currPos, 2) === peg$c488) {
+          s1 = peg$c488;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c491); }
+          if (peg$silentFails === 0) { peg$fail(peg$c489); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12808,7 +12755,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c493(s2, s3);
+              s1 = peg$c491(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12833,16 +12780,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c490) {
-                s3 = peg$c490;
+              if (input.substr(peg$currPos, 2) === peg$c488) {
+                s3 = peg$c488;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c491); }
+                if (peg$silentFails === 0) { peg$fail(peg$c489); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c494(s1, s2);
+                s1 = peg$c492(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12858,16 +12805,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c490) {
-              s1 = peg$c490;
+            if (input.substr(peg$currPos, 2) === peg$c488) {
+              s1 = peg$c488;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c491); }
+              if (peg$silentFails === 0) { peg$fail(peg$c489); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c495();
+              s1 = peg$c493();
             }
             s0 = s1;
           }
@@ -12904,7 +12851,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c496(s2);
+        s1 = peg$c494(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12933,7 +12880,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c497(s1);
+        s1 = peg$c495(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12954,17 +12901,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c279;
+        s2 = peg$c277;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c498(s1, s3);
+          s1 = peg$c496(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12989,17 +12936,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c279;
+        s2 = peg$c277;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c499(s1, s3);
+          s1 = peg$c497(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13024,7 +12971,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c500(s1);
+      s1 = peg$c498(s1);
     }
     s0 = s1;
 
@@ -13047,22 +12994,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c460.test(input.charAt(peg$currPos))) {
+    if (peg$c458.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c459); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c460.test(input.charAt(peg$currPos))) {
+        if (peg$c458.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c461); }
+          if (peg$silentFails === 0) { peg$fail(peg$c459); }
         }
       }
     } else {
@@ -13082,11 +13029,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c277;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13111,33 +13058,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c277;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c460.test(input.charAt(peg$currPos))) {
+          if (peg$c458.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c461); }
+            if (peg$silentFails === 0) { peg$fail(peg$c459); }
           }
         }
       } else {
@@ -13153,21 +13100,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c460.test(input.charAt(peg$currPos))) {
+          if (peg$c458.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c461); }
+            if (peg$silentFails === 0) { peg$fail(peg$c459); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c460.test(input.charAt(peg$currPos))) {
+            if (peg$c458.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c461); }
+              if (peg$silentFails === 0) { peg$fail(peg$c459); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13177,7 +13124,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c501();
+              s1 = peg$c499();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13202,11 +13149,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c277;
+        s1 = peg$c275;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13221,22 +13168,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c460.test(input.charAt(peg$currPos))) {
+          if (peg$c458.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c461); }
+            if (peg$silentFails === 0) { peg$fail(peg$c459); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c460.test(input.charAt(peg$currPos))) {
+              if (peg$c458.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                if (peg$silentFails === 0) { peg$fail(peg$c459); }
               }
             }
           } else {
@@ -13249,7 +13196,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c501();
+              s1 = peg$c499();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13288,20 +13235,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c502) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c500) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c503); }
+      if (peg$silentFails === 0) { peg$fail(peg$c501); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c504.test(input.charAt(peg$currPos))) {
+      if (peg$c502.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c505); }
+        if (peg$silentFails === 0) { peg$fail(peg$c503); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13330,12 +13277,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c506) {
-      s0 = peg$c506;
+    if (input.substr(peg$currPos, 3) === peg$c504) {
+      s0 = peg$c504;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c507); }
+      if (peg$silentFails === 0) { peg$fail(peg$c505); }
     }
 
     return s0;
@@ -13346,31 +13293,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c277;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c275;
+        s1 = peg$c273;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c276); }
+        if (peg$silentFails === 0) { peg$fail(peg$c274); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c508) {
-        s2 = peg$c508;
+      if (input.substr(peg$currPos, 3) === peg$c506) {
+        s2 = peg$c506;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c509); }
+        if (peg$silentFails === 0) { peg$fail(peg$c507); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13413,12 +13360,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c510.test(input.charAt(peg$currPos))) {
+    if (peg$c508.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c511); }
+      if (peg$silentFails === 0) { peg$fail(peg$c509); }
     }
 
     return s0;
@@ -13429,11 +13376,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c397;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c398); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13444,15 +13391,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c397;
+          s3 = peg$c395;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c398); }
+          if (peg$silentFails === 0) { peg$fail(peg$c396); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c512(s2);
+          s1 = peg$c510(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13469,11 +13416,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c399;
+        s1 = peg$c397;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c400); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13484,15 +13431,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c399;
+            s3 = peg$c397;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c400); }
+            if (peg$silentFails === 0) { peg$fail(peg$c398); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c512(s2);
+            s1 = peg$c510(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13518,11 +13465,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c397;
+      s2 = peg$c395;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c398); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13540,7 +13487,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c513); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13557,11 +13504,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c402;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13596,7 +13543,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c514(s1, s2);
+        s1 = peg$c512(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13625,12 +13572,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c515.test(input.charAt(peg$currPos))) {
+    if (peg$c513.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c516); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13646,12 +13593,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
     }
 
@@ -13663,11 +13610,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c402;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13726,7 +13673,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c517(s3, s4);
+            s1 = peg$c515(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13837,7 +13784,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c518();
+          s1 = peg$c516();
         }
         s0 = s1;
       }
@@ -13851,12 +13798,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
     }
 
@@ -13868,11 +13815,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c402;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -13908,7 +13855,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c519();
+      s1 = peg$c517();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -13922,16 +13869,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c520();
+        s1 = peg$c518();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c504.test(input.charAt(peg$currPos))) {
+        if (peg$c502.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c505); }
+          if (peg$silentFails === 0) { peg$fail(peg$c503); }
         }
       }
     }
@@ -13946,11 +13893,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c399;
+      s2 = peg$c397;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13968,7 +13915,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c513); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13985,11 +13932,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c402;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14025,20 +13972,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c399;
+      s0 = peg$c397;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c397;
+        s1 = peg$c395;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c398); }
+        if (peg$silentFails === 0) { peg$fail(peg$c396); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14047,94 +13994,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c402;
+          s0 = peg$c400;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c403); }
+          if (peg$silentFails === 0) { peg$fail(peg$c401); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c521;
+            s1 = peg$c519;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c522); }
+            if (peg$silentFails === 0) { peg$fail(peg$c520); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c523();
+            s1 = peg$c521();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c524;
+              s1 = peg$c522;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c525); }
+              if (peg$silentFails === 0) { peg$fail(peg$c523); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c526();
+              s1 = peg$c524();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c527;
+                s1 = peg$c525;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c528); }
+                if (peg$silentFails === 0) { peg$fail(peg$c526); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c529();
+                s1 = peg$c527();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c530;
+                  s1 = peg$c528;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c531); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c529); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c532();
+                  s1 = peg$c530();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c533;
+                    s1 = peg$c531;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c534); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c532); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c535();
+                    s1 = peg$c533();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c536;
+                      s1 = peg$c534;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c537); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c535); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c538();
+                      s1 = peg$c536();
                     }
                     s0 = s1;
                   }
@@ -14162,7 +14109,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c519();
+      s1 = peg$c517();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14176,16 +14123,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c539();
+        s1 = peg$c537();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c504.test(input.charAt(peg$currPos))) {
+        if (peg$c502.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c505); }
+          if (peg$silentFails === 0) { peg$fail(peg$c503); }
         }
       }
     }
@@ -14198,11 +14145,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c540;
+      s1 = peg$c538;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c541); }
+      if (peg$silentFails === 0) { peg$fail(peg$c539); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14234,7 +14181,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c542(s2);
+        s1 = peg$c540(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14247,11 +14194,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c540;
+        s1 = peg$c538;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c541); }
+        if (peg$silentFails === 0) { peg$fail(peg$c539); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14318,15 +14265,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c304;
+              s4 = peg$c302;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c542(s3);
+              s1 = peg$c540(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14354,21 +14301,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c279;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c279;
+          s3 = peg$c277;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c280); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14410,21 +14357,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c543.test(input.charAt(peg$currPos))) {
+    if (peg$c541.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c544); }
+      if (peg$silentFails === 0) { peg$fail(peg$c542); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c402;
+        s3 = peg$c400;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14432,7 +14379,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c513); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14449,21 +14396,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c543.test(input.charAt(peg$currPos))) {
+        if (peg$c541.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c544); }
+          if (peg$silentFails === 0) { peg$fail(peg$c542); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c402;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14471,7 +14418,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c513); }
+              if (peg$silentFails === 0) { peg$fail(peg$c511); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14501,12 +14448,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c545.test(input.charAt(peg$currPos))) {
+    if (peg$c543.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c546); }
+      if (peg$silentFails === 0) { peg$fail(peg$c544); }
     }
 
     return s0;
@@ -14564,7 +14511,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
 
     return s0;
@@ -14575,51 +14522,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c548;
+      s0 = peg$c546;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c549); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c550;
+        s0 = peg$c548;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c551); }
+        if (peg$silentFails === 0) { peg$fail(peg$c549); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c552;
+          s0 = peg$c550;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c553); }
+          if (peg$silentFails === 0) { peg$fail(peg$c551); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c554;
+            s0 = peg$c552;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c555); }
+            if (peg$silentFails === 0) { peg$fail(peg$c553); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c556;
+              s0 = peg$c554;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c557); }
+              if (peg$silentFails === 0) { peg$fail(peg$c555); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c558;
+                s0 = peg$c556;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c559); }
+                if (peg$silentFails === 0) { peg$fail(peg$c557); }
               }
             }
           }
@@ -14628,7 +14575,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c545); }
     }
 
     return s0;
@@ -14637,12 +14584,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c560.test(input.charAt(peg$currPos))) {
+    if (peg$c558.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c561); }
+      if (peg$silentFails === 0) { peg$fail(peg$c559); }
     }
 
     return s0;
@@ -14655,7 +14602,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c562); }
+      if (peg$silentFails === 0) { peg$fail(peg$c560); }
     }
 
     return s0;
@@ -14665,12 +14612,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c567) {
-      s1 = peg$c567;
+    if (input.substr(peg$currPos, 2) === peg$c565) {
+      s1 = peg$c565;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c568); }
+      if (peg$silentFails === 0) { peg$fail(peg$c566); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14750,7 +14697,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -4130,63 +4130,20 @@ var g = &grammar{
 							label: "locals",
 							expr: &zeroOrOneExpr{
 								pos: position{line: 528, col: 33, offset: 15376},
-								expr: &actionExpr{
-									pos: position{line: 528, col: 34, offset: 15377},
-									run: (*parser).callonOverOp9,
-									expr: &seqExpr{
-										pos: position{line: 528, col: 34, offset: 15377},
-										exprs: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 528, col: 34, offset: 15377},
-												name: "_",
-											},
-											&litMatcher{
-												pos:        position{line: 528, col: 36, offset: 15379},
-												val:        "with",
-												ignoreCase: false,
-											},
-											&ruleRefExpr{
-												pos:  position{line: 528, col: 43, offset: 15386},
-												name: "_",
-											},
-											&labeledExpr{
-												pos:   position{line: 528, col: 45, offset: 15388},
-												label: "l",
-												expr: &ruleRefExpr{
-													pos:  position{line: 528, col: 47, offset: 15390},
-													name: "LetAssignments",
-												},
-											},
-										},
-									},
+								expr: &ruleRefExpr{
+									pos:  position{line: 528, col: 33, offset: 15376},
+									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 82, offset: 15425},
+							pos:   position{line: 528, col: 41, offset: 15384},
 							label: "scope",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 528, col: 88, offset: 15431},
-								expr: &actionExpr{
-									pos: position{line: 528, col: 89, offset: 15432},
-									run: (*parser).callonOverOp18,
-									expr: &seqExpr{
-										pos: position{line: 528, col: 89, offset: 15432},
-										exprs: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 528, col: 89, offset: 15432},
-												name: "__",
-											},
-											&labeledExpr{
-												pos:   position{line: 528, col: 92, offset: 15435},
-												label: "s",
-												expr: &ruleRefExpr{
-													pos:  position{line: 528, col: 94, offset: 15437},
-													name: "Scope",
-												},
-											},
-										},
-									},
+								pos: position{line: 528, col: 47, offset: 15390},
+								expr: &ruleRefExpr{
+									pos:  position{line: 528, col: 47, offset: 15390},
+									name: "Scope",
 								},
 							},
 						},
@@ -4196,45 +4153,49 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 536, col: 1, offset: 15706},
+			pos:  position{line: 536, col: 1, offset: 15640},
 			expr: &actionExpr{
-				pos: position{line: 536, col: 9, offset: 15714},
+				pos: position{line: 537, col: 5, offset: 15650},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 536, col: 9, offset: 15714},
+					pos: position{line: 537, col: 5, offset: 15650},
 					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 537, col: 5, offset: 15650},
+							name: "__",
+						},
 						&litMatcher{
-							pos:        position{line: 536, col: 9, offset: 15714},
+							pos:        position{line: 537, col: 8, offset: 15653},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 536, col: 14, offset: 15719},
+							pos:  position{line: 537, col: 13, offset: 15658},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 536, col: 17, offset: 15722},
+							pos:        position{line: 537, col: 16, offset: 15661},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 536, col: 21, offset: 15726},
+							pos:  position{line: 537, col: 20, offset: 15665},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 536, col: 24, offset: 15729},
+							pos:   position{line: 537, col: 23, offset: 15668},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 536, col: 28, offset: 15733},
+								pos:  position{line: 537, col: 27, offset: 15672},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 536, col: 39, offset: 15744},
+							pos:  position{line: 537, col: 38, offset: 15683},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 536, col: 42, offset: 15747},
+							pos:        position{line: 537, col: 41, offset: 15686},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4243,52 +4204,65 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "LetAssignments",
-			pos:  position{line: 538, col: 1, offset: 15772},
+			name: "Locals",
+			pos:  position{line: 539, col: 1, offset: 15711},
 			expr: &actionExpr{
-				pos: position{line: 539, col: 5, offset: 15791},
-				run: (*parser).callonLetAssignments1,
+				pos: position{line: 540, col: 5, offset: 15722},
+				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 539, col: 5, offset: 15791},
+					pos: position{line: 540, col: 5, offset: 15722},
 					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 540, col: 5, offset: 15722},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 540, col: 7, offset: 15724},
+							val:        "with",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 540, col: 14, offset: 15731},
+							name: "_",
+						},
 						&labeledExpr{
-							pos:   position{line: 539, col: 5, offset: 15791},
+							pos:   position{line: 540, col: 16, offset: 15733},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 539, col: 11, offset: 15797},
-								name: "LetAssignment",
+								pos:  position{line: 540, col: 22, offset: 15739},
+								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 539, col: 25, offset: 15811},
+							pos:   position{line: 540, col: 39, offset: 15756},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 539, col: 30, offset: 15816},
+								pos: position{line: 540, col: 44, offset: 15761},
 								expr: &actionExpr{
-									pos: position{line: 539, col: 31, offset: 15817},
-									run: (*parser).callonLetAssignments7,
+									pos: position{line: 540, col: 45, offset: 15762},
+									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 539, col: 31, offset: 15817},
+										pos: position{line: 540, col: 45, offset: 15762},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 539, col: 31, offset: 15817},
+												pos:  position{line: 540, col: 45, offset: 15762},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 539, col: 34, offset: 15820},
+												pos:        position{line: 540, col: 48, offset: 15765},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 539, col: 38, offset: 15824},
+												pos:  position{line: 540, col: 52, offset: 15769},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 539, col: 41, offset: 15827},
+												pos:   position{line: 540, col: 55, offset: 15772},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 539, col: 43, offset: 15829},
-													name: "LetAssignment",
+													pos:  position{line: 540, col: 57, offset: 15774},
+													name: "LocalsAssignment",
 												},
 											},
 										},
@@ -4301,43 +4275,43 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "LetAssignment",
-			pos:  position{line: 543, col: 1, offset: 15947},
+			name: "LocalsAssignment",
+			pos:  position{line: 544, col: 1, offset: 15895},
 			expr: &choiceExpr{
-				pos: position{line: 544, col: 5, offset: 15965},
+				pos: position{line: 545, col: 5, offset: 15916},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 544, col: 5, offset: 15965},
-						run: (*parser).callonLetAssignment2,
+						pos: position{line: 545, col: 5, offset: 15916},
+						run: (*parser).callonLocalsAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 544, col: 5, offset: 15965},
+							pos: position{line: 545, col: 5, offset: 15916},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 544, col: 5, offset: 15965},
+									pos:   position{line: 545, col: 5, offset: 15916},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 544, col: 8, offset: 15968},
+										pos:  position{line: 545, col: 8, offset: 15919},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 544, col: 23, offset: 15983},
+									pos:  position{line: 545, col: 23, offset: 15934},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 544, col: 26, offset: 15986},
+									pos:        position{line: 545, col: 26, offset: 15937},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 544, col: 30, offset: 15990},
+									pos:  position{line: 545, col: 30, offset: 15941},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 544, col: 33, offset: 15993},
+									pos:   position{line: 545, col: 33, offset: 15944},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 544, col: 38, offset: 15998},
+										pos:  position{line: 545, col: 38, offset: 15949},
 										name: "Expr",
 									},
 								},
@@ -4345,13 +4319,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 16080},
-						run: (*parser).callonLetAssignment11,
+						pos: position{line: 548, col: 5, offset: 16031},
+						run: (*parser).callonLocalsAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 547, col: 5, offset: 16080},
+							pos:   position{line: 548, col: 5, offset: 16031},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 547, col: 8, offset: 16083},
+								pos:  position{line: 548, col: 8, offset: 16034},
 								name: "IdentifierName",
 							},
 						},
@@ -4361,27 +4335,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 551, col: 1, offset: 16213},
+			pos:  position{line: 552, col: 1, offset: 16164},
 			expr: &actionExpr{
-				pos: position{line: 552, col: 5, offset: 16225},
+				pos: position{line: 553, col: 5, offset: 16176},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 552, col: 5, offset: 16225},
+					pos: position{line: 553, col: 5, offset: 16176},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 552, col: 5, offset: 16225},
+							pos:        position{line: 553, col: 5, offset: 16176},
 							val:        "yield",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 552, col: 13, offset: 16233},
+							pos:  position{line: 553, col: 13, offset: 16184},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 552, col: 15, offset: 16235},
+							pos:   position{line: 553, col: 15, offset: 16186},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 552, col: 21, offset: 16241},
+								pos:  position{line: 553, col: 21, offset: 16192},
 								name: "Exprs",
 							},
 						},
@@ -4391,30 +4365,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 556, col: 1, offset: 16325},
+			pos:  position{line: 557, col: 1, offset: 16276},
 			expr: &actionExpr{
-				pos: position{line: 557, col: 5, offset: 16337},
+				pos: position{line: 558, col: 5, offset: 16288},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 557, col: 5, offset: 16337},
+					pos: position{line: 558, col: 5, offset: 16288},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 557, col: 5, offset: 16337},
+							pos:  position{line: 558, col: 5, offset: 16288},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 557, col: 7, offset: 16339},
+							pos:  position{line: 558, col: 7, offset: 16290},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 557, col: 10, offset: 16342},
+							pos:  position{line: 558, col: 10, offset: 16293},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 557, col: 12, offset: 16344},
+							pos:   position{line: 558, col: 12, offset: 16295},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 557, col: 16, offset: 16348},
+								pos:  position{line: 558, col: 16, offset: 16299},
 								name: "Type",
 							},
 						},
@@ -4424,30 +4398,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 559, col: 1, offset: 16373},
+			pos:  position{line: 560, col: 1, offset: 16324},
 			expr: &actionExpr{
-				pos: position{line: 560, col: 5, offset: 16383},
+				pos: position{line: 561, col: 5, offset: 16334},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 560, col: 5, offset: 16383},
+					pos: position{line: 561, col: 5, offset: 16334},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 560, col: 5, offset: 16383},
+							pos:  position{line: 561, col: 5, offset: 16334},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 560, col: 7, offset: 16385},
+							pos:  position{line: 561, col: 7, offset: 16336},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 560, col: 10, offset: 16388},
+							pos:  position{line: 561, col: 10, offset: 16339},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 560, col: 12, offset: 16390},
+							pos:   position{line: 561, col: 12, offset: 16341},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 560, col: 16, offset: 16394},
+								pos:  position{line: 561, col: 16, offset: 16345},
 								name: "Lval",
 							},
 						},
@@ -4457,58 +4431,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 564, col: 1, offset: 16445},
+			pos:  position{line: 565, col: 1, offset: 16396},
 			expr: &ruleRefExpr{
-				pos:  position{line: 564, col: 8, offset: 16452},
+				pos:  position{line: 565, col: 8, offset: 16403},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 566, col: 1, offset: 16463},
+			pos:  position{line: 567, col: 1, offset: 16414},
 			expr: &actionExpr{
-				pos: position{line: 567, col: 5, offset: 16473},
+				pos: position{line: 568, col: 5, offset: 16424},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 567, col: 5, offset: 16473},
+					pos: position{line: 568, col: 5, offset: 16424},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 567, col: 5, offset: 16473},
+							pos:   position{line: 568, col: 5, offset: 16424},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 567, col: 11, offset: 16479},
+								pos:  position{line: 568, col: 11, offset: 16430},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 567, col: 16, offset: 16484},
+							pos:   position{line: 568, col: 16, offset: 16435},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 567, col: 21, offset: 16489},
+								pos: position{line: 568, col: 21, offset: 16440},
 								expr: &actionExpr{
-									pos: position{line: 567, col: 22, offset: 16490},
+									pos: position{line: 568, col: 22, offset: 16441},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 567, col: 22, offset: 16490},
+										pos: position{line: 568, col: 22, offset: 16441},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 567, col: 22, offset: 16490},
+												pos:  position{line: 568, col: 22, offset: 16441},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 567, col: 25, offset: 16493},
+												pos:        position{line: 568, col: 25, offset: 16444},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 567, col: 29, offset: 16497},
+												pos:  position{line: 568, col: 29, offset: 16448},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 567, col: 32, offset: 16500},
+												pos:   position{line: 568, col: 32, offset: 16451},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 567, col: 37, offset: 16505},
+													pos:  position{line: 568, col: 37, offset: 16456},
 													name: "Lval",
 												},
 											},
@@ -4523,52 +4497,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 571, col: 1, offset: 16617},
+			pos:  position{line: 572, col: 1, offset: 16568},
 			expr: &ruleRefExpr{
-				pos:  position{line: 571, col: 13, offset: 16629},
+				pos:  position{line: 572, col: 13, offset: 16580},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 573, col: 1, offset: 16635},
+			pos:  position{line: 574, col: 1, offset: 16586},
 			expr: &actionExpr{
-				pos: position{line: 574, col: 5, offset: 16650},
+				pos: position{line: 575, col: 5, offset: 16601},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 574, col: 5, offset: 16650},
+					pos: position{line: 575, col: 5, offset: 16601},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 574, col: 5, offset: 16650},
+							pos:   position{line: 575, col: 5, offset: 16601},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 574, col: 11, offset: 16656},
+								pos:  position{line: 575, col: 11, offset: 16607},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 574, col: 21, offset: 16666},
+							pos:   position{line: 575, col: 21, offset: 16617},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 574, col: 26, offset: 16671},
+								pos: position{line: 575, col: 26, offset: 16622},
 								expr: &seqExpr{
-									pos: position{line: 574, col: 27, offset: 16672},
+									pos: position{line: 575, col: 27, offset: 16623},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 574, col: 27, offset: 16672},
+											pos:  position{line: 575, col: 27, offset: 16623},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 574, col: 30, offset: 16675},
+											pos:        position{line: 575, col: 30, offset: 16626},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 574, col: 34, offset: 16679},
+											pos:  position{line: 575, col: 34, offset: 16630},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 574, col: 37, offset: 16682},
+											pos:  position{line: 575, col: 37, offset: 16633},
 											name: "FieldExpr",
 										},
 									},
@@ -4581,50 +4555,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 584, col: 1, offset: 16881},
+			pos:  position{line: 585, col: 1, offset: 16832},
 			expr: &actionExpr{
-				pos: position{line: 585, col: 5, offset: 16897},
+				pos: position{line: 586, col: 5, offset: 16848},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 585, col: 5, offset: 16897},
+					pos: position{line: 586, col: 5, offset: 16848},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 585, col: 5, offset: 16897},
+							pos:   position{line: 586, col: 5, offset: 16848},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 585, col: 11, offset: 16903},
+								pos:  position{line: 586, col: 11, offset: 16854},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 585, col: 22, offset: 16914},
+							pos:   position{line: 586, col: 22, offset: 16865},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 585, col: 27, offset: 16919},
+								pos: position{line: 586, col: 27, offset: 16870},
 								expr: &actionExpr{
-									pos: position{line: 585, col: 28, offset: 16920},
+									pos: position{line: 586, col: 28, offset: 16871},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 585, col: 28, offset: 16920},
+										pos: position{line: 586, col: 28, offset: 16871},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 585, col: 28, offset: 16920},
+												pos:  position{line: 586, col: 28, offset: 16871},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 585, col: 31, offset: 16923},
+												pos:        position{line: 586, col: 31, offset: 16874},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 585, col: 35, offset: 16927},
+												pos:  position{line: 586, col: 35, offset: 16878},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 585, col: 38, offset: 16930},
+												pos:   position{line: 586, col: 38, offset: 16881},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 585, col: 40, offset: 16932},
+													pos:  position{line: 586, col: 40, offset: 16883},
 													name: "Assignment",
 												},
 											},
@@ -4639,39 +4613,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 589, col: 1, offset: 17043},
+			pos:  position{line: 590, col: 1, offset: 16994},
 			expr: &actionExpr{
-				pos: position{line: 590, col: 5, offset: 17058},
+				pos: position{line: 591, col: 5, offset: 17009},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 590, col: 5, offset: 17058},
+					pos: position{line: 591, col: 5, offset: 17009},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 590, col: 5, offset: 17058},
+							pos:   position{line: 591, col: 5, offset: 17009},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 590, col: 9, offset: 17062},
+								pos:  position{line: 591, col: 9, offset: 17013},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 590, col: 14, offset: 17067},
+							pos:  position{line: 591, col: 14, offset: 17018},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 590, col: 17, offset: 17070},
+							pos:        position{line: 591, col: 17, offset: 17021},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 590, col: 22, offset: 17075},
+							pos:  position{line: 591, col: 22, offset: 17026},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 590, col: 25, offset: 17078},
+							pos:   position{line: 591, col: 25, offset: 17029},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 590, col: 29, offset: 17082},
+								pos:  position{line: 591, col: 29, offset: 17033},
 								name: "Expr",
 							},
 						},
@@ -4681,71 +4655,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 592, col: 1, offset: 17173},
+			pos:  position{line: 593, col: 1, offset: 17124},
 			expr: &ruleRefExpr{
-				pos:  position{line: 592, col: 8, offset: 17180},
+				pos:  position{line: 593, col: 8, offset: 17131},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 594, col: 1, offset: 17197},
+			pos:  position{line: 595, col: 1, offset: 17148},
 			expr: &choiceExpr{
-				pos: position{line: 595, col: 5, offset: 17217},
+				pos: position{line: 596, col: 5, offset: 17168},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 595, col: 5, offset: 17217},
+						pos: position{line: 596, col: 5, offset: 17168},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 595, col: 5, offset: 17217},
+							pos: position{line: 596, col: 5, offset: 17168},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 595, col: 5, offset: 17217},
+									pos:   position{line: 596, col: 5, offset: 17168},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 595, col: 15, offset: 17227},
+										pos:  position{line: 596, col: 15, offset: 17178},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 595, col: 29, offset: 17241},
+									pos:  position{line: 596, col: 29, offset: 17192},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 595, col: 32, offset: 17244},
+									pos:        position{line: 596, col: 32, offset: 17195},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 595, col: 36, offset: 17248},
+									pos:  position{line: 596, col: 36, offset: 17199},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 595, col: 39, offset: 17251},
+									pos:   position{line: 596, col: 39, offset: 17202},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 595, col: 50, offset: 17262},
+										pos:  position{line: 596, col: 50, offset: 17213},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 595, col: 55, offset: 17267},
+									pos:  position{line: 596, col: 55, offset: 17218},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 595, col: 58, offset: 17270},
+									pos:        position{line: 596, col: 58, offset: 17221},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 595, col: 62, offset: 17274},
+									pos:  position{line: 596, col: 62, offset: 17225},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 595, col: 65, offset: 17277},
+									pos:   position{line: 596, col: 65, offset: 17228},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 595, col: 76, offset: 17288},
+										pos:  position{line: 596, col: 76, offset: 17239},
 										name: "Expr",
 									},
 								},
@@ -4753,7 +4727,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 598, col: 5, offset: 17428},
+						pos:  position{line: 599, col: 5, offset: 17379},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4761,53 +4735,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 600, col: 1, offset: 17443},
+			pos:  position{line: 601, col: 1, offset: 17394},
 			expr: &actionExpr{
-				pos: position{line: 601, col: 5, offset: 17461},
+				pos: position{line: 602, col: 5, offset: 17412},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 601, col: 5, offset: 17461},
+					pos: position{line: 602, col: 5, offset: 17412},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 601, col: 5, offset: 17461},
+							pos:   position{line: 602, col: 5, offset: 17412},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 601, col: 11, offset: 17467},
+								pos:  position{line: 602, col: 11, offset: 17418},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 602, col: 5, offset: 17486},
+							pos:   position{line: 603, col: 5, offset: 17437},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 602, col: 10, offset: 17491},
+								pos: position{line: 603, col: 10, offset: 17442},
 								expr: &actionExpr{
-									pos: position{line: 602, col: 11, offset: 17492},
+									pos: position{line: 603, col: 11, offset: 17443},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 602, col: 11, offset: 17492},
+										pos: position{line: 603, col: 11, offset: 17443},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 602, col: 11, offset: 17492},
+												pos:  position{line: 603, col: 11, offset: 17443},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 602, col: 14, offset: 17495},
+												pos:   position{line: 603, col: 14, offset: 17446},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 602, col: 17, offset: 17498},
+													pos:  position{line: 603, col: 17, offset: 17449},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 602, col: 25, offset: 17506},
+												pos:  position{line: 603, col: 25, offset: 17457},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 602, col: 28, offset: 17509},
+												pos:   position{line: 603, col: 28, offset: 17460},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 602, col: 33, offset: 17514},
+													pos:  position{line: 603, col: 33, offset: 17465},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4822,53 +4796,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 606, col: 1, offset: 17632},
+			pos:  position{line: 607, col: 1, offset: 17583},
 			expr: &actionExpr{
-				pos: position{line: 607, col: 5, offset: 17651},
+				pos: position{line: 608, col: 5, offset: 17602},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 607, col: 5, offset: 17651},
+					pos: position{line: 608, col: 5, offset: 17602},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 607, col: 5, offset: 17651},
+							pos:   position{line: 608, col: 5, offset: 17602},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 607, col: 11, offset: 17657},
+								pos:  position{line: 608, col: 11, offset: 17608},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 608, col: 5, offset: 17676},
+							pos:   position{line: 609, col: 5, offset: 17627},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 608, col: 10, offset: 17681},
+								pos: position{line: 609, col: 10, offset: 17632},
 								expr: &actionExpr{
-									pos: position{line: 608, col: 11, offset: 17682},
+									pos: position{line: 609, col: 11, offset: 17633},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 608, col: 11, offset: 17682},
+										pos: position{line: 609, col: 11, offset: 17633},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 608, col: 11, offset: 17682},
+												pos:  position{line: 609, col: 11, offset: 17633},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 608, col: 14, offset: 17685},
+												pos:   position{line: 609, col: 14, offset: 17636},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 608, col: 17, offset: 17688},
+													pos:  position{line: 609, col: 17, offset: 17639},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 608, col: 26, offset: 17697},
+												pos:  position{line: 609, col: 26, offset: 17648},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 608, col: 29, offset: 17700},
+												pos:   position{line: 609, col: 29, offset: 17651},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 608, col: 34, offset: 17705},
+													pos:  position{line: 609, col: 34, offset: 17656},
 													name: "ComparisonExpr",
 												},
 											},
@@ -4883,72 +4857,72 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 612, col: 1, offset: 17823},
+			pos:  position{line: 613, col: 1, offset: 17774},
 			expr: &actionExpr{
-				pos: position{line: 613, col: 5, offset: 17842},
+				pos: position{line: 614, col: 5, offset: 17793},
 				run: (*parser).callonComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 613, col: 5, offset: 17842},
+					pos: position{line: 614, col: 5, offset: 17793},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 613, col: 5, offset: 17842},
+							pos:   position{line: 614, col: 5, offset: 17793},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 613, col: 9, offset: 17846},
+								pos:  position{line: 614, col: 9, offset: 17797},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 613, col: 22, offset: 17859},
+							pos:   position{line: 614, col: 22, offset: 17810},
 							label: "opAndRHS",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 613, col: 31, offset: 17868},
+								pos: position{line: 614, col: 31, offset: 17819},
 								expr: &choiceExpr{
-									pos: position{line: 613, col: 32, offset: 17869},
+									pos: position{line: 614, col: 32, offset: 17820},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 613, col: 32, offset: 17869},
+											pos: position{line: 614, col: 32, offset: 17820},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 613, col: 32, offset: 17869},
+													pos:  position{line: 614, col: 32, offset: 17820},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 613, col: 35, offset: 17872},
+													pos:  position{line: 614, col: 35, offset: 17823},
 													name: "Comparator",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 613, col: 46, offset: 17883},
+													pos:  position{line: 614, col: 46, offset: 17834},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 613, col: 49, offset: 17886},
+													pos:  position{line: 614, col: 49, offset: 17837},
 													name: "AdditiveExpr",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 613, col: 64, offset: 17901},
+											pos: position{line: 614, col: 64, offset: 17852},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 613, col: 64, offset: 17901},
+													pos:  position{line: 614, col: 64, offset: 17852},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 613, col: 68, offset: 17905},
+													pos: position{line: 614, col: 68, offset: 17856},
 													run: (*parser).callonComparisonExpr15,
 													expr: &litMatcher{
-														pos:        position{line: 613, col: 68, offset: 17905},
+														pos:        position{line: 614, col: 68, offset: 17856},
 														val:        "~",
 														ignoreCase: false,
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 613, col: 104, offset: 17941},
+													pos:  position{line: 614, col: 104, offset: 17892},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 613, col: 107, offset: 17944},
+													pos:  position{line: 614, col: 107, offset: 17895},
 													name: "Regexp",
 												},
 											},
@@ -4963,53 +4937,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 622, col: 1, offset: 18205},
+			pos:  position{line: 623, col: 1, offset: 18156},
 			expr: &actionExpr{
-				pos: position{line: 623, col: 5, offset: 18222},
+				pos: position{line: 624, col: 5, offset: 18173},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 623, col: 5, offset: 18222},
+					pos: position{line: 624, col: 5, offset: 18173},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 623, col: 5, offset: 18222},
+							pos:   position{line: 624, col: 5, offset: 18173},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 623, col: 11, offset: 18228},
+								pos:  position{line: 624, col: 11, offset: 18179},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 624, col: 5, offset: 18251},
+							pos:   position{line: 625, col: 5, offset: 18202},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 624, col: 10, offset: 18256},
+								pos: position{line: 625, col: 10, offset: 18207},
 								expr: &actionExpr{
-									pos: position{line: 624, col: 11, offset: 18257},
+									pos: position{line: 625, col: 11, offset: 18208},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 624, col: 11, offset: 18257},
+										pos: position{line: 625, col: 11, offset: 18208},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 624, col: 11, offset: 18257},
+												pos:  position{line: 625, col: 11, offset: 18208},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 624, col: 14, offset: 18260},
+												pos:   position{line: 625, col: 14, offset: 18211},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 624, col: 17, offset: 18263},
+													pos:  position{line: 625, col: 17, offset: 18214},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 624, col: 34, offset: 18280},
+												pos:  position{line: 625, col: 34, offset: 18231},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 624, col: 37, offset: 18283},
+												pos:   position{line: 625, col: 37, offset: 18234},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 624, col: 42, offset: 18288},
+													pos:  position{line: 625, col: 42, offset: 18239},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5024,20 +4998,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 628, col: 1, offset: 18410},
+			pos:  position{line: 629, col: 1, offset: 18361},
 			expr: &actionExpr{
-				pos: position{line: 628, col: 20, offset: 18429},
+				pos: position{line: 629, col: 20, offset: 18380},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 628, col: 21, offset: 18430},
+					pos: position{line: 629, col: 21, offset: 18381},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 628, col: 21, offset: 18430},
+							pos:        position{line: 629, col: 21, offset: 18381},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 628, col: 27, offset: 18436},
+							pos:        position{line: 629, col: 27, offset: 18387},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5047,53 +5021,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 630, col: 1, offset: 18473},
+			pos:  position{line: 631, col: 1, offset: 18424},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 18496},
+				pos: position{line: 632, col: 5, offset: 18447},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 5, offset: 18496},
+					pos: position{line: 632, col: 5, offset: 18447},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 631, col: 5, offset: 18496},
+							pos:   position{line: 632, col: 5, offset: 18447},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 11, offset: 18502},
+								pos:  position{line: 632, col: 11, offset: 18453},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 632, col: 5, offset: 18514},
+							pos:   position{line: 633, col: 5, offset: 18465},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 632, col: 10, offset: 18519},
+								pos: position{line: 633, col: 10, offset: 18470},
 								expr: &actionExpr{
-									pos: position{line: 632, col: 11, offset: 18520},
+									pos: position{line: 633, col: 11, offset: 18471},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 632, col: 11, offset: 18520},
+										pos: position{line: 633, col: 11, offset: 18471},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 632, col: 11, offset: 18520},
+												pos:  position{line: 633, col: 11, offset: 18471},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 632, col: 14, offset: 18523},
+												pos:   position{line: 633, col: 14, offset: 18474},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 632, col: 17, offset: 18526},
+													pos:  position{line: 633, col: 17, offset: 18477},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 632, col: 40, offset: 18549},
+												pos:  position{line: 633, col: 40, offset: 18500},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 632, col: 43, offset: 18552},
+												pos:   position{line: 633, col: 43, offset: 18503},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 632, col: 48, offset: 18557},
+													pos:  position{line: 633, col: 48, offset: 18508},
 													name: "NotExpr",
 												},
 											},
@@ -5108,25 +5082,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 636, col: 1, offset: 18668},
+			pos:  position{line: 637, col: 1, offset: 18619},
 			expr: &actionExpr{
-				pos: position{line: 636, col: 26, offset: 18693},
+				pos: position{line: 637, col: 26, offset: 18644},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 636, col: 27, offset: 18694},
+					pos: position{line: 637, col: 27, offset: 18645},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 636, col: 27, offset: 18694},
+							pos:        position{line: 637, col: 27, offset: 18645},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 636, col: 33, offset: 18700},
+							pos:        position{line: 637, col: 33, offset: 18651},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 636, col: 39, offset: 18706},
+							pos:        position{line: 637, col: 39, offset: 18657},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5136,30 +5110,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 638, col: 1, offset: 18743},
+			pos:  position{line: 639, col: 1, offset: 18694},
 			expr: &choiceExpr{
-				pos: position{line: 639, col: 5, offset: 18755},
+				pos: position{line: 640, col: 5, offset: 18706},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 639, col: 5, offset: 18755},
+						pos: position{line: 640, col: 5, offset: 18706},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 639, col: 5, offset: 18755},
+							pos: position{line: 640, col: 5, offset: 18706},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 639, col: 5, offset: 18755},
+									pos:        position{line: 640, col: 5, offset: 18706},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 639, col: 9, offset: 18759},
+									pos:  position{line: 640, col: 9, offset: 18710},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 639, col: 12, offset: 18762},
+									pos:   position{line: 640, col: 12, offset: 18713},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 14, offset: 18764},
+										pos:  position{line: 640, col: 14, offset: 18715},
 										name: "NotExpr",
 									},
 								},
@@ -5167,7 +5141,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 642, col: 5, offset: 18873},
+						pos:  position{line: 643, col: 5, offset: 18824},
 						name: "NegationExpr",
 					},
 				},
@@ -5175,37 +5149,37 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 644, col: 1, offset: 18887},
+			pos:  position{line: 645, col: 1, offset: 18838},
 			expr: &choiceExpr{
-				pos: position{line: 645, col: 5, offset: 18904},
+				pos: position{line: 646, col: 5, offset: 18855},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 645, col: 5, offset: 18904},
+						pos: position{line: 646, col: 5, offset: 18855},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 645, col: 5, offset: 18904},
+							pos: position{line: 646, col: 5, offset: 18855},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 645, col: 5, offset: 18904},
+									pos: position{line: 646, col: 5, offset: 18855},
 									expr: &ruleRefExpr{
-										pos:  position{line: 645, col: 6, offset: 18905},
+										pos:  position{line: 646, col: 6, offset: 18856},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 645, col: 14, offset: 18913},
+									pos:        position{line: 646, col: 14, offset: 18864},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 645, col: 18, offset: 18917},
+									pos:  position{line: 646, col: 18, offset: 18868},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 645, col: 21, offset: 18920},
+									pos:   position{line: 646, col: 21, offset: 18871},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 645, col: 23, offset: 18922},
+										pos:  position{line: 646, col: 23, offset: 18873},
 										name: "FuncExpr",
 									},
 								},
@@ -5213,7 +5187,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 648, col: 5, offset: 19032},
+						pos:  position{line: 649, col: 5, offset: 18983},
 						name: "FuncExpr",
 					},
 				},
@@ -5221,31 +5195,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 650, col: 1, offset: 19042},
+			pos:  position{line: 651, col: 1, offset: 18993},
 			expr: &choiceExpr{
-				pos: position{line: 651, col: 5, offset: 19055},
+				pos: position{line: 652, col: 5, offset: 19006},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 651, col: 5, offset: 19055},
+						pos: position{line: 652, col: 5, offset: 19006},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 651, col: 5, offset: 19055},
+							pos: position{line: 652, col: 5, offset: 19006},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 651, col: 5, offset: 19055},
+									pos:   position{line: 652, col: 5, offset: 19006},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 651, col: 11, offset: 19061},
+										pos:  position{line: 652, col: 11, offset: 19012},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 651, col: 16, offset: 19066},
+									pos:   position{line: 652, col: 16, offset: 19017},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 651, col: 21, offset: 19071},
+										pos: position{line: 652, col: 21, offset: 19022},
 										expr: &ruleRefExpr{
-											pos:  position{line: 651, col: 22, offset: 19072},
+											pos:  position{line: 652, col: 22, offset: 19023},
 											name: "Deref",
 										},
 									},
@@ -5254,26 +5228,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 654, col: 5, offset: 19143},
+						pos: position{line: 655, col: 5, offset: 19094},
 						run: (*parser).callonFuncExpr9,
 						expr: &seqExpr{
-							pos: position{line: 654, col: 5, offset: 19143},
+							pos: position{line: 655, col: 5, offset: 19094},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 654, col: 5, offset: 19143},
+									pos:   position{line: 655, col: 5, offset: 19094},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 654, col: 11, offset: 19149},
+										pos:  position{line: 655, col: 11, offset: 19100},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 654, col: 20, offset: 19158},
+									pos:   position{line: 655, col: 20, offset: 19109},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 654, col: 25, offset: 19163},
+										pos: position{line: 655, col: 25, offset: 19114},
 										expr: &ruleRefExpr{
-											pos:  position{line: 654, col: 26, offset: 19164},
+											pos:  position{line: 655, col: 26, offset: 19115},
 											name: "Deref",
 										},
 									},
@@ -5282,11 +5256,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 657, col: 5, offset: 19235},
+						pos:  position{line: 658, col: 5, offset: 19186},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 658, col: 5, offset: 19249},
+						pos:  position{line: 659, col: 5, offset: 19200},
 						name: "Primary",
 					},
 				},
@@ -5294,20 +5268,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 660, col: 1, offset: 19258},
+			pos:  position{line: 661, col: 1, offset: 19209},
 			expr: &seqExpr{
-				pos: position{line: 660, col: 13, offset: 19270},
+				pos: position{line: 661, col: 13, offset: 19221},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 660, col: 13, offset: 19270},
+						pos:  position{line: 661, col: 13, offset: 19221},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 660, col: 22, offset: 19279},
+						pos:  position{line: 661, col: 22, offset: 19230},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 660, col: 25, offset: 19282},
+						pos:        position{line: 661, col: 25, offset: 19233},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5316,17 +5290,17 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 662, col: 1, offset: 19287},
+			pos:  position{line: 663, col: 1, offset: 19238},
 			expr: &choiceExpr{
-				pos: position{line: 663, col: 5, offset: 19300},
+				pos: position{line: 664, col: 5, offset: 19251},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 663, col: 5, offset: 19300},
+						pos:        position{line: 664, col: 5, offset: 19251},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 664, col: 5, offset: 19310},
+						pos:        position{line: 665, col: 5, offset: 19261},
 						val:        "select",
 						ignoreCase: false,
 					},
@@ -5335,48 +5309,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 666, col: 1, offset: 19320},
+			pos:  position{line: 667, col: 1, offset: 19271},
 			expr: &actionExpr{
-				pos: position{line: 667, col: 5, offset: 19329},
+				pos: position{line: 668, col: 5, offset: 19280},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 667, col: 5, offset: 19329},
+					pos: position{line: 668, col: 5, offset: 19280},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 667, col: 5, offset: 19329},
+							pos:   position{line: 668, col: 5, offset: 19280},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 667, col: 9, offset: 19333},
+								pos:  position{line: 668, col: 9, offset: 19284},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 667, col: 18, offset: 19342},
+							pos:  position{line: 668, col: 18, offset: 19293},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 667, col: 21, offset: 19345},
+							pos:        position{line: 668, col: 21, offset: 19296},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 667, col: 25, offset: 19349},
+							pos:  position{line: 668, col: 25, offset: 19300},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 667, col: 28, offset: 19352},
+							pos:   position{line: 668, col: 28, offset: 19303},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 667, col: 33, offset: 19357},
+								pos:  position{line: 668, col: 33, offset: 19308},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 667, col: 38, offset: 19362},
+							pos:  position{line: 668, col: 38, offset: 19313},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 667, col: 41, offset: 19365},
+							pos:        position{line: 668, col: 41, offset: 19316},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5386,72 +5360,72 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 671, col: 1, offset: 19462},
+			pos:  position{line: 672, col: 1, offset: 19413},
 			expr: &choiceExpr{
-				pos: position{line: 672, col: 5, offset: 19475},
+				pos: position{line: 673, col: 5, offset: 19426},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 672, col: 5, offset: 19475},
+						pos:  position{line: 673, col: 5, offset: 19426},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 19484},
+						pos: position{line: 674, col: 5, offset: 19435},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 673, col: 5, offset: 19484},
+							pos: position{line: 674, col: 5, offset: 19435},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 673, col: 5, offset: 19484},
+									pos: position{line: 674, col: 5, offset: 19435},
 									expr: &ruleRefExpr{
-										pos:  position{line: 673, col: 6, offset: 19485},
+										pos:  position{line: 674, col: 6, offset: 19436},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 673, col: 16, offset: 19495},
+									pos:   position{line: 674, col: 16, offset: 19446},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 673, col: 19, offset: 19498},
+										pos:  position{line: 674, col: 19, offset: 19449},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 673, col: 34, offset: 19513},
+									pos:  position{line: 674, col: 34, offset: 19464},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 673, col: 37, offset: 19516},
+									pos:        position{line: 674, col: 37, offset: 19467},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 673, col: 41, offset: 19520},
+									pos:  position{line: 674, col: 41, offset: 19471},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 673, col: 44, offset: 19523},
+									pos:   position{line: 674, col: 44, offset: 19474},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 673, col: 49, offset: 19528},
+										pos:  position{line: 674, col: 49, offset: 19479},
 										name: "OptionalExprs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 673, col: 63, offset: 19542},
+									pos:  position{line: 674, col: 63, offset: 19493},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 673, col: 66, offset: 19545},
+									pos:        position{line: 674, col: 66, offset: 19496},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 673, col: 70, offset: 19549},
+									pos:   position{line: 674, col: 70, offset: 19500},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 673, col: 76, offset: 19555},
+										pos: position{line: 674, col: 76, offset: 19506},
 										expr: &ruleRefExpr{
-											pos:  position{line: 673, col: 76, offset: 19555},
+											pos:  position{line: 674, col: 76, offset: 19506},
 											name: "WhereClause",
 										},
 									},
@@ -5464,48 +5438,48 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 677, col: 1, offset: 19676},
+			pos:  position{line: 678, col: 1, offset: 19627},
 			expr: &choiceExpr{
-				pos: position{line: 678, col: 5, offset: 19685},
+				pos: position{line: 679, col: 5, offset: 19636},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 678, col: 5, offset: 19685},
+						pos: position{line: 679, col: 5, offset: 19636},
 						run: (*parser).callonGrep2,
 						expr: &seqExpr{
-							pos: position{line: 678, col: 5, offset: 19685},
+							pos: position{line: 679, col: 5, offset: 19636},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 678, col: 5, offset: 19685},
+									pos:        position{line: 679, col: 5, offset: 19636},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 678, col: 12, offset: 19692},
+									pos:  position{line: 679, col: 12, offset: 19643},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 678, col: 15, offset: 19695},
+									pos:        position{line: 679, col: 15, offset: 19646},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 678, col: 19, offset: 19699},
+									pos:  position{line: 679, col: 19, offset: 19650},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 678, col: 22, offset: 19702},
+									pos:   position{line: 679, col: 22, offset: 19653},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 678, col: 30, offset: 19710},
+										pos:  position{line: 679, col: 30, offset: 19661},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 678, col: 38, offset: 19718},
+									pos:  position{line: 679, col: 38, offset: 19669},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 678, col: 41, offset: 19721},
+									pos:        position{line: 679, col: 41, offset: 19672},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5513,64 +5487,64 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 19876},
+						pos: position{line: 682, col: 5, offset: 19827},
 						run: (*parser).callonGrep12,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 5, offset: 19876},
+							pos: position{line: 682, col: 5, offset: 19827},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 681, col: 5, offset: 19876},
+									pos:        position{line: 682, col: 5, offset: 19827},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 12, offset: 19883},
+									pos:  position{line: 682, col: 12, offset: 19834},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 681, col: 15, offset: 19886},
+									pos:        position{line: 682, col: 15, offset: 19837},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 19, offset: 19890},
+									pos:  position{line: 682, col: 19, offset: 19841},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 681, col: 22, offset: 19893},
+									pos:   position{line: 682, col: 22, offset: 19844},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 681, col: 30, offset: 19901},
+										pos:  position{line: 682, col: 30, offset: 19852},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 38, offset: 19909},
+									pos:  position{line: 682, col: 38, offset: 19860},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 681, col: 42, offset: 19913},
+									pos:        position{line: 682, col: 42, offset: 19864},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 46, offset: 19917},
+									pos:  position{line: 682, col: 46, offset: 19868},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 681, col: 49, offset: 19920},
+									pos:   position{line: 682, col: 49, offset: 19871},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 681, col: 54, offset: 19925},
+										pos:  position{line: 682, col: 54, offset: 19876},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 59, offset: 19930},
+									pos:  position{line: 682, col: 59, offset: 19881},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 681, col: 62, offset: 19933},
+									pos:        position{line: 682, col: 62, offset: 19884},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5582,26 +5556,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 685, col: 1, offset: 20037},
+			pos:  position{line: 686, col: 1, offset: 19988},
 			expr: &choiceExpr{
-				pos: position{line: 686, col: 5, offset: 20049},
+				pos: position{line: 687, col: 5, offset: 20000},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 686, col: 5, offset: 20049},
+						pos:  position{line: 687, col: 5, offset: 20000},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 687, col: 5, offset: 20060},
+						pos:  position{line: 688, col: 5, offset: 20011},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 20069},
+						pos: position{line: 689, col: 5, offset: 20020},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 688, col: 5, offset: 20069},
+							pos:   position{line: 689, col: 5, offset: 20020},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 688, col: 7, offset: 20071},
+								pos:  position{line: 689, col: 7, offset: 20022},
 								name: "QuotedString",
 							},
 						},
@@ -5611,19 +5585,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 692, col: 1, offset: 20163},
+			pos:  position{line: 693, col: 1, offset: 20114},
 			expr: &choiceExpr{
-				pos: position{line: 693, col: 5, offset: 20181},
+				pos: position{line: 694, col: 5, offset: 20132},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 693, col: 5, offset: 20181},
+						pos:  position{line: 694, col: 5, offset: 20132},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 694, col: 5, offset: 20191},
+						pos: position{line: 695, col: 5, offset: 20142},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 694, col: 5, offset: 20191},
+							pos:  position{line: 695, col: 5, offset: 20142},
 							name: "__",
 						},
 					},
@@ -5632,50 +5606,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 696, col: 1, offset: 20227},
+			pos:  position{line: 697, col: 1, offset: 20178},
 			expr: &actionExpr{
-				pos: position{line: 697, col: 5, offset: 20237},
+				pos: position{line: 698, col: 5, offset: 20188},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 697, col: 5, offset: 20237},
+					pos: position{line: 698, col: 5, offset: 20188},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 697, col: 5, offset: 20237},
+							pos:   position{line: 698, col: 5, offset: 20188},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 697, col: 11, offset: 20243},
+								pos:  position{line: 698, col: 11, offset: 20194},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 697, col: 16, offset: 20248},
+							pos:   position{line: 698, col: 16, offset: 20199},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 697, col: 21, offset: 20253},
+								pos: position{line: 698, col: 21, offset: 20204},
 								expr: &actionExpr{
-									pos: position{line: 697, col: 22, offset: 20254},
+									pos: position{line: 698, col: 22, offset: 20205},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 697, col: 22, offset: 20254},
+										pos: position{line: 698, col: 22, offset: 20205},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 697, col: 22, offset: 20254},
+												pos:  position{line: 698, col: 22, offset: 20205},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 697, col: 25, offset: 20257},
+												pos:        position{line: 698, col: 25, offset: 20208},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 697, col: 29, offset: 20261},
+												pos:  position{line: 698, col: 29, offset: 20212},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 697, col: 32, offset: 20264},
+												pos:   position{line: 698, col: 32, offset: 20215},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 697, col: 34, offset: 20266},
+													pos:  position{line: 698, col: 34, offset: 20217},
 													name: "Expr",
 												},
 											},
@@ -5690,35 +5664,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 701, col: 1, offset: 20375},
+			pos:  position{line: 702, col: 1, offset: 20326},
 			expr: &actionExpr{
-				pos: position{line: 702, col: 5, offset: 20389},
+				pos: position{line: 703, col: 5, offset: 20340},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 702, col: 5, offset: 20389},
+					pos: position{line: 703, col: 5, offset: 20340},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 702, col: 5, offset: 20389},
+							pos: position{line: 703, col: 5, offset: 20340},
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 6, offset: 20390},
+								pos:  position{line: 703, col: 6, offset: 20341},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 702, col: 10, offset: 20394},
+							pos:   position{line: 703, col: 10, offset: 20345},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 16, offset: 20400},
+								pos:  position{line: 703, col: 16, offset: 20351},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 702, col: 27, offset: 20411},
+							pos:   position{line: 703, col: 27, offset: 20362},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 702, col: 32, offset: 20416},
+								pos: position{line: 703, col: 32, offset: 20367},
 								expr: &ruleRefExpr{
-									pos:  position{line: 702, col: 33, offset: 20417},
+									pos:  position{line: 703, col: 33, offset: 20368},
 									name: "Deref",
 								},
 							},
@@ -5729,55 +5703,55 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 706, col: 1, offset: 20485},
+			pos:  position{line: 707, col: 1, offset: 20436},
 			expr: &choiceExpr{
-				pos: position{line: 707, col: 5, offset: 20495},
+				pos: position{line: 708, col: 5, offset: 20446},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 707, col: 5, offset: 20495},
+						pos: position{line: 708, col: 5, offset: 20446},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 707, col: 5, offset: 20495},
+							pos: position{line: 708, col: 5, offset: 20446},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 707, col: 5, offset: 20495},
+									pos:        position{line: 708, col: 5, offset: 20446},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 707, col: 9, offset: 20499},
+									pos:   position{line: 708, col: 9, offset: 20450},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 707, col: 14, offset: 20504},
+										pos:  position{line: 708, col: 14, offset: 20455},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 707, col: 27, offset: 20517},
+									pos:  position{line: 708, col: 27, offset: 20468},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 707, col: 30, offset: 20520},
+									pos:        position{line: 708, col: 30, offset: 20471},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 707, col: 34, offset: 20524},
+									pos:  position{line: 708, col: 34, offset: 20475},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 707, col: 37, offset: 20527},
+									pos:   position{line: 708, col: 37, offset: 20478},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 707, col: 40, offset: 20530},
+										pos: position{line: 708, col: 40, offset: 20481},
 										expr: &ruleRefExpr{
-											pos:  position{line: 707, col: 40, offset: 20530},
+											pos:  position{line: 708, col: 40, offset: 20481},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 707, col: 54, offset: 20544},
+									pos:        position{line: 708, col: 54, offset: 20495},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5785,39 +5759,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 20715},
+						pos: position{line: 714, col: 5, offset: 20666},
 						run: (*parser).callonDeref14,
 						expr: &seqExpr{
-							pos: position{line: 713, col: 5, offset: 20715},
+							pos: position{line: 714, col: 5, offset: 20666},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 713, col: 5, offset: 20715},
+									pos:        position{line: 714, col: 5, offset: 20666},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 713, col: 9, offset: 20719},
+									pos:  position{line: 714, col: 9, offset: 20670},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 713, col: 12, offset: 20722},
+									pos:        position{line: 714, col: 12, offset: 20673},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 713, col: 16, offset: 20726},
+									pos:  position{line: 714, col: 16, offset: 20677},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 713, col: 19, offset: 20729},
+									pos:   position{line: 714, col: 19, offset: 20680},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 713, col: 22, offset: 20732},
+										pos:  position{line: 714, col: 22, offset: 20683},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 713, col: 35, offset: 20745},
+									pos:        position{line: 714, col: 35, offset: 20696},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5825,26 +5799,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 20916},
+						pos: position{line: 720, col: 5, offset: 20867},
 						run: (*parser).callonDeref23,
 						expr: &seqExpr{
-							pos: position{line: 719, col: 5, offset: 20916},
+							pos: position{line: 720, col: 5, offset: 20867},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 719, col: 5, offset: 20916},
+									pos:        position{line: 720, col: 5, offset: 20867},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 719, col: 9, offset: 20920},
+									pos:   position{line: 720, col: 9, offset: 20871},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 719, col: 14, offset: 20925},
+										pos:  position{line: 720, col: 14, offset: 20876},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 719, col: 19, offset: 20930},
+									pos:        position{line: 720, col: 19, offset: 20881},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5852,21 +5826,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 720, col: 5, offset: 20979},
+						pos: position{line: 721, col: 5, offset: 20930},
 						run: (*parser).callonDeref29,
 						expr: &seqExpr{
-							pos: position{line: 720, col: 5, offset: 20979},
+							pos: position{line: 721, col: 5, offset: 20930},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 720, col: 5, offset: 20979},
+									pos:        position{line: 721, col: 5, offset: 20930},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 720, col: 9, offset: 20983},
+									pos:   position{line: 721, col: 9, offset: 20934},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 720, col: 12, offset: 20986},
+										pos:  position{line: 721, col: 12, offset: 20937},
 										name: "Identifier",
 									},
 								},
@@ -5878,59 +5852,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 722, col: 1, offset: 21037},
+			pos:  position{line: 723, col: 1, offset: 20988},
 			expr: &choiceExpr{
-				pos: position{line: 723, col: 5, offset: 21049},
+				pos: position{line: 724, col: 5, offset: 21000},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 723, col: 5, offset: 21049},
+						pos:  position{line: 724, col: 5, offset: 21000},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 724, col: 5, offset: 21060},
+						pos:  position{line: 725, col: 5, offset: 21011},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 725, col: 5, offset: 21070},
+						pos:  position{line: 726, col: 5, offset: 21021},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 726, col: 5, offset: 21078},
+						pos:  position{line: 727, col: 5, offset: 21029},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 727, col: 5, offset: 21086},
+						pos:  position{line: 728, col: 5, offset: 21037},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 728, col: 5, offset: 21098},
+						pos: position{line: 729, col: 5, offset: 21049},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 728, col: 5, offset: 21098},
+							pos: position{line: 729, col: 5, offset: 21049},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 728, col: 5, offset: 21098},
+									pos:        position{line: 729, col: 5, offset: 21049},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 728, col: 9, offset: 21102},
+									pos:  position{line: 729, col: 9, offset: 21053},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 12, offset: 21105},
+									pos:   position{line: 729, col: 12, offset: 21056},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 728, col: 17, offset: 21110},
+										pos:  position{line: 729, col: 17, offset: 21061},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 728, col: 26, offset: 21119},
+									pos:  position{line: 729, col: 26, offset: 21070},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 728, col: 29, offset: 21122},
+									pos:        position{line: 729, col: 29, offset: 21073},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5938,34 +5912,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 729, col: 5, offset: 21152},
+						pos: position{line: 730, col: 5, offset: 21103},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 729, col: 5, offset: 21152},
+							pos: position{line: 730, col: 5, offset: 21103},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 729, col: 5, offset: 21152},
+									pos:        position{line: 730, col: 5, offset: 21103},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 729, col: 9, offset: 21156},
+									pos:  position{line: 730, col: 9, offset: 21107},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 729, col: 12, offset: 21159},
+									pos:   position{line: 730, col: 12, offset: 21110},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 729, col: 17, offset: 21164},
+										pos:  position{line: 730, col: 17, offset: 21115},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 729, col: 22, offset: 21169},
+									pos:  position{line: 730, col: 22, offset: 21120},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 729, col: 25, offset: 21172},
+									pos:        position{line: 730, col: 25, offset: 21123},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5977,85 +5951,59 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 731, col: 1, offset: 21198},
+			pos:  position{line: 732, col: 1, offset: 21149},
 			expr: &actionExpr{
-				pos: position{line: 732, col: 5, offset: 21211},
+				pos: position{line: 733, col: 5, offset: 21162},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 732, col: 5, offset: 21211},
+					pos: position{line: 733, col: 5, offset: 21162},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 732, col: 5, offset: 21211},
+							pos:        position{line: 733, col: 5, offset: 21162},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 732, col: 12, offset: 21218},
+							pos:  position{line: 733, col: 12, offset: 21169},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 732, col: 14, offset: 21220},
+							pos:   position{line: 733, col: 14, offset: 21171},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 732, col: 20, offset: 21226},
+								pos:  position{line: 733, col: 20, offset: 21177},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 732, col: 26, offset: 21232},
+							pos:   position{line: 733, col: 26, offset: 21183},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 732, col: 33, offset: 21239},
-								expr: &actionExpr{
-									pos: position{line: 732, col: 34, offset: 21240},
-									run: (*parser).callonOverExpr9,
-									expr: &seqExpr{
-										pos: position{line: 732, col: 34, offset: 21240},
-										exprs: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 732, col: 34, offset: 21240},
-												name: "_",
-											},
-											&litMatcher{
-												pos:        position{line: 732, col: 36, offset: 21242},
-												val:        "with",
-												ignoreCase: false,
-											},
-											&ruleRefExpr{
-												pos:  position{line: 732, col: 43, offset: 21249},
-												name: "_",
-											},
-											&labeledExpr{
-												pos:   position{line: 732, col: 45, offset: 21251},
-												label: "l",
-												expr: &ruleRefExpr{
-													pos:  position{line: 732, col: 47, offset: 21253},
-													name: "LetAssignments",
-												},
-											},
-										},
-									},
+								pos: position{line: 733, col: 33, offset: 21190},
+								expr: &ruleRefExpr{
+									pos:  position{line: 733, col: 33, offset: 21190},
+									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 732, col: 82, offset: 21288},
+							pos:  position{line: 733, col: 41, offset: 21198},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 732, col: 85, offset: 21291},
+							pos:        position{line: 733, col: 44, offset: 21201},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 732, col: 89, offset: 21295},
+							pos:  position{line: 733, col: 48, offset: 21205},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 732, col: 92, offset: 21298},
+							pos:   position{line: 733, col: 51, offset: 21208},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 732, col: 98, offset: 21304},
+								pos:  position{line: 733, col: 57, offset: 21214},
 								name: "Sequential",
 							},
 						},
@@ -6065,36 +6013,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 736, col: 1, offset: 21435},
+			pos:  position{line: 737, col: 1, offset: 21345},
 			expr: &actionExpr{
-				pos: position{line: 737, col: 5, offset: 21446},
+				pos: position{line: 738, col: 5, offset: 21356},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 737, col: 5, offset: 21446},
+					pos: position{line: 738, col: 5, offset: 21356},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 737, col: 5, offset: 21446},
+							pos:        position{line: 738, col: 5, offset: 21356},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 737, col: 9, offset: 21450},
+							pos:  position{line: 738, col: 9, offset: 21360},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 737, col: 12, offset: 21453},
+							pos:   position{line: 738, col: 12, offset: 21363},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 737, col: 18, offset: 21459},
+								pos:  position{line: 738, col: 18, offset: 21369},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 737, col: 30, offset: 21471},
+							pos:  position{line: 738, col: 30, offset: 21381},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 737, col: 33, offset: 21474},
+							pos:        position{line: 738, col: 33, offset: 21384},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6104,31 +6052,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 741, col: 1, offset: 21564},
+			pos:  position{line: 742, col: 1, offset: 21474},
 			expr: &choiceExpr{
-				pos: position{line: 742, col: 5, offset: 21580},
+				pos: position{line: 743, col: 5, offset: 21490},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 742, col: 5, offset: 21580},
+						pos: position{line: 743, col: 5, offset: 21490},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 742, col: 5, offset: 21580},
+							pos: position{line: 743, col: 5, offset: 21490},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 742, col: 5, offset: 21580},
+									pos:   position{line: 743, col: 5, offset: 21490},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 11, offset: 21586},
+										pos:  position{line: 743, col: 11, offset: 21496},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 742, col: 22, offset: 21597},
+									pos:   position{line: 743, col: 22, offset: 21507},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 742, col: 27, offset: 21602},
+										pos: position{line: 743, col: 27, offset: 21512},
 										expr: &ruleRefExpr{
-											pos:  position{line: 742, col: 27, offset: 21602},
+											pos:  position{line: 743, col: 27, offset: 21512},
 											name: "RecordElemTail",
 										},
 									},
@@ -6137,10 +6085,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 745, col: 5, offset: 21701},
+						pos: position{line: 746, col: 5, offset: 21611},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 745, col: 5, offset: 21701},
+							pos:  position{line: 746, col: 5, offset: 21611},
 							name: "__",
 						},
 					},
@@ -6149,31 +6097,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 747, col: 1, offset: 21737},
+			pos:  position{line: 748, col: 1, offset: 21647},
 			expr: &actionExpr{
-				pos: position{line: 747, col: 18, offset: 21754},
+				pos: position{line: 748, col: 18, offset: 21664},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 747, col: 18, offset: 21754},
+					pos: position{line: 748, col: 18, offset: 21664},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 747, col: 18, offset: 21754},
+							pos:  position{line: 748, col: 18, offset: 21664},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 747, col: 21, offset: 21757},
+							pos:        position{line: 748, col: 21, offset: 21667},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 747, col: 25, offset: 21761},
+							pos:  position{line: 748, col: 25, offset: 21671},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 747, col: 28, offset: 21764},
+							pos:   position{line: 748, col: 28, offset: 21674},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 747, col: 33, offset: 21769},
+								pos:  position{line: 748, col: 33, offset: 21679},
 								name: "RecordElem",
 							},
 						},
@@ -6183,20 +6131,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 749, col: 1, offset: 21802},
+			pos:  position{line: 750, col: 1, offset: 21712},
 			expr: &choiceExpr{
-				pos: position{line: 750, col: 5, offset: 21817},
+				pos: position{line: 751, col: 5, offset: 21727},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 750, col: 5, offset: 21817},
+						pos:  position{line: 751, col: 5, offset: 21727},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 751, col: 5, offset: 21828},
+						pos:  position{line: 752, col: 5, offset: 21738},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 752, col: 5, offset: 21838},
+						pos:  position{line: 753, col: 5, offset: 21748},
 						name: "Identifier",
 					},
 				},
@@ -6204,27 +6152,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 754, col: 1, offset: 21850},
+			pos:  position{line: 755, col: 1, offset: 21760},
 			expr: &actionExpr{
-				pos: position{line: 755, col: 5, offset: 21861},
+				pos: position{line: 756, col: 5, offset: 21771},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 755, col: 5, offset: 21861},
+					pos: position{line: 756, col: 5, offset: 21771},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 755, col: 5, offset: 21861},
+							pos:        position{line: 756, col: 5, offset: 21771},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 755, col: 11, offset: 21867},
+							pos:  position{line: 756, col: 11, offset: 21777},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 755, col: 14, offset: 21870},
+							pos:   position{line: 756, col: 14, offset: 21780},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 755, col: 19, offset: 21875},
+								pos:  position{line: 756, col: 19, offset: 21785},
 								name: "Expr",
 							},
 						},
@@ -6234,39 +6182,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 759, col: 1, offset: 21961},
+			pos:  position{line: 760, col: 1, offset: 21871},
 			expr: &actionExpr{
-				pos: position{line: 760, col: 5, offset: 21971},
+				pos: position{line: 761, col: 5, offset: 21881},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 760, col: 5, offset: 21971},
+					pos: position{line: 761, col: 5, offset: 21881},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 760, col: 5, offset: 21971},
+							pos:   position{line: 761, col: 5, offset: 21881},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 760, col: 10, offset: 21976},
+								pos:  position{line: 761, col: 10, offset: 21886},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 760, col: 20, offset: 21986},
+							pos:  position{line: 761, col: 20, offset: 21896},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 760, col: 23, offset: 21989},
+							pos:        position{line: 761, col: 23, offset: 21899},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 760, col: 27, offset: 21993},
+							pos:  position{line: 761, col: 27, offset: 21903},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 760, col: 30, offset: 21996},
+							pos:   position{line: 761, col: 30, offset: 21906},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 760, col: 36, offset: 22002},
+								pos:  position{line: 761, col: 36, offset: 21912},
 								name: "Expr",
 							},
 						},
@@ -6276,36 +6224,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 764, col: 1, offset: 22102},
+			pos:  position{line: 765, col: 1, offset: 22012},
 			expr: &actionExpr{
-				pos: position{line: 765, col: 5, offset: 22112},
+				pos: position{line: 766, col: 5, offset: 22022},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 765, col: 5, offset: 22112},
+					pos: position{line: 766, col: 5, offset: 22022},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 765, col: 5, offset: 22112},
+							pos:        position{line: 766, col: 5, offset: 22022},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 765, col: 9, offset: 22116},
+							pos:  position{line: 766, col: 9, offset: 22026},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 12, offset: 22119},
+							pos:   position{line: 766, col: 12, offset: 22029},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 765, col: 18, offset: 22125},
+								pos:  position{line: 766, col: 18, offset: 22035},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 765, col: 32, offset: 22139},
+							pos:  position{line: 766, col: 32, offset: 22049},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 765, col: 35, offset: 22142},
+							pos:        position{line: 766, col: 35, offset: 22052},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6315,36 +6263,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 769, col: 1, offset: 22232},
+			pos:  position{line: 770, col: 1, offset: 22142},
 			expr: &actionExpr{
-				pos: position{line: 770, col: 5, offset: 22240},
+				pos: position{line: 771, col: 5, offset: 22150},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 770, col: 5, offset: 22240},
+					pos: position{line: 771, col: 5, offset: 22150},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 770, col: 5, offset: 22240},
+							pos:        position{line: 771, col: 5, offset: 22150},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 770, col: 10, offset: 22245},
+							pos:  position{line: 771, col: 10, offset: 22155},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 770, col: 13, offset: 22248},
+							pos:   position{line: 771, col: 13, offset: 22158},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 770, col: 19, offset: 22254},
+								pos:  position{line: 771, col: 19, offset: 22164},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 770, col: 33, offset: 22268},
+							pos:  position{line: 771, col: 33, offset: 22178},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 770, col: 36, offset: 22271},
+							pos:        position{line: 771, col: 36, offset: 22181},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6354,36 +6302,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 774, col: 1, offset: 22360},
+			pos:  position{line: 775, col: 1, offset: 22270},
 			expr: &actionExpr{
-				pos: position{line: 775, col: 5, offset: 22368},
+				pos: position{line: 776, col: 5, offset: 22278},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 775, col: 5, offset: 22368},
+					pos: position{line: 776, col: 5, offset: 22278},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 775, col: 5, offset: 22368},
+							pos:        position{line: 776, col: 5, offset: 22278},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 775, col: 10, offset: 22373},
+							pos:  position{line: 776, col: 10, offset: 22283},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 775, col: 13, offset: 22376},
+							pos:   position{line: 776, col: 13, offset: 22286},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 775, col: 19, offset: 22382},
+								pos:  position{line: 776, col: 19, offset: 22292},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 775, col: 27, offset: 22390},
+							pos:  position{line: 776, col: 27, offset: 22300},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 775, col: 30, offset: 22393},
+							pos:        position{line: 776, col: 30, offset: 22303},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6393,31 +6341,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 779, col: 1, offset: 22484},
+			pos:  position{line: 780, col: 1, offset: 22394},
 			expr: &choiceExpr{
-				pos: position{line: 780, col: 5, offset: 22496},
+				pos: position{line: 781, col: 5, offset: 22406},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 780, col: 5, offset: 22496},
+						pos: position{line: 781, col: 5, offset: 22406},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 780, col: 5, offset: 22496},
+							pos: position{line: 781, col: 5, offset: 22406},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 780, col: 5, offset: 22496},
+									pos:   position{line: 781, col: 5, offset: 22406},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 780, col: 11, offset: 22502},
+										pos:  position{line: 781, col: 11, offset: 22412},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 780, col: 17, offset: 22508},
+									pos:   position{line: 781, col: 17, offset: 22418},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 780, col: 22, offset: 22513},
+										pos: position{line: 781, col: 22, offset: 22423},
 										expr: &ruleRefExpr{
-											pos:  position{line: 780, col: 22, offset: 22513},
+											pos:  position{line: 781, col: 22, offset: 22423},
 											name: "EntryTail",
 										},
 									},
@@ -6426,10 +6374,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 783, col: 5, offset: 22607},
+						pos: position{line: 784, col: 5, offset: 22517},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 783, col: 5, offset: 22607},
+							pos:  position{line: 784, col: 5, offset: 22517},
 							name: "__",
 						},
 					},
@@ -6438,31 +6386,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 786, col: 1, offset: 22644},
+			pos:  position{line: 787, col: 1, offset: 22554},
 			expr: &actionExpr{
-				pos: position{line: 786, col: 13, offset: 22656},
+				pos: position{line: 787, col: 13, offset: 22566},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 786, col: 13, offset: 22656},
+					pos: position{line: 787, col: 13, offset: 22566},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 786, col: 13, offset: 22656},
+							pos:  position{line: 787, col: 13, offset: 22566},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 786, col: 16, offset: 22659},
+							pos:        position{line: 787, col: 16, offset: 22569},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 786, col: 20, offset: 22663},
+							pos:  position{line: 787, col: 20, offset: 22573},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 786, col: 23, offset: 22666},
+							pos:   position{line: 787, col: 23, offset: 22576},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 786, col: 25, offset: 22668},
+								pos:  position{line: 787, col: 25, offset: 22578},
 								name: "Entry",
 							},
 						},
@@ -6472,39 +6420,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 788, col: 1, offset: 22693},
+			pos:  position{line: 789, col: 1, offset: 22603},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 5, offset: 22703},
+				pos: position{line: 790, col: 5, offset: 22613},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 5, offset: 22703},
+					pos: position{line: 790, col: 5, offset: 22613},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 789, col: 5, offset: 22703},
+							pos:   position{line: 790, col: 5, offset: 22613},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 9, offset: 22707},
+								pos:  position{line: 790, col: 9, offset: 22617},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 14, offset: 22712},
+							pos:  position{line: 790, col: 14, offset: 22622},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 789, col: 17, offset: 22715},
+							pos:        position{line: 790, col: 17, offset: 22625},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 21, offset: 22719},
+							pos:  position{line: 790, col: 21, offset: 22629},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 24, offset: 22722},
+							pos:   position{line: 790, col: 24, offset: 22632},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 30, offset: 22728},
+								pos:  position{line: 790, col: 30, offset: 22638},
 								name: "Expr",
 							},
 						},
@@ -6514,92 +6462,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 795, col: 1, offset: 22835},
+			pos:  position{line: 796, col: 1, offset: 22745},
 			expr: &actionExpr{
-				pos: position{line: 796, col: 5, offset: 22845},
+				pos: position{line: 797, col: 5, offset: 22755},
 				run: (*parser).callonSQLOp1,
 				expr: &seqExpr{
-					pos: position{line: 796, col: 5, offset: 22845},
+					pos: position{line: 797, col: 5, offset: 22755},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 796, col: 5, offset: 22845},
+							pos:   position{line: 797, col: 5, offset: 22755},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 796, col: 15, offset: 22855},
+								pos:  position{line: 797, col: 15, offset: 22765},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 797, col: 5, offset: 22869},
+							pos:   position{line: 798, col: 5, offset: 22779},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 797, col: 10, offset: 22874},
+								pos: position{line: 798, col: 10, offset: 22784},
 								expr: &ruleRefExpr{
-									pos:  position{line: 797, col: 10, offset: 22874},
+									pos:  position{line: 798, col: 10, offset: 22784},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 5, offset: 22887},
+							pos:   position{line: 799, col: 5, offset: 22797},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 798, col: 11, offset: 22893},
+								pos: position{line: 799, col: 11, offset: 22803},
 								expr: &ruleRefExpr{
-									pos:  position{line: 798, col: 11, offset: 22893},
+									pos:  position{line: 799, col: 11, offset: 22803},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 799, col: 5, offset: 22907},
+							pos:   position{line: 800, col: 5, offset: 22817},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 799, col: 11, offset: 22913},
+								pos: position{line: 800, col: 11, offset: 22823},
 								expr: &ruleRefExpr{
-									pos:  position{line: 799, col: 11, offset: 22913},
+									pos:  position{line: 800, col: 11, offset: 22823},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 800, col: 5, offset: 22927},
+							pos:   position{line: 801, col: 5, offset: 22837},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 800, col: 13, offset: 22935},
+								pos: position{line: 801, col: 13, offset: 22845},
 								expr: &ruleRefExpr{
-									pos:  position{line: 800, col: 13, offset: 22935},
+									pos:  position{line: 801, col: 13, offset: 22845},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 5, offset: 22951},
+							pos:   position{line: 802, col: 5, offset: 22861},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 801, col: 12, offset: 22958},
+								pos: position{line: 802, col: 12, offset: 22868},
 								expr: &ruleRefExpr{
-									pos:  position{line: 801, col: 12, offset: 22958},
+									pos:  position{line: 802, col: 12, offset: 22868},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 802, col: 5, offset: 22973},
+							pos:   position{line: 803, col: 5, offset: 22883},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 802, col: 13, offset: 22981},
+								pos: position{line: 803, col: 13, offset: 22891},
 								expr: &ruleRefExpr{
-									pos:  position{line: 802, col: 13, offset: 22981},
+									pos:  position{line: 803, col: 13, offset: 22891},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 5, offset: 22997},
+							pos:   position{line: 804, col: 5, offset: 22907},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 11, offset: 23003},
+								pos:  position{line: 804, col: 11, offset: 22913},
 								name: "SQLLimit",
 							},
 						},
@@ -6609,26 +6557,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 827, col: 1, offset: 23370},
+			pos:  position{line: 828, col: 1, offset: 23280},
 			expr: &choiceExpr{
-				pos: position{line: 828, col: 5, offset: 23384},
+				pos: position{line: 829, col: 5, offset: 23294},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 828, col: 5, offset: 23384},
+						pos: position{line: 829, col: 5, offset: 23294},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 828, col: 5, offset: 23384},
+							pos: position{line: 829, col: 5, offset: 23294},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 828, col: 5, offset: 23384},
+									pos:  position{line: 829, col: 5, offset: 23294},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 828, col: 12, offset: 23391},
+									pos:  position{line: 829, col: 12, offset: 23301},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 828, col: 14, offset: 23393},
+									pos:        position{line: 829, col: 14, offset: 23303},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6636,24 +6584,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 829, col: 5, offset: 23421},
+						pos: position{line: 830, col: 5, offset: 23331},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 829, col: 5, offset: 23421},
+							pos: position{line: 830, col: 5, offset: 23331},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 829, col: 5, offset: 23421},
+									pos:  position{line: 830, col: 5, offset: 23331},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 829, col: 12, offset: 23428},
+									pos:  position{line: 830, col: 12, offset: 23338},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 829, col: 14, offset: 23430},
+									pos:   position{line: 830, col: 14, offset: 23340},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 829, col: 26, offset: 23442},
+										pos:  position{line: 830, col: 26, offset: 23352},
 										name: "SQLAssignments",
 									},
 								},
@@ -6665,41 +6613,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 831, col: 1, offset: 23486},
+			pos:  position{line: 832, col: 1, offset: 23396},
 			expr: &choiceExpr{
-				pos: position{line: 832, col: 5, offset: 23504},
+				pos: position{line: 833, col: 5, offset: 23414},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 832, col: 5, offset: 23504},
+						pos: position{line: 833, col: 5, offset: 23414},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 832, col: 5, offset: 23504},
+							pos: position{line: 833, col: 5, offset: 23414},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 832, col: 5, offset: 23504},
+									pos:   position{line: 833, col: 5, offset: 23414},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 832, col: 9, offset: 23508},
+										pos:  position{line: 833, col: 9, offset: 23418},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 832, col: 14, offset: 23513},
+									pos:  position{line: 833, col: 14, offset: 23423},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 832, col: 16, offset: 23515},
+									pos:  position{line: 833, col: 16, offset: 23425},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 832, col: 19, offset: 23518},
+									pos:  position{line: 833, col: 19, offset: 23428},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 832, col: 21, offset: 23520},
+									pos:   position{line: 833, col: 21, offset: 23430},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 832, col: 25, offset: 23524},
+										pos:  position{line: 833, col: 25, offset: 23434},
 										name: "Lval",
 									},
 								},
@@ -6707,13 +6655,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 833, col: 5, offset: 23618},
+						pos: position{line: 834, col: 5, offset: 23528},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 833, col: 5, offset: 23618},
+							pos:   position{line: 834, col: 5, offset: 23528},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 833, col: 10, offset: 23623},
+								pos:  position{line: 834, col: 10, offset: 23533},
 								name: "Expr",
 							},
 						},
@@ -6723,50 +6671,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 835, col: 1, offset: 23715},
+			pos:  position{line: 836, col: 1, offset: 23625},
 			expr: &actionExpr{
-				pos: position{line: 836, col: 5, offset: 23734},
+				pos: position{line: 837, col: 5, offset: 23644},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 836, col: 5, offset: 23734},
+					pos: position{line: 837, col: 5, offset: 23644},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 836, col: 5, offset: 23734},
+							pos:   position{line: 837, col: 5, offset: 23644},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 836, col: 11, offset: 23740},
+								pos:  position{line: 837, col: 11, offset: 23650},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 836, col: 25, offset: 23754},
+							pos:   position{line: 837, col: 25, offset: 23664},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 836, col: 30, offset: 23759},
+								pos: position{line: 837, col: 30, offset: 23669},
 								expr: &actionExpr{
-									pos: position{line: 836, col: 31, offset: 23760},
+									pos: position{line: 837, col: 31, offset: 23670},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 836, col: 31, offset: 23760},
+										pos: position{line: 837, col: 31, offset: 23670},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 836, col: 31, offset: 23760},
+												pos:  position{line: 837, col: 31, offset: 23670},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 836, col: 34, offset: 23763},
+												pos:        position{line: 837, col: 34, offset: 23673},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 836, col: 38, offset: 23767},
+												pos:  position{line: 837, col: 38, offset: 23677},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 836, col: 41, offset: 23770},
+												pos:   position{line: 837, col: 41, offset: 23680},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 836, col: 46, offset: 23775},
+													pos:  position{line: 837, col: 46, offset: 23685},
 													name: "SQLAssignment",
 												},
 											},
@@ -6781,43 +6729,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 840, col: 1, offset: 23896},
+			pos:  position{line: 841, col: 1, offset: 23806},
 			expr: &choiceExpr{
-				pos: position{line: 841, col: 5, offset: 23908},
+				pos: position{line: 842, col: 5, offset: 23818},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 841, col: 5, offset: 23908},
+						pos: position{line: 842, col: 5, offset: 23818},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 841, col: 5, offset: 23908},
+							pos: position{line: 842, col: 5, offset: 23818},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 841, col: 5, offset: 23908},
+									pos:  position{line: 842, col: 5, offset: 23818},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 841, col: 7, offset: 23910},
+									pos:  position{line: 842, col: 7, offset: 23820},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 841, col: 12, offset: 23915},
+									pos:  position{line: 842, col: 12, offset: 23825},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 841, col: 14, offset: 23917},
+									pos:   position{line: 842, col: 14, offset: 23827},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 841, col: 20, offset: 23923},
+										pos:  position{line: 842, col: 20, offset: 23833},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 841, col: 29, offset: 23932},
+									pos:   position{line: 842, col: 29, offset: 23842},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 841, col: 35, offset: 23938},
+										pos: position{line: 842, col: 35, offset: 23848},
 										expr: &ruleRefExpr{
-											pos:  position{line: 841, col: 35, offset: 23938},
+											pos:  position{line: 842, col: 35, offset: 23848},
 											name: "SQLAlias",
 										},
 									},
@@ -6826,25 +6774,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 844, col: 5, offset: 24033},
+						pos: position{line: 845, col: 5, offset: 23943},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 844, col: 5, offset: 24033},
+							pos: position{line: 845, col: 5, offset: 23943},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 844, col: 5, offset: 24033},
+									pos:  position{line: 845, col: 5, offset: 23943},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 844, col: 7, offset: 24035},
+									pos:  position{line: 845, col: 7, offset: 23945},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 844, col: 12, offset: 24040},
+									pos:  position{line: 845, col: 12, offset: 23950},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 844, col: 14, offset: 24042},
+									pos:        position{line: 845, col: 14, offset: 23952},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6856,33 +6804,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 846, col: 1, offset: 24067},
+			pos:  position{line: 847, col: 1, offset: 23977},
 			expr: &choiceExpr{
-				pos: position{line: 847, col: 5, offset: 24080},
+				pos: position{line: 848, col: 5, offset: 23990},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 847, col: 5, offset: 24080},
+						pos: position{line: 848, col: 5, offset: 23990},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 847, col: 5, offset: 24080},
+							pos: position{line: 848, col: 5, offset: 23990},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 5, offset: 24080},
+									pos:  position{line: 848, col: 5, offset: 23990},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 7, offset: 24082},
+									pos:  position{line: 848, col: 7, offset: 23992},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 10, offset: 24085},
+									pos:  position{line: 848, col: 10, offset: 23995},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 847, col: 12, offset: 24087},
+									pos:   position{line: 848, col: 12, offset: 23997},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 847, col: 15, offset: 24090},
+										pos:  position{line: 848, col: 15, offset: 24000},
 										name: "Lval",
 									},
 								},
@@ -6890,36 +6838,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 848, col: 5, offset: 24118},
+						pos: position{line: 849, col: 5, offset: 24028},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 848, col: 5, offset: 24118},
+							pos: position{line: 849, col: 5, offset: 24028},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 5, offset: 24118},
+									pos:  position{line: 849, col: 5, offset: 24028},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 848, col: 7, offset: 24120},
+									pos: position{line: 849, col: 7, offset: 24030},
 									expr: &seqExpr{
-										pos: position{line: 848, col: 9, offset: 24122},
+										pos: position{line: 849, col: 9, offset: 24032},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 848, col: 9, offset: 24122},
+												pos:  position{line: 849, col: 9, offset: 24032},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 848, col: 27, offset: 24140},
+												pos:  position{line: 849, col: 27, offset: 24050},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 848, col: 30, offset: 24143},
+									pos:   position{line: 849, col: 30, offset: 24053},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 848, col: 33, offset: 24146},
+										pos:  position{line: 849, col: 33, offset: 24056},
 										name: "Lval",
 									},
 								},
@@ -6931,42 +6879,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 850, col: 1, offset: 24171},
+			pos:  position{line: 851, col: 1, offset: 24081},
 			expr: &ruleRefExpr{
-				pos:  position{line: 851, col: 5, offset: 24184},
+				pos:  position{line: 852, col: 5, offset: 24094},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 853, col: 1, offset: 24190},
+			pos:  position{line: 854, col: 1, offset: 24100},
 			expr: &actionExpr{
-				pos: position{line: 854, col: 5, offset: 24203},
+				pos: position{line: 855, col: 5, offset: 24113},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 854, col: 5, offset: 24203},
+					pos: position{line: 855, col: 5, offset: 24113},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 854, col: 5, offset: 24203},
+							pos:   position{line: 855, col: 5, offset: 24113},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 854, col: 11, offset: 24209},
+								pos:  position{line: 855, col: 11, offset: 24119},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 854, col: 19, offset: 24217},
+							pos:   position{line: 855, col: 19, offset: 24127},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 854, col: 24, offset: 24222},
+								pos: position{line: 855, col: 24, offset: 24132},
 								expr: &actionExpr{
-									pos: position{line: 854, col: 25, offset: 24223},
+									pos: position{line: 855, col: 25, offset: 24133},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 854, col: 25, offset: 24223},
+										pos:   position{line: 855, col: 25, offset: 24133},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 854, col: 30, offset: 24228},
+											pos:  position{line: 855, col: 30, offset: 24138},
 											name: "SQLJoin",
 										},
 									},
@@ -6979,90 +6927,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 858, col: 1, offset: 24343},
+			pos:  position{line: 859, col: 1, offset: 24253},
 			expr: &actionExpr{
-				pos: position{line: 859, col: 5, offset: 24355},
+				pos: position{line: 860, col: 5, offset: 24265},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 859, col: 5, offset: 24355},
+					pos: position{line: 860, col: 5, offset: 24265},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 859, col: 5, offset: 24355},
+							pos:   position{line: 860, col: 5, offset: 24265},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 859, col: 11, offset: 24361},
+								pos:  position{line: 860, col: 11, offset: 24271},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 24, offset: 24374},
+							pos:  position{line: 860, col: 24, offset: 24284},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 26, offset: 24376},
+							pos:  position{line: 860, col: 26, offset: 24286},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 31, offset: 24381},
+							pos:  position{line: 860, col: 31, offset: 24291},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 859, col: 33, offset: 24383},
+							pos:   position{line: 860, col: 33, offset: 24293},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 859, col: 39, offset: 24389},
+								pos:  position{line: 860, col: 39, offset: 24299},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 859, col: 48, offset: 24398},
+							pos:   position{line: 860, col: 48, offset: 24308},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 859, col: 54, offset: 24404},
+								pos: position{line: 860, col: 54, offset: 24314},
 								expr: &ruleRefExpr{
-									pos:  position{line: 859, col: 54, offset: 24404},
+									pos:  position{line: 860, col: 54, offset: 24314},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 64, offset: 24414},
+							pos:  position{line: 860, col: 64, offset: 24324},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 66, offset: 24416},
+							pos:  position{line: 860, col: 66, offset: 24326},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 69, offset: 24419},
+							pos:  position{line: 860, col: 69, offset: 24329},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 859, col: 71, offset: 24421},
+							pos:   position{line: 860, col: 71, offset: 24331},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 859, col: 79, offset: 24429},
+								pos:  position{line: 860, col: 79, offset: 24339},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 87, offset: 24437},
+							pos:  position{line: 860, col: 87, offset: 24347},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 859, col: 90, offset: 24440},
+							pos:        position{line: 860, col: 90, offset: 24350},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 859, col: 94, offset: 24444},
+							pos:  position{line: 860, col: 94, offset: 24354},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 859, col: 97, offset: 24447},
+							pos:   position{line: 860, col: 97, offset: 24357},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 859, col: 106, offset: 24456},
+								pos:  position{line: 860, col: 106, offset: 24366},
 								name: "JoinKey",
 							},
 						},
@@ -7072,40 +7020,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 874, col: 1, offset: 24687},
+			pos:  position{line: 875, col: 1, offset: 24597},
 			expr: &choiceExpr{
-				pos: position{line: 875, col: 5, offset: 24704},
+				pos: position{line: 876, col: 5, offset: 24614},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 875, col: 5, offset: 24704},
+						pos: position{line: 876, col: 5, offset: 24614},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 875, col: 5, offset: 24704},
+							pos: position{line: 876, col: 5, offset: 24614},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 875, col: 5, offset: 24704},
+									pos:  position{line: 876, col: 5, offset: 24614},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 875, col: 7, offset: 24706},
+									pos:   position{line: 876, col: 7, offset: 24616},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 875, col: 14, offset: 24713},
+										pos: position{line: 876, col: 14, offset: 24623},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 875, col: 14, offset: 24713},
+												pos:  position{line: 876, col: 14, offset: 24623},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 875, col: 21, offset: 24720},
+												pos:  position{line: 876, col: 21, offset: 24630},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 875, col: 29, offset: 24728},
+												pos:  position{line: 876, col: 29, offset: 24638},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 875, col: 36, offset: 24735},
+												pos:  position{line: 876, col: 36, offset: 24645},
 												name: "RIGHT",
 											},
 										},
@@ -7115,10 +7063,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 876, col: 5, offset: 24768},
+						pos: position{line: 877, col: 5, offset: 24678},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 876, col: 5, offset: 24768},
+							pos:        position{line: 877, col: 5, offset: 24678},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7128,30 +7076,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 878, col: 1, offset: 24796},
+			pos:  position{line: 879, col: 1, offset: 24706},
 			expr: &actionExpr{
-				pos: position{line: 879, col: 5, offset: 24809},
+				pos: position{line: 880, col: 5, offset: 24719},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 879, col: 5, offset: 24809},
+					pos: position{line: 880, col: 5, offset: 24719},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 5, offset: 24809},
+							pos:  position{line: 880, col: 5, offset: 24719},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 7, offset: 24811},
+							pos:  position{line: 880, col: 7, offset: 24721},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 13, offset: 24817},
+							pos:  position{line: 880, col: 13, offset: 24727},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 15, offset: 24819},
+							pos:   position{line: 880, col: 15, offset: 24729},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 20, offset: 24824},
+								pos:  position{line: 880, col: 20, offset: 24734},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7161,38 +7109,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 881, col: 1, offset: 24860},
+			pos:  position{line: 882, col: 1, offset: 24770},
 			expr: &actionExpr{
-				pos: position{line: 882, col: 5, offset: 24875},
+				pos: position{line: 883, col: 5, offset: 24785},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 882, col: 5, offset: 24875},
+					pos: position{line: 883, col: 5, offset: 24785},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 882, col: 5, offset: 24875},
+							pos:  position{line: 883, col: 5, offset: 24785},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 882, col: 7, offset: 24877},
+							pos:  position{line: 883, col: 7, offset: 24787},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 882, col: 13, offset: 24883},
+							pos:  position{line: 883, col: 13, offset: 24793},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 882, col: 15, offset: 24885},
+							pos:  position{line: 883, col: 15, offset: 24795},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 882, col: 18, offset: 24888},
+							pos:  position{line: 883, col: 18, offset: 24798},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 882, col: 20, offset: 24890},
+							pos:   position{line: 883, col: 20, offset: 24800},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 882, col: 28, offset: 24898},
+								pos:  position{line: 883, col: 28, offset: 24808},
 								name: "FieldExprs",
 							},
 						},
@@ -7202,30 +7150,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 884, col: 1, offset: 24934},
+			pos:  position{line: 885, col: 1, offset: 24844},
 			expr: &actionExpr{
-				pos: position{line: 885, col: 5, offset: 24948},
+				pos: position{line: 886, col: 5, offset: 24858},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 885, col: 5, offset: 24948},
+					pos: position{line: 886, col: 5, offset: 24858},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 885, col: 5, offset: 24948},
+							pos:  position{line: 886, col: 5, offset: 24858},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 885, col: 7, offset: 24950},
+							pos:  position{line: 886, col: 7, offset: 24860},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 885, col: 14, offset: 24957},
+							pos:  position{line: 886, col: 14, offset: 24867},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 885, col: 16, offset: 24959},
+							pos:   position{line: 886, col: 16, offset: 24869},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 885, col: 21, offset: 24964},
+								pos:  position{line: 886, col: 21, offset: 24874},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7235,46 +7183,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 887, col: 1, offset: 25000},
+			pos:  position{line: 888, col: 1, offset: 24910},
 			expr: &actionExpr{
-				pos: position{line: 888, col: 5, offset: 25015},
+				pos: position{line: 889, col: 5, offset: 24925},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 888, col: 5, offset: 25015},
+					pos: position{line: 889, col: 5, offset: 24925},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 5, offset: 25015},
+							pos:  position{line: 889, col: 5, offset: 24925},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 7, offset: 25017},
+							pos:  position{line: 889, col: 7, offset: 24927},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 13, offset: 25023},
+							pos:  position{line: 889, col: 13, offset: 24933},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 15, offset: 25025},
+							pos:  position{line: 889, col: 15, offset: 24935},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 888, col: 18, offset: 25028},
+							pos:  position{line: 889, col: 18, offset: 24938},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 888, col: 20, offset: 25030},
+							pos:   position{line: 889, col: 20, offset: 24940},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 888, col: 25, offset: 25035},
+								pos:  position{line: 889, col: 25, offset: 24945},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 888, col: 31, offset: 25041},
+							pos:   position{line: 889, col: 31, offset: 24951},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 888, col: 37, offset: 25047},
+								pos:  position{line: 889, col: 37, offset: 24957},
 								name: "SQLOrder",
 							},
 						},
@@ -7284,32 +7232,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 892, col: 1, offset: 25157},
+			pos:  position{line: 893, col: 1, offset: 25067},
 			expr: &choiceExpr{
-				pos: position{line: 893, col: 5, offset: 25170},
+				pos: position{line: 894, col: 5, offset: 25080},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 893, col: 5, offset: 25170},
+						pos: position{line: 894, col: 5, offset: 25080},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 893, col: 5, offset: 25170},
+							pos: position{line: 894, col: 5, offset: 25080},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 893, col: 5, offset: 25170},
+									pos:  position{line: 894, col: 5, offset: 25080},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 893, col: 7, offset: 25172},
+									pos:   position{line: 894, col: 7, offset: 25082},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 893, col: 12, offset: 25177},
+										pos: position{line: 894, col: 12, offset: 25087},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 12, offset: 25177},
+												pos:  position{line: 894, col: 12, offset: 25087},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 18, offset: 25183},
+												pos:  position{line: 894, col: 18, offset: 25093},
 												name: "DESC",
 											},
 										},
@@ -7319,10 +7267,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 894, col: 5, offset: 25213},
+						pos: position{line: 895, col: 5, offset: 25123},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 894, col: 5, offset: 25213},
+							pos:        position{line: 895, col: 5, offset: 25123},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7332,33 +7280,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 896, col: 1, offset: 25239},
+			pos:  position{line: 897, col: 1, offset: 25149},
 			expr: &choiceExpr{
-				pos: position{line: 897, col: 5, offset: 25252},
+				pos: position{line: 898, col: 5, offset: 25162},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 897, col: 5, offset: 25252},
+						pos: position{line: 898, col: 5, offset: 25162},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 897, col: 5, offset: 25252},
+							pos: position{line: 898, col: 5, offset: 25162},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 897, col: 5, offset: 25252},
+									pos:  position{line: 898, col: 5, offset: 25162},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 897, col: 7, offset: 25254},
+									pos:  position{line: 898, col: 7, offset: 25164},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 897, col: 13, offset: 25260},
+									pos:  position{line: 898, col: 13, offset: 25170},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 897, col: 15, offset: 25262},
+									pos:   position{line: 898, col: 15, offset: 25172},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 897, col: 21, offset: 25268},
+										pos:  position{line: 898, col: 21, offset: 25178},
 										name: "UInt",
 									},
 								},
@@ -7366,10 +7314,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 898, col: 5, offset: 25299},
+						pos: position{line: 899, col: 5, offset: 25209},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 898, col: 5, offset: 25299},
+							pos:        position{line: 899, col: 5, offset: 25209},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7379,12 +7327,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 900, col: 1, offset: 25321},
+			pos:  position{line: 901, col: 1, offset: 25231},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 10, offset: 25330},
+				pos: position{line: 901, col: 10, offset: 25240},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 900, col: 10, offset: 25330},
+					pos:        position{line: 901, col: 10, offset: 25240},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7392,12 +7340,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 901, col: 1, offset: 25365},
+			pos:  position{line: 902, col: 1, offset: 25275},
 			expr: &actionExpr{
-				pos: position{line: 901, col: 6, offset: 25370},
+				pos: position{line: 902, col: 6, offset: 25280},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 901, col: 6, offset: 25370},
+					pos:        position{line: 902, col: 6, offset: 25280},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7405,12 +7353,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 902, col: 1, offset: 25397},
+			pos:  position{line: 903, col: 1, offset: 25307},
 			expr: &actionExpr{
-				pos: position{line: 902, col: 8, offset: 25404},
+				pos: position{line: 903, col: 8, offset: 25314},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 902, col: 8, offset: 25404},
+					pos:        position{line: 903, col: 8, offset: 25314},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7418,12 +7366,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 903, col: 1, offset: 25435},
+			pos:  position{line: 904, col: 1, offset: 25345},
 			expr: &actionExpr{
-				pos: position{line: 903, col: 8, offset: 25442},
+				pos: position{line: 904, col: 8, offset: 25352},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 903, col: 8, offset: 25442},
+					pos:        position{line: 904, col: 8, offset: 25352},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7431,12 +7379,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 904, col: 1, offset: 25473},
+			pos:  position{line: 905, col: 1, offset: 25383},
 			expr: &actionExpr{
-				pos: position{line: 904, col: 9, offset: 25481},
+				pos: position{line: 905, col: 9, offset: 25391},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 904, col: 9, offset: 25481},
+					pos:        position{line: 905, col: 9, offset: 25391},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7444,12 +7392,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 905, col: 1, offset: 25514},
+			pos:  position{line: 906, col: 1, offset: 25424},
 			expr: &actionExpr{
-				pos: position{line: 905, col: 9, offset: 25522},
+				pos: position{line: 906, col: 9, offset: 25432},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 905, col: 9, offset: 25522},
+					pos:        position{line: 906, col: 9, offset: 25432},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7457,12 +7405,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 906, col: 1, offset: 25555},
+			pos:  position{line: 907, col: 1, offset: 25465},
 			expr: &actionExpr{
-				pos: position{line: 906, col: 6, offset: 25560},
+				pos: position{line: 907, col: 6, offset: 25470},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 906, col: 6, offset: 25560},
+					pos:        position{line: 907, col: 6, offset: 25470},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7470,12 +7418,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 907, col: 1, offset: 25587},
+			pos:  position{line: 908, col: 1, offset: 25497},
 			expr: &actionExpr{
-				pos: position{line: 907, col: 10, offset: 25596},
+				pos: position{line: 908, col: 10, offset: 25506},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 907, col: 10, offset: 25596},
+					pos:        position{line: 908, col: 10, offset: 25506},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7483,12 +7431,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 908, col: 1, offset: 25631},
+			pos:  position{line: 909, col: 1, offset: 25541},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 9, offset: 25639},
+				pos: position{line: 909, col: 9, offset: 25549},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 908, col: 9, offset: 25639},
+					pos:        position{line: 909, col: 9, offset: 25549},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7496,12 +7444,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 909, col: 1, offset: 25672},
+			pos:  position{line: 910, col: 1, offset: 25582},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 6, offset: 25677},
+				pos: position{line: 910, col: 6, offset: 25587},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 909, col: 6, offset: 25677},
+					pos:        position{line: 910, col: 6, offset: 25587},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7509,12 +7457,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 910, col: 1, offset: 25704},
+			pos:  position{line: 911, col: 1, offset: 25614},
 			expr: &actionExpr{
-				pos: position{line: 910, col: 9, offset: 25712},
+				pos: position{line: 911, col: 9, offset: 25622},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 910, col: 9, offset: 25712},
+					pos:        position{line: 911, col: 9, offset: 25622},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7522,12 +7470,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 911, col: 1, offset: 25745},
+			pos:  position{line: 912, col: 1, offset: 25655},
 			expr: &actionExpr{
-				pos: position{line: 911, col: 7, offset: 25751},
+				pos: position{line: 912, col: 7, offset: 25661},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 911, col: 7, offset: 25751},
+					pos:        position{line: 912, col: 7, offset: 25661},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7535,12 +7483,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 912, col: 1, offset: 25780},
+			pos:  position{line: 913, col: 1, offset: 25690},
 			expr: &actionExpr{
-				pos: position{line: 912, col: 8, offset: 25787},
+				pos: position{line: 913, col: 8, offset: 25697},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 912, col: 8, offset: 25787},
+					pos:        position{line: 913, col: 8, offset: 25697},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7548,12 +7496,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 913, col: 1, offset: 25818},
+			pos:  position{line: 914, col: 1, offset: 25728},
 			expr: &actionExpr{
-				pos: position{line: 913, col: 8, offset: 25825},
+				pos: position{line: 914, col: 8, offset: 25735},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 913, col: 8, offset: 25825},
+					pos:        position{line: 914, col: 8, offset: 25735},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7561,12 +7509,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 914, col: 1, offset: 25856},
+			pos:  position{line: 915, col: 1, offset: 25766},
 			expr: &actionExpr{
-				pos: position{line: 914, col: 8, offset: 25863},
+				pos: position{line: 915, col: 8, offset: 25773},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 914, col: 8, offset: 25863},
+					pos:        position{line: 915, col: 8, offset: 25773},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7574,12 +7522,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 915, col: 1, offset: 25894},
+			pos:  position{line: 916, col: 1, offset: 25804},
 			expr: &actionExpr{
-				pos: position{line: 915, col: 9, offset: 25902},
+				pos: position{line: 916, col: 9, offset: 25812},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 915, col: 9, offset: 25902},
+					pos:        position{line: 916, col: 9, offset: 25812},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7587,12 +7535,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 916, col: 1, offset: 25935},
+			pos:  position{line: 917, col: 1, offset: 25845},
 			expr: &actionExpr{
-				pos: position{line: 916, col: 9, offset: 25943},
+				pos: position{line: 917, col: 9, offset: 25853},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 916, col: 9, offset: 25943},
+					pos:        position{line: 917, col: 9, offset: 25853},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7600,48 +7548,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 918, col: 1, offset: 25977},
+			pos:  position{line: 919, col: 1, offset: 25887},
 			expr: &choiceExpr{
-				pos: position{line: 919, col: 5, offset: 25999},
+				pos: position{line: 920, col: 5, offset: 25909},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 5, offset: 25999},
+						pos:  position{line: 920, col: 5, offset: 25909},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 14, offset: 26008},
+						pos:  position{line: 920, col: 14, offset: 25918},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 19, offset: 26013},
+						pos:  position{line: 920, col: 19, offset: 25923},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 27, offset: 26021},
+						pos:  position{line: 920, col: 27, offset: 25931},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 34, offset: 26028},
+						pos:  position{line: 920, col: 34, offset: 25938},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 42, offset: 26036},
+						pos:  position{line: 920, col: 42, offset: 25946},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 50, offset: 26044},
+						pos:  position{line: 920, col: 50, offset: 25954},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 59, offset: 26053},
+						pos:  position{line: 920, col: 59, offset: 25963},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 67, offset: 26061},
+						pos:  position{line: 920, col: 67, offset: 25971},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 919, col: 75, offset: 26069},
+						pos:  position{line: 920, col: 75, offset: 25979},
 						name: "ON",
 					},
 				},
@@ -7649,52 +7597,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 923, col: 1, offset: 26095},
+			pos:  position{line: 924, col: 1, offset: 26005},
 			expr: &choiceExpr{
-				pos: position{line: 924, col: 5, offset: 26107},
+				pos: position{line: 925, col: 5, offset: 26017},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 924, col: 5, offset: 26107},
+						pos:  position{line: 925, col: 5, offset: 26017},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 925, col: 5, offset: 26123},
+						pos:  position{line: 926, col: 5, offset: 26033},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 926, col: 5, offset: 26143},
+						pos:  position{line: 927, col: 5, offset: 26053},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 927, col: 5, offset: 26161},
+						pos:  position{line: 928, col: 5, offset: 26071},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 928, col: 5, offset: 26180},
+						pos:  position{line: 929, col: 5, offset: 26090},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 929, col: 5, offset: 26197},
+						pos:  position{line: 930, col: 5, offset: 26107},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 930, col: 5, offset: 26210},
+						pos:  position{line: 931, col: 5, offset: 26120},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 931, col: 5, offset: 26219},
+						pos:  position{line: 932, col: 5, offset: 26129},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 932, col: 5, offset: 26236},
+						pos:  position{line: 933, col: 5, offset: 26146},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 933, col: 5, offset: 26255},
+						pos:  position{line: 934, col: 5, offset: 26165},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 934, col: 5, offset: 26274},
+						pos:  position{line: 935, col: 5, offset: 26184},
 						name: "NullLiteral",
 					},
 				},
@@ -7702,28 +7650,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 936, col: 1, offset: 26287},
+			pos:  position{line: 937, col: 1, offset: 26197},
 			expr: &choiceExpr{
-				pos: position{line: 937, col: 5, offset: 26305},
+				pos: position{line: 938, col: 5, offset: 26215},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 937, col: 5, offset: 26305},
+						pos: position{line: 938, col: 5, offset: 26215},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 937, col: 5, offset: 26305},
+							pos: position{line: 938, col: 5, offset: 26215},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 937, col: 5, offset: 26305},
+									pos:   position{line: 938, col: 5, offset: 26215},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 937, col: 7, offset: 26307},
+										pos:  position{line: 938, col: 7, offset: 26217},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 937, col: 14, offset: 26314},
+									pos: position{line: 938, col: 14, offset: 26224},
 									expr: &ruleRefExpr{
-										pos:  position{line: 937, col: 15, offset: 26315},
+										pos:  position{line: 938, col: 15, offset: 26225},
 										name: "IdentifierRest",
 									},
 								},
@@ -7731,13 +7679,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 940, col: 5, offset: 26430},
+						pos: position{line: 941, col: 5, offset: 26340},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 940, col: 5, offset: 26430},
+							pos:   position{line: 941, col: 5, offset: 26340},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 7, offset: 26432},
+								pos:  position{line: 941, col: 7, offset: 26342},
 								name: "IP4Net",
 							},
 						},
@@ -7747,28 +7695,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 944, col: 1, offset: 26536},
+			pos:  position{line: 945, col: 1, offset: 26446},
 			expr: &choiceExpr{
-				pos: position{line: 945, col: 5, offset: 26555},
+				pos: position{line: 946, col: 5, offset: 26465},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 945, col: 5, offset: 26555},
+						pos: position{line: 946, col: 5, offset: 26465},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 945, col: 5, offset: 26555},
+							pos: position{line: 946, col: 5, offset: 26465},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 945, col: 5, offset: 26555},
+									pos:   position{line: 946, col: 5, offset: 26465},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 945, col: 7, offset: 26557},
+										pos:  position{line: 946, col: 7, offset: 26467},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 945, col: 11, offset: 26561},
+									pos: position{line: 946, col: 11, offset: 26471},
 									expr: &ruleRefExpr{
-										pos:  position{line: 945, col: 12, offset: 26562},
+										pos:  position{line: 946, col: 12, offset: 26472},
 										name: "IdentifierRest",
 									},
 								},
@@ -7776,13 +7724,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 948, col: 5, offset: 26676},
+						pos: position{line: 949, col: 5, offset: 26586},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 948, col: 5, offset: 26676},
+							pos:   position{line: 949, col: 5, offset: 26586},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 948, col: 7, offset: 26678},
+								pos:  position{line: 949, col: 7, offset: 26588},
 								name: "IP",
 							},
 						},
@@ -7792,15 +7740,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 952, col: 1, offset: 26777},
+			pos:  position{line: 953, col: 1, offset: 26687},
 			expr: &actionExpr{
-				pos: position{line: 953, col: 5, offset: 26794},
+				pos: position{line: 954, col: 5, offset: 26704},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 953, col: 5, offset: 26794},
+					pos:   position{line: 954, col: 5, offset: 26704},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 953, col: 7, offset: 26796},
+						pos:  position{line: 954, col: 7, offset: 26706},
 						name: "FloatString",
 					},
 				},
@@ -7808,15 +7756,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 957, col: 1, offset: 26909},
+			pos:  position{line: 958, col: 1, offset: 26819},
 			expr: &actionExpr{
-				pos: position{line: 958, col: 5, offset: 26928},
+				pos: position{line: 959, col: 5, offset: 26838},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 958, col: 5, offset: 26928},
+					pos:   position{line: 959, col: 5, offset: 26838},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 958, col: 7, offset: 26930},
+						pos:  position{line: 959, col: 7, offset: 26840},
 						name: "IntString",
 					},
 				},
@@ -7824,24 +7772,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 962, col: 1, offset: 27039},
+			pos:  position{line: 963, col: 1, offset: 26949},
 			expr: &choiceExpr{
-				pos: position{line: 963, col: 5, offset: 27058},
+				pos: position{line: 964, col: 5, offset: 26968},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 963, col: 5, offset: 27058},
+						pos: position{line: 964, col: 5, offset: 26968},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 963, col: 5, offset: 27058},
+							pos:        position{line: 964, col: 5, offset: 26968},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 964, col: 5, offset: 27171},
+						pos: position{line: 965, col: 5, offset: 27081},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 964, col: 5, offset: 27171},
+							pos:        position{line: 965, col: 5, offset: 27081},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7851,12 +7799,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 966, col: 1, offset: 27282},
+			pos:  position{line: 967, col: 1, offset: 27192},
 			expr: &actionExpr{
-				pos: position{line: 967, col: 5, offset: 27298},
+				pos: position{line: 968, col: 5, offset: 27208},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 967, col: 5, offset: 27298},
+					pos:        position{line: 968, col: 5, offset: 27208},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7864,22 +7812,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 969, col: 1, offset: 27404},
+			pos:  position{line: 970, col: 1, offset: 27314},
 			expr: &actionExpr{
-				pos: position{line: 970, col: 5, offset: 27421},
+				pos: position{line: 971, col: 5, offset: 27331},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 970, col: 5, offset: 27421},
+					pos: position{line: 971, col: 5, offset: 27331},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 970, col: 5, offset: 27421},
+							pos:        position{line: 971, col: 5, offset: 27331},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 970, col: 10, offset: 27426},
+							pos: position{line: 971, col: 10, offset: 27336},
 							expr: &ruleRefExpr{
-								pos:  position{line: 970, col: 10, offset: 27426},
+								pos:  position{line: 971, col: 10, offset: 27336},
 								name: "HexDigit",
 							},
 						},
@@ -7889,28 +7837,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 974, col: 1, offset: 27541},
+			pos:  position{line: 975, col: 1, offset: 27451},
 			expr: &actionExpr{
-				pos: position{line: 975, col: 5, offset: 27557},
+				pos: position{line: 976, col: 5, offset: 27467},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 975, col: 5, offset: 27557},
+					pos: position{line: 976, col: 5, offset: 27467},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 975, col: 5, offset: 27557},
+							pos:        position{line: 976, col: 5, offset: 27467},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 975, col: 9, offset: 27561},
+							pos:   position{line: 976, col: 9, offset: 27471},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 975, col: 13, offset: 27565},
+								pos:  position{line: 976, col: 13, offset: 27475},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 975, col: 18, offset: 27570},
+							pos:        position{line: 976, col: 18, offset: 27480},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -7920,22 +7868,22 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 979, col: 1, offset: 27659},
+			pos:  position{line: 980, col: 1, offset: 27569},
 			expr: &choiceExpr{
-				pos: position{line: 980, col: 5, offset: 27672},
+				pos: position{line: 981, col: 5, offset: 27582},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 980, col: 5, offset: 27672},
+						pos:  position{line: 981, col: 5, offset: 27582},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 981, col: 5, offset: 27688},
+						pos: position{line: 982, col: 5, offset: 27598},
 						run: (*parser).callonCastType3,
 						expr: &labeledExpr{
-							pos:   position{line: 981, col: 5, offset: 27688},
+							pos:   position{line: 982, col: 5, offset: 27598},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 981, col: 9, offset: 27692},
+								pos:  position{line: 982, col: 9, offset: 27602},
 								name: "PrimitiveType",
 							},
 						},
@@ -7945,20 +7893,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 985, col: 1, offset: 27791},
+			pos:  position{line: 986, col: 1, offset: 27701},
 			expr: &choiceExpr{
-				pos: position{line: 986, col: 5, offset: 27800},
+				pos: position{line: 987, col: 5, offset: 27710},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 986, col: 5, offset: 27800},
+						pos:  position{line: 987, col: 5, offset: 27710},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 987, col: 5, offset: 27816},
+						pos:  position{line: 988, col: 5, offset: 27726},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 988, col: 5, offset: 27834},
+						pos:  position{line: 989, col: 5, offset: 27744},
 						name: "ComplexType",
 					},
 				},
@@ -7966,28 +7914,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 990, col: 1, offset: 27847},
+			pos:  position{line: 991, col: 1, offset: 27757},
 			expr: &choiceExpr{
-				pos: position{line: 991, col: 5, offset: 27865},
+				pos: position{line: 992, col: 5, offset: 27775},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 991, col: 5, offset: 27865},
+						pos: position{line: 992, col: 5, offset: 27775},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 991, col: 5, offset: 27865},
+							pos: position{line: 992, col: 5, offset: 27775},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 991, col: 5, offset: 27865},
+									pos:   position{line: 992, col: 5, offset: 27775},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 991, col: 10, offset: 27870},
+										pos:  position{line: 992, col: 10, offset: 27780},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 991, col: 24, offset: 27884},
+									pos: position{line: 992, col: 24, offset: 27794},
 									expr: &ruleRefExpr{
-										pos:  position{line: 991, col: 25, offset: 27885},
+										pos:  position{line: 992, col: 25, offset: 27795},
 										name: "IdentifierRest",
 									},
 								},
@@ -7995,37 +7943,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 992, col: 5, offset: 27925},
+						pos: position{line: 993, col: 5, offset: 27835},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 992, col: 5, offset: 27925},
+							pos: position{line: 993, col: 5, offset: 27835},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 992, col: 5, offset: 27925},
+									pos:   position{line: 993, col: 5, offset: 27835},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 992, col: 10, offset: 27930},
+										pos:  position{line: 993, col: 10, offset: 27840},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 992, col: 25, offset: 27945},
+									pos:  position{line: 993, col: 25, offset: 27855},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 992, col: 28, offset: 27948},
+									pos:        position{line: 993, col: 28, offset: 27858},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 992, col: 32, offset: 27952},
+									pos:  position{line: 993, col: 32, offset: 27862},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 992, col: 35, offset: 27955},
+									pos:   position{line: 993, col: 35, offset: 27865},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 992, col: 39, offset: 27959},
+										pos:  position{line: 993, col: 39, offset: 27869},
 										name: "Type",
 									},
 								},
@@ -8033,42 +7981,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 995, col: 5, offset: 28061},
+						pos: position{line: 996, col: 5, offset: 27971},
 						run: (*parser).callonAmbiguousType17,
 						expr: &labeledExpr{
-							pos:   position{line: 995, col: 5, offset: 28061},
+							pos:   position{line: 996, col: 5, offset: 27971},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 995, col: 10, offset: 28066},
+								pos:  position{line: 996, col: 10, offset: 27976},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 998, col: 5, offset: 28168},
+						pos: position{line: 999, col: 5, offset: 28078},
 						run: (*parser).callonAmbiguousType20,
 						expr: &seqExpr{
-							pos: position{line: 998, col: 5, offset: 28168},
+							pos: position{line: 999, col: 5, offset: 28078},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 998, col: 5, offset: 28168},
+									pos:        position{line: 999, col: 5, offset: 28078},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 998, col: 9, offset: 28172},
+									pos:  position{line: 999, col: 9, offset: 28082},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 998, col: 12, offset: 28175},
+									pos:   position{line: 999, col: 12, offset: 28085},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 998, col: 14, offset: 28177},
+										pos:  position{line: 999, col: 14, offset: 28087},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 998, col: 25, offset: 28188},
+									pos:        position{line: 999, col: 25, offset: 28098},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8080,15 +8028,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1000, col: 1, offset: 28211},
+			pos:  position{line: 1001, col: 1, offset: 28121},
 			expr: &actionExpr{
-				pos: position{line: 1001, col: 5, offset: 28225},
+				pos: position{line: 1002, col: 5, offset: 28135},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1001, col: 5, offset: 28225},
+					pos:   position{line: 1002, col: 5, offset: 28135},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1001, col: 11, offset: 28231},
+						pos:  position{line: 1002, col: 11, offset: 28141},
 						name: "TypeList",
 					},
 				},
@@ -8096,28 +8044,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1005, col: 1, offset: 28327},
+			pos:  position{line: 1006, col: 1, offset: 28237},
 			expr: &actionExpr{
-				pos: position{line: 1006, col: 5, offset: 28340},
+				pos: position{line: 1007, col: 5, offset: 28250},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1006, col: 5, offset: 28340},
+					pos: position{line: 1007, col: 5, offset: 28250},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1006, col: 5, offset: 28340},
+							pos:   position{line: 1007, col: 5, offset: 28250},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1006, col: 11, offset: 28346},
+								pos:  position{line: 1007, col: 11, offset: 28256},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1006, col: 16, offset: 28351},
+							pos:   position{line: 1007, col: 16, offset: 28261},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1006, col: 21, offset: 28356},
+								pos: position{line: 1007, col: 21, offset: 28266},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1006, col: 21, offset: 28356},
+									pos:  position{line: 1007, col: 21, offset: 28266},
 									name: "TypeListTail",
 								},
 							},
@@ -8128,31 +8076,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1010, col: 1, offset: 28450},
+			pos:  position{line: 1011, col: 1, offset: 28360},
 			expr: &actionExpr{
-				pos: position{line: 1010, col: 16, offset: 28465},
+				pos: position{line: 1011, col: 16, offset: 28375},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1010, col: 16, offset: 28465},
+					pos: position{line: 1011, col: 16, offset: 28375},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1010, col: 16, offset: 28465},
+							pos:  position{line: 1011, col: 16, offset: 28375},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1010, col: 19, offset: 28468},
+							pos:        position{line: 1011, col: 19, offset: 28378},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1010, col: 23, offset: 28472},
+							pos:  position{line: 1011, col: 23, offset: 28382},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1010, col: 26, offset: 28475},
+							pos:   position{line: 1011, col: 26, offset: 28385},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1010, col: 30, offset: 28479},
+								pos:  position{line: 1011, col: 30, offset: 28389},
 								name: "Type",
 							},
 						},
@@ -8162,39 +8110,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1012, col: 1, offset: 28505},
+			pos:  position{line: 1013, col: 1, offset: 28415},
 			expr: &choiceExpr{
-				pos: position{line: 1013, col: 5, offset: 28521},
+				pos: position{line: 1014, col: 5, offset: 28431},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1013, col: 5, offset: 28521},
+						pos: position{line: 1014, col: 5, offset: 28431},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1013, col: 5, offset: 28521},
+							pos: position{line: 1014, col: 5, offset: 28431},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1013, col: 5, offset: 28521},
+									pos:        position{line: 1014, col: 5, offset: 28431},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 9, offset: 28525},
+									pos:  position{line: 1014, col: 9, offset: 28435},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 12, offset: 28528},
+									pos:   position{line: 1014, col: 12, offset: 28438},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 19, offset: 28535},
+										pos:  position{line: 1014, col: 19, offset: 28445},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 33, offset: 28549},
+									pos:  position{line: 1014, col: 33, offset: 28459},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1013, col: 36, offset: 28552},
+									pos:        position{line: 1014, col: 36, offset: 28462},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8202,34 +8150,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1016, col: 5, offset: 28647},
+						pos: position{line: 1017, col: 5, offset: 28557},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1016, col: 5, offset: 28647},
+							pos: position{line: 1017, col: 5, offset: 28557},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1016, col: 5, offset: 28647},
+									pos:        position{line: 1017, col: 5, offset: 28557},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1016, col: 9, offset: 28651},
+									pos:  position{line: 1017, col: 9, offset: 28561},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1016, col: 12, offset: 28654},
+									pos:   position{line: 1017, col: 12, offset: 28564},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1016, col: 16, offset: 28658},
+										pos:  position{line: 1017, col: 16, offset: 28568},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1016, col: 21, offset: 28663},
+									pos:  position{line: 1017, col: 21, offset: 28573},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1016, col: 24, offset: 28666},
+									pos:        position{line: 1017, col: 24, offset: 28576},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8237,34 +8185,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 28755},
+						pos: position{line: 1020, col: 5, offset: 28665},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1019, col: 5, offset: 28755},
+							pos: position{line: 1020, col: 5, offset: 28665},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1019, col: 5, offset: 28755},
+									pos:        position{line: 1020, col: 5, offset: 28665},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 10, offset: 28760},
+									pos:  position{line: 1020, col: 10, offset: 28670},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1019, col: 14, offset: 28764},
+									pos:   position{line: 1020, col: 14, offset: 28674},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 18, offset: 28768},
+										pos:  position{line: 1020, col: 18, offset: 28678},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 23, offset: 28773},
+									pos:  position{line: 1020, col: 23, offset: 28683},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 26, offset: 28776},
+									pos:        position{line: 1020, col: 26, offset: 28686},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8272,55 +8220,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1022, col: 5, offset: 28864},
+						pos: position{line: 1023, col: 5, offset: 28774},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1022, col: 5, offset: 28864},
+							pos: position{line: 1023, col: 5, offset: 28774},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1022, col: 5, offset: 28864},
+									pos:        position{line: 1023, col: 5, offset: 28774},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1022, col: 10, offset: 28869},
+									pos:  position{line: 1023, col: 10, offset: 28779},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1022, col: 13, offset: 28872},
+									pos:   position{line: 1023, col: 13, offset: 28782},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1022, col: 21, offset: 28880},
+										pos:  position{line: 1023, col: 21, offset: 28790},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1022, col: 26, offset: 28885},
+									pos:  position{line: 1023, col: 26, offset: 28795},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1022, col: 29, offset: 28888},
+									pos:        position{line: 1023, col: 29, offset: 28798},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1022, col: 33, offset: 28892},
+									pos:  position{line: 1023, col: 33, offset: 28802},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1022, col: 36, offset: 28895},
+									pos:   position{line: 1023, col: 36, offset: 28805},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1022, col: 44, offset: 28903},
+										pos:  position{line: 1023, col: 44, offset: 28813},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1022, col: 49, offset: 28908},
+									pos:  position{line: 1023, col: 49, offset: 28818},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1022, col: 52, offset: 28911},
+									pos:        position{line: 1023, col: 52, offset: 28821},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8332,15 +8280,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1026, col: 1, offset: 29025},
+			pos:  position{line: 1027, col: 1, offset: 28935},
 			expr: &actionExpr{
-				pos: position{line: 1027, col: 5, offset: 29045},
+				pos: position{line: 1028, col: 5, offset: 28955},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1027, col: 5, offset: 29045},
+					pos:   position{line: 1028, col: 5, offset: 28955},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1027, col: 7, offset: 29047},
+						pos:  position{line: 1028, col: 7, offset: 28957},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8348,34 +8296,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1034, col: 1, offset: 29263},
+			pos:  position{line: 1035, col: 1, offset: 29173},
 			expr: &choiceExpr{
-				pos: position{line: 1035, col: 5, offset: 29288},
+				pos: position{line: 1036, col: 5, offset: 29198},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1035, col: 5, offset: 29288},
+						pos: position{line: 1036, col: 5, offset: 29198},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1035, col: 5, offset: 29288},
+							pos: position{line: 1036, col: 5, offset: 29198},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1035, col: 5, offset: 29288},
+									pos:        position{line: 1036, col: 5, offset: 29198},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1035, col: 9, offset: 29292},
+									pos:   position{line: 1036, col: 9, offset: 29202},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1035, col: 11, offset: 29294},
+										pos: position{line: 1036, col: 11, offset: 29204},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1035, col: 11, offset: 29294},
+											pos:  position{line: 1036, col: 11, offset: 29204},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1035, col: 37, offset: 29320},
+									pos:        position{line: 1036, col: 37, offset: 29230},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8383,29 +8331,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1036, col: 5, offset: 29346},
+						pos: position{line: 1037, col: 5, offset: 29256},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1036, col: 5, offset: 29346},
+							pos: position{line: 1037, col: 5, offset: 29256},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1036, col: 5, offset: 29346},
+									pos:        position{line: 1037, col: 5, offset: 29256},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1036, col: 9, offset: 29350},
+									pos:   position{line: 1037, col: 9, offset: 29260},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1036, col: 11, offset: 29352},
+										pos: position{line: 1037, col: 11, offset: 29262},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1036, col: 11, offset: 29352},
+											pos:  position{line: 1037, col: 11, offset: 29262},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1036, col: 37, offset: 29378},
+									pos:        position{line: 1037, col: 37, offset: 29288},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8417,24 +8365,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1038, col: 1, offset: 29401},
+			pos:  position{line: 1039, col: 1, offset: 29311},
 			expr: &choiceExpr{
-				pos: position{line: 1039, col: 5, offset: 29430},
+				pos: position{line: 1040, col: 5, offset: 29340},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1039, col: 5, offset: 29430},
+						pos:  position{line: 1040, col: 5, offset: 29340},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1040, col: 5, offset: 29447},
+						pos: position{line: 1041, col: 5, offset: 29357},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1040, col: 5, offset: 29447},
+							pos:   position{line: 1041, col: 5, offset: 29357},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1040, col: 7, offset: 29449},
+								pos: position{line: 1041, col: 7, offset: 29359},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1040, col: 7, offset: 29449},
+									pos:  position{line: 1041, col: 7, offset: 29359},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8445,26 +8393,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1044, col: 1, offset: 29586},
+			pos:  position{line: 1045, col: 1, offset: 29496},
 			expr: &choiceExpr{
-				pos: position{line: 1045, col: 5, offset: 29615},
+				pos: position{line: 1046, col: 5, offset: 29525},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1045, col: 5, offset: 29615},
+						pos: position{line: 1046, col: 5, offset: 29525},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1045, col: 5, offset: 29615},
+							pos: position{line: 1046, col: 5, offset: 29525},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1045, col: 5, offset: 29615},
+									pos:        position{line: 1046, col: 5, offset: 29525},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1045, col: 10, offset: 29620},
+									pos:   position{line: 1046, col: 10, offset: 29530},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1045, col: 12, offset: 29622},
+										pos:        position{line: 1046, col: 12, offset: 29532},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8473,24 +8421,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1046, col: 5, offset: 29649},
+						pos: position{line: 1047, col: 5, offset: 29559},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1046, col: 5, offset: 29649},
+							pos: position{line: 1047, col: 5, offset: 29559},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1046, col: 5, offset: 29649},
+									pos: position{line: 1047, col: 5, offset: 29559},
 									expr: &litMatcher{
-										pos:        position{line: 1046, col: 8, offset: 29652},
+										pos:        position{line: 1047, col: 8, offset: 29562},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 15, offset: 29659},
+									pos:   position{line: 1047, col: 15, offset: 29569},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1046, col: 17, offset: 29661},
+										pos:  position{line: 1047, col: 17, offset: 29571},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8502,24 +8450,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1048, col: 1, offset: 29697},
+			pos:  position{line: 1049, col: 1, offset: 29607},
 			expr: &choiceExpr{
-				pos: position{line: 1049, col: 5, offset: 29726},
+				pos: position{line: 1050, col: 5, offset: 29636},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1049, col: 5, offset: 29726},
+						pos:  position{line: 1050, col: 5, offset: 29636},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1050, col: 5, offset: 29743},
+						pos: position{line: 1051, col: 5, offset: 29653},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1050, col: 5, offset: 29743},
+							pos:   position{line: 1051, col: 5, offset: 29653},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1050, col: 7, offset: 29745},
+								pos: position{line: 1051, col: 7, offset: 29655},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1050, col: 7, offset: 29745},
+									pos:  position{line: 1051, col: 7, offset: 29655},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8530,26 +8478,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1054, col: 1, offset: 29882},
+			pos:  position{line: 1055, col: 1, offset: 29792},
 			expr: &choiceExpr{
-				pos: position{line: 1055, col: 5, offset: 29911},
+				pos: position{line: 1056, col: 5, offset: 29821},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1055, col: 5, offset: 29911},
+						pos: position{line: 1056, col: 5, offset: 29821},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1055, col: 5, offset: 29911},
+							pos: position{line: 1056, col: 5, offset: 29821},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1055, col: 5, offset: 29911},
+									pos:        position{line: 1056, col: 5, offset: 29821},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1055, col: 10, offset: 29916},
+									pos:   position{line: 1056, col: 10, offset: 29826},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1055, col: 12, offset: 29918},
+										pos:        position{line: 1056, col: 12, offset: 29828},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8558,24 +8506,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1056, col: 5, offset: 29945},
+						pos: position{line: 1057, col: 5, offset: 29855},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1056, col: 5, offset: 29945},
+							pos: position{line: 1057, col: 5, offset: 29855},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1056, col: 5, offset: 29945},
+									pos: position{line: 1057, col: 5, offset: 29855},
 									expr: &litMatcher{
-										pos:        position{line: 1056, col: 8, offset: 29948},
+										pos:        position{line: 1057, col: 8, offset: 29858},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1056, col: 15, offset: 29955},
+									pos:   position{line: 1057, col: 15, offset: 29865},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1056, col: 17, offset: 29957},
+										pos:  position{line: 1057, col: 17, offset: 29867},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8587,36 +8535,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1058, col: 1, offset: 29993},
+			pos:  position{line: 1059, col: 1, offset: 29903},
 			expr: &actionExpr{
-				pos: position{line: 1059, col: 5, offset: 30010},
+				pos: position{line: 1060, col: 5, offset: 29920},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1059, col: 5, offset: 30010},
+					pos: position{line: 1060, col: 5, offset: 29920},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1059, col: 5, offset: 30010},
+							pos:        position{line: 1060, col: 5, offset: 29920},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1059, col: 10, offset: 30015},
+							pos:  position{line: 1060, col: 10, offset: 29925},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1059, col: 13, offset: 30018},
+							pos:   position{line: 1060, col: 13, offset: 29928},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1059, col: 15, offset: 30020},
+								pos:  position{line: 1060, col: 15, offset: 29930},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1059, col: 20, offset: 30025},
+							pos:  position{line: 1060, col: 20, offset: 29935},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1059, col: 23, offset: 30028},
+							pos:        position{line: 1060, col: 23, offset: 29938},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8626,105 +8574,105 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1074, col: 1, offset: 30324},
+			pos:  position{line: 1075, col: 1, offset: 30234},
 			expr: &actionExpr{
-				pos: position{line: 1075, col: 5, offset: 30342},
+				pos: position{line: 1076, col: 5, offset: 30252},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1075, col: 9, offset: 30346},
+					pos: position{line: 1076, col: 9, offset: 30256},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1075, col: 9, offset: 30346},
+							pos:        position{line: 1076, col: 9, offset: 30256},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1075, col: 19, offset: 30356},
+							pos:        position{line: 1076, col: 19, offset: 30266},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1075, col: 30, offset: 30367},
+							pos:        position{line: 1076, col: 30, offset: 30277},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1075, col: 41, offset: 30378},
+							pos:        position{line: 1076, col: 41, offset: 30288},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1076, col: 9, offset: 30395},
+							pos:        position{line: 1077, col: 9, offset: 30305},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1076, col: 18, offset: 30404},
+							pos:        position{line: 1077, col: 18, offset: 30314},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1076, col: 28, offset: 30414},
+							pos:        position{line: 1077, col: 28, offset: 30324},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1076, col: 38, offset: 30424},
+							pos:        position{line: 1077, col: 38, offset: 30334},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1077, col: 9, offset: 30440},
+							pos:        position{line: 1078, col: 9, offset: 30350},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1077, col: 21, offset: 30452},
+							pos:        position{line: 1078, col: 21, offset: 30362},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1078, col: 9, offset: 30470},
+							pos:        position{line: 1079, col: 9, offset: 30380},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1078, col: 18, offset: 30479},
+							pos:        position{line: 1079, col: 18, offset: 30389},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1079, col: 9, offset: 30496},
+							pos:        position{line: 1080, col: 9, offset: 30406},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1079, col: 22, offset: 30509},
+							pos:        position{line: 1080, col: 22, offset: 30419},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1080, col: 9, offset: 30524},
+							pos:        position{line: 1081, col: 9, offset: 30434},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1081, col: 9, offset: 30540},
+							pos:        position{line: 1082, col: 9, offset: 30450},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1081, col: 16, offset: 30547},
+							pos:        position{line: 1082, col: 16, offset: 30457},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1082, col: 9, offset: 30561},
+							pos:        position{line: 1083, col: 9, offset: 30471},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1082, col: 18, offset: 30570},
+							pos:        position{line: 1083, col: 18, offset: 30480},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8734,31 +8682,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1086, col: 1, offset: 30686},
+			pos:  position{line: 1087, col: 1, offset: 30596},
 			expr: &choiceExpr{
-				pos: position{line: 1087, col: 5, offset: 30704},
+				pos: position{line: 1088, col: 5, offset: 30614},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1087, col: 5, offset: 30704},
+						pos: position{line: 1088, col: 5, offset: 30614},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1087, col: 5, offset: 30704},
+							pos: position{line: 1088, col: 5, offset: 30614},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1087, col: 5, offset: 30704},
+									pos:   position{line: 1088, col: 5, offset: 30614},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1087, col: 11, offset: 30710},
+										pos:  position{line: 1088, col: 11, offset: 30620},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1087, col: 21, offset: 30720},
+									pos:   position{line: 1088, col: 21, offset: 30630},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1087, col: 26, offset: 30725},
+										pos: position{line: 1088, col: 26, offset: 30635},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1087, col: 26, offset: 30725},
+											pos:  position{line: 1088, col: 26, offset: 30635},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -8767,10 +8715,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1090, col: 5, offset: 30827},
+						pos: position{line: 1091, col: 5, offset: 30737},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1090, col: 5, offset: 30827},
+							pos:        position{line: 1091, col: 5, offset: 30737},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8780,31 +8728,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1092, col: 1, offset: 30851},
+			pos:  position{line: 1093, col: 1, offset: 30761},
 			expr: &actionExpr{
-				pos: position{line: 1092, col: 21, offset: 30871},
+				pos: position{line: 1093, col: 21, offset: 30781},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1092, col: 21, offset: 30871},
+					pos: position{line: 1093, col: 21, offset: 30781},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1092, col: 21, offset: 30871},
+							pos:  position{line: 1093, col: 21, offset: 30781},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1092, col: 24, offset: 30874},
+							pos:        position{line: 1093, col: 24, offset: 30784},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1092, col: 28, offset: 30878},
+							pos:  position{line: 1093, col: 28, offset: 30788},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1092, col: 31, offset: 30881},
+							pos:   position{line: 1093, col: 31, offset: 30791},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1092, col: 35, offset: 30885},
+								pos:  position{line: 1093, col: 35, offset: 30795},
 								name: "TypeField",
 							},
 						},
@@ -8814,39 +8762,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1094, col: 1, offset: 30916},
+			pos:  position{line: 1095, col: 1, offset: 30826},
 			expr: &actionExpr{
-				pos: position{line: 1095, col: 5, offset: 30930},
+				pos: position{line: 1096, col: 5, offset: 30840},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1095, col: 5, offset: 30930},
+					pos: position{line: 1096, col: 5, offset: 30840},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1095, col: 5, offset: 30930},
+							pos:   position{line: 1096, col: 5, offset: 30840},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1095, col: 10, offset: 30935},
+								pos:  position{line: 1096, col: 10, offset: 30845},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1095, col: 20, offset: 30945},
+							pos:  position{line: 1096, col: 20, offset: 30855},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1095, col: 23, offset: 30948},
+							pos:        position{line: 1096, col: 23, offset: 30858},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1095, col: 27, offset: 30952},
+							pos:  position{line: 1096, col: 27, offset: 30862},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1095, col: 30, offset: 30955},
+							pos:   position{line: 1096, col: 30, offset: 30865},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1095, col: 34, offset: 30959},
+								pos:  position{line: 1096, col: 34, offset: 30869},
 								name: "Type",
 							},
 						},
@@ -8856,16 +8804,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1099, col: 1, offset: 31041},
+			pos:  position{line: 1100, col: 1, offset: 30951},
 			expr: &choiceExpr{
-				pos: position{line: 1100, col: 5, offset: 31055},
+				pos: position{line: 1101, col: 5, offset: 30965},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 31055},
+						pos:  position{line: 1101, col: 5, offset: 30965},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1101, col: 5, offset: 31074},
+						pos:  position{line: 1102, col: 5, offset: 30984},
 						name: "QuotedString",
 					},
 				},
@@ -8873,32 +8821,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1103, col: 1, offset: 31088},
+			pos:  position{line: 1104, col: 1, offset: 30998},
 			expr: &actionExpr{
-				pos: position{line: 1103, col: 12, offset: 31099},
+				pos: position{line: 1104, col: 12, offset: 31009},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1103, col: 12, offset: 31099},
+					pos: position{line: 1104, col: 12, offset: 31009},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1103, col: 13, offset: 31100},
+							pos: position{line: 1104, col: 13, offset: 31010},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1103, col: 13, offset: 31100},
+									pos:        position{line: 1104, col: 13, offset: 31010},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 21, offset: 31108},
+									pos:        position{line: 1104, col: 21, offset: 31018},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1103, col: 28, offset: 31115},
+							pos: position{line: 1104, col: 28, offset: 31025},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1103, col: 29, offset: 31116},
+								pos:  position{line: 1104, col: 29, offset: 31026},
 								name: "IdentifierRest",
 							},
 						},
@@ -8908,32 +8856,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1104, col: 1, offset: 31153},
+			pos:  position{line: 1105, col: 1, offset: 31063},
 			expr: &actionExpr{
-				pos: position{line: 1104, col: 11, offset: 31163},
+				pos: position{line: 1105, col: 11, offset: 31073},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1104, col: 11, offset: 31163},
+					pos: position{line: 1105, col: 11, offset: 31073},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1104, col: 12, offset: 31164},
+							pos: position{line: 1105, col: 12, offset: 31074},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1104, col: 12, offset: 31164},
+									pos:        position{line: 1105, col: 12, offset: 31074},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1104, col: 19, offset: 31171},
+									pos:        position{line: 1105, col: 19, offset: 31081},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1104, col: 25, offset: 31177},
+							pos: position{line: 1105, col: 25, offset: 31087},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1104, col: 26, offset: 31178},
+								pos:  position{line: 1105, col: 26, offset: 31088},
 								name: "IdentifierRest",
 							},
 						},
@@ -8943,22 +8891,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1105, col: 1, offset: 31214},
+			pos:  position{line: 1106, col: 1, offset: 31124},
 			expr: &actionExpr{
-				pos: position{line: 1105, col: 11, offset: 31224},
+				pos: position{line: 1106, col: 11, offset: 31134},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1105, col: 11, offset: 31224},
+					pos: position{line: 1106, col: 11, offset: 31134},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1105, col: 11, offset: 31224},
+							pos:        position{line: 1106, col: 11, offset: 31134},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1105, col: 16, offset: 31229},
+							pos: position{line: 1106, col: 16, offset: 31139},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1105, col: 17, offset: 31230},
+								pos:  position{line: 1106, col: 17, offset: 31140},
 								name: "IdentifierRest",
 							},
 						},
@@ -8968,32 +8916,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1106, col: 1, offset: 31266},
+			pos:  position{line: 1107, col: 1, offset: 31176},
 			expr: &actionExpr{
-				pos: position{line: 1106, col: 12, offset: 31277},
+				pos: position{line: 1107, col: 12, offset: 31187},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1106, col: 12, offset: 31277},
+					pos: position{line: 1107, col: 12, offset: 31187},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1106, col: 13, offset: 31278},
+							pos: position{line: 1107, col: 13, offset: 31188},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1106, col: 13, offset: 31278},
+									pos:        position{line: 1107, col: 13, offset: 31188},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1106, col: 21, offset: 31286},
+									pos:        position{line: 1107, col: 21, offset: 31196},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1106, col: 28, offset: 31293},
+							pos: position{line: 1107, col: 28, offset: 31203},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1106, col: 29, offset: 31294},
+								pos:  position{line: 1107, col: 29, offset: 31204},
 								name: "IdentifierRest",
 							},
 						},
@@ -9003,22 +8951,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1107, col: 1, offset: 31331},
+			pos:  position{line: 1108, col: 1, offset: 31241},
 			expr: &actionExpr{
-				pos: position{line: 1107, col: 11, offset: 31341},
+				pos: position{line: 1108, col: 11, offset: 31251},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1107, col: 11, offset: 31341},
+					pos: position{line: 1108, col: 11, offset: 31251},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1107, col: 11, offset: 31341},
+							pos:        position{line: 1108, col: 11, offset: 31251},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1107, col: 16, offset: 31346},
+							pos: position{line: 1108, col: 16, offset: 31256},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1107, col: 17, offset: 31347},
+								pos:  position{line: 1108, col: 17, offset: 31257},
 								name: "IdentifierRest",
 							},
 						},
@@ -9028,9 +8976,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1109, col: 1, offset: 31384},
+			pos:  position{line: 1110, col: 1, offset: 31294},
 			expr: &charClassMatcher{
-				pos:        position{line: 1109, col: 19, offset: 31402},
+				pos:        position{line: 1110, col: 19, offset: 31312},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9040,16 +8988,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1111, col: 1, offset: 31414},
+			pos:  position{line: 1112, col: 1, offset: 31324},
 			expr: &choiceExpr{
-				pos: position{line: 1111, col: 18, offset: 31431},
+				pos: position{line: 1112, col: 18, offset: 31341},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1111, col: 18, offset: 31431},
+						pos:  position{line: 1112, col: 18, offset: 31341},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1111, col: 36, offset: 31449},
+						pos:        position{line: 1112, col: 36, offset: 31359},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9060,15 +9008,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1113, col: 1, offset: 31456},
+			pos:  position{line: 1114, col: 1, offset: 31366},
 			expr: &actionExpr{
-				pos: position{line: 1114, col: 5, offset: 31471},
+				pos: position{line: 1115, col: 5, offset: 31381},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1114, col: 5, offset: 31471},
+					pos:   position{line: 1115, col: 5, offset: 31381},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1114, col: 8, offset: 31474},
+						pos:  position{line: 1115, col: 8, offset: 31384},
 						name: "IdentifierName",
 					},
 				},
@@ -9076,29 +9024,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1116, col: 1, offset: 31555},
+			pos:  position{line: 1117, col: 1, offset: 31465},
 			expr: &choiceExpr{
-				pos: position{line: 1117, col: 5, offset: 31574},
+				pos: position{line: 1118, col: 5, offset: 31484},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1117, col: 5, offset: 31574},
+						pos: position{line: 1118, col: 5, offset: 31484},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1117, col: 5, offset: 31574},
+							pos: position{line: 1118, col: 5, offset: 31484},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1117, col: 5, offset: 31574},
+									pos: position{line: 1118, col: 5, offset: 31484},
 									expr: &seqExpr{
-										pos: position{line: 1117, col: 7, offset: 31576},
+										pos: position{line: 1118, col: 7, offset: 31486},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1117, col: 7, offset: 31576},
+												pos:  position{line: 1118, col: 7, offset: 31486},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1117, col: 15, offset: 31584},
+												pos: position{line: 1118, col: 15, offset: 31494},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1117, col: 16, offset: 31585},
+													pos:  position{line: 1118, col: 16, offset: 31495},
 													name: "IdentifierRest",
 												},
 											},
@@ -9106,13 +9054,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1117, col: 32, offset: 31601},
+									pos:  position{line: 1118, col: 32, offset: 31511},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1117, col: 48, offset: 31617},
+									pos: position{line: 1118, col: 48, offset: 31527},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1117, col: 48, offset: 31617},
+										pos:  position{line: 1118, col: 48, offset: 31527},
 										name: "IdentifierRest",
 									},
 								},
@@ -9120,30 +9068,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1118, col: 5, offset: 31669},
+						pos: position{line: 1119, col: 5, offset: 31579},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1118, col: 5, offset: 31669},
+							pos:        position{line: 1119, col: 5, offset: 31579},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1119, col: 5, offset: 31708},
+						pos: position{line: 1120, col: 5, offset: 31618},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1119, col: 5, offset: 31708},
+							pos: position{line: 1120, col: 5, offset: 31618},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1119, col: 5, offset: 31708},
+									pos:        position{line: 1120, col: 5, offset: 31618},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1119, col: 10, offset: 31713},
+									pos:   position{line: 1120, col: 10, offset: 31623},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1119, col: 13, offset: 31716},
+										pos:  position{line: 1120, col: 13, offset: 31626},
 										name: "IDGuard",
 									},
 								},
@@ -9151,39 +9099,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1121, col: 5, offset: 31807},
+						pos: position{line: 1122, col: 5, offset: 31717},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1121, col: 5, offset: 31807},
+							pos:        position{line: 1122, col: 5, offset: 31717},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1122, col: 5, offset: 31849},
+						pos: position{line: 1123, col: 5, offset: 31759},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1122, col: 5, offset: 31849},
+							pos: position{line: 1123, col: 5, offset: 31759},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1122, col: 5, offset: 31849},
+									pos:   position{line: 1123, col: 5, offset: 31759},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1122, col: 8, offset: 31852},
+										pos:  position{line: 1123, col: 8, offset: 31762},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1122, col: 26, offset: 31870},
+									pos: position{line: 1123, col: 26, offset: 31780},
 									expr: &seqExpr{
-										pos: position{line: 1122, col: 28, offset: 31872},
+										pos: position{line: 1123, col: 28, offset: 31782},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1122, col: 28, offset: 31872},
+												pos:  position{line: 1123, col: 28, offset: 31782},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1122, col: 31, offset: 31875},
+												pos:        position{line: 1123, col: 31, offset: 31785},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9198,24 +9146,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1124, col: 1, offset: 31900},
+			pos:  position{line: 1125, col: 1, offset: 31810},
 			expr: &choiceExpr{
-				pos: position{line: 1125, col: 5, offset: 31912},
+				pos: position{line: 1126, col: 5, offset: 31822},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1125, col: 5, offset: 31912},
+						pos:  position{line: 1126, col: 5, offset: 31822},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1126, col: 5, offset: 31931},
+						pos:  position{line: 1127, col: 5, offset: 31841},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1127, col: 5, offset: 31947},
+						pos:  position{line: 1128, col: 5, offset: 31857},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1128, col: 5, offset: 31955},
+						pos:  position{line: 1129, col: 5, offset: 31865},
 						name: "Infinity",
 					},
 				},
@@ -9223,24 +9171,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1130, col: 1, offset: 31965},
+			pos:  position{line: 1131, col: 1, offset: 31875},
 			expr: &actionExpr{
-				pos: position{line: 1131, col: 5, offset: 31974},
+				pos: position{line: 1132, col: 5, offset: 31884},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1131, col: 5, offset: 31974},
+					pos: position{line: 1132, col: 5, offset: 31884},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1131, col: 5, offset: 31974},
+							pos:  position{line: 1132, col: 5, offset: 31884},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1131, col: 14, offset: 31983},
+							pos:        position{line: 1132, col: 14, offset: 31893},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1131, col: 18, offset: 31987},
+							pos:  position{line: 1132, col: 18, offset: 31897},
 							name: "FullTime",
 						},
 					},
@@ -9249,30 +9197,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1135, col: 1, offset: 32107},
+			pos:  position{line: 1136, col: 1, offset: 32017},
 			expr: &seqExpr{
-				pos: position{line: 1135, col: 12, offset: 32118},
+				pos: position{line: 1136, col: 12, offset: 32028},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1135, col: 12, offset: 32118},
+						pos:  position{line: 1136, col: 12, offset: 32028},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1135, col: 15, offset: 32121},
+						pos:        position{line: 1136, col: 15, offset: 32031},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1135, col: 19, offset: 32125},
+						pos:  position{line: 1136, col: 19, offset: 32035},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1135, col: 22, offset: 32128},
+						pos:        position{line: 1136, col: 22, offset: 32038},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1135, col: 26, offset: 32132},
+						pos:  position{line: 1136, col: 26, offset: 32042},
 						name: "D2",
 					},
 				},
@@ -9280,33 +9228,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1137, col: 1, offset: 32136},
+			pos:  position{line: 1138, col: 1, offset: 32046},
 			expr: &seqExpr{
-				pos: position{line: 1137, col: 6, offset: 32141},
+				pos: position{line: 1138, col: 6, offset: 32051},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1137, col: 6, offset: 32141},
+						pos:        position{line: 1138, col: 6, offset: 32051},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1137, col: 11, offset: 32146},
+						pos:        position{line: 1138, col: 11, offset: 32056},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1137, col: 16, offset: 32151},
+						pos:        position{line: 1138, col: 16, offset: 32061},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1137, col: 21, offset: 32156},
+						pos:        position{line: 1138, col: 21, offset: 32066},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9317,19 +9265,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1138, col: 1, offset: 32162},
+			pos:  position{line: 1139, col: 1, offset: 32072},
 			expr: &seqExpr{
-				pos: position{line: 1138, col: 6, offset: 32167},
+				pos: position{line: 1139, col: 6, offset: 32077},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1138, col: 6, offset: 32167},
+						pos:        position{line: 1139, col: 6, offset: 32077},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1138, col: 11, offset: 32172},
+						pos:        position{line: 1139, col: 11, offset: 32082},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9340,16 +9288,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1140, col: 1, offset: 32179},
+			pos:  position{line: 1141, col: 1, offset: 32089},
 			expr: &seqExpr{
-				pos: position{line: 1140, col: 12, offset: 32190},
+				pos: position{line: 1141, col: 12, offset: 32100},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1140, col: 12, offset: 32190},
+						pos:  position{line: 1141, col: 12, offset: 32100},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1140, col: 24, offset: 32202},
+						pos:  position{line: 1141, col: 24, offset: 32112},
 						name: "TimeOffset",
 					},
 				},
@@ -9357,46 +9305,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1142, col: 1, offset: 32214},
+			pos:  position{line: 1143, col: 1, offset: 32124},
 			expr: &seqExpr{
-				pos: position{line: 1142, col: 15, offset: 32228},
+				pos: position{line: 1143, col: 15, offset: 32138},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1142, col: 15, offset: 32228},
+						pos:  position{line: 1143, col: 15, offset: 32138},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1142, col: 18, offset: 32231},
+						pos:        position{line: 1143, col: 18, offset: 32141},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1142, col: 22, offset: 32235},
+						pos:  position{line: 1143, col: 22, offset: 32145},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1142, col: 25, offset: 32238},
+						pos:        position{line: 1143, col: 25, offset: 32148},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1142, col: 29, offset: 32242},
+						pos:  position{line: 1143, col: 29, offset: 32152},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1142, col: 32, offset: 32245},
+						pos: position{line: 1143, col: 32, offset: 32155},
 						expr: &seqExpr{
-							pos: position{line: 1142, col: 33, offset: 32246},
+							pos: position{line: 1143, col: 33, offset: 32156},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1142, col: 33, offset: 32246},
+									pos:        position{line: 1143, col: 33, offset: 32156},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1142, col: 37, offset: 32250},
+									pos: position{line: 1143, col: 37, offset: 32160},
 									expr: &charClassMatcher{
-										pos:        position{line: 1142, col: 37, offset: 32250},
+										pos:        position{line: 1143, col: 37, offset: 32160},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9411,60 +9359,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1144, col: 1, offset: 32260},
+			pos:  position{line: 1145, col: 1, offset: 32170},
 			expr: &choiceExpr{
-				pos: position{line: 1145, col: 5, offset: 32275},
+				pos: position{line: 1146, col: 5, offset: 32185},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1145, col: 5, offset: 32275},
+						pos:        position{line: 1146, col: 5, offset: 32185},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1146, col: 5, offset: 32283},
+						pos: position{line: 1147, col: 5, offset: 32193},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1146, col: 6, offset: 32284},
+								pos: position{line: 1147, col: 6, offset: 32194},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1146, col: 6, offset: 32284},
+										pos:        position{line: 1147, col: 6, offset: 32194},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1146, col: 12, offset: 32290},
+										pos:        position{line: 1147, col: 12, offset: 32200},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1146, col: 17, offset: 32295},
+								pos:  position{line: 1147, col: 17, offset: 32205},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1146, col: 20, offset: 32298},
+								pos:        position{line: 1147, col: 20, offset: 32208},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1146, col: 24, offset: 32302},
+								pos:  position{line: 1147, col: 24, offset: 32212},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1146, col: 27, offset: 32305},
+								pos: position{line: 1147, col: 27, offset: 32215},
 								expr: &seqExpr{
-									pos: position{line: 1146, col: 28, offset: 32306},
+									pos: position{line: 1147, col: 28, offset: 32216},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1146, col: 28, offset: 32306},
+											pos:        position{line: 1147, col: 28, offset: 32216},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1146, col: 32, offset: 32310},
+											pos: position{line: 1147, col: 32, offset: 32220},
 											expr: &charClassMatcher{
-												pos:        position{line: 1146, col: 32, offset: 32310},
+												pos:        position{line: 1147, col: 32, offset: 32220},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9481,32 +9429,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1148, col: 1, offset: 32320},
+			pos:  position{line: 1149, col: 1, offset: 32230},
 			expr: &actionExpr{
-				pos: position{line: 1149, col: 5, offset: 32333},
+				pos: position{line: 1150, col: 5, offset: 32243},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1149, col: 5, offset: 32333},
+					pos: position{line: 1150, col: 5, offset: 32243},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1149, col: 5, offset: 32333},
+							pos: position{line: 1150, col: 5, offset: 32243},
 							expr: &litMatcher{
-								pos:        position{line: 1149, col: 5, offset: 32333},
+								pos:        position{line: 1150, col: 5, offset: 32243},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1149, col: 10, offset: 32338},
+							pos: position{line: 1150, col: 10, offset: 32248},
 							expr: &seqExpr{
-								pos: position{line: 1149, col: 11, offset: 32339},
+								pos: position{line: 1150, col: 11, offset: 32249},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1149, col: 11, offset: 32339},
+										pos:  position{line: 1150, col: 11, offset: 32249},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1149, col: 19, offset: 32347},
+										pos:  position{line: 1150, col: 19, offset: 32257},
 										name: "TimeUnit",
 									},
 								},
@@ -9518,26 +9466,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1153, col: 1, offset: 32473},
+			pos:  position{line: 1154, col: 1, offset: 32383},
 			expr: &seqExpr{
-				pos: position{line: 1153, col: 11, offset: 32483},
+				pos: position{line: 1154, col: 11, offset: 32393},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 11, offset: 32483},
+						pos:  position{line: 1154, col: 11, offset: 32393},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1153, col: 16, offset: 32488},
+						pos: position{line: 1154, col: 16, offset: 32398},
 						expr: &seqExpr{
-							pos: position{line: 1153, col: 17, offset: 32489},
+							pos: position{line: 1154, col: 17, offset: 32399},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1153, col: 17, offset: 32489},
+									pos:        position{line: 1154, col: 17, offset: 32399},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1153, col: 21, offset: 32493},
+									pos:  position{line: 1154, col: 21, offset: 32403},
 									name: "UInt",
 								},
 							},
@@ -9548,52 +9496,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1155, col: 1, offset: 32501},
+			pos:  position{line: 1156, col: 1, offset: 32411},
 			expr: &choiceExpr{
-				pos: position{line: 1156, col: 5, offset: 32514},
+				pos: position{line: 1157, col: 5, offset: 32424},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1156, col: 5, offset: 32514},
+						pos:        position{line: 1157, col: 5, offset: 32424},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1157, col: 5, offset: 32523},
+						pos:        position{line: 1158, col: 5, offset: 32433},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1158, col: 5, offset: 32532},
+						pos:        position{line: 1159, col: 5, offset: 32442},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1159, col: 5, offset: 32541},
+						pos:        position{line: 1160, col: 5, offset: 32451},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1160, col: 5, offset: 32549},
+						pos:        position{line: 1161, col: 5, offset: 32459},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1161, col: 5, offset: 32557},
+						pos:        position{line: 1162, col: 5, offset: 32467},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1162, col: 5, offset: 32565},
+						pos:        position{line: 1163, col: 5, offset: 32475},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1163, col: 5, offset: 32573},
+						pos:        position{line: 1164, col: 5, offset: 32483},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1164, col: 5, offset: 32581},
+						pos:        position{line: 1165, col: 5, offset: 32491},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9602,42 +9550,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1166, col: 1, offset: 32586},
+			pos:  position{line: 1167, col: 1, offset: 32496},
 			expr: &actionExpr{
-				pos: position{line: 1167, col: 5, offset: 32593},
+				pos: position{line: 1168, col: 5, offset: 32503},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1167, col: 5, offset: 32593},
+					pos: position{line: 1168, col: 5, offset: 32503},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1167, col: 5, offset: 32593},
+							pos:  position{line: 1168, col: 5, offset: 32503},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1167, col: 10, offset: 32598},
+							pos:        position{line: 1168, col: 10, offset: 32508},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1167, col: 14, offset: 32602},
+							pos:  position{line: 1168, col: 14, offset: 32512},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1167, col: 19, offset: 32607},
+							pos:        position{line: 1168, col: 19, offset: 32517},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1167, col: 23, offset: 32611},
+							pos:  position{line: 1168, col: 23, offset: 32521},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1167, col: 28, offset: 32616},
+							pos:        position{line: 1168, col: 28, offset: 32526},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1167, col: 32, offset: 32620},
+							pos:  position{line: 1168, col: 32, offset: 32530},
 							name: "UInt",
 						},
 					},
@@ -9646,42 +9594,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1169, col: 1, offset: 32657},
+			pos:  position{line: 1170, col: 1, offset: 32567},
 			expr: &actionExpr{
-				pos: position{line: 1170, col: 5, offset: 32665},
+				pos: position{line: 1171, col: 5, offset: 32575},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1170, col: 5, offset: 32665},
+					pos: position{line: 1171, col: 5, offset: 32575},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1170, col: 5, offset: 32665},
+							pos: position{line: 1171, col: 5, offset: 32575},
 							expr: &seqExpr{
-								pos: position{line: 1170, col: 8, offset: 32668},
+								pos: position{line: 1171, col: 8, offset: 32578},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1170, col: 8, offset: 32668},
+										pos:  position{line: 1171, col: 8, offset: 32578},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1170, col: 12, offset: 32672},
+										pos:        position{line: 1171, col: 12, offset: 32582},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1170, col: 16, offset: 32676},
+										pos:  position{line: 1171, col: 16, offset: 32586},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1170, col: 20, offset: 32680},
+										pos: position{line: 1171, col: 20, offset: 32590},
 										expr: &choiceExpr{
-											pos: position{line: 1170, col: 22, offset: 32682},
+											pos: position{line: 1171, col: 22, offset: 32592},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1170, col: 22, offset: 32682},
+													pos:  position{line: 1171, col: 22, offset: 32592},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1170, col: 33, offset: 32693},
+													pos:        position{line: 1171, col: 33, offset: 32603},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9692,10 +9640,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1170, col: 39, offset: 32699},
+							pos:   position{line: 1171, col: 39, offset: 32609},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1170, col: 41, offset: 32701},
+								pos:  position{line: 1171, col: 41, offset: 32611},
 								name: "IP6Variations",
 							},
 						},
@@ -9705,32 +9653,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1174, col: 1, offset: 32865},
+			pos:  position{line: 1175, col: 1, offset: 32775},
 			expr: &choiceExpr{
-				pos: position{line: 1175, col: 5, offset: 32883},
+				pos: position{line: 1176, col: 5, offset: 32793},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1175, col: 5, offset: 32883},
+						pos: position{line: 1176, col: 5, offset: 32793},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1175, col: 5, offset: 32883},
+							pos: position{line: 1176, col: 5, offset: 32793},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1175, col: 5, offset: 32883},
+									pos:   position{line: 1176, col: 5, offset: 32793},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1175, col: 7, offset: 32885},
+										pos: position{line: 1176, col: 7, offset: 32795},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1175, col: 7, offset: 32885},
+											pos:  position{line: 1176, col: 7, offset: 32795},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1175, col: 17, offset: 32895},
+									pos:   position{line: 1176, col: 17, offset: 32805},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1175, col: 19, offset: 32897},
+										pos:  position{line: 1176, col: 19, offset: 32807},
 										name: "IP6Tail",
 									},
 								},
@@ -9738,51 +9686,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1178, col: 5, offset: 32961},
+						pos: position{line: 1179, col: 5, offset: 32871},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1178, col: 5, offset: 32961},
+							pos: position{line: 1179, col: 5, offset: 32871},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1178, col: 5, offset: 32961},
+									pos:   position{line: 1179, col: 5, offset: 32871},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1178, col: 7, offset: 32963},
+										pos:  position{line: 1179, col: 7, offset: 32873},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1178, col: 11, offset: 32967},
+									pos:   position{line: 1179, col: 11, offset: 32877},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1178, col: 13, offset: 32969},
+										pos: position{line: 1179, col: 13, offset: 32879},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1178, col: 13, offset: 32969},
+											pos:  position{line: 1179, col: 13, offset: 32879},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1178, col: 23, offset: 32979},
+									pos:        position{line: 1179, col: 23, offset: 32889},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1178, col: 28, offset: 32984},
+									pos:   position{line: 1179, col: 28, offset: 32894},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1178, col: 30, offset: 32986},
+										pos: position{line: 1179, col: 30, offset: 32896},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1178, col: 30, offset: 32986},
+											pos:  position{line: 1179, col: 30, offset: 32896},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1178, col: 40, offset: 32996},
+									pos:   position{line: 1179, col: 40, offset: 32906},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1178, col: 42, offset: 32998},
+										pos:  position{line: 1179, col: 42, offset: 32908},
 										name: "IP6Tail",
 									},
 								},
@@ -9790,32 +9738,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1181, col: 5, offset: 33097},
+						pos: position{line: 1182, col: 5, offset: 33007},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1181, col: 5, offset: 33097},
+							pos: position{line: 1182, col: 5, offset: 33007},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1181, col: 5, offset: 33097},
+									pos:        position{line: 1182, col: 5, offset: 33007},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 10, offset: 33102},
+									pos:   position{line: 1182, col: 10, offset: 33012},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1181, col: 12, offset: 33104},
+										pos: position{line: 1182, col: 12, offset: 33014},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1181, col: 12, offset: 33104},
+											pos:  position{line: 1182, col: 12, offset: 33014},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 22, offset: 33114},
+									pos:   position{line: 1182, col: 22, offset: 33024},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1181, col: 24, offset: 33116},
+										pos:  position{line: 1182, col: 24, offset: 33026},
 										name: "IP6Tail",
 									},
 								},
@@ -9823,32 +9771,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1184, col: 5, offset: 33187},
+						pos: position{line: 1185, col: 5, offset: 33097},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1184, col: 5, offset: 33187},
+							pos: position{line: 1185, col: 5, offset: 33097},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1184, col: 5, offset: 33187},
+									pos:   position{line: 1185, col: 5, offset: 33097},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1184, col: 7, offset: 33189},
+										pos:  position{line: 1185, col: 7, offset: 33099},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1184, col: 11, offset: 33193},
+									pos:   position{line: 1185, col: 11, offset: 33103},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1184, col: 13, offset: 33195},
+										pos: position{line: 1185, col: 13, offset: 33105},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1184, col: 13, offset: 33195},
+											pos:  position{line: 1185, col: 13, offset: 33105},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1184, col: 23, offset: 33205},
+									pos:        position{line: 1185, col: 23, offset: 33115},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -9856,10 +9804,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1187, col: 5, offset: 33273},
+						pos: position{line: 1188, col: 5, offset: 33183},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1187, col: 5, offset: 33273},
+							pos:        position{line: 1188, col: 5, offset: 33183},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -9869,16 +9817,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1191, col: 1, offset: 33310},
+			pos:  position{line: 1192, col: 1, offset: 33220},
 			expr: &choiceExpr{
-				pos: position{line: 1192, col: 5, offset: 33322},
+				pos: position{line: 1193, col: 5, offset: 33232},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1192, col: 5, offset: 33322},
+						pos:  position{line: 1193, col: 5, offset: 33232},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1193, col: 5, offset: 33329},
+						pos:  position{line: 1194, col: 5, offset: 33239},
 						name: "Hex",
 					},
 				},
@@ -9886,23 +9834,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1195, col: 1, offset: 33334},
+			pos:  position{line: 1196, col: 1, offset: 33244},
 			expr: &actionExpr{
-				pos: position{line: 1195, col: 12, offset: 33345},
+				pos: position{line: 1196, col: 12, offset: 33255},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1195, col: 12, offset: 33345},
+					pos: position{line: 1196, col: 12, offset: 33255},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1195, col: 12, offset: 33345},
+							pos:        position{line: 1196, col: 12, offset: 33255},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1195, col: 16, offset: 33349},
+							pos:   position{line: 1196, col: 16, offset: 33259},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1195, col: 18, offset: 33351},
+								pos:  position{line: 1196, col: 18, offset: 33261},
 								name: "Hex",
 							},
 						},
@@ -9912,23 +9860,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1197, col: 1, offset: 33389},
+			pos:  position{line: 1198, col: 1, offset: 33299},
 			expr: &actionExpr{
-				pos: position{line: 1197, col: 12, offset: 33400},
+				pos: position{line: 1198, col: 12, offset: 33310},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1197, col: 12, offset: 33400},
+					pos: position{line: 1198, col: 12, offset: 33310},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1197, col: 12, offset: 33400},
+							pos:   position{line: 1198, col: 12, offset: 33310},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1197, col: 14, offset: 33402},
+								pos:  position{line: 1198, col: 14, offset: 33312},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1197, col: 18, offset: 33406},
+							pos:        position{line: 1198, col: 18, offset: 33316},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -9938,31 +9886,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1199, col: 1, offset: 33444},
+			pos:  position{line: 1200, col: 1, offset: 33354},
 			expr: &actionExpr{
-				pos: position{line: 1200, col: 5, offset: 33455},
+				pos: position{line: 1201, col: 5, offset: 33365},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1200, col: 5, offset: 33455},
+					pos: position{line: 1201, col: 5, offset: 33365},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1200, col: 5, offset: 33455},
+							pos:   position{line: 1201, col: 5, offset: 33365},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1200, col: 7, offset: 33457},
+								pos:  position{line: 1201, col: 7, offset: 33367},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1200, col: 10, offset: 33460},
+							pos:        position{line: 1201, col: 10, offset: 33370},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1200, col: 14, offset: 33464},
+							pos:   position{line: 1201, col: 14, offset: 33374},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1200, col: 16, offset: 33466},
+								pos:  position{line: 1201, col: 16, offset: 33376},
 								name: "UInt",
 							},
 						},
@@ -9972,31 +9920,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1204, col: 1, offset: 33539},
+			pos:  position{line: 1205, col: 1, offset: 33449},
 			expr: &actionExpr{
-				pos: position{line: 1205, col: 5, offset: 33550},
+				pos: position{line: 1206, col: 5, offset: 33460},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1205, col: 5, offset: 33550},
+					pos: position{line: 1206, col: 5, offset: 33460},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1205, col: 5, offset: 33550},
+							pos:   position{line: 1206, col: 5, offset: 33460},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1205, col: 7, offset: 33552},
+								pos:  position{line: 1206, col: 7, offset: 33462},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1205, col: 11, offset: 33556},
+							pos:        position{line: 1206, col: 11, offset: 33466},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1205, col: 15, offset: 33560},
+							pos:   position{line: 1206, col: 15, offset: 33470},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1205, col: 17, offset: 33562},
+								pos:  position{line: 1206, col: 17, offset: 33472},
 								name: "UInt",
 							},
 						},
@@ -10006,15 +9954,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1209, col: 1, offset: 33625},
+			pos:  position{line: 1210, col: 1, offset: 33535},
 			expr: &actionExpr{
-				pos: position{line: 1210, col: 4, offset: 33633},
+				pos: position{line: 1211, col: 4, offset: 33543},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1210, col: 4, offset: 33633},
+					pos:   position{line: 1211, col: 4, offset: 33543},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1210, col: 6, offset: 33635},
+						pos:  position{line: 1211, col: 6, offset: 33545},
 						name: "UIntString",
 					},
 				},
@@ -10022,16 +9970,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1212, col: 1, offset: 33675},
+			pos:  position{line: 1213, col: 1, offset: 33585},
 			expr: &choiceExpr{
-				pos: position{line: 1213, col: 5, offset: 33689},
+				pos: position{line: 1214, col: 5, offset: 33599},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1213, col: 5, offset: 33689},
+						pos:  position{line: 1214, col: 5, offset: 33599},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1214, col: 5, offset: 33704},
+						pos:  position{line: 1215, col: 5, offset: 33614},
 						name: "MinusIntString",
 					},
 				},
@@ -10039,14 +9987,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1216, col: 1, offset: 33720},
+			pos:  position{line: 1217, col: 1, offset: 33630},
 			expr: &actionExpr{
-				pos: position{line: 1216, col: 14, offset: 33733},
+				pos: position{line: 1217, col: 14, offset: 33643},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1216, col: 14, offset: 33733},
+					pos: position{line: 1217, col: 14, offset: 33643},
 					expr: &charClassMatcher{
-						pos:        position{line: 1216, col: 14, offset: 33733},
+						pos:        position{line: 1217, col: 14, offset: 33643},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10057,20 +10005,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1218, col: 1, offset: 33772},
+			pos:  position{line: 1219, col: 1, offset: 33682},
 			expr: &actionExpr{
-				pos: position{line: 1219, col: 5, offset: 33791},
+				pos: position{line: 1220, col: 5, offset: 33701},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1219, col: 5, offset: 33791},
+					pos: position{line: 1220, col: 5, offset: 33701},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1219, col: 5, offset: 33791},
+							pos:        position{line: 1220, col: 5, offset: 33701},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1219, col: 9, offset: 33795},
+							pos:  position{line: 1220, col: 9, offset: 33705},
 							name: "UIntString",
 						},
 					},
@@ -10079,28 +10027,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1221, col: 1, offset: 33838},
+			pos:  position{line: 1222, col: 1, offset: 33748},
 			expr: &choiceExpr{
-				pos: position{line: 1222, col: 5, offset: 33854},
+				pos: position{line: 1223, col: 5, offset: 33764},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1222, col: 5, offset: 33854},
+						pos: position{line: 1223, col: 5, offset: 33764},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1222, col: 5, offset: 33854},
+							pos: position{line: 1223, col: 5, offset: 33764},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1222, col: 5, offset: 33854},
+									pos: position{line: 1223, col: 5, offset: 33764},
 									expr: &litMatcher{
-										pos:        position{line: 1222, col: 5, offset: 33854},
+										pos:        position{line: 1223, col: 5, offset: 33764},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1222, col: 10, offset: 33859},
+									pos: position{line: 1223, col: 10, offset: 33769},
 									expr: &charClassMatcher{
-										pos:        position{line: 1222, col: 10, offset: 33859},
+										pos:        position{line: 1223, col: 10, offset: 33769},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10108,14 +10056,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1222, col: 17, offset: 33866},
+									pos:        position{line: 1223, col: 17, offset: 33776},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1222, col: 21, offset: 33870},
+									pos: position{line: 1223, col: 21, offset: 33780},
 									expr: &charClassMatcher{
-										pos:        position{line: 1222, col: 21, offset: 33870},
+										pos:        position{line: 1223, col: 21, offset: 33780},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10123,9 +10071,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1222, col: 28, offset: 33877},
+									pos: position{line: 1223, col: 28, offset: 33787},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1222, col: 28, offset: 33877},
+										pos:  position{line: 1223, col: 28, offset: 33787},
 										name: "ExponentPart",
 									},
 								},
@@ -10133,28 +10081,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1225, col: 5, offset: 33936},
+						pos: position{line: 1226, col: 5, offset: 33846},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1225, col: 5, offset: 33936},
+							pos: position{line: 1226, col: 5, offset: 33846},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1225, col: 5, offset: 33936},
+									pos: position{line: 1226, col: 5, offset: 33846},
 									expr: &litMatcher{
-										pos:        position{line: 1225, col: 5, offset: 33936},
+										pos:        position{line: 1226, col: 5, offset: 33846},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1225, col: 10, offset: 33941},
+									pos:        position{line: 1226, col: 10, offset: 33851},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1225, col: 14, offset: 33945},
+									pos: position{line: 1226, col: 14, offset: 33855},
 									expr: &charClassMatcher{
-										pos:        position{line: 1225, col: 14, offset: 33945},
+										pos:        position{line: 1226, col: 14, offset: 33855},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10162,9 +10110,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1225, col: 21, offset: 33952},
+									pos: position{line: 1226, col: 21, offset: 33862},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1225, col: 21, offset: 33952},
+										pos:  position{line: 1226, col: 21, offset: 33862},
 										name: "ExponentPart",
 									},
 								},
@@ -10172,17 +10120,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1228, col: 5, offset: 34011},
+						pos: position{line: 1229, col: 5, offset: 33921},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1228, col: 7, offset: 34013},
+							pos: position{line: 1229, col: 7, offset: 33923},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1228, col: 7, offset: 34013},
+									pos:  position{line: 1229, col: 7, offset: 33923},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1228, col: 13, offset: 34019},
+									pos:  position{line: 1229, col: 13, offset: 33929},
 									name: "Infinity",
 								},
 							},
@@ -10193,19 +10141,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1231, col: 1, offset: 34063},
+			pos:  position{line: 1232, col: 1, offset: 33973},
 			expr: &seqExpr{
-				pos: position{line: 1231, col: 16, offset: 34078},
+				pos: position{line: 1232, col: 16, offset: 33988},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1231, col: 16, offset: 34078},
+						pos:        position{line: 1232, col: 16, offset: 33988},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1231, col: 21, offset: 34083},
+						pos: position{line: 1232, col: 21, offset: 33993},
 						expr: &charClassMatcher{
-							pos:        position{line: 1231, col: 21, offset: 34083},
+							pos:        position{line: 1232, col: 21, offset: 33993},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10213,7 +10161,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 27, offset: 34089},
+						pos:  position{line: 1232, col: 27, offset: 33999},
 						name: "UIntString",
 					},
 				},
@@ -10221,31 +10169,31 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1233, col: 1, offset: 34101},
+			pos:  position{line: 1234, col: 1, offset: 34011},
 			expr: &litMatcher{
-				pos:        position{line: 1233, col: 7, offset: 34107},
+				pos:        position{line: 1234, col: 7, offset: 34017},
 				val:        "NaN",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1235, col: 1, offset: 34114},
+			pos:  position{line: 1236, col: 1, offset: 34024},
 			expr: &seqExpr{
-				pos: position{line: 1235, col: 12, offset: 34125},
+				pos: position{line: 1236, col: 12, offset: 34035},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 1235, col: 12, offset: 34125},
+						pos: position{line: 1236, col: 12, offset: 34035},
 						expr: &choiceExpr{
-							pos: position{line: 1235, col: 13, offset: 34126},
+							pos: position{line: 1236, col: 13, offset: 34036},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1235, col: 13, offset: 34126},
+									pos:        position{line: 1236, col: 13, offset: 34036},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1235, col: 19, offset: 34132},
+									pos:        position{line: 1236, col: 19, offset: 34042},
 									val:        "+",
 									ignoreCase: false,
 								},
@@ -10253,7 +10201,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1235, col: 25, offset: 34138},
+						pos:        position{line: 1236, col: 25, offset: 34048},
 						val:        "Inf",
 						ignoreCase: false,
 					},
@@ -10262,14 +10210,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1237, col: 1, offset: 34145},
+			pos:  position{line: 1238, col: 1, offset: 34055},
 			expr: &actionExpr{
-				pos: position{line: 1237, col: 7, offset: 34151},
+				pos: position{line: 1238, col: 7, offset: 34061},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1237, col: 7, offset: 34151},
+					pos: position{line: 1238, col: 7, offset: 34061},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1237, col: 7, offset: 34151},
+						pos:  position{line: 1238, col: 7, offset: 34061},
 						name: "HexDigit",
 					},
 				},
@@ -10277,9 +10225,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1239, col: 1, offset: 34193},
+			pos:  position{line: 1240, col: 1, offset: 34103},
 			expr: &charClassMatcher{
-				pos:        position{line: 1239, col: 12, offset: 34204},
+				pos:        position{line: 1240, col: 12, offset: 34114},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10288,34 +10236,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1241, col: 1, offset: 34217},
+			pos:  position{line: 1242, col: 1, offset: 34127},
 			expr: &choiceExpr{
-				pos: position{line: 1242, col: 5, offset: 34234},
+				pos: position{line: 1243, col: 5, offset: 34144},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1242, col: 5, offset: 34234},
+						pos: position{line: 1243, col: 5, offset: 34144},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1242, col: 5, offset: 34234},
+							pos: position{line: 1243, col: 5, offset: 34144},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1242, col: 5, offset: 34234},
+									pos:        position{line: 1243, col: 5, offset: 34144},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1242, col: 9, offset: 34238},
+									pos:   position{line: 1243, col: 9, offset: 34148},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1242, col: 11, offset: 34240},
+										pos: position{line: 1243, col: 11, offset: 34150},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1242, col: 11, offset: 34240},
+											pos:  position{line: 1243, col: 11, offset: 34150},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1242, col: 29, offset: 34258},
+									pos:        position{line: 1243, col: 29, offset: 34168},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10323,29 +10271,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1243, col: 5, offset: 34295},
+						pos: position{line: 1244, col: 5, offset: 34205},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1243, col: 5, offset: 34295},
+							pos: position{line: 1244, col: 5, offset: 34205},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1243, col: 5, offset: 34295},
+									pos:        position{line: 1244, col: 5, offset: 34205},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1243, col: 9, offset: 34299},
+									pos:   position{line: 1244, col: 9, offset: 34209},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1243, col: 11, offset: 34301},
+										pos: position{line: 1244, col: 11, offset: 34211},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1243, col: 11, offset: 34301},
+											pos:  position{line: 1244, col: 11, offset: 34211},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1243, col: 29, offset: 34319},
+									pos:        position{line: 1244, col: 29, offset: 34229},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10357,55 +10305,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1245, col: 1, offset: 34353},
+			pos:  position{line: 1246, col: 1, offset: 34263},
 			expr: &choiceExpr{
-				pos: position{line: 1246, col: 5, offset: 34374},
+				pos: position{line: 1247, col: 5, offset: 34284},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1246, col: 5, offset: 34374},
+						pos: position{line: 1247, col: 5, offset: 34284},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1246, col: 5, offset: 34374},
+							pos: position{line: 1247, col: 5, offset: 34284},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1246, col: 5, offset: 34374},
+									pos: position{line: 1247, col: 5, offset: 34284},
 									expr: &choiceExpr{
-										pos: position{line: 1246, col: 7, offset: 34376},
+										pos: position{line: 1247, col: 7, offset: 34286},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1246, col: 7, offset: 34376},
+												pos:        position{line: 1247, col: 7, offset: 34286},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1246, col: 13, offset: 34382},
+												pos:  position{line: 1247, col: 13, offset: 34292},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1246, col: 26, offset: 34395,
+									line: 1247, col: 26, offset: 34305,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1247, col: 5, offset: 34432},
+						pos: position{line: 1248, col: 5, offset: 34342},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1247, col: 5, offset: 34432},
+							pos: position{line: 1248, col: 5, offset: 34342},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1247, col: 5, offset: 34432},
+									pos:        position{line: 1248, col: 5, offset: 34342},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1247, col: 10, offset: 34437},
+									pos:   position{line: 1248, col: 10, offset: 34347},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1247, col: 12, offset: 34439},
+										pos:  position{line: 1248, col: 12, offset: 34349},
 										name: "EscapeSequence",
 									},
 								},
@@ -10417,28 +10365,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1249, col: 1, offset: 34473},
+			pos:  position{line: 1250, col: 1, offset: 34383},
 			expr: &actionExpr{
-				pos: position{line: 1250, col: 5, offset: 34485},
+				pos: position{line: 1251, col: 5, offset: 34395},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1250, col: 5, offset: 34485},
+					pos: position{line: 1251, col: 5, offset: 34395},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1250, col: 5, offset: 34485},
+							pos:   position{line: 1251, col: 5, offset: 34395},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1250, col: 10, offset: 34490},
+								pos:  position{line: 1251, col: 10, offset: 34400},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1250, col: 23, offset: 34503},
+							pos:   position{line: 1251, col: 23, offset: 34413},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1250, col: 28, offset: 34508},
+								pos: position{line: 1251, col: 28, offset: 34418},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1250, col: 28, offset: 34508},
+									pos:  position{line: 1251, col: 28, offset: 34418},
 									name: "KeyWordRest",
 								},
 							},
@@ -10449,16 +10397,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1252, col: 1, offset: 34570},
+			pos:  position{line: 1253, col: 1, offset: 34480},
 			expr: &choiceExpr{
-				pos: position{line: 1253, col: 5, offset: 34587},
+				pos: position{line: 1254, col: 5, offset: 34497},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 5, offset: 34587},
+						pos:  position{line: 1254, col: 5, offset: 34497},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1254, col: 5, offset: 34604},
+						pos:  position{line: 1255, col: 5, offset: 34514},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10466,12 +10414,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1256, col: 1, offset: 34616},
+			pos:  position{line: 1257, col: 1, offset: 34526},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 16, offset: 34631},
+				pos: position{line: 1257, col: 16, offset: 34541},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1256, col: 16, offset: 34631},
+					pos:        position{line: 1257, col: 16, offset: 34541},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10482,16 +10430,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1258, col: 1, offset: 34680},
+			pos:  position{line: 1259, col: 1, offset: 34590},
 			expr: &choiceExpr{
-				pos: position{line: 1259, col: 5, offset: 34696},
+				pos: position{line: 1260, col: 5, offset: 34606},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 5, offset: 34696},
+						pos:  position{line: 1260, col: 5, offset: 34606},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1260, col: 5, offset: 34713},
+						pos:        position{line: 1261, col: 5, offset: 34623},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10502,30 +10450,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1262, col: 1, offset: 34720},
+			pos:  position{line: 1263, col: 1, offset: 34630},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 14, offset: 34733},
+				pos: position{line: 1263, col: 14, offset: 34643},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1262, col: 14, offset: 34733},
+					pos: position{line: 1263, col: 14, offset: 34643},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1262, col: 14, offset: 34733},
+							pos:        position{line: 1263, col: 14, offset: 34643},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1262, col: 19, offset: 34738},
+							pos:   position{line: 1263, col: 19, offset: 34648},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1262, col: 22, offset: 34741},
+								pos: position{line: 1263, col: 22, offset: 34651},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1262, col: 22, offset: 34741},
+										pos:  position{line: 1263, col: 22, offset: 34651},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1262, col: 38, offset: 34757},
+										pos:  position{line: 1263, col: 38, offset: 34667},
 										name: "EscapeSequence",
 									},
 								},
@@ -10537,42 +10485,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1264, col: 1, offset: 34793},
+			pos:  position{line: 1265, col: 1, offset: 34703},
 			expr: &actionExpr{
-				pos: position{line: 1265, col: 5, offset: 34809},
+				pos: position{line: 1266, col: 5, offset: 34719},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1265, col: 5, offset: 34809},
+					pos: position{line: 1266, col: 5, offset: 34719},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1265, col: 5, offset: 34809},
+							pos: position{line: 1266, col: 5, offset: 34719},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1265, col: 6, offset: 34810},
+								pos:  position{line: 1266, col: 6, offset: 34720},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1265, col: 22, offset: 34826},
+							pos: position{line: 1266, col: 22, offset: 34736},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1265, col: 23, offset: 34827},
+								pos:  position{line: 1266, col: 23, offset: 34737},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1265, col: 35, offset: 34839},
+							pos:   position{line: 1266, col: 35, offset: 34749},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1265, col: 40, offset: 34844},
+								pos:  position{line: 1266, col: 40, offset: 34754},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1265, col: 50, offset: 34854},
+							pos:   position{line: 1266, col: 50, offset: 34764},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1265, col: 55, offset: 34859},
+								pos: position{line: 1266, col: 55, offset: 34769},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1265, col: 55, offset: 34859},
+									pos:  position{line: 1266, col: 55, offset: 34769},
 									name: "GlobRest",
 								},
 							},
@@ -10583,20 +10531,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1269, col: 1, offset: 34928},
+			pos:  position{line: 1270, col: 1, offset: 34838},
 			expr: &seqExpr{
-				pos: position{line: 1269, col: 19, offset: 34946},
+				pos: position{line: 1270, col: 19, offset: 34856},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1269, col: 19, offset: 34946},
+						pos: position{line: 1270, col: 19, offset: 34856},
 						expr: &litMatcher{
-							pos:        position{line: 1269, col: 19, offset: 34946},
+							pos:        position{line: 1270, col: 19, offset: 34856},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1269, col: 24, offset: 34951},
+						pos:  position{line: 1270, col: 24, offset: 34861},
 						name: "KeyWordStart",
 					},
 				},
@@ -10604,19 +10552,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1270, col: 1, offset: 34964},
+			pos:  position{line: 1271, col: 1, offset: 34874},
 			expr: &seqExpr{
-				pos: position{line: 1270, col: 15, offset: 34978},
+				pos: position{line: 1271, col: 15, offset: 34888},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1270, col: 15, offset: 34978},
+						pos: position{line: 1271, col: 15, offset: 34888},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1270, col: 15, offset: 34978},
+							pos:  position{line: 1271, col: 15, offset: 34888},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1270, col: 28, offset: 34991},
+						pos:        position{line: 1271, col: 28, offset: 34901},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10625,23 +10573,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1272, col: 1, offset: 34996},
+			pos:  position{line: 1273, col: 1, offset: 34906},
 			expr: &choiceExpr{
-				pos: position{line: 1273, col: 5, offset: 35010},
+				pos: position{line: 1274, col: 5, offset: 34920},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 35010},
+						pos:  position{line: 1274, col: 5, offset: 34920},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1274, col: 5, offset: 35027},
+						pos:  position{line: 1275, col: 5, offset: 34937},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1275, col: 5, offset: 35039},
+						pos: position{line: 1276, col: 5, offset: 34949},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1275, col: 5, offset: 35039},
+							pos:        position{line: 1276, col: 5, offset: 34949},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10651,16 +10599,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1277, col: 1, offset: 35063},
+			pos:  position{line: 1278, col: 1, offset: 34973},
 			expr: &choiceExpr{
-				pos: position{line: 1278, col: 5, offset: 35076},
+				pos: position{line: 1279, col: 5, offset: 34986},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 35076},
+						pos:  position{line: 1279, col: 5, offset: 34986},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1279, col: 5, offset: 35090},
+						pos:        position{line: 1280, col: 5, offset: 35000},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10671,30 +10619,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1281, col: 1, offset: 35097},
+			pos:  position{line: 1282, col: 1, offset: 35007},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 11, offset: 35107},
+				pos: position{line: 1282, col: 11, offset: 35017},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1281, col: 11, offset: 35107},
+					pos: position{line: 1282, col: 11, offset: 35017},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1281, col: 11, offset: 35107},
+							pos:        position{line: 1282, col: 11, offset: 35017},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1281, col: 16, offset: 35112},
+							pos:   position{line: 1282, col: 16, offset: 35022},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1281, col: 19, offset: 35115},
+								pos: position{line: 1282, col: 19, offset: 35025},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1281, col: 19, offset: 35115},
+										pos:  position{line: 1282, col: 19, offset: 35025},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1281, col: 32, offset: 35128},
+										pos:  position{line: 1282, col: 32, offset: 35038},
 										name: "EscapeSequence",
 									},
 								},
@@ -10706,30 +10654,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1283, col: 1, offset: 35164},
+			pos:  position{line: 1284, col: 1, offset: 35074},
 			expr: &choiceExpr{
-				pos: position{line: 1284, col: 5, offset: 35179},
+				pos: position{line: 1285, col: 5, offset: 35089},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1284, col: 5, offset: 35179},
+						pos: position{line: 1285, col: 5, offset: 35089},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1284, col: 5, offset: 35179},
+							pos:        position{line: 1285, col: 5, offset: 35089},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1285, col: 5, offset: 35207},
+						pos: position{line: 1286, col: 5, offset: 35117},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1285, col: 5, offset: 35207},
+							pos:        position{line: 1286, col: 5, offset: 35117},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1286, col: 5, offset: 35237},
+						pos:        position{line: 1287, col: 5, offset: 35147},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10740,55 +10688,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1289, col: 1, offset: 35244},
+			pos:  position{line: 1290, col: 1, offset: 35154},
 			expr: &choiceExpr{
-				pos: position{line: 1290, col: 5, offset: 35265},
+				pos: position{line: 1291, col: 5, offset: 35175},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 35265},
+						pos: position{line: 1291, col: 5, offset: 35175},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1290, col: 5, offset: 35265},
+							pos: position{line: 1291, col: 5, offset: 35175},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1290, col: 5, offset: 35265},
+									pos: position{line: 1291, col: 5, offset: 35175},
 									expr: &choiceExpr{
-										pos: position{line: 1290, col: 7, offset: 35267},
+										pos: position{line: 1291, col: 7, offset: 35177},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1290, col: 7, offset: 35267},
+												pos:        position{line: 1291, col: 7, offset: 35177},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1290, col: 13, offset: 35273},
+												pos:  position{line: 1291, col: 13, offset: 35183},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1290, col: 26, offset: 35286,
+									line: 1291, col: 26, offset: 35196,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1291, col: 5, offset: 35323},
+						pos: position{line: 1292, col: 5, offset: 35233},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1291, col: 5, offset: 35323},
+							pos: position{line: 1292, col: 5, offset: 35233},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1291, col: 5, offset: 35323},
+									pos:        position{line: 1292, col: 5, offset: 35233},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1291, col: 10, offset: 35328},
+									pos:   position{line: 1292, col: 10, offset: 35238},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1291, col: 12, offset: 35330},
+										pos:  position{line: 1292, col: 12, offset: 35240},
 										name: "EscapeSequence",
 									},
 								},
@@ -10800,16 +10748,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1293, col: 1, offset: 35364},
+			pos:  position{line: 1294, col: 1, offset: 35274},
 			expr: &choiceExpr{
-				pos: position{line: 1294, col: 5, offset: 35383},
+				pos: position{line: 1295, col: 5, offset: 35293},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1294, col: 5, offset: 35383},
+						pos:  position{line: 1295, col: 5, offset: 35293},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1295, col: 5, offset: 35404},
+						pos:  position{line: 1296, col: 5, offset: 35314},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10817,79 +10765,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1297, col: 1, offset: 35419},
+			pos:  position{line: 1298, col: 1, offset: 35329},
 			expr: &choiceExpr{
-				pos: position{line: 1298, col: 5, offset: 35440},
+				pos: position{line: 1299, col: 5, offset: 35350},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1298, col: 5, offset: 35440},
+						pos:        position{line: 1299, col: 5, offset: 35350},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1299, col: 5, offset: 35448},
+						pos: position{line: 1300, col: 5, offset: 35358},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1299, col: 5, offset: 35448},
+							pos:        position{line: 1300, col: 5, offset: 35358},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1300, col: 5, offset: 35488},
+						pos:        position{line: 1301, col: 5, offset: 35398},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1301, col: 5, offset: 35497},
+						pos: position{line: 1302, col: 5, offset: 35407},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1301, col: 5, offset: 35497},
+							pos:        position{line: 1302, col: 5, offset: 35407},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1302, col: 5, offset: 35526},
+						pos: position{line: 1303, col: 5, offset: 35436},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1302, col: 5, offset: 35526},
+							pos:        position{line: 1303, col: 5, offset: 35436},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1303, col: 5, offset: 35555},
+						pos: position{line: 1304, col: 5, offset: 35465},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1303, col: 5, offset: 35555},
+							pos:        position{line: 1304, col: 5, offset: 35465},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1304, col: 5, offset: 35584},
+						pos: position{line: 1305, col: 5, offset: 35494},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1304, col: 5, offset: 35584},
+							pos:        position{line: 1305, col: 5, offset: 35494},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1305, col: 5, offset: 35613},
+						pos: position{line: 1306, col: 5, offset: 35523},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1305, col: 5, offset: 35613},
+							pos:        position{line: 1306, col: 5, offset: 35523},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1306, col: 5, offset: 35642},
+						pos: position{line: 1307, col: 5, offset: 35552},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1306, col: 5, offset: 35642},
+							pos:        position{line: 1307, col: 5, offset: 35552},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -10899,30 +10847,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1308, col: 1, offset: 35668},
+			pos:  position{line: 1309, col: 1, offset: 35578},
 			expr: &choiceExpr{
-				pos: position{line: 1309, col: 5, offset: 35686},
+				pos: position{line: 1310, col: 5, offset: 35596},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 35686},
+						pos: position{line: 1310, col: 5, offset: 35596},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1309, col: 5, offset: 35686},
+							pos:        position{line: 1310, col: 5, offset: 35596},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 35714},
+						pos: position{line: 1311, col: 5, offset: 35624},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1310, col: 5, offset: 35714},
+							pos:        position{line: 1311, col: 5, offset: 35624},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1311, col: 5, offset: 35742},
+						pos:        position{line: 1312, col: 5, offset: 35652},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10933,41 +10881,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1313, col: 1, offset: 35748},
+			pos:  position{line: 1314, col: 1, offset: 35658},
 			expr: &choiceExpr{
-				pos: position{line: 1314, col: 5, offset: 35766},
+				pos: position{line: 1315, col: 5, offset: 35676},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 35766},
+						pos: position{line: 1315, col: 5, offset: 35676},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1314, col: 5, offset: 35766},
+							pos: position{line: 1315, col: 5, offset: 35676},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1314, col: 5, offset: 35766},
+									pos:        position{line: 1315, col: 5, offset: 35676},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1314, col: 9, offset: 35770},
+									pos:   position{line: 1315, col: 9, offset: 35680},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1314, col: 16, offset: 35777},
+										pos: position{line: 1315, col: 16, offset: 35687},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1314, col: 16, offset: 35777},
+												pos:  position{line: 1315, col: 16, offset: 35687},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1314, col: 25, offset: 35786},
+												pos:  position{line: 1315, col: 25, offset: 35696},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1314, col: 34, offset: 35795},
+												pos:  position{line: 1315, col: 34, offset: 35705},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1314, col: 43, offset: 35804},
+												pos:  position{line: 1315, col: 43, offset: 35714},
 												name: "HexDigit",
 											},
 										},
@@ -10977,63 +10925,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 35867},
+						pos: position{line: 1318, col: 5, offset: 35777},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1317, col: 5, offset: 35867},
+							pos: position{line: 1318, col: 5, offset: 35777},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1317, col: 5, offset: 35867},
+									pos:        position{line: 1318, col: 5, offset: 35777},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1317, col: 9, offset: 35871},
+									pos:        position{line: 1318, col: 9, offset: 35781},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1317, col: 13, offset: 35875},
+									pos:   position{line: 1318, col: 13, offset: 35785},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1317, col: 20, offset: 35882},
+										pos: position{line: 1318, col: 20, offset: 35792},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1317, col: 20, offset: 35882},
+												pos:  position{line: 1318, col: 20, offset: 35792},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 29, offset: 35891},
+												pos: position{line: 1318, col: 29, offset: 35801},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 29, offset: 35891},
+													pos:  position{line: 1318, col: 29, offset: 35801},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 39, offset: 35901},
+												pos: position{line: 1318, col: 39, offset: 35811},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 39, offset: 35901},
+													pos:  position{line: 1318, col: 39, offset: 35811},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 49, offset: 35911},
+												pos: position{line: 1318, col: 49, offset: 35821},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 49, offset: 35911},
+													pos:  position{line: 1318, col: 49, offset: 35821},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 59, offset: 35921},
+												pos: position{line: 1318, col: 59, offset: 35831},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 59, offset: 35921},
+													pos:  position{line: 1318, col: 59, offset: 35831},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1317, col: 69, offset: 35931},
+												pos: position{line: 1318, col: 69, offset: 35841},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 69, offset: 35931},
+													pos:  position{line: 1318, col: 69, offset: 35841},
 													name: "HexDigit",
 												},
 											},
@@ -11041,7 +10989,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1317, col: 80, offset: 35942},
+									pos:        position{line: 1318, col: 80, offset: 35852},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11053,35 +11001,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1321, col: 1, offset: 35996},
+			pos:  position{line: 1322, col: 1, offset: 35906},
 			expr: &actionExpr{
-				pos: position{line: 1322, col: 5, offset: 36014},
+				pos: position{line: 1323, col: 5, offset: 35924},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1322, col: 5, offset: 36014},
+					pos: position{line: 1323, col: 5, offset: 35924},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1322, col: 5, offset: 36014},
+							pos:        position{line: 1323, col: 5, offset: 35924},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1322, col: 9, offset: 36018},
+							pos:   position{line: 1323, col: 9, offset: 35928},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1322, col: 14, offset: 36023},
+								pos:  position{line: 1323, col: 14, offset: 35933},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1322, col: 25, offset: 36034},
+							pos:        position{line: 1323, col: 25, offset: 35944},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1322, col: 29, offset: 36038},
+							pos: position{line: 1323, col: 29, offset: 35948},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1322, col: 30, offset: 36039},
+								pos:  position{line: 1323, col: 30, offset: 35949},
 								name: "KeyWordStart",
 							},
 						},
@@ -11091,32 +11039,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1324, col: 1, offset: 36074},
+			pos:  position{line: 1325, col: 1, offset: 35984},
 			expr: &actionExpr{
-				pos: position{line: 1325, col: 5, offset: 36089},
+				pos: position{line: 1326, col: 5, offset: 35999},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1325, col: 5, offset: 36089},
+					pos: position{line: 1326, col: 5, offset: 35999},
 					expr: &choiceExpr{
-						pos: position{line: 1325, col: 6, offset: 36090},
+						pos: position{line: 1326, col: 6, offset: 36000},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1325, col: 6, offset: 36090},
+								pos:        position{line: 1326, col: 6, offset: 36000},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1325, col: 15, offset: 36099},
+								pos: position{line: 1326, col: 15, offset: 36009},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1325, col: 15, offset: 36099},
+										pos:        position{line: 1326, col: 15, offset: 36009},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1325, col: 20, offset: 36104,
+										line: 1326, col: 20, offset: 36014,
 									},
 								},
 							},
@@ -11127,9 +11075,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1327, col: 1, offset: 36140},
+			pos:  position{line: 1328, col: 1, offset: 36050},
 			expr: &charClassMatcher{
-				pos:        position{line: 1328, col: 5, offset: 36156},
+				pos:        position{line: 1329, col: 5, offset: 36066},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11139,42 +11087,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1330, col: 1, offset: 36171},
+			pos:  position{line: 1331, col: 1, offset: 36081},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1330, col: 6, offset: 36176},
+				pos: position{line: 1331, col: 6, offset: 36086},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1330, col: 6, offset: 36176},
+					pos:  position{line: 1331, col: 6, offset: 36086},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1332, col: 1, offset: 36187},
+			pos:  position{line: 1333, col: 1, offset: 36097},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1332, col: 6, offset: 36192},
+				pos: position{line: 1333, col: 6, offset: 36102},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1332, col: 6, offset: 36192},
+					pos:  position{line: 1333, col: 6, offset: 36102},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1334, col: 1, offset: 36203},
+			pos:  position{line: 1335, col: 1, offset: 36113},
 			expr: &choiceExpr{
-				pos: position{line: 1335, col: 5, offset: 36216},
+				pos: position{line: 1336, col: 5, offset: 36126},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1335, col: 5, offset: 36216},
+						pos:  position{line: 1336, col: 5, offset: 36126},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1336, col: 5, offset: 36231},
+						pos:  position{line: 1337, col: 5, offset: 36141},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1337, col: 5, offset: 36250},
+						pos:  position{line: 1338, col: 5, offset: 36160},
 						name: "Comment",
 					},
 				},
@@ -11182,45 +11130,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1339, col: 1, offset: 36259},
+			pos:  position{line: 1340, col: 1, offset: 36169},
 			expr: &anyMatcher{
-				line: 1340, col: 5, offset: 36279,
+				line: 1341, col: 5, offset: 36189,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1342, col: 1, offset: 36282},
+			pos:         position{line: 1343, col: 1, offset: 36192},
 			expr: &choiceExpr{
-				pos: position{line: 1343, col: 5, offset: 36310},
+				pos: position{line: 1344, col: 5, offset: 36220},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1343, col: 5, offset: 36310},
+						pos:        position{line: 1344, col: 5, offset: 36220},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1344, col: 5, offset: 36319},
+						pos:        position{line: 1345, col: 5, offset: 36229},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1345, col: 5, offset: 36328},
+						pos:        position{line: 1346, col: 5, offset: 36238},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1346, col: 5, offset: 36337},
+						pos:        position{line: 1347, col: 5, offset: 36247},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1347, col: 5, offset: 36345},
+						pos:        position{line: 1348, col: 5, offset: 36255},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1348, col: 5, offset: 36358},
+						pos:        position{line: 1349, col: 5, offset: 36268},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11229,9 +11177,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1350, col: 1, offset: 36368},
+			pos:  position{line: 1351, col: 1, offset: 36278},
 			expr: &charClassMatcher{
-				pos:        position{line: 1351, col: 5, offset: 36387},
+				pos:        position{line: 1352, col: 5, offset: 36297},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11241,45 +11189,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1357, col: 1, offset: 36717},
+			pos:         position{line: 1358, col: 1, offset: 36627},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1360, col: 5, offset: 36788},
+				pos:  position{line: 1361, col: 5, offset: 36698},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1362, col: 1, offset: 36807},
+			pos:  position{line: 1363, col: 1, offset: 36717},
 			expr: &seqExpr{
-				pos: position{line: 1363, col: 5, offset: 36828},
+				pos: position{line: 1364, col: 5, offset: 36738},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1363, col: 5, offset: 36828},
+						pos:        position{line: 1364, col: 5, offset: 36738},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1363, col: 10, offset: 36833},
+						pos: position{line: 1364, col: 10, offset: 36743},
 						expr: &seqExpr{
-							pos: position{line: 1363, col: 11, offset: 36834},
+							pos: position{line: 1364, col: 11, offset: 36744},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1363, col: 11, offset: 36834},
+									pos: position{line: 1364, col: 11, offset: 36744},
 									expr: &litMatcher{
-										pos:        position{line: 1363, col: 12, offset: 36835},
+										pos:        position{line: 1364, col: 12, offset: 36745},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1363, col: 17, offset: 36840},
+									pos:  position{line: 1364, col: 17, offset: 36750},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1363, col: 35, offset: 36858},
+						pos:        position{line: 1364, col: 35, offset: 36768},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11288,29 +11236,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1365, col: 1, offset: 36864},
+			pos:  position{line: 1366, col: 1, offset: 36774},
 			expr: &seqExpr{
-				pos: position{line: 1366, col: 5, offset: 36886},
+				pos: position{line: 1367, col: 5, offset: 36796},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1366, col: 5, offset: 36886},
+						pos:        position{line: 1367, col: 5, offset: 36796},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1366, col: 10, offset: 36891},
+						pos: position{line: 1367, col: 10, offset: 36801},
 						expr: &seqExpr{
-							pos: position{line: 1366, col: 11, offset: 36892},
+							pos: position{line: 1367, col: 11, offset: 36802},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1366, col: 11, offset: 36892},
+									pos: position{line: 1367, col: 11, offset: 36802},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 12, offset: 36893},
+										pos:  position{line: 1367, col: 12, offset: 36803},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1366, col: 27, offset: 36908},
+									pos:  position{line: 1367, col: 27, offset: 36818},
 									name: "SourceCharacter",
 								},
 							},
@@ -11321,19 +11269,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1368, col: 1, offset: 36927},
+			pos:  position{line: 1369, col: 1, offset: 36837},
 			expr: &seqExpr{
-				pos: position{line: 1368, col: 7, offset: 36933},
+				pos: position{line: 1369, col: 7, offset: 36843},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1368, col: 7, offset: 36933},
+						pos: position{line: 1369, col: 7, offset: 36843},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1368, col: 7, offset: 36933},
+							pos:  position{line: 1369, col: 7, offset: 36843},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 19, offset: 36945},
+						pos:  position{line: 1369, col: 19, offset: 36855},
 						name: "LineTerminator",
 					},
 				},
@@ -11341,16 +11289,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1370, col: 1, offset: 36961},
+			pos:  position{line: 1371, col: 1, offset: 36871},
 			expr: &choiceExpr{
-				pos: position{line: 1370, col: 7, offset: 36967},
+				pos: position{line: 1371, col: 7, offset: 36877},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1370, col: 7, offset: 36967},
+						pos:  position{line: 1371, col: 7, offset: 36877},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1370, col: 11, offset: 36971},
+						pos:  position{line: 1371, col: 11, offset: 36881},
 						name: "EOF",
 					},
 				},
@@ -11358,21 +11306,21 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1372, col: 1, offset: 36976},
+			pos:  position{line: 1373, col: 1, offset: 36886},
 			expr: &notExpr{
-				pos: position{line: 1372, col: 7, offset: 36982},
+				pos: position{line: 1373, col: 7, offset: 36892},
 				expr: &anyMatcher{
-					line: 1372, col: 8, offset: 36983,
+					line: 1373, col: 8, offset: 36893,
 				},
 			},
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1374, col: 1, offset: 36986},
+			pos:  position{line: 1375, col: 1, offset: 36896},
 			expr: &notExpr{
-				pos: position{line: 1374, col: 8, offset: 36993},
+				pos: position{line: 1375, col: 8, offset: 36903},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1374, col: 9, offset: 36994},
+					pos:  position{line: 1375, col: 9, offset: 36904},
 					name: "KeyWordChars",
 				},
 			},
@@ -12653,26 +12601,6 @@ func (p *parser) callonMergeOp1() (interface{}, error) {
 	return p.cur.onMergeOp1(stack["expr"])
 }
 
-func (c *current) onOverOp9(l interface{}) (interface{}, error) {
-	return l, nil
-}
-
-func (p *parser) callonOverOp9() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOverOp9(stack["l"])
-}
-
-func (c *current) onOverOp18(s interface{}) (interface{}, error) {
-	return s, nil
-}
-
-func (p *parser) callonOverOp18() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOverOp18(stack["s"])
-}
-
 func (c *current) onOverOp1(exprs, locals, scope interface{}) (interface{}, error) {
 	var over = map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope}
 	if locals != nil {
@@ -12698,47 +12626,47 @@ func (p *parser) callonScope1() (interface{}, error) {
 	return p.cur.onScope1(stack["seq"])
 }
 
-func (c *current) onLetAssignments7(a interface{}) (interface{}, error) {
+func (c *current) onLocals10(a interface{}) (interface{}, error) {
 	return a, nil
 }
 
-func (p *parser) callonLetAssignments7() (interface{}, error) {
+func (p *parser) callonLocals10() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLetAssignments7(stack["a"])
+	return p.cur.onLocals10(stack["a"])
 }
 
-func (c *current) onLetAssignments1(first, rest interface{}) (interface{}, error) {
+func (c *current) onLocals1(first, rest interface{}) (interface{}, error) {
 	return append([]interface{}{first}, (rest.([]interface{}))...), nil
 
 }
 
-func (p *parser) callonLetAssignments1() (interface{}, error) {
+func (p *parser) callonLocals1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLetAssignments1(stack["first"], stack["rest"])
+	return p.cur.onLocals1(stack["first"], stack["rest"])
 }
 
-func (c *current) onLetAssignment2(id, expr interface{}) (interface{}, error) {
+func (c *current) onLocalsAssignment2(id, expr interface{}) (interface{}, error) {
 	return map[string]interface{}{"name": id, "expr": expr}, nil
 
 }
 
-func (p *parser) callonLetAssignment2() (interface{}, error) {
+func (p *parser) callonLocalsAssignment2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLetAssignment2(stack["id"], stack["expr"])
+	return p.cur.onLocalsAssignment2(stack["id"], stack["expr"])
 }
 
-func (c *current) onLetAssignment11(id interface{}) (interface{}, error) {
+func (c *current) onLocalsAssignment11(id interface{}) (interface{}, error) {
 	return map[string]interface{}{"name": id, "expr": map[string]interface{}{"kind": "ID", "name": id}}, nil
 
 }
 
-func (p *parser) callonLetAssignment11() (interface{}, error) {
+func (p *parser) callonLocalsAssignment11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLetAssignment11(stack["id"])
+	return p.cur.onLocalsAssignment11(stack["id"])
 }
 
 func (c *current) onYieldOp1(exprs interface{}) (interface{}, error) {
@@ -13187,16 +13115,6 @@ func (p *parser) callonPrimary15() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPrimary15(stack["expr"])
-}
-
-func (c *current) onOverExpr9(l interface{}) (interface{}, error) {
-	return l, nil
-}
-
-func (p *parser) callonOverExpr9() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOverExpr9(stack["l"])
 }
 
 func (c *current) onOverExpr1(exprs, locals, scope interface{}) (interface{}, error) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -55,74 +55,40 @@ var g = &grammar{
 		{
 			name: "Sequential",
 			pos:  position{line: 9, col: 1, offset: 80},
-			expr: &choiceExpr{
+			expr: &actionExpr{
 				pos: position{line: 10, col: 5, offset: 95},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 10, col: 5, offset: 95},
-						run: (*parser).callonSequential2,
-						expr: &seqExpr{
-							pos: position{line: 10, col: 5, offset: 95},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 10, col: 5, offset: 95},
-									label: "consts",
-									expr: &ruleRefExpr{
-										pos:  position{line: 10, col: 12, offset: 102},
-										name: "Consts",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 10, col: 19, offset: 109},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 10, col: 22, offset: 112},
-									label: "first",
-									expr: &ruleRefExpr{
-										pos:  position{line: 10, col: 28, offset: 118},
-										name: "Operation",
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 10, col: 38, offset: 128},
-									label: "rest",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 10, col: 43, offset: 133},
-										expr: &ruleRefExpr{
-											pos:  position{line: 10, col: 43, offset: 133},
-											name: "SequentialTail",
-										},
-									},
-								},
+				run: (*parser).callonSequential1,
+				expr: &seqExpr{
+					pos: position{line: 10, col: 5, offset: 95},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 10, col: 5, offset: 95},
+							label: "consts",
+							expr: &ruleRefExpr{
+								pos:  position{line: 10, col: 12, offset: 102},
+								name: "Consts",
 							},
 						},
-					},
-					&actionExpr{
-						pos: position{line: 13, col: 5, offset: 306},
-						run: (*parser).callonSequential12,
-						expr: &seqExpr{
-							pos: position{line: 13, col: 5, offset: 306},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 13, col: 5, offset: 306},
-									label: "consts",
-									expr: &ruleRefExpr{
-										pos:  position{line: 13, col: 12, offset: 313},
-										name: "Consts",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 13, col: 19, offset: 320},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 13, col: 22, offset: 323},
-									label: "op",
-									expr: &ruleRefExpr{
-										pos:  position{line: 13, col: 25, offset: 326},
-										name: "Operation",
-									},
+						&ruleRefExpr{
+							pos:  position{line: 10, col: 19, offset: 109},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 10, col: 22, offset: 112},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 10, col: 28, offset: 118},
+								name: "Operation",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 10, col: 38, offset: 128},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 10, col: 43, offset: 133},
+								expr: &ruleRefExpr{
+									pos:  position{line: 10, col: 43, offset: 133},
+									name: "SequentialTail",
 								},
 							},
 						},
@@ -132,30 +98,30 @@ var g = &grammar{
 		},
 		{
 			name: "SequentialTail",
-			pos:  position{line: 17, col: 1, offset: 451},
+			pos:  position{line: 14, col: 1, offset: 303},
 			expr: &actionExpr{
-				pos: position{line: 17, col: 18, offset: 468},
+				pos: position{line: 14, col: 18, offset: 320},
 				run: (*parser).callonSequentialTail1,
 				expr: &seqExpr{
-					pos: position{line: 17, col: 18, offset: 468},
+					pos: position{line: 14, col: 18, offset: 320},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 17, col: 18, offset: 468},
+							pos:  position{line: 14, col: 18, offset: 320},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 17, col: 21, offset: 471},
+							pos:  position{line: 14, col: 21, offset: 323},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 17, col: 26, offset: 476},
+							pos:  position{line: 14, col: 26, offset: 328},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 17, col: 29, offset: 479},
+							pos:   position{line: 14, col: 29, offset: 331},
 							label: "p",
 							expr: &ruleRefExpr{
-								pos:  position{line: 17, col: 31, offset: 481},
+								pos:  position{line: 14, col: 31, offset: 333},
 								name: "Operation",
 							},
 						},
@@ -165,22 +131,22 @@ var g = &grammar{
 		},
 		{
 			name: "Consts",
-			pos:  position{line: 19, col: 1, offset: 510},
+			pos:  position{line: 16, col: 1, offset: 362},
 			expr: &choiceExpr{
-				pos: position{line: 20, col: 5, offset: 521},
+				pos: position{line: 17, col: 5, offset: 373},
 				alternatives: []interface{}{
 					&oneOrMoreExpr{
-						pos: position{line: 20, col: 5, offset: 521},
+						pos: position{line: 17, col: 5, offset: 373},
 						expr: &ruleRefExpr{
-							pos:  position{line: 20, col: 5, offset: 521},
+							pos:  position{line: 17, col: 5, offset: 373},
 							name: "Const",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 21, col: 5, offset: 532},
+						pos: position{line: 18, col: 5, offset: 384},
 						run: (*parser).callonConsts4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 21, col: 5, offset: 532},
+							pos:  position{line: 18, col: 5, offset: 384},
 							name: "__",
 						},
 					},
@@ -189,22 +155,22 @@ var g = &grammar{
 		},
 		{
 			name: "Const",
-			pos:  position{line: 23, col: 1, offset: 568},
+			pos:  position{line: 20, col: 1, offset: 420},
 			expr: &actionExpr{
-				pos: position{line: 23, col: 9, offset: 576},
+				pos: position{line: 20, col: 9, offset: 428},
 				run: (*parser).callonConst1,
 				expr: &seqExpr{
-					pos: position{line: 23, col: 9, offset: 576},
+					pos: position{line: 20, col: 9, offset: 428},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 23, col: 9, offset: 576},
+							pos:  position{line: 20, col: 9, offset: 428},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 23, col: 12, offset: 579},
+							pos:   position{line: 20, col: 12, offset: 431},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 23, col: 14, offset: 581},
+								pos:  position{line: 20, col: 14, offset: 433},
 								name: "ConstDef",
 							},
 						},
@@ -214,51 +180,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConstDef",
-			pos:  position{line: 25, col: 1, offset: 609},
+			pos:  position{line: 22, col: 1, offset: 461},
 			expr: &choiceExpr{
-				pos: position{line: 26, col: 5, offset: 622},
+				pos: position{line: 23, col: 5, offset: 474},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 26, col: 5, offset: 622},
+						pos: position{line: 23, col: 5, offset: 474},
 						run: (*parser).callonConstDef2,
 						expr: &seqExpr{
-							pos: position{line: 26, col: 5, offset: 622},
+							pos: position{line: 23, col: 5, offset: 474},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 26, col: 5, offset: 622},
+									pos:        position{line: 23, col: 5, offset: 474},
 									val:        "const",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 26, col: 13, offset: 630},
+									pos:  position{line: 23, col: 13, offset: 482},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 26, col: 15, offset: 632},
+									pos:   position{line: 23, col: 15, offset: 484},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 26, col: 18, offset: 635},
+										pos:  position{line: 23, col: 18, offset: 487},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 26, col: 33, offset: 650},
+									pos:  position{line: 23, col: 33, offset: 502},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 26, col: 36, offset: 653},
+									pos:        position{line: 23, col: 36, offset: 505},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 26, col: 40, offset: 657},
+									pos:  position{line: 23, col: 40, offset: 509},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 26, col: 43, offset: 660},
+									pos:   position{line: 23, col: 43, offset: 512},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 26, col: 48, offset: 665},
+										pos:  position{line: 23, col: 48, offset: 517},
 										name: "Expr",
 									},
 								},
@@ -266,46 +232,46 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 29, col: 5, offset: 747},
+						pos: position{line: 26, col: 5, offset: 599},
 						run: (*parser).callonConstDef13,
 						expr: &seqExpr{
-							pos: position{line: 29, col: 5, offset: 747},
+							pos: position{line: 26, col: 5, offset: 599},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 29, col: 5, offset: 747},
+									pos:        position{line: 26, col: 5, offset: 599},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 29, col: 12, offset: 754},
+									pos:  position{line: 26, col: 12, offset: 606},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 29, col: 14, offset: 756},
+									pos:   position{line: 26, col: 14, offset: 608},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 29, col: 17, offset: 759},
+										pos:  position{line: 26, col: 17, offset: 611},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 29, col: 32, offset: 774},
+									pos:  position{line: 26, col: 32, offset: 626},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 29, col: 35, offset: 777},
+									pos:        position{line: 26, col: 35, offset: 629},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 29, col: 39, offset: 781},
+									pos:  position{line: 26, col: 39, offset: 633},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 29, col: 42, offset: 784},
+									pos:   position{line: 26, col: 42, offset: 636},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 29, col: 46, offset: 788},
+										pos:  position{line: 26, col: 46, offset: 640},
 										name: "Type",
 									},
 								},
@@ -317,47 +283,47 @@ var g = &grammar{
 		},
 		{
 			name: "Operation",
-			pos:  position{line: 39, col: 1, offset: 1012},
+			pos:  position{line: 35, col: 1, offset: 863},
 			expr: &choiceExpr{
-				pos: position{line: 40, col: 5, offset: 1026},
+				pos: position{line: 36, col: 5, offset: 877},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 40, col: 5, offset: 1026},
+						pos: position{line: 36, col: 5, offset: 877},
 						run: (*parser).callonOperation2,
 						expr: &seqExpr{
-							pos: position{line: 40, col: 5, offset: 1026},
+							pos: position{line: 36, col: 5, offset: 877},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 40, col: 5, offset: 1026},
+									pos:        position{line: 36, col: 5, offset: 877},
 									val:        "fork",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 40, col: 12, offset: 1033},
+									pos:  position{line: 36, col: 12, offset: 884},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 40, col: 15, offset: 1036},
+									pos:        position{line: 36, col: 15, offset: 887},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 40, col: 19, offset: 1040},
+									pos:   position{line: 36, col: 19, offset: 891},
 									label: "ops",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 40, col: 23, offset: 1044},
+										pos: position{line: 36, col: 23, offset: 895},
 										expr: &ruleRefExpr{
-											pos:  position{line: 40, col: 23, offset: 1044},
+											pos:  position{line: 36, col: 23, offset: 895},
 											name: "Leg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 40, col: 28, offset: 1049},
+									pos:  position{line: 36, col: 28, offset: 900},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 40, col: 31, offset: 1052},
+									pos:        position{line: 36, col: 31, offset: 903},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -365,54 +331,54 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 43, col: 5, offset: 1141},
+						pos: position{line: 39, col: 5, offset: 992},
 						run: (*parser).callonOperation12,
 						expr: &seqExpr{
-							pos: position{line: 43, col: 5, offset: 1141},
+							pos: position{line: 39, col: 5, offset: 992},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 43, col: 5, offset: 1141},
+									pos:        position{line: 39, col: 5, offset: 992},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 43, col: 14, offset: 1150},
+									pos:  position{line: 39, col: 14, offset: 1001},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 43, col: 16, offset: 1152},
+									pos:   position{line: 39, col: 16, offset: 1003},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 43, col: 21, offset: 1157},
+										pos:  position{line: 39, col: 21, offset: 1008},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 43, col: 26, offset: 1162},
+									pos:  position{line: 39, col: 26, offset: 1013},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 43, col: 28, offset: 1164},
+									pos:        position{line: 39, col: 28, offset: 1015},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 43, col: 32, offset: 1168},
+									pos:   position{line: 39, col: 32, offset: 1019},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 43, col: 38, offset: 1174},
+										pos: position{line: 39, col: 38, offset: 1025},
 										expr: &ruleRefExpr{
-											pos:  position{line: 43, col: 38, offset: 1174},
+											pos:  position{line: 39, col: 38, offset: 1025},
 											name: "SwitchLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 43, col: 49, offset: 1185},
+									pos:  position{line: 39, col: 49, offset: 1036},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 43, col: 52, offset: 1188},
+									pos:        position{line: 39, col: 52, offset: 1039},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -420,42 +386,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 46, col: 5, offset: 1293},
+						pos: position{line: 42, col: 5, offset: 1144},
 						run: (*parser).callonOperation25,
 						expr: &seqExpr{
-							pos: position{line: 46, col: 5, offset: 1293},
+							pos: position{line: 42, col: 5, offset: 1144},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 46, col: 5, offset: 1293},
+									pos:        position{line: 42, col: 5, offset: 1144},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 46, col: 14, offset: 1302},
+									pos:  position{line: 42, col: 14, offset: 1153},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 46, col: 17, offset: 1305},
+									pos:        position{line: 42, col: 17, offset: 1156},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 46, col: 21, offset: 1309},
+									pos:   position{line: 42, col: 21, offset: 1160},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 46, col: 27, offset: 1315},
+										pos: position{line: 42, col: 27, offset: 1166},
 										expr: &ruleRefExpr{
-											pos:  position{line: 46, col: 27, offset: 1315},
+											pos:  position{line: 42, col: 27, offset: 1166},
 											name: "SwitchLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 46, col: 38, offset: 1326},
+									pos:  position{line: 42, col: 38, offset: 1177},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 46, col: 41, offset: 1329},
+									pos:        position{line: 42, col: 41, offset: 1180},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -463,42 +429,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 49, col: 5, offset: 1433},
+						pos: position{line: 45, col: 5, offset: 1284},
 						run: (*parser).callonOperation35,
 						expr: &seqExpr{
-							pos: position{line: 49, col: 5, offset: 1433},
+							pos: position{line: 45, col: 5, offset: 1284},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 49, col: 5, offset: 1433},
+									pos:        position{line: 45, col: 5, offset: 1284},
 									val:        "from",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 49, col: 12, offset: 1440},
+									pos:  position{line: 45, col: 12, offset: 1291},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 49, col: 15, offset: 1443},
+									pos:        position{line: 45, col: 15, offset: 1294},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 49, col: 19, offset: 1447},
+									pos:   position{line: 45, col: 19, offset: 1298},
 									label: "trunks",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 49, col: 26, offset: 1454},
+										pos: position{line: 45, col: 26, offset: 1305},
 										expr: &ruleRefExpr{
-											pos:  position{line: 49, col: 26, offset: 1454},
+											pos:  position{line: 45, col: 26, offset: 1305},
 											name: "FromLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 49, col: 35, offset: 1463},
+									pos:  position{line: 45, col: 35, offset: 1314},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 49, col: 38, offset: 1466},
+									pos:        position{line: 45, col: 38, offset: 1317},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -506,31 +472,31 @@ var g = &grammar{
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 52, col: 5, offset: 1557},
+						pos:   position{line: 48, col: 5, offset: 1408},
 						label: "op",
 						expr: &ruleRefExpr{
-							pos:  position{line: 52, col: 8, offset: 1560},
+							pos:  position{line: 48, col: 8, offset: 1411},
 							name: "Operator",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 53, col: 5, offset: 1573},
+						pos: position{line: 49, col: 5, offset: 1424},
 						run: (*parser).callonOperation47,
 						expr: &seqExpr{
-							pos: position{line: 53, col: 5, offset: 1573},
+							pos: position{line: 49, col: 5, offset: 1424},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 53, col: 5, offset: 1573},
+									pos:   position{line: 49, col: 5, offset: 1424},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 53, col: 7, offset: 1575},
+										pos:  position{line: 49, col: 7, offset: 1426},
 										name: "OpAssignment",
 									},
 								},
 								&andExpr{
-									pos: position{line: 53, col: 20, offset: 1588},
+									pos: position{line: 49, col: 20, offset: 1439},
 									expr: &ruleRefExpr{
-										pos:  position{line: 53, col: 21, offset: 1589},
+										pos:  position{line: 49, col: 21, offset: 1440},
 										name: "EndOfOp",
 									},
 								},
@@ -538,39 +504,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 54, col: 5, offset: 1619},
+						pos: position{line: 50, col: 5, offset: 1470},
 						run: (*parser).callonOperation53,
 						expr: &seqExpr{
-							pos: position{line: 54, col: 5, offset: 1619},
+							pos: position{line: 50, col: 5, offset: 1470},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 54, col: 5, offset: 1619},
+									pos: position{line: 50, col: 5, offset: 1470},
 									expr: &seqExpr{
-										pos: position{line: 54, col: 7, offset: 1621},
+										pos: position{line: 50, col: 7, offset: 1472},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 54, col: 7, offset: 1621},
+												pos:  position{line: 50, col: 7, offset: 1472},
 												name: "Function",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 54, col: 16, offset: 1630},
+												pos:  position{line: 50, col: 16, offset: 1481},
 												name: "EndOfOp",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 54, col: 25, offset: 1639},
+									pos:   position{line: 50, col: 25, offset: 1490},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 54, col: 27, offset: 1641},
+										pos:  position{line: 50, col: 27, offset: 1492},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 54, col: 39, offset: 1653},
+									pos: position{line: 50, col: 39, offset: 1504},
 									expr: &ruleRefExpr{
-										pos:  position{line: 54, col: 40, offset: 1654},
+										pos:  position{line: 50, col: 40, offset: 1505},
 										name: "EndOfOp",
 									},
 								},
@@ -578,25 +544,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 55, col: 5, offset: 1685},
+						pos: position{line: 51, col: 5, offset: 1536},
 						run: (*parser).callonOperation63,
 						expr: &seqExpr{
-							pos: position{line: 55, col: 5, offset: 1685},
+							pos: position{line: 51, col: 5, offset: 1536},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 55, col: 5, offset: 1685},
+									pos:        position{line: 51, col: 5, offset: 1536},
 									val:        "search",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 55, col: 14, offset: 1694},
+									pos:  position{line: 51, col: 14, offset: 1545},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 55, col: 16, offset: 1696},
+									pos:   position{line: 51, col: 16, offset: 1547},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 55, col: 21, offset: 1701},
+										pos:  position{line: 51, col: 21, offset: 1552},
 										name: "SearchBoolean",
 									},
 								},
@@ -604,37 +570,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 58, col: 5, offset: 1800},
+						pos: position{line: 54, col: 5, offset: 1651},
 						run: (*parser).callonOperation69,
 						expr: &labeledExpr{
-							pos:   position{line: 58, col: 5, offset: 1800},
+							pos:   position{line: 54, col: 5, offset: 1651},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 58, col: 10, offset: 1805},
+								pos:  position{line: 54, col: 10, offset: 1656},
 								name: "SearchBoolean",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 61, col: 5, offset: 1904},
+						pos: position{line: 57, col: 5, offset: 1755},
 						run: (*parser).callonOperation72,
 						expr: &labeledExpr{
-							pos:   position{line: 61, col: 5, offset: 1904},
+							pos:   position{line: 57, col: 5, offset: 1755},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 61, col: 10, offset: 1909},
+								pos:  position{line: 57, col: 10, offset: 1760},
 								name: "Cast",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 64, col: 5, offset: 1997},
+						pos: position{line: 60, col: 5, offset: 1848},
 						run: (*parser).callonOperation75,
 						expr: &labeledExpr{
-							pos:   position{line: 64, col: 5, offset: 1997},
+							pos:   position{line: 60, col: 5, offset: 1848},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 64, col: 10, offset: 2002},
+								pos:  position{line: 60, col: 10, offset: 1853},
 								name: "Expr",
 							},
 						},
@@ -644,37 +610,37 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 68, col: 1, offset: 2089},
+			pos:  position{line: 64, col: 1, offset: 1940},
 			expr: &seqExpr{
-				pos: position{line: 68, col: 11, offset: 2099},
+				pos: position{line: 64, col: 11, offset: 1950},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 68, col: 11, offset: 2099},
+						pos:  position{line: 64, col: 11, offset: 1950},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 68, col: 15, offset: 2103},
+						pos: position{line: 64, col: 15, offset: 1954},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 68, col: 15, offset: 2103},
+								pos:  position{line: 64, col: 15, offset: 1954},
 								name: "Pipe",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 68, col: 22, offset: 2110},
+								pos:  position{line: 64, col: 22, offset: 1961},
 								name: "SearchKeywordGuard",
 							},
 							&litMatcher{
-								pos:        position{line: 68, col: 43, offset: 2131},
+								pos:        position{line: 64, col: 43, offset: 1982},
 								val:        "=>",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 68, col: 50, offset: 2138},
+								pos:        position{line: 64, col: 50, offset: 1989},
 								val:        ")",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 68, col: 56, offset: 2144},
+								pos:  position{line: 64, col: 56, offset: 1995},
 								name: "EOF",
 							},
 						},
@@ -684,27 +650,27 @@ var g = &grammar{
 		},
 		{
 			name: "Pipe",
-			pos:  position{line: 69, col: 1, offset: 2149},
+			pos:  position{line: 65, col: 1, offset: 2000},
 			expr: &seqExpr{
-				pos: position{line: 69, col: 8, offset: 2156},
+				pos: position{line: 65, col: 8, offset: 2007},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 69, col: 8, offset: 2156},
+						pos:        position{line: 65, col: 8, offset: 2007},
 						val:        "|",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 69, col: 12, offset: 2160},
+						pos: position{line: 65, col: 12, offset: 2011},
 						expr: &choiceExpr{
-							pos: position{line: 69, col: 14, offset: 2162},
+							pos: position{line: 65, col: 14, offset: 2013},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 69, col: 14, offset: 2162},
+									pos:        position{line: 65, col: 14, offset: 2013},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 69, col: 20, offset: 2168},
+									pos:        position{line: 65, col: 20, offset: 2019},
 									val:        "[",
 									ignoreCase: false,
 								},
@@ -716,31 +682,31 @@ var g = &grammar{
 		},
 		{
 			name: "Leg",
-			pos:  position{line: 71, col: 1, offset: 2174},
+			pos:  position{line: 67, col: 1, offset: 2025},
 			expr: &actionExpr{
-				pos: position{line: 72, col: 5, offset: 2182},
+				pos: position{line: 68, col: 5, offset: 2033},
 				run: (*parser).callonLeg1,
 				expr: &seqExpr{
-					pos: position{line: 72, col: 5, offset: 2182},
+					pos: position{line: 68, col: 5, offset: 2033},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 72, col: 5, offset: 2182},
+							pos:  position{line: 68, col: 5, offset: 2033},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 72, col: 8, offset: 2185},
+							pos:        position{line: 68, col: 8, offset: 2036},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 72, col: 13, offset: 2190},
+							pos:  position{line: 68, col: 13, offset: 2041},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 72, col: 16, offset: 2193},
+							pos:   position{line: 68, col: 16, offset: 2044},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 72, col: 18, offset: 2195},
+								pos:  position{line: 68, col: 18, offset: 2046},
 								name: "Sequential",
 							},
 						},
@@ -750,43 +716,43 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchLeg",
-			pos:  position{line: 74, col: 1, offset: 2225},
+			pos:  position{line: 70, col: 1, offset: 2076},
 			expr: &actionExpr{
-				pos: position{line: 75, col: 5, offset: 2239},
+				pos: position{line: 71, col: 5, offset: 2090},
 				run: (*parser).callonSwitchLeg1,
 				expr: &seqExpr{
-					pos: position{line: 75, col: 5, offset: 2239},
+					pos: position{line: 71, col: 5, offset: 2090},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 75, col: 5, offset: 2239},
+							pos:  position{line: 71, col: 5, offset: 2090},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 75, col: 8, offset: 2242},
+							pos:   position{line: 71, col: 8, offset: 2093},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 75, col: 13, offset: 2247},
+								pos:  position{line: 71, col: 13, offset: 2098},
 								name: "Case",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 75, col: 18, offset: 2252},
+							pos:  position{line: 71, col: 18, offset: 2103},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 75, col: 21, offset: 2255},
+							pos:        position{line: 71, col: 21, offset: 2106},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 75, col: 26, offset: 2260},
+							pos:  position{line: 71, col: 26, offset: 2111},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 75, col: 29, offset: 2263},
+							pos:   position{line: 71, col: 29, offset: 2114},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 75, col: 32, offset: 2266},
+								pos:  position{line: 71, col: 32, offset: 2117},
 								name: "Sequential",
 							},
 						},
@@ -796,30 +762,30 @@ var g = &grammar{
 		},
 		{
 			name: "Case",
-			pos:  position{line: 79, col: 1, offset: 2351},
+			pos:  position{line: 75, col: 1, offset: 2202},
 			expr: &choiceExpr{
-				pos: position{line: 80, col: 5, offset: 2360},
+				pos: position{line: 76, col: 5, offset: 2211},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 80, col: 5, offset: 2360},
+						pos: position{line: 76, col: 5, offset: 2211},
 						run: (*parser).callonCase2,
 						expr: &seqExpr{
-							pos: position{line: 80, col: 5, offset: 2360},
+							pos: position{line: 76, col: 5, offset: 2211},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 80, col: 5, offset: 2360},
+									pos:        position{line: 76, col: 5, offset: 2211},
 									val:        "case",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 80, col: 12, offset: 2367},
+									pos:  position{line: 76, col: 12, offset: 2218},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 80, col: 14, offset: 2369},
+									pos:   position{line: 76, col: 14, offset: 2220},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 80, col: 19, offset: 2374},
+										pos:  position{line: 76, col: 19, offset: 2225},
 										name: "Expr",
 									},
 								},
@@ -827,10 +793,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 81, col: 5, offset: 2404},
+						pos: position{line: 77, col: 5, offset: 2255},
 						run: (*parser).callonCase8,
 						expr: &litMatcher{
-							pos:        position{line: 81, col: 5, offset: 2404},
+							pos:        position{line: 77, col: 5, offset: 2255},
 							val:        "default",
 							ignoreCase: false,
 						},
@@ -840,37 +806,37 @@ var g = &grammar{
 		},
 		{
 			name: "FromLeg",
-			pos:  position{line: 83, col: 1, offset: 2435},
+			pos:  position{line: 79, col: 1, offset: 2286},
 			expr: &choiceExpr{
-				pos: position{line: 84, col: 5, offset: 2447},
+				pos: position{line: 80, col: 5, offset: 2298},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 84, col: 5, offset: 2447},
+						pos: position{line: 80, col: 5, offset: 2298},
 						run: (*parser).callonFromLeg2,
 						expr: &seqExpr{
-							pos: position{line: 84, col: 5, offset: 2447},
+							pos: position{line: 80, col: 5, offset: 2298},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 84, col: 5, offset: 2447},
+									pos:  position{line: 80, col: 5, offset: 2298},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 84, col: 8, offset: 2450},
+									pos:   position{line: 80, col: 8, offset: 2301},
 									label: "source",
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 15, offset: 2457},
+										pos:  position{line: 80, col: 15, offset: 2308},
 										name: "FromHead",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 84, col: 24, offset: 2466},
+									pos:  position{line: 80, col: 24, offset: 2317},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 84, col: 28, offset: 2470},
+									pos:   position{line: 80, col: 28, offset: 2321},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 32, offset: 2474},
+										pos:  position{line: 80, col: 32, offset: 2325},
 										name: "Sequential",
 									},
 								},
@@ -878,20 +844,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 87, col: 5, offset: 2585},
+						pos: position{line: 83, col: 5, offset: 2436},
 						run: (*parser).callonFromLeg10,
 						expr: &seqExpr{
-							pos: position{line: 87, col: 5, offset: 2585},
+							pos: position{line: 83, col: 5, offset: 2436},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 87, col: 5, offset: 2585},
+									pos:  position{line: 83, col: 5, offset: 2436},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 87, col: 8, offset: 2588},
+									pos:   position{line: 83, col: 8, offset: 2439},
 									label: "source",
 									expr: &ruleRefExpr{
-										pos:  position{line: 87, col: 15, offset: 2595},
+										pos:  position{line: 83, col: 15, offset: 2446},
 										name: "FromSource",
 									},
 								},
@@ -903,27 +869,27 @@ var g = &grammar{
 		},
 		{
 			name: "FromHead",
-			pos:  position{line: 91, col: 1, offset: 2703},
+			pos:  position{line: 87, col: 1, offset: 2554},
 			expr: &actionExpr{
-				pos: position{line: 92, col: 5, offset: 2716},
+				pos: position{line: 88, col: 5, offset: 2567},
 				run: (*parser).callonFromHead1,
 				expr: &seqExpr{
-					pos: position{line: 92, col: 5, offset: 2716},
+					pos: position{line: 88, col: 5, offset: 2567},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 92, col: 5, offset: 2716},
+							pos:   position{line: 88, col: 5, offset: 2567},
 							label: "src",
 							expr: &ruleRefExpr{
-								pos:  position{line: 92, col: 9, offset: 2720},
+								pos:  position{line: 88, col: 9, offset: 2571},
 								name: "FromSource",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 92, col: 20, offset: 2731},
+							pos:  position{line: 88, col: 20, offset: 2582},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 92, col: 23, offset: 2734},
+							pos:        position{line: 88, col: 23, offset: 2585},
 							val:        "=>",
 							ignoreCase: false,
 						},
@@ -933,24 +899,24 @@ var g = &grammar{
 		},
 		{
 			name: "FromSource",
-			pos:  position{line: 94, col: 1, offset: 2760},
+			pos:  position{line: 90, col: 1, offset: 2611},
 			expr: &choiceExpr{
-				pos: position{line: 95, col: 5, offset: 2775},
+				pos: position{line: 91, col: 5, offset: 2626},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 95, col: 5, offset: 2775},
+						pos:  position{line: 91, col: 5, offset: 2626},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 96, col: 5, offset: 2784},
+						pos:  position{line: 92, col: 5, offset: 2635},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 97, col: 5, offset: 2792},
+						pos:  position{line: 93, col: 5, offset: 2643},
 						name: "Pool",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 98, col: 5, offset: 2801},
+						pos:  position{line: 94, col: 5, offset: 2652},
 						name: "PassOp",
 					},
 				},
@@ -958,59 +924,59 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 100, col: 1, offset: 2809},
+			pos:  position{line: 96, col: 1, offset: 2660},
 			expr: &seqExpr{
-				pos: position{line: 100, col: 13, offset: 2821},
+				pos: position{line: 96, col: 13, offset: 2672},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 100, col: 13, offset: 2821},
+						pos:  position{line: 96, col: 13, offset: 2672},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 100, col: 17, offset: 2825},
+						pos: position{line: 96, col: 17, offset: 2676},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 100, col: 18, offset: 2826},
+								pos: position{line: 96, col: 18, offset: 2677},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 100, col: 18, offset: 2826},
+										pos: position{line: 96, col: 18, offset: 2677},
 										expr: &litMatcher{
-											pos:        position{line: 100, col: 19, offset: 2827},
+											pos:        position{line: 96, col: 19, offset: 2678},
 											val:        "=>",
 											ignoreCase: false,
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 100, col: 24, offset: 2832},
+										pos:  position{line: 96, col: 24, offset: 2683},
 										name: "Comparator",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 100, col: 38, offset: 2846},
+								pos:  position{line: 96, col: 38, offset: 2697},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 100, col: 57, offset: 2865},
+								pos:  position{line: 96, col: 57, offset: 2716},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 100, col: 82, offset: 2890},
+								pos:        position{line: 96, col: 82, offset: 2741},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 100, col: 88, offset: 2896},
+								pos:        position{line: 96, col: 88, offset: 2747},
 								val:        "(",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 100, col: 94, offset: 2902},
+								pos:        position{line: 96, col: 94, offset: 2753},
 								val:        "[",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 100, col: 100, offset: 2908},
+								pos:        position{line: 96, col: 100, offset: 2759},
 								val:        "~",
 								ignoreCase: false,
 							},
@@ -1021,57 +987,57 @@ var g = &grammar{
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 102, col: 1, offset: 2914},
+			pos:  position{line: 98, col: 1, offset: 2765},
 			expr: &actionExpr{
-				pos: position{line: 102, col: 14, offset: 2927},
+				pos: position{line: 98, col: 14, offset: 2778},
 				run: (*parser).callonComparator1,
 				expr: &choiceExpr{
-					pos: position{line: 102, col: 15, offset: 2928},
+					pos: position{line: 98, col: 15, offset: 2779},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 102, col: 15, offset: 2928},
+							pos:        position{line: 98, col: 15, offset: 2779},
 							val:        "==",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 102, col: 22, offset: 2935},
+							pos:        position{line: 98, col: 22, offset: 2786},
 							val:        "!=",
 							ignoreCase: false,
 						},
 						&seqExpr{
-							pos: position{line: 102, col: 30, offset: 2943},
+							pos: position{line: 98, col: 30, offset: 2794},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 102, col: 30, offset: 2943},
+									pos:        position{line: 98, col: 30, offset: 2794},
 									val:        "in",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 102, col: 35, offset: 2948},
+									pos: position{line: 98, col: 35, offset: 2799},
 									expr: &ruleRefExpr{
-										pos:  position{line: 102, col: 36, offset: 2949},
+										pos:  position{line: 98, col: 36, offset: 2800},
 										name: "IdentifierRest",
 									},
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 102, col: 54, offset: 2967},
+							pos:        position{line: 98, col: 54, offset: 2818},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 102, col: 61, offset: 2974},
+							pos:        position{line: 98, col: 61, offset: 2825},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 102, col: 67, offset: 2980},
+							pos:        position{line: 98, col: 67, offset: 2831},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 102, col: 74, offset: 2987},
+							pos:        position{line: 98, col: 74, offset: 2838},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1081,28 +1047,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 104, col: 1, offset: 3024},
+			pos:  position{line: 100, col: 1, offset: 2875},
 			expr: &actionExpr{
-				pos: position{line: 105, col: 5, offset: 3042},
+				pos: position{line: 101, col: 5, offset: 2893},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 105, col: 5, offset: 3042},
+					pos: position{line: 101, col: 5, offset: 2893},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 105, col: 5, offset: 3042},
+							pos:   position{line: 101, col: 5, offset: 2893},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 105, col: 11, offset: 3048},
+								pos:  position{line: 101, col: 11, offset: 2899},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 105, col: 21, offset: 3058},
+							pos:   position{line: 101, col: 21, offset: 2909},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 105, col: 26, offset: 3063},
+								pos: position{line: 101, col: 26, offset: 2914},
 								expr: &ruleRefExpr{
-									pos:  position{line: 105, col: 26, offset: 3063},
+									pos:  position{line: 101, col: 26, offset: 2914},
 									name: "SearchOrTerm",
 								},
 							},
@@ -1113,30 +1079,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 109, col: 1, offset: 3137},
+			pos:  position{line: 105, col: 1, offset: 2988},
 			expr: &actionExpr{
-				pos: position{line: 109, col: 16, offset: 3152},
+				pos: position{line: 105, col: 16, offset: 3003},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 109, col: 16, offset: 3152},
+					pos: position{line: 105, col: 16, offset: 3003},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 109, col: 16, offset: 3152},
+							pos:  position{line: 105, col: 16, offset: 3003},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 109, col: 18, offset: 3154},
+							pos:  position{line: 105, col: 18, offset: 3005},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 109, col: 26, offset: 3162},
+							pos:  position{line: 105, col: 26, offset: 3013},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 109, col: 28, offset: 3164},
+							pos:   position{line: 105, col: 28, offset: 3015},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 109, col: 30, offset: 3166},
+								pos:  position{line: 105, col: 30, offset: 3017},
 								name: "SearchAnd",
 							},
 						},
@@ -1146,73 +1112,73 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 111, col: 1, offset: 3216},
+			pos:  position{line: 107, col: 1, offset: 3067},
 			expr: &actionExpr{
-				pos: position{line: 112, col: 5, offset: 3230},
+				pos: position{line: 108, col: 5, offset: 3081},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 112, col: 5, offset: 3230},
+					pos: position{line: 108, col: 5, offset: 3081},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 112, col: 5, offset: 3230},
+							pos:   position{line: 108, col: 5, offset: 3081},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 112, col: 11, offset: 3236},
+								pos:  position{line: 108, col: 11, offset: 3087},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 113, col: 5, offset: 3253},
+							pos:   position{line: 109, col: 5, offset: 3104},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 113, col: 10, offset: 3258},
+								pos: position{line: 109, col: 10, offset: 3109},
 								expr: &actionExpr{
-									pos: position{line: 113, col: 11, offset: 3259},
+									pos: position{line: 109, col: 11, offset: 3110},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 113, col: 11, offset: 3259},
+										pos: position{line: 109, col: 11, offset: 3110},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 113, col: 11, offset: 3259},
+												pos: position{line: 109, col: 11, offset: 3110},
 												expr: &seqExpr{
-													pos: position{line: 113, col: 12, offset: 3260},
+													pos: position{line: 109, col: 12, offset: 3111},
 													exprs: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 113, col: 12, offset: 3260},
+															pos:  position{line: 109, col: 12, offset: 3111},
 															name: "_",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 113, col: 14, offset: 3262},
+															pos:  position{line: 109, col: 14, offset: 3113},
 															name: "AndToken",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 113, col: 25, offset: 3273},
+												pos:  position{line: 109, col: 25, offset: 3124},
 												name: "_",
 											},
 											&notExpr{
-												pos: position{line: 113, col: 27, offset: 3275},
+												pos: position{line: 109, col: 27, offset: 3126},
 												expr: &choiceExpr{
-													pos: position{line: 113, col: 29, offset: 3277},
+													pos: position{line: 109, col: 29, offset: 3128},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 113, col: 29, offset: 3277},
+															pos:  position{line: 109, col: 29, offset: 3128},
 															name: "OrToken",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 113, col: 39, offset: 3287},
+															pos:  position{line: 109, col: 39, offset: 3138},
 															name: "SearchKeywordGuard",
 														},
 													},
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 113, col: 59, offset: 3307},
+												pos:   position{line: 109, col: 59, offset: 3158},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 113, col: 64, offset: 3312},
+													pos:  position{line: 109, col: 64, offset: 3163},
 													name: "SearchFactor",
 												},
 											},
@@ -1227,32 +1193,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchKeywordGuard",
-			pos:  position{line: 117, col: 1, offset: 3428},
+			pos:  position{line: 113, col: 1, offset: 3279},
 			expr: &choiceExpr{
-				pos: position{line: 118, col: 5, offset: 3451},
+				pos: position{line: 114, col: 5, offset: 3302},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 118, col: 5, offset: 3451},
+						pos: position{line: 114, col: 5, offset: 3302},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 118, col: 5, offset: 3451},
+								pos:  position{line: 114, col: 5, offset: 3302},
 								name: "FromHead",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 118, col: 14, offset: 3460},
+								pos:  position{line: 114, col: 14, offset: 3311},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 119, col: 5, offset: 3467},
+						pos: position{line: 115, col: 5, offset: 3318},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 119, col: 5, offset: 3467},
+								pos:  position{line: 115, col: 5, offset: 3318},
 								name: "Case",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 119, col: 10, offset: 3472},
+								pos:  position{line: 115, col: 10, offset: 3323},
 								name: "__",
 							},
 						},
@@ -1262,42 +1228,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 121, col: 1, offset: 3476},
+			pos:  position{line: 117, col: 1, offset: 3327},
 			expr: &choiceExpr{
-				pos: position{line: 122, col: 5, offset: 3493},
+				pos: position{line: 118, col: 5, offset: 3344},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 122, col: 5, offset: 3493},
+						pos: position{line: 118, col: 5, offset: 3344},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 122, col: 5, offset: 3493},
+							pos: position{line: 118, col: 5, offset: 3344},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 122, col: 6, offset: 3494},
+									pos: position{line: 118, col: 6, offset: 3345},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 122, col: 6, offset: 3494},
+											pos: position{line: 118, col: 6, offset: 3345},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 122, col: 6, offset: 3494},
+													pos:  position{line: 118, col: 6, offset: 3345},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 122, col: 15, offset: 3503},
+													pos:  position{line: 118, col: 15, offset: 3354},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 122, col: 19, offset: 3507},
+											pos: position{line: 118, col: 19, offset: 3358},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 122, col: 19, offset: 3507},
+													pos:        position{line: 118, col: 19, offset: 3358},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 122, col: 23, offset: 3511},
+													pos:  position{line: 118, col: 23, offset: 3362},
 													name: "__",
 												},
 											},
@@ -1305,10 +1271,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 122, col: 27, offset: 3515},
+									pos:   position{line: 118, col: 27, offset: 3366},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 122, col: 29, offset: 3517},
+										pos:  position{line: 118, col: 29, offset: 3368},
 										name: "SearchFactor",
 									},
 								},
@@ -1316,34 +1282,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 125, col: 5, offset: 3629},
+						pos: position{line: 121, col: 5, offset: 3480},
 						run: (*parser).callonSearchFactor13,
 						expr: &seqExpr{
-							pos: position{line: 125, col: 5, offset: 3629},
+							pos: position{line: 121, col: 5, offset: 3480},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 125, col: 5, offset: 3629},
+									pos:        position{line: 121, col: 5, offset: 3480},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 125, col: 9, offset: 3633},
+									pos:  position{line: 121, col: 9, offset: 3484},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 125, col: 12, offset: 3636},
+									pos:   position{line: 121, col: 12, offset: 3487},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 125, col: 17, offset: 3641},
+										pos:  position{line: 121, col: 17, offset: 3492},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 125, col: 31, offset: 3655},
+									pos:  position{line: 121, col: 31, offset: 3506},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 125, col: 34, offset: 3658},
+									pos:        position{line: 121, col: 34, offset: 3509},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1351,7 +1317,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 126, col: 5, offset: 3687},
+						pos:  position{line: 122, col: 5, offset: 3538},
 						name: "SearchExpr",
 					},
 				},
@@ -1359,44 +1325,56 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 128, col: 1, offset: 3699},
+			pos:  position{line: 124, col: 1, offset: 3550},
 			expr: &choiceExpr{
-				pos: position{line: 129, col: 5, offset: 3714},
+				pos: position{line: 125, col: 5, offset: 3565},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 129, col: 5, offset: 3714},
+						pos:  position{line: 125, col: 5, offset: 3565},
 						name: "Glob",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 130, col: 5, offset: 3723},
+						pos:  position{line: 126, col: 5, offset: 3574},
 						name: "Regexp",
 					},
 					&actionExpr{
-						pos: position{line: 131, col: 5, offset: 3734},
+						pos: position{line: 127, col: 5, offset: 3585},
 						run: (*parser).callonSearchExpr4,
 						expr: &seqExpr{
-							pos: position{line: 131, col: 5, offset: 3734},
+							pos: position{line: 127, col: 5, offset: 3585},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 131, col: 5, offset: 3734},
+									pos:   position{line: 127, col: 5, offset: 3585},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 131, col: 7, offset: 3736},
+										pos:  position{line: 127, col: 7, offset: 3587},
 										name: "SearchValue",
 									},
 								},
-								&andExpr{
-									pos: position{line: 131, col: 19, offset: 3748},
-									expr: &seqExpr{
-										pos: position{line: 131, col: 21, offset: 3750},
-										exprs: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 131, col: 21, offset: 3750},
-												name: "_",
+								&choiceExpr{
+									pos: position{line: 127, col: 20, offset: 3600},
+									alternatives: []interface{}{
+										&notExpr{
+											pos: position{line: 127, col: 20, offset: 3600},
+											expr: &ruleRefExpr{
+												pos:  position{line: 127, col: 21, offset: 3601},
+												name: "ExprGuard",
 											},
-											&ruleRefExpr{
-												pos:  position{line: 131, col: 23, offset: 3752},
-												name: "Glob",
+										},
+										&andExpr{
+											pos: position{line: 127, col: 33, offset: 3613},
+											expr: &seqExpr{
+												pos: position{line: 127, col: 35, offset: 3615},
+												exprs: []interface{}{
+													&ruleRefExpr{
+														pos:  position{line: 127, col: 35, offset: 3615},
+														name: "_",
+													},
+													&ruleRefExpr{
+														pos:  position{line: 127, col: 37, offset: 3617},
+														name: "Glob",
+													},
+												},
 											},
 										},
 									},
@@ -1405,44 +1383,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 134, col: 5, offset: 3863},
-						run: (*parser).callonSearchExpr12,
+						pos: position{line: 130, col: 5, offset: 3729},
+						run: (*parser).callonSearchExpr15,
 						expr: &seqExpr{
-							pos: position{line: 134, col: 5, offset: 3863},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 134, col: 5, offset: 3863},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 134, col: 7, offset: 3865},
-										name: "SearchValue",
-									},
-								},
-								&notExpr{
-									pos: position{line: 134, col: 19, offset: 3877},
-									expr: &ruleRefExpr{
-										pos:  position{line: 134, col: 20, offset: 3878},
-										name: "ExprGuard",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 137, col: 5, offset: 3993},
-						run: (*parser).callonSearchExpr18,
-						expr: &seqExpr{
-							pos: position{line: 137, col: 5, offset: 3993},
+							pos: position{line: 130, col: 5, offset: 3729},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 137, col: 5, offset: 3993},
+									pos:        position{line: 130, col: 5, offset: 3729},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 137, col: 9, offset: 3997},
+									pos: position{line: 130, col: 9, offset: 3733},
 									expr: &ruleRefExpr{
-										pos:  position{line: 137, col: 10, offset: 3998},
+										pos:  position{line: 130, col: 10, offset: 3734},
 										name: "ExprGuard",
 									},
 								},
@@ -1450,7 +1404,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 140, col: 5, offset: 4114},
+						pos:  position{line: 133, col: 5, offset: 3850},
 						name: "SearchPredicate",
 					},
 				},
@@ -1458,45 +1412,45 @@ var g = &grammar{
 		},
 		{
 			name: "SearchPredicate",
-			pos:  position{line: 142, col: 1, offset: 4131},
+			pos:  position{line: 135, col: 1, offset: 3867},
 			expr: &choiceExpr{
-				pos: position{line: 143, col: 5, offset: 4151},
+				pos: position{line: 136, col: 5, offset: 3887},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 143, col: 5, offset: 4151},
+						pos: position{line: 136, col: 5, offset: 3887},
 						run: (*parser).callonSearchPredicate2,
 						expr: &seqExpr{
-							pos: position{line: 143, col: 5, offset: 4151},
+							pos: position{line: 136, col: 5, offset: 3887},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 143, col: 5, offset: 4151},
+									pos:   position{line: 136, col: 5, offset: 3887},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 9, offset: 4155},
+										pos:  position{line: 136, col: 9, offset: 3891},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 143, col: 22, offset: 4168},
+									pos:  position{line: 136, col: 22, offset: 3904},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 143, col: 25, offset: 4171},
+									pos:   position{line: 136, col: 25, offset: 3907},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 28, offset: 4174},
+										pos:  position{line: 136, col: 28, offset: 3910},
 										name: "Comparator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 143, col: 39, offset: 4185},
+									pos:  position{line: 136, col: 39, offset: 3921},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 143, col: 42, offset: 4188},
+									pos:   position{line: 136, col: 42, offset: 3924},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 46, offset: 4192},
+										pos:  position{line: 136, col: 46, offset: 3928},
 										name: "AdditiveExpr",
 									},
 								},
@@ -1504,26 +1458,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 146, col: 6, offset: 4315},
+						pos: position{line: 139, col: 6, offset: 4051},
 						run: (*parser).callonSearchPredicate12,
 						expr: &seqExpr{
-							pos: position{line: 146, col: 6, offset: 4315},
+							pos: position{line: 139, col: 6, offset: 4051},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 146, col: 6, offset: 4315},
+									pos:   position{line: 139, col: 6, offset: 4051},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 146, col: 12, offset: 4321},
+										pos:  position{line: 139, col: 12, offset: 4057},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 146, col: 21, offset: 4330},
+									pos:   position{line: 139, col: 21, offset: 4066},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 146, col: 26, offset: 4335},
+										pos: position{line: 139, col: 26, offset: 4071},
 										expr: &ruleRefExpr{
-											pos:  position{line: 146, col: 27, offset: 4336},
+											pos:  position{line: 139, col: 27, offset: 4072},
 											name: "Deref",
 										},
 									},
@@ -1536,32 +1490,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 150, col: 1, offset: 4408},
+			pos:  position{line: 143, col: 1, offset: 4144},
 			expr: &choiceExpr{
-				pos: position{line: 151, col: 5, offset: 4424},
+				pos: position{line: 144, col: 5, offset: 4160},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 151, col: 5, offset: 4424},
+						pos:  position{line: 144, col: 5, offset: 4160},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 152, col: 5, offset: 4436},
+						pos: position{line: 145, col: 5, offset: 4172},
 						run: (*parser).callonSearchValue3,
 						expr: &seqExpr{
-							pos: position{line: 152, col: 5, offset: 4436},
+							pos: position{line: 145, col: 5, offset: 4172},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 152, col: 5, offset: 4436},
+									pos: position{line: 145, col: 5, offset: 4172},
 									expr: &ruleRefExpr{
-										pos:  position{line: 152, col: 6, offset: 4437},
+										pos:  position{line: 145, col: 6, offset: 4173},
 										name: "RegexpPattern",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 152, col: 20, offset: 4451},
+									pos:   position{line: 145, col: 20, offset: 4187},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 152, col: 22, offset: 4453},
+										pos:  position{line: 145, col: 22, offset: 4189},
 										name: "KeyWord",
 									},
 								},
@@ -1573,15 +1527,15 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 156, col: 1, offset: 4561},
+			pos:  position{line: 149, col: 1, offset: 4297},
 			expr: &actionExpr{
-				pos: position{line: 157, col: 5, offset: 4570},
+				pos: position{line: 150, col: 5, offset: 4306},
 				run: (*parser).callonGlob1,
 				expr: &labeledExpr{
-					pos:   position{line: 157, col: 5, offset: 4570},
+					pos:   position{line: 150, col: 5, offset: 4306},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 157, col: 13, offset: 4578},
+						pos:  position{line: 150, col: 13, offset: 4314},
 						name: "GlobPattern",
 					},
 				},
@@ -1589,15 +1543,15 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 161, col: 1, offset: 4674},
+			pos:  position{line: 154, col: 1, offset: 4410},
 			expr: &actionExpr{
-				pos: position{line: 162, col: 5, offset: 4685},
+				pos: position{line: 155, col: 5, offset: 4421},
 				run: (*parser).callonRegexp1,
 				expr: &labeledExpr{
-					pos:   position{line: 162, col: 5, offset: 4685},
+					pos:   position{line: 155, col: 5, offset: 4421},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 162, col: 13, offset: 4693},
+						pos:  position{line: 155, col: 13, offset: 4429},
 						name: "RegexpPattern",
 					},
 				},
@@ -1605,36 +1559,36 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 168, col: 1, offset: 4819},
+			pos:  position{line: 161, col: 1, offset: 4555},
 			expr: &choiceExpr{
-				pos: position{line: 169, col: 5, offset: 4835},
+				pos: position{line: 162, col: 5, offset: 4571},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 169, col: 5, offset: 4835},
+						pos: position{line: 162, col: 5, offset: 4571},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 169, col: 5, offset: 4835},
+							pos: position{line: 162, col: 5, offset: 4571},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 169, col: 5, offset: 4835},
+									pos: position{line: 162, col: 5, offset: 4571},
 									expr: &ruleRefExpr{
-										pos:  position{line: 169, col: 5, offset: 4835},
+										pos:  position{line: 162, col: 5, offset: 4571},
 										name: "Summarize",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 169, col: 16, offset: 4846},
+									pos:   position{line: 162, col: 16, offset: 4582},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 169, col: 21, offset: 4851},
+										pos:  position{line: 162, col: 21, offset: 4587},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 169, col: 33, offset: 4863},
+									pos:   position{line: 162, col: 33, offset: 4599},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 169, col: 39, offset: 4869},
+										pos:  position{line: 162, col: 39, offset: 4605},
 										name: "LimitArg",
 									},
 								},
@@ -1642,40 +1596,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 172, col: 5, offset: 4995},
+						pos: position{line: 165, col: 5, offset: 4731},
 						run: (*parser).callonAggregation10,
 						expr: &seqExpr{
-							pos: position{line: 172, col: 5, offset: 4995},
+							pos: position{line: 165, col: 5, offset: 4731},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 172, col: 5, offset: 4995},
+									pos: position{line: 165, col: 5, offset: 4731},
 									expr: &ruleRefExpr{
-										pos:  position{line: 172, col: 5, offset: 4995},
+										pos:  position{line: 165, col: 5, offset: 4731},
 										name: "Summarize",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 172, col: 16, offset: 5006},
+									pos:   position{line: 165, col: 16, offset: 4742},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 172, col: 21, offset: 5011},
+										pos:  position{line: 165, col: 21, offset: 4747},
 										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 172, col: 36, offset: 5026},
+									pos:   position{line: 165, col: 36, offset: 4762},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 172, col: 41, offset: 5031},
+										pos: position{line: 165, col: 41, offset: 4767},
 										expr: &seqExpr{
-											pos: position{line: 172, col: 42, offset: 5032},
+											pos: position{line: 165, col: 42, offset: 4768},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 172, col: 42, offset: 5032},
+													pos:  position{line: 165, col: 42, offset: 4768},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 172, col: 44, offset: 5034},
+													pos:  position{line: 165, col: 44, offset: 4770},
 													name: "GroupByKeys",
 												},
 											},
@@ -1683,10 +1637,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 172, col: 58, offset: 5048},
+									pos:   position{line: 165, col: 58, offset: 4784},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 172, col: 64, offset: 5054},
+										pos:  position{line: 165, col: 64, offset: 4790},
 										name: "LimitArg",
 									},
 								},
@@ -1698,17 +1652,17 @@ var g = &grammar{
 		},
 		{
 			name: "Summarize",
-			pos:  position{line: 180, col: 1, offset: 5268},
+			pos:  position{line: 173, col: 1, offset: 5004},
 			expr: &seqExpr{
-				pos: position{line: 180, col: 13, offset: 5280},
+				pos: position{line: 173, col: 13, offset: 5016},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 180, col: 13, offset: 5280},
+						pos:        position{line: 173, col: 13, offset: 5016},
 						val:        "summarize",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 180, col: 25, offset: 5292},
+						pos:  position{line: 173, col: 25, offset: 5028},
 						name: "_",
 					},
 				},
@@ -1716,26 +1670,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 182, col: 1, offset: 5295},
+			pos:  position{line: 175, col: 1, offset: 5031},
 			expr: &actionExpr{
-				pos: position{line: 183, col: 5, offset: 5311},
+				pos: position{line: 176, col: 5, offset: 5047},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 183, col: 5, offset: 5311},
+					pos: position{line: 176, col: 5, offset: 5047},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 183, col: 5, offset: 5311},
+							pos:  position{line: 176, col: 5, offset: 5047},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 183, col: 13, offset: 5319},
+							pos:  position{line: 176, col: 13, offset: 5055},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 183, col: 15, offset: 5321},
+							pos:   position{line: 176, col: 15, offset: 5057},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 183, col: 23, offset: 5329},
+								pos:  position{line: 176, col: 23, offset: 5065},
 								name: "FlexAssignments",
 							},
 						},
@@ -1745,43 +1699,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 185, col: 1, offset: 5370},
+			pos:  position{line: 178, col: 1, offset: 5106},
 			expr: &choiceExpr{
-				pos: position{line: 186, col: 5, offset: 5383},
+				pos: position{line: 179, col: 5, offset: 5119},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 186, col: 5, offset: 5383},
+						pos: position{line: 179, col: 5, offset: 5119},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 186, col: 5, offset: 5383},
+							pos: position{line: 179, col: 5, offset: 5119},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 186, col: 5, offset: 5383},
+									pos:  position{line: 179, col: 5, offset: 5119},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 186, col: 7, offset: 5385},
+									pos:        position{line: 179, col: 7, offset: 5121},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 186, col: 14, offset: 5392},
+									pos:  position{line: 179, col: 14, offset: 5128},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 186, col: 16, offset: 5394},
+									pos:        position{line: 179, col: 16, offset: 5130},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 186, col: 25, offset: 5403},
+									pos:  position{line: 179, col: 25, offset: 5139},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 186, col: 27, offset: 5405},
+									pos:   position{line: 179, col: 27, offset: 5141},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 186, col: 33, offset: 5411},
+										pos:  position{line: 179, col: 33, offset: 5147},
 										name: "UInt",
 									},
 								},
@@ -1789,10 +1743,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 187, col: 5, offset: 5442},
+						pos: position{line: 180, col: 5, offset: 5178},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 187, col: 5, offset: 5442},
+							pos:        position{line: 180, col: 5, offset: 5178},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -1802,22 +1756,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 192, col: 1, offset: 5702},
+			pos:  position{line: 185, col: 1, offset: 5438},
 			expr: &choiceExpr{
-				pos: position{line: 193, col: 5, offset: 5721},
+				pos: position{line: 186, col: 5, offset: 5457},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 193, col: 5, offset: 5721},
+						pos:  position{line: 186, col: 5, offset: 5457},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 194, col: 5, offset: 5736},
+						pos: position{line: 187, col: 5, offset: 5472},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 194, col: 5, offset: 5736},
+							pos:   position{line: 187, col: 5, offset: 5472},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 194, col: 10, offset: 5741},
+								pos:  position{line: 187, col: 10, offset: 5477},
 								name: "Expr",
 							},
 						},
@@ -1827,50 +1781,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 196, col: 1, offset: 5833},
+			pos:  position{line: 189, col: 1, offset: 5569},
 			expr: &actionExpr{
-				pos: position{line: 197, col: 5, offset: 5853},
+				pos: position{line: 190, col: 5, offset: 5589},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 197, col: 5, offset: 5853},
+					pos: position{line: 190, col: 5, offset: 5589},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 197, col: 5, offset: 5853},
+							pos:   position{line: 190, col: 5, offset: 5589},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 197, col: 11, offset: 5859},
+								pos:  position{line: 190, col: 11, offset: 5595},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 197, col: 26, offset: 5874},
+							pos:   position{line: 190, col: 26, offset: 5610},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 197, col: 31, offset: 5879},
+								pos: position{line: 190, col: 31, offset: 5615},
 								expr: &actionExpr{
-									pos: position{line: 197, col: 32, offset: 5880},
+									pos: position{line: 190, col: 32, offset: 5616},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 197, col: 32, offset: 5880},
+										pos: position{line: 190, col: 32, offset: 5616},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 197, col: 32, offset: 5880},
+												pos:  position{line: 190, col: 32, offset: 5616},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 197, col: 35, offset: 5883},
+												pos:        position{line: 190, col: 35, offset: 5619},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 197, col: 39, offset: 5887},
+												pos:  position{line: 190, col: 39, offset: 5623},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 197, col: 42, offset: 5890},
+												pos:   position{line: 190, col: 42, offset: 5626},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 197, col: 47, offset: 5895},
+													pos:  position{line: 190, col: 47, offset: 5631},
 													name: "FlexAssignment",
 												},
 											},
@@ -1885,42 +1839,42 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignment",
-			pos:  position{line: 201, col: 1, offset: 6017},
+			pos:  position{line: 194, col: 1, offset: 5753},
 			expr: &choiceExpr{
-				pos: position{line: 202, col: 5, offset: 6035},
+				pos: position{line: 195, col: 5, offset: 5771},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 202, col: 5, offset: 6035},
+						pos: position{line: 195, col: 5, offset: 5771},
 						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 202, col: 5, offset: 6035},
+							pos: position{line: 195, col: 5, offset: 5771},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 202, col: 5, offset: 6035},
+									pos:   position{line: 195, col: 5, offset: 5771},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 202, col: 10, offset: 6040},
+										pos:  position{line: 195, col: 10, offset: 5776},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 202, col: 15, offset: 6045},
+									pos:  position{line: 195, col: 15, offset: 5781},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 202, col: 18, offset: 6048},
+									pos:        position{line: 195, col: 18, offset: 5784},
 									val:        ":=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 202, col: 23, offset: 6053},
+									pos:  position{line: 195, col: 23, offset: 5789},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 202, col: 26, offset: 6056},
+									pos:   position{line: 195, col: 26, offset: 5792},
 									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 202, col: 30, offset: 6060},
+										pos:  position{line: 195, col: 30, offset: 5796},
 										name: "Agg",
 									},
 								},
@@ -1928,13 +1882,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 205, col: 5, offset: 6164},
+						pos: position{line: 198, col: 5, offset: 5900},
 						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 205, col: 5, offset: 6164},
+							pos:   position{line: 198, col: 5, offset: 5900},
 							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 205, col: 9, offset: 6168},
+								pos:  position{line: 198, col: 9, offset: 5904},
 								name: "Agg",
 							},
 						},
@@ -1944,72 +1898,72 @@ var g = &grammar{
 		},
 		{
 			name: "Agg",
-			pos:  position{line: 209, col: 1, offset: 6268},
+			pos:  position{line: 202, col: 1, offset: 6004},
 			expr: &actionExpr{
-				pos: position{line: 210, col: 5, offset: 6276},
+				pos: position{line: 203, col: 5, offset: 6012},
 				run: (*parser).callonAgg1,
 				expr: &seqExpr{
-					pos: position{line: 210, col: 5, offset: 6276},
+					pos: position{line: 203, col: 5, offset: 6012},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 210, col: 5, offset: 6276},
+							pos: position{line: 203, col: 5, offset: 6012},
 							expr: &ruleRefExpr{
-								pos:  position{line: 210, col: 6, offset: 6277},
+								pos:  position{line: 203, col: 6, offset: 6013},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 210, col: 16, offset: 6287},
+							pos:   position{line: 203, col: 16, offset: 6023},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 210, col: 19, offset: 6290},
+								pos:  position{line: 203, col: 19, offset: 6026},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 210, col: 27, offset: 6298},
+							pos:  position{line: 203, col: 27, offset: 6034},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 210, col: 30, offset: 6301},
+							pos:        position{line: 203, col: 30, offset: 6037},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 210, col: 34, offset: 6305},
+							pos:  position{line: 203, col: 34, offset: 6041},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 210, col: 37, offset: 6308},
+							pos:   position{line: 203, col: 37, offset: 6044},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 210, col: 42, offset: 6313},
+								pos: position{line: 203, col: 42, offset: 6049},
 								expr: &ruleRefExpr{
-									pos:  position{line: 210, col: 42, offset: 6313},
+									pos:  position{line: 203, col: 42, offset: 6049},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 210, col: 49, offset: 6320},
+							pos:  position{line: 203, col: 49, offset: 6056},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 210, col: 52, offset: 6323},
+							pos:        position{line: 203, col: 52, offset: 6059},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 210, col: 56, offset: 6327},
+							pos: position{line: 203, col: 56, offset: 6063},
 							expr: &seqExpr{
-								pos: position{line: 210, col: 58, offset: 6329},
+								pos: position{line: 203, col: 58, offset: 6065},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 210, col: 58, offset: 6329},
+										pos:  position{line: 203, col: 58, offset: 6065},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 210, col: 61, offset: 6332},
+										pos:        position{line: 203, col: 61, offset: 6068},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -2017,12 +1971,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 210, col: 66, offset: 6337},
+							pos:   position{line: 203, col: 66, offset: 6073},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 210, col: 72, offset: 6343},
+								pos: position{line: 203, col: 72, offset: 6079},
 								expr: &ruleRefExpr{
-									pos:  position{line: 210, col: 72, offset: 6343},
+									pos:  position{line: 203, col: 72, offset: 6079},
 									name: "WhereClause",
 								},
 							},
@@ -2033,20 +1987,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 218, col: 1, offset: 6533},
+			pos:  position{line: 211, col: 1, offset: 6269},
 			expr: &choiceExpr{
-				pos: position{line: 219, col: 5, offset: 6545},
+				pos: position{line: 212, col: 5, offset: 6281},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 5, offset: 6545},
+						pos:  position{line: 212, col: 5, offset: 6281},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 220, col: 5, offset: 6564},
+						pos:  position{line: 213, col: 5, offset: 6300},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 221, col: 5, offset: 6577},
+						pos:  position{line: 214, col: 5, offset: 6313},
 						name: "OrToken",
 					},
 				},
@@ -2054,31 +2008,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 223, col: 1, offset: 6586},
+			pos:  position{line: 216, col: 1, offset: 6322},
 			expr: &actionExpr{
-				pos: position{line: 223, col: 15, offset: 6600},
+				pos: position{line: 216, col: 15, offset: 6336},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 223, col: 15, offset: 6600},
+					pos: position{line: 216, col: 15, offset: 6336},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 223, col: 15, offset: 6600},
+							pos:  position{line: 216, col: 15, offset: 6336},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 17, offset: 6602},
+							pos:        position{line: 216, col: 17, offset: 6338},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 223, col: 25, offset: 6610},
+							pos:  position{line: 216, col: 25, offset: 6346},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 223, col: 27, offset: 6612},
+							pos:   position{line: 216, col: 27, offset: 6348},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 223, col: 32, offset: 6617},
+								pos:  position{line: 216, col: 32, offset: 6353},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -2088,44 +2042,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 225, col: 1, offset: 6653},
+			pos:  position{line: 218, col: 1, offset: 6389},
 			expr: &actionExpr{
-				pos: position{line: 226, col: 5, offset: 6672},
+				pos: position{line: 219, col: 5, offset: 6408},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 226, col: 5, offset: 6672},
+					pos: position{line: 219, col: 5, offset: 6408},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 226, col: 5, offset: 6672},
+							pos:   position{line: 219, col: 5, offset: 6408},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 226, col: 11, offset: 6678},
+								pos:  position{line: 219, col: 11, offset: 6414},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 226, col: 25, offset: 6692},
+							pos:   position{line: 219, col: 25, offset: 6428},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 226, col: 30, offset: 6697},
+								pos: position{line: 219, col: 30, offset: 6433},
 								expr: &seqExpr{
-									pos: position{line: 226, col: 31, offset: 6698},
+									pos: position{line: 219, col: 31, offset: 6434},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 226, col: 31, offset: 6698},
+											pos:  position{line: 219, col: 31, offset: 6434},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 226, col: 34, offset: 6701},
+											pos:        position{line: 219, col: 34, offset: 6437},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 226, col: 38, offset: 6705},
+											pos:  position{line: 219, col: 38, offset: 6441},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 226, col: 41, offset: 6708},
+											pos:  position{line: 219, col: 41, offset: 6444},
 											name: "AggAssignment",
 										},
 									},
@@ -2138,92 +2092,92 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 236, col: 1, offset: 6932},
+			pos:  position{line: 229, col: 1, offset: 6668},
 			expr: &choiceExpr{
-				pos: position{line: 237, col: 5, offset: 6945},
+				pos: position{line: 230, col: 5, offset: 6681},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 237, col: 5, offset: 6945},
+						pos:  position{line: 230, col: 5, offset: 6681},
 						name: "SortOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 238, col: 5, offset: 6956},
+						pos:  position{line: 231, col: 5, offset: 6692},
 						name: "TopOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 239, col: 5, offset: 6966},
+						pos:  position{line: 232, col: 5, offset: 6702},
 						name: "CutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 240, col: 5, offset: 6976},
+						pos:  position{line: 233, col: 5, offset: 6712},
 						name: "DropOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 241, col: 5, offset: 6987},
+						pos:  position{line: 234, col: 5, offset: 6723},
 						name: "HeadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 242, col: 5, offset: 6998},
+						pos:  position{line: 235, col: 5, offset: 6734},
 						name: "TailOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 243, col: 5, offset: 7009},
+						pos:  position{line: 236, col: 5, offset: 6745},
 						name: "WhereOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 244, col: 5, offset: 7021},
+						pos:  position{line: 237, col: 5, offset: 6757},
 						name: "UniqOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 5, offset: 7032},
+						pos:  position{line: 238, col: 5, offset: 6768},
 						name: "PutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 246, col: 5, offset: 7042},
+						pos:  position{line: 239, col: 5, offset: 6778},
 						name: "RenameOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 247, col: 5, offset: 7055},
+						pos:  position{line: 240, col: 5, offset: 6791},
 						name: "FuseOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 248, col: 5, offset: 7066},
+						pos:  position{line: 241, col: 5, offset: 6802},
 						name: "ShapeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 249, col: 5, offset: 7078},
+						pos:  position{line: 242, col: 5, offset: 6814},
 						name: "JoinOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 250, col: 5, offset: 7089},
+						pos:  position{line: 243, col: 5, offset: 6825},
 						name: "SampleOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 251, col: 5, offset: 7102},
+						pos:  position{line: 244, col: 5, offset: 6838},
 						name: "SQLOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 252, col: 5, offset: 7112},
+						pos:  position{line: 245, col: 5, offset: 6848},
 						name: "FromOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 253, col: 5, offset: 7123},
+						pos:  position{line: 246, col: 5, offset: 6859},
 						name: "PassOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 254, col: 5, offset: 7134},
+						pos:  position{line: 247, col: 5, offset: 6870},
 						name: "ExplodeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 255, col: 5, offset: 7148},
+						pos:  position{line: 248, col: 5, offset: 6884},
 						name: "MergeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 256, col: 5, offset: 7160},
+						pos:  position{line: 249, col: 5, offset: 6896},
 						name: "OverOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 5, offset: 7171},
+						pos:  position{line: 250, col: 5, offset: 6907},
 						name: "YieldOp",
 					},
 				},
@@ -2231,53 +2185,53 @@ var g = &grammar{
 		},
 		{
 			name: "SortOp",
-			pos:  position{line: 259, col: 1, offset: 7180},
+			pos:  position{line: 252, col: 1, offset: 6916},
 			expr: &actionExpr{
-				pos: position{line: 260, col: 5, offset: 7191},
+				pos: position{line: 253, col: 5, offset: 6927},
 				run: (*parser).callonSortOp1,
 				expr: &seqExpr{
-					pos: position{line: 260, col: 5, offset: 7191},
+					pos: position{line: 253, col: 5, offset: 6927},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 260, col: 5, offset: 7191},
+							pos:        position{line: 253, col: 5, offset: 6927},
 							val:        "sort",
 							ignoreCase: false,
 						},
 						&andExpr{
-							pos: position{line: 260, col: 12, offset: 7198},
+							pos: position{line: 253, col: 12, offset: 6934},
 							expr: &ruleRefExpr{
-								pos:  position{line: 260, col: 13, offset: 7199},
+								pos:  position{line: 253, col: 13, offset: 6935},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 260, col: 18, offset: 7204},
+							pos:   position{line: 253, col: 18, offset: 6940},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 260, col: 23, offset: 7209},
+								pos:  position{line: 253, col: 23, offset: 6945},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 260, col: 32, offset: 7218},
+							pos:   position{line: 253, col: 32, offset: 6954},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 260, col: 37, offset: 7223},
+								pos: position{line: 253, col: 37, offset: 6959},
 								expr: &actionExpr{
-									pos: position{line: 260, col: 38, offset: 7224},
+									pos: position{line: 253, col: 38, offset: 6960},
 									run: (*parser).callonSortOp10,
 									expr: &seqExpr{
-										pos: position{line: 260, col: 38, offset: 7224},
+										pos: position{line: 253, col: 38, offset: 6960},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 260, col: 38, offset: 7224},
+												pos:  position{line: 253, col: 38, offset: 6960},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 260, col: 40, offset: 7226},
+												pos:   position{line: 253, col: 40, offset: 6962},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 260, col: 42, offset: 7228},
+													pos:  position{line: 253, col: 42, offset: 6964},
 													name: "Exprs",
 												},
 											},
@@ -2292,30 +2246,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 274, col: 1, offset: 7639},
+			pos:  position{line: 267, col: 1, offset: 7375},
 			expr: &actionExpr{
-				pos: position{line: 274, col: 12, offset: 7650},
+				pos: position{line: 267, col: 12, offset: 7386},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 274, col: 12, offset: 7650},
+					pos:   position{line: 267, col: 12, offset: 7386},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 274, col: 17, offset: 7655},
+						pos: position{line: 267, col: 17, offset: 7391},
 						expr: &actionExpr{
-							pos: position{line: 274, col: 18, offset: 7656},
+							pos: position{line: 267, col: 18, offset: 7392},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 274, col: 18, offset: 7656},
+								pos: position{line: 267, col: 18, offset: 7392},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 274, col: 18, offset: 7656},
+										pos:  position{line: 267, col: 18, offset: 7392},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 274, col: 20, offset: 7658},
+										pos:   position{line: 267, col: 20, offset: 7394},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 274, col: 22, offset: 7660},
+											pos:  position{line: 267, col: 22, offset: 7396},
 											name: "SortArg",
 										},
 									},
@@ -2328,50 +2282,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 276, col: 1, offset: 7716},
+			pos:  position{line: 269, col: 1, offset: 7452},
 			expr: &choiceExpr{
-				pos: position{line: 277, col: 5, offset: 7728},
+				pos: position{line: 270, col: 5, offset: 7464},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 277, col: 5, offset: 7728},
+						pos: position{line: 270, col: 5, offset: 7464},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 277, col: 5, offset: 7728},
+							pos:        position{line: 270, col: 5, offset: 7464},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 278, col: 5, offset: 7803},
+						pos: position{line: 271, col: 5, offset: 7539},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 278, col: 5, offset: 7803},
+							pos: position{line: 271, col: 5, offset: 7539},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 278, col: 5, offset: 7803},
+									pos:        position{line: 271, col: 5, offset: 7539},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 278, col: 14, offset: 7812},
+									pos:  position{line: 271, col: 14, offset: 7548},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 278, col: 16, offset: 7814},
+									pos:   position{line: 271, col: 16, offset: 7550},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 278, col: 23, offset: 7821},
+										pos: position{line: 271, col: 23, offset: 7557},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 278, col: 24, offset: 7822},
+											pos: position{line: 271, col: 24, offset: 7558},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 278, col: 24, offset: 7822},
+													pos:        position{line: 271, col: 24, offset: 7558},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 278, col: 34, offset: 7832},
+													pos:        position{line: 271, col: 34, offset: 7568},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2387,45 +2341,45 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 280, col: 1, offset: 7946},
+			pos:  position{line: 273, col: 1, offset: 7682},
 			expr: &actionExpr{
-				pos: position{line: 281, col: 5, offset: 7956},
+				pos: position{line: 274, col: 5, offset: 7692},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 281, col: 5, offset: 7956},
+					pos: position{line: 274, col: 5, offset: 7692},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 281, col: 5, offset: 7956},
+							pos:        position{line: 274, col: 5, offset: 7692},
 							val:        "top",
 							ignoreCase: false,
 						},
 						&andExpr{
-							pos: position{line: 281, col: 11, offset: 7962},
+							pos: position{line: 274, col: 11, offset: 7698},
 							expr: &ruleRefExpr{
-								pos:  position{line: 281, col: 12, offset: 7963},
+								pos:  position{line: 274, col: 12, offset: 7699},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 17, offset: 7968},
+							pos:   position{line: 274, col: 17, offset: 7704},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 23, offset: 7974},
+								pos: position{line: 274, col: 23, offset: 7710},
 								expr: &actionExpr{
-									pos: position{line: 281, col: 24, offset: 7975},
+									pos: position{line: 274, col: 24, offset: 7711},
 									run: (*parser).callonTopOp8,
 									expr: &seqExpr{
-										pos: position{line: 281, col: 24, offset: 7975},
+										pos: position{line: 274, col: 24, offset: 7711},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 281, col: 24, offset: 7975},
+												pos:  position{line: 274, col: 24, offset: 7711},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 281, col: 26, offset: 7977},
+												pos:   position{line: 274, col: 26, offset: 7713},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 281, col: 28, offset: 7979},
+													pos:  position{line: 274, col: 28, offset: 7715},
 													name: "UInt",
 												},
 											},
@@ -2435,19 +2389,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 52, offset: 8003},
+							pos:   position{line: 274, col: 52, offset: 7739},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 58, offset: 8009},
+								pos: position{line: 274, col: 58, offset: 7745},
 								expr: &seqExpr{
-									pos: position{line: 281, col: 59, offset: 8010},
+									pos: position{line: 274, col: 59, offset: 7746},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 59, offset: 8010},
+											pos:  position{line: 274, col: 59, offset: 7746},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 281, col: 61, offset: 8012},
+											pos:        position{line: 274, col: 61, offset: 7748},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2456,25 +2410,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 72, offset: 8023},
+							pos:   position{line: 274, col: 72, offset: 7759},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 79, offset: 8030},
+								pos: position{line: 274, col: 79, offset: 7766},
 								expr: &actionExpr{
-									pos: position{line: 281, col: 80, offset: 8031},
+									pos: position{line: 274, col: 80, offset: 7767},
 									run: (*parser).callonTopOp20,
 									expr: &seqExpr{
-										pos: position{line: 281, col: 80, offset: 8031},
+										pos: position{line: 274, col: 80, offset: 7767},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 281, col: 80, offset: 8031},
+												pos:  position{line: 274, col: 80, offset: 7767},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 281, col: 82, offset: 8033},
+												pos:   position{line: 274, col: 82, offset: 7769},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 281, col: 84, offset: 8035},
+													pos:  position{line: 274, col: 84, offset: 7771},
 													name: "FieldExprs",
 												},
 											},
@@ -2489,27 +2443,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 295, col: 1, offset: 8370},
+			pos:  position{line: 288, col: 1, offset: 8106},
 			expr: &actionExpr{
-				pos: position{line: 296, col: 5, offset: 8380},
+				pos: position{line: 289, col: 5, offset: 8116},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 296, col: 5, offset: 8380},
+					pos: position{line: 289, col: 5, offset: 8116},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 296, col: 5, offset: 8380},
+							pos:        position{line: 289, col: 5, offset: 8116},
 							val:        "cut",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 296, col: 11, offset: 8386},
+							pos:  position{line: 289, col: 11, offset: 8122},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 296, col: 13, offset: 8388},
+							pos:   position{line: 289, col: 13, offset: 8124},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 296, col: 18, offset: 8393},
+								pos:  position{line: 289, col: 18, offset: 8129},
 								name: "FlexAssignments",
 							},
 						},
@@ -2519,27 +2473,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 300, col: 1, offset: 8488},
+			pos:  position{line: 293, col: 1, offset: 8224},
 			expr: &actionExpr{
-				pos: position{line: 301, col: 5, offset: 8499},
+				pos: position{line: 294, col: 5, offset: 8235},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 301, col: 5, offset: 8499},
+					pos: position{line: 294, col: 5, offset: 8235},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 301, col: 5, offset: 8499},
+							pos:        position{line: 294, col: 5, offset: 8235},
 							val:        "drop",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 301, col: 12, offset: 8506},
+							pos:  position{line: 294, col: 12, offset: 8242},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 301, col: 14, offset: 8508},
+							pos:   position{line: 294, col: 14, offset: 8244},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 301, col: 19, offset: 8513},
+								pos:  position{line: 294, col: 19, offset: 8249},
 								name: "FieldExprs",
 							},
 						},
@@ -2549,30 +2503,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 305, col: 1, offset: 8604},
+			pos:  position{line: 298, col: 1, offset: 8340},
 			expr: &choiceExpr{
-				pos: position{line: 306, col: 5, offset: 8615},
+				pos: position{line: 299, col: 5, offset: 8351},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 306, col: 5, offset: 8615},
+						pos: position{line: 299, col: 5, offset: 8351},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 306, col: 5, offset: 8615},
+							pos: position{line: 299, col: 5, offset: 8351},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 306, col: 5, offset: 8615},
+									pos:        position{line: 299, col: 5, offset: 8351},
 									val:        "head",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 306, col: 12, offset: 8622},
+									pos:  position{line: 299, col: 12, offset: 8358},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 306, col: 14, offset: 8624},
+									pos:   position{line: 299, col: 14, offset: 8360},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 306, col: 20, offset: 8630},
+										pos:  position{line: 299, col: 20, offset: 8366},
 										name: "UInt",
 									},
 								},
@@ -2580,10 +2534,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 307, col: 5, offset: 8710},
+						pos: position{line: 300, col: 5, offset: 8446},
 						run: (*parser).callonHeadOp8,
 						expr: &litMatcher{
-							pos:        position{line: 307, col: 5, offset: 8710},
+							pos:        position{line: 300, col: 5, offset: 8446},
 							val:        "head",
 							ignoreCase: false,
 						},
@@ -2593,30 +2547,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 309, col: 1, offset: 8785},
+			pos:  position{line: 302, col: 1, offset: 8521},
 			expr: &choiceExpr{
-				pos: position{line: 310, col: 5, offset: 8796},
+				pos: position{line: 303, col: 5, offset: 8532},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 310, col: 5, offset: 8796},
+						pos: position{line: 303, col: 5, offset: 8532},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 310, col: 5, offset: 8796},
+							pos: position{line: 303, col: 5, offset: 8532},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 310, col: 5, offset: 8796},
+									pos:        position{line: 303, col: 5, offset: 8532},
 									val:        "tail",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 310, col: 12, offset: 8803},
+									pos:  position{line: 303, col: 12, offset: 8539},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 310, col: 14, offset: 8805},
+									pos:   position{line: 303, col: 14, offset: 8541},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 310, col: 20, offset: 8811},
+										pos:  position{line: 303, col: 20, offset: 8547},
 										name: "UInt",
 									},
 								},
@@ -2624,10 +2578,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 311, col: 5, offset: 8891},
+						pos: position{line: 304, col: 5, offset: 8627},
 						run: (*parser).callonTailOp8,
 						expr: &litMatcher{
-							pos:        position{line: 311, col: 5, offset: 8891},
+							pos:        position{line: 304, col: 5, offset: 8627},
 							val:        "tail",
 							ignoreCase: false,
 						},
@@ -2637,27 +2591,27 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 313, col: 1, offset: 8966},
+			pos:  position{line: 306, col: 1, offset: 8702},
 			expr: &actionExpr{
-				pos: position{line: 314, col: 5, offset: 8978},
+				pos: position{line: 307, col: 5, offset: 8714},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 314, col: 5, offset: 8978},
+					pos: position{line: 307, col: 5, offset: 8714},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 314, col: 5, offset: 8978},
+							pos:        position{line: 307, col: 5, offset: 8714},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 314, col: 13, offset: 8986},
+							pos:  position{line: 307, col: 13, offset: 8722},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 314, col: 15, offset: 8988},
+							pos:   position{line: 307, col: 15, offset: 8724},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 314, col: 20, offset: 8993},
+								pos:  position{line: 307, col: 20, offset: 8729},
 								name: "Expr",
 							},
 						},
@@ -2667,27 +2621,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 318, col: 1, offset: 9079},
+			pos:  position{line: 311, col: 1, offset: 8815},
 			expr: &choiceExpr{
-				pos: position{line: 319, col: 5, offset: 9090},
+				pos: position{line: 312, col: 5, offset: 8826},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 319, col: 5, offset: 9090},
+						pos: position{line: 312, col: 5, offset: 8826},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 319, col: 5, offset: 9090},
+							pos: position{line: 312, col: 5, offset: 8826},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 319, col: 5, offset: 9090},
+									pos:        position{line: 312, col: 5, offset: 8826},
 									val:        "uniq",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 319, col: 12, offset: 9097},
+									pos:  position{line: 312, col: 12, offset: 8833},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 319, col: 14, offset: 9099},
+									pos:        position{line: 312, col: 14, offset: 8835},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2695,10 +2649,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 322, col: 5, offset: 9188},
+						pos: position{line: 315, col: 5, offset: 8924},
 						run: (*parser).callonUniqOp7,
 						expr: &litMatcher{
-							pos:        position{line: 322, col: 5, offset: 9188},
+							pos:        position{line: 315, col: 5, offset: 8924},
 							val:        "uniq",
 							ignoreCase: false,
 						},
@@ -2708,27 +2662,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 326, col: 1, offset: 9277},
+			pos:  position{line: 319, col: 1, offset: 9013},
 			expr: &actionExpr{
-				pos: position{line: 327, col: 5, offset: 9287},
+				pos: position{line: 320, col: 5, offset: 9023},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 327, col: 5, offset: 9287},
+					pos: position{line: 320, col: 5, offset: 9023},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 327, col: 5, offset: 9287},
+							pos:        position{line: 320, col: 5, offset: 9023},
 							val:        "put",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 327, col: 11, offset: 9293},
+							pos:  position{line: 320, col: 11, offset: 9029},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 327, col: 13, offset: 9295},
+							pos:   position{line: 320, col: 13, offset: 9031},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 327, col: 18, offset: 9300},
+								pos:  position{line: 320, col: 18, offset: 9036},
 								name: "Assignments",
 							},
 						},
@@ -2738,59 +2692,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 331, col: 1, offset: 9391},
+			pos:  position{line: 324, col: 1, offset: 9127},
 			expr: &actionExpr{
-				pos: position{line: 332, col: 5, offset: 9404},
+				pos: position{line: 325, col: 5, offset: 9140},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 332, col: 5, offset: 9404},
+					pos: position{line: 325, col: 5, offset: 9140},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 332, col: 5, offset: 9404},
+							pos:        position{line: 325, col: 5, offset: 9140},
 							val:        "rename",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 332, col: 14, offset: 9413},
+							pos:  position{line: 325, col: 14, offset: 9149},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 16, offset: 9415},
+							pos:   position{line: 325, col: 16, offset: 9151},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 332, col: 22, offset: 9421},
+								pos:  position{line: 325, col: 22, offset: 9157},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 33, offset: 9432},
+							pos:   position{line: 325, col: 33, offset: 9168},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 332, col: 38, offset: 9437},
+								pos: position{line: 325, col: 38, offset: 9173},
 								expr: &actionExpr{
-									pos: position{line: 332, col: 39, offset: 9438},
+									pos: position{line: 325, col: 39, offset: 9174},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 332, col: 39, offset: 9438},
+										pos: position{line: 325, col: 39, offset: 9174},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 332, col: 39, offset: 9438},
+												pos:  position{line: 325, col: 39, offset: 9174},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 332, col: 42, offset: 9441},
+												pos:        position{line: 325, col: 42, offset: 9177},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 332, col: 46, offset: 9445},
+												pos:  position{line: 325, col: 46, offset: 9181},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 332, col: 49, offset: 9448},
+												pos:   position{line: 325, col: 49, offset: 9184},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 332, col: 52, offset: 9451},
+													pos:  position{line: 325, col: 52, offset: 9187},
 													name: "Assignment",
 												},
 											},
@@ -2805,29 +2759,29 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 340, col: 1, offset: 9858},
+			pos:  position{line: 333, col: 1, offset: 9594},
 			expr: &actionExpr{
-				pos: position{line: 341, col: 5, offset: 9869},
+				pos: position{line: 334, col: 5, offset: 9605},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 341, col: 5, offset: 9869},
+					pos: position{line: 334, col: 5, offset: 9605},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 341, col: 5, offset: 9869},
+							pos:        position{line: 334, col: 5, offset: 9605},
 							val:        "fuse",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 341, col: 12, offset: 9876},
+							pos: position{line: 334, col: 12, offset: 9612},
 							expr: &seqExpr{
-								pos: position{line: 341, col: 14, offset: 9878},
+								pos: position{line: 334, col: 14, offset: 9614},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 341, col: 14, offset: 9878},
+										pos:  position{line: 334, col: 14, offset: 9614},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 341, col: 17, offset: 9881},
+										pos:        position{line: 334, col: 17, offset: 9617},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -2835,9 +2789,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 341, col: 22, offset: 9886},
+							pos: position{line: 334, col: 22, offset: 9622},
 							expr: &ruleRefExpr{
-								pos:  position{line: 341, col: 23, offset: 9887},
+								pos:  position{line: 334, col: 23, offset: 9623},
 								name: "EOKW",
 							},
 						},
@@ -2847,29 +2801,29 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 345, col: 1, offset: 9958},
+			pos:  position{line: 338, col: 1, offset: 9694},
 			expr: &actionExpr{
-				pos: position{line: 346, col: 5, offset: 9970},
+				pos: position{line: 339, col: 5, offset: 9706},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 346, col: 5, offset: 9970},
+					pos: position{line: 339, col: 5, offset: 9706},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 346, col: 5, offset: 9970},
+							pos:        position{line: 339, col: 5, offset: 9706},
 							val:        "shape",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 346, col: 13, offset: 9978},
+							pos: position{line: 339, col: 13, offset: 9714},
 							expr: &seqExpr{
-								pos: position{line: 346, col: 15, offset: 9980},
+								pos: position{line: 339, col: 15, offset: 9716},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 346, col: 15, offset: 9980},
+										pos:  position{line: 339, col: 15, offset: 9716},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 346, col: 18, offset: 9983},
+										pos:        position{line: 339, col: 18, offset: 9719},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -2877,9 +2831,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 346, col: 23, offset: 9988},
+							pos: position{line: 339, col: 23, offset: 9724},
 							expr: &ruleRefExpr{
-								pos:  position{line: 346, col: 24, offset: 9989},
+								pos:  position{line: 339, col: 24, offset: 9725},
 								name: "EOKW",
 							},
 						},
@@ -2889,84 +2843,84 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 350, col: 1, offset: 10061},
+			pos:  position{line: 343, col: 1, offset: 9797},
 			expr: &choiceExpr{
-				pos: position{line: 351, col: 5, offset: 10072},
+				pos: position{line: 344, col: 5, offset: 9808},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 351, col: 5, offset: 10072},
+						pos: position{line: 344, col: 5, offset: 9808},
 						run: (*parser).callonJoinOp2,
 						expr: &seqExpr{
-							pos: position{line: 351, col: 5, offset: 10072},
+							pos: position{line: 344, col: 5, offset: 9808},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 351, col: 5, offset: 10072},
+									pos:   position{line: 344, col: 5, offset: 9808},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 351, col: 11, offset: 10078},
+										pos:  position{line: 344, col: 11, offset: 9814},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 351, col: 21, offset: 10088},
+									pos:        position{line: 344, col: 21, offset: 9824},
 									val:        "join",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 28, offset: 10095},
+									pos:  position{line: 344, col: 28, offset: 9831},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 30, offset: 10097},
+									pos:  position{line: 344, col: 30, offset: 9833},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 33, offset: 10100},
+									pos:  position{line: 344, col: 33, offset: 9836},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 35, offset: 10102},
+									pos:   position{line: 344, col: 35, offset: 9838},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 351, col: 43, offset: 10110},
+										pos:  position{line: 344, col: 43, offset: 9846},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 51, offset: 10118},
+									pos:  position{line: 344, col: 51, offset: 9854},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 351, col: 54, offset: 10121},
+									pos:        position{line: 344, col: 54, offset: 9857},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 58, offset: 10125},
+									pos:  position{line: 344, col: 58, offset: 9861},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 61, offset: 10128},
+									pos:   position{line: 344, col: 61, offset: 9864},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 351, col: 70, offset: 10137},
+										pos:  position{line: 344, col: 70, offset: 9873},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 78, offset: 10145},
+									pos:   position{line: 344, col: 78, offset: 9881},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 351, col: 86, offset: 10153},
+										pos: position{line: 344, col: 86, offset: 9889},
 										expr: &seqExpr{
-											pos: position{line: 351, col: 87, offset: 10154},
+											pos: position{line: 344, col: 87, offset: 9890},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 351, col: 87, offset: 10154},
+													pos:  position{line: 344, col: 87, offset: 9890},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 351, col: 89, offset: 10156},
+													pos:  position{line: 344, col: 89, offset: 9892},
 													name: "FlexAssignments",
 												},
 											},
@@ -2977,58 +2931,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 358, col: 5, offset: 10416},
+						pos: position{line: 351, col: 5, offset: 10152},
 						run: (*parser).callonJoinOp22,
 						expr: &seqExpr{
-							pos: position{line: 358, col: 5, offset: 10416},
+							pos: position{line: 351, col: 5, offset: 10152},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 358, col: 5, offset: 10416},
+									pos:   position{line: 351, col: 5, offset: 10152},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 358, col: 11, offset: 10422},
+										pos:  position{line: 351, col: 11, offset: 10158},
 										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 358, col: 22, offset: 10433},
+									pos:        position{line: 351, col: 22, offset: 10169},
 									val:        "join",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 29, offset: 10440},
+									pos:  position{line: 351, col: 29, offset: 10176},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 31, offset: 10442},
+									pos:  position{line: 351, col: 31, offset: 10178},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 34, offset: 10445},
+									pos:  position{line: 351, col: 34, offset: 10181},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 358, col: 36, offset: 10447},
+									pos:   position{line: 351, col: 36, offset: 10183},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 358, col: 40, offset: 10451},
+										pos:  position{line: 351, col: 40, offset: 10187},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 358, col: 48, offset: 10459},
+									pos:   position{line: 351, col: 48, offset: 10195},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 358, col: 56, offset: 10467},
+										pos: position{line: 351, col: 56, offset: 10203},
 										expr: &seqExpr{
-											pos: position{line: 358, col: 57, offset: 10468},
+											pos: position{line: 351, col: 57, offset: 10204},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 358, col: 57, offset: 10468},
+													pos:  position{line: 351, col: 57, offset: 10204},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 358, col: 59, offset: 10470},
+													pos:  position{line: 351, col: 59, offset: 10206},
 													name: "FlexAssignments",
 												},
 											},
@@ -3043,87 +2997,87 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 366, col: 1, offset: 10718},
+			pos:  position{line: 359, col: 1, offset: 10454},
 			expr: &choiceExpr{
-				pos: position{line: 367, col: 5, offset: 10732},
+				pos: position{line: 360, col: 5, offset: 10468},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 367, col: 5, offset: 10732},
+						pos: position{line: 360, col: 5, offset: 10468},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 367, col: 5, offset: 10732},
+							pos: position{line: 360, col: 5, offset: 10468},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 367, col: 5, offset: 10732},
+									pos:        position{line: 360, col: 5, offset: 10468},
 									val:        "anti",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 367, col: 12, offset: 10739},
+									pos:  position{line: 360, col: 12, offset: 10475},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 368, col: 5, offset: 10769},
+						pos: position{line: 361, col: 5, offset: 10505},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 368, col: 5, offset: 10769},
+							pos: position{line: 361, col: 5, offset: 10505},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 368, col: 5, offset: 10769},
+									pos:        position{line: 361, col: 5, offset: 10505},
 									val:        "inner",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 368, col: 13, offset: 10777},
+									pos:  position{line: 361, col: 13, offset: 10513},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 369, col: 5, offset: 10807},
+						pos: position{line: 362, col: 5, offset: 10543},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 369, col: 5, offset: 10807},
+							pos: position{line: 362, col: 5, offset: 10543},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 369, col: 5, offset: 10807},
+									pos:        position{line: 362, col: 5, offset: 10543},
 									val:        "left",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 369, col: 13, offset: 10815},
+									pos:  position{line: 362, col: 13, offset: 10551},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 10844},
+						pos: position{line: 363, col: 5, offset: 10580},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 370, col: 5, offset: 10844},
+							pos: position{line: 363, col: 5, offset: 10580},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 370, col: 5, offset: 10844},
+									pos:        position{line: 363, col: 5, offset: 10580},
 									val:        "right",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 370, col: 13, offset: 10852},
+									pos:  position{line: 363, col: 13, offset: 10588},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 371, col: 5, offset: 10882},
+						pos: position{line: 364, col: 5, offset: 10618},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 371, col: 5, offset: 10882},
+							pos:        position{line: 364, col: 5, offset: 10618},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3133,35 +3087,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 373, col: 1, offset: 10918},
+			pos:  position{line: 366, col: 1, offset: 10654},
 			expr: &choiceExpr{
-				pos: position{line: 374, col: 5, offset: 10930},
+				pos: position{line: 367, col: 5, offset: 10666},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 374, col: 5, offset: 10930},
+						pos:  position{line: 367, col: 5, offset: 10666},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 375, col: 5, offset: 10939},
+						pos: position{line: 368, col: 5, offset: 10675},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 375, col: 5, offset: 10939},
+							pos: position{line: 368, col: 5, offset: 10675},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 375, col: 5, offset: 10939},
+									pos:        position{line: 368, col: 5, offset: 10675},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 375, col: 9, offset: 10943},
+									pos:   position{line: 368, col: 9, offset: 10679},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 375, col: 14, offset: 10948},
+										pos:  position{line: 368, col: 14, offset: 10684},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 375, col: 19, offset: 10953},
+									pos:        position{line: 368, col: 19, offset: 10689},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3173,30 +3127,30 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 377, col: 1, offset: 10979},
+			pos:  position{line: 370, col: 1, offset: 10715},
 			expr: &actionExpr{
-				pos: position{line: 378, col: 5, offset: 10992},
+				pos: position{line: 371, col: 5, offset: 10728},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 378, col: 5, offset: 10992},
+					pos: position{line: 371, col: 5, offset: 10728},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 378, col: 5, offset: 10992},
+							pos:        position{line: 371, col: 5, offset: 10728},
 							val:        "sample",
 							ignoreCase: false,
 						},
 						&andExpr{
-							pos: position{line: 378, col: 14, offset: 11001},
+							pos: position{line: 371, col: 14, offset: 10737},
 							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 15, offset: 11002},
+								pos:  position{line: 371, col: 15, offset: 10738},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 378, col: 20, offset: 11007},
+							pos:   position{line: 371, col: 20, offset: 10743},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 22, offset: 11009},
+								pos:  position{line: 371, col: 22, offset: 10745},
 								name: "SampleExpr",
 							},
 						},
@@ -3206,15 +3160,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 420, col: 1, offset: 12509},
+			pos:  position{line: 413, col: 1, offset: 12245},
 			expr: &actionExpr{
-				pos: position{line: 421, col: 5, offset: 12526},
+				pos: position{line: 414, col: 5, offset: 12262},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 421, col: 5, offset: 12526},
+					pos:   position{line: 414, col: 5, offset: 12262},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 421, col: 7, offset: 12528},
+						pos:  position{line: 414, col: 7, offset: 12264},
 						name: "Assignments",
 					},
 				},
@@ -3222,25 +3176,25 @@ var g = &grammar{
 		},
 		{
 			name: "SampleExpr",
-			pos:  position{line: 425, col: 1, offset: 12628},
+			pos:  position{line: 418, col: 1, offset: 12364},
 			expr: &choiceExpr{
-				pos: position{line: 426, col: 5, offset: 12643},
+				pos: position{line: 419, col: 5, offset: 12379},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 426, col: 5, offset: 12643},
+						pos: position{line: 419, col: 5, offset: 12379},
 						run: (*parser).callonSampleExpr2,
 						expr: &seqExpr{
-							pos: position{line: 426, col: 5, offset: 12643},
+							pos: position{line: 419, col: 5, offset: 12379},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 426, col: 5, offset: 12643},
+									pos:  position{line: 419, col: 5, offset: 12379},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 426, col: 7, offset: 12645},
+									pos:   position{line: 419, col: 7, offset: 12381},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 426, col: 12, offset: 12650},
+										pos:  position{line: 419, col: 12, offset: 12386},
 										name: "Lval",
 									},
 								},
@@ -3248,10 +3202,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 427, col: 5, offset: 12679},
+						pos: position{line: 420, col: 5, offset: 12415},
 						run: (*parser).callonSampleExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 427, col: 5, offset: 12679},
+							pos:        position{line: 420, col: 5, offset: 12415},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3261,15 +3215,15 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 429, col: 1, offset: 12750},
+			pos:  position{line: 422, col: 1, offset: 12486},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 12761},
+				pos: position{line: 423, col: 5, offset: 12497},
 				run: (*parser).callonFromOp1,
 				expr: &labeledExpr{
-					pos:   position{line: 430, col: 5, offset: 12761},
+					pos:   position{line: 423, col: 5, offset: 12497},
 					label: "source",
 					expr: &ruleRefExpr{
-						pos:  position{line: 430, col: 12, offset: 12768},
+						pos:  position{line: 423, col: 12, offset: 12504},
 						name: "FromAny",
 					},
 				},
@@ -3277,20 +3231,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromAny",
-			pos:  position{line: 434, col: 1, offset: 12924},
+			pos:  position{line: 427, col: 1, offset: 12660},
 			expr: &choiceExpr{
-				pos: position{line: 435, col: 5, offset: 12936},
+				pos: position{line: 428, col: 5, offset: 12672},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 435, col: 5, offset: 12936},
+						pos:  position{line: 428, col: 5, offset: 12672},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 436, col: 5, offset: 12945},
+						pos:  position{line: 429, col: 5, offset: 12681},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 437, col: 5, offset: 12953},
+						pos:  position{line: 430, col: 5, offset: 12689},
 						name: "From",
 					},
 				},
@@ -3298,48 +3252,48 @@ var g = &grammar{
 		},
 		{
 			name: "File",
-			pos:  position{line: 439, col: 1, offset: 12959},
+			pos:  position{line: 432, col: 1, offset: 12695},
 			expr: &actionExpr{
-				pos: position{line: 440, col: 5, offset: 12968},
+				pos: position{line: 433, col: 5, offset: 12704},
 				run: (*parser).callonFile1,
 				expr: &seqExpr{
-					pos: position{line: 440, col: 5, offset: 12968},
+					pos: position{line: 433, col: 5, offset: 12704},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 440, col: 5, offset: 12968},
+							pos:        position{line: 433, col: 5, offset: 12704},
 							val:        "file",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 440, col: 12, offset: 12975},
+							pos:  position{line: 433, col: 12, offset: 12711},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 14, offset: 12977},
+							pos:   position{line: 433, col: 14, offset: 12713},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 440, col: 19, offset: 12982},
+								pos:  position{line: 433, col: 19, offset: 12718},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 24, offset: 12987},
+							pos:   position{line: 433, col: 24, offset: 12723},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 440, col: 31, offset: 12994},
+								pos: position{line: 433, col: 31, offset: 12730},
 								expr: &ruleRefExpr{
-									pos:  position{line: 440, col: 31, offset: 12994},
+									pos:  position{line: 433, col: 31, offset: 12730},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 42, offset: 13005},
+							pos:   position{line: 433, col: 42, offset: 12741},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 440, col: 49, offset: 13012},
+								pos: position{line: 433, col: 49, offset: 12748},
 								expr: &ruleRefExpr{
-									pos:  position{line: 440, col: 49, offset: 13012},
+									pos:  position{line: 433, col: 49, offset: 12748},
 									name: "LayoutArg",
 								},
 							},
@@ -3350,27 +3304,27 @@ var g = &grammar{
 		},
 		{
 			name: "From",
-			pos:  position{line: 444, col: 1, offset: 13141},
+			pos:  position{line: 437, col: 1, offset: 12877},
 			expr: &actionExpr{
-				pos: position{line: 445, col: 5, offset: 13150},
+				pos: position{line: 438, col: 5, offset: 12886},
 				run: (*parser).callonFrom1,
 				expr: &seqExpr{
-					pos: position{line: 445, col: 5, offset: 13150},
+					pos: position{line: 438, col: 5, offset: 12886},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 445, col: 5, offset: 13150},
+							pos:        position{line: 438, col: 5, offset: 12886},
 							val:        "from",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 445, col: 12, offset: 13157},
+							pos:  position{line: 438, col: 12, offset: 12893},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 14, offset: 13159},
+							pos:   position{line: 438, col: 14, offset: 12895},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 19, offset: 13164},
+								pos:  position{line: 438, col: 19, offset: 12900},
 								name: "PoolBody",
 							},
 						},
@@ -3380,27 +3334,27 @@ var g = &grammar{
 		},
 		{
 			name: "Pool",
-			pos:  position{line: 447, col: 1, offset: 13195},
+			pos:  position{line: 440, col: 1, offset: 12931},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 5, offset: 13204},
+				pos: position{line: 441, col: 5, offset: 12940},
 				run: (*parser).callonPool1,
 				expr: &seqExpr{
-					pos: position{line: 448, col: 5, offset: 13204},
+					pos: position{line: 441, col: 5, offset: 12940},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 448, col: 5, offset: 13204},
+							pos:        position{line: 441, col: 5, offset: 12940},
 							val:        "pool",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 448, col: 12, offset: 13211},
+							pos:  position{line: 441, col: 12, offset: 12947},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 448, col: 14, offset: 13213},
+							pos:   position{line: 441, col: 14, offset: 12949},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 448, col: 19, offset: 13218},
+								pos:  position{line: 441, col: 19, offset: 12954},
 								name: "PoolBody",
 							},
 						},
@@ -3410,50 +3364,50 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBody",
-			pos:  position{line: 450, col: 1, offset: 13249},
+			pos:  position{line: 443, col: 1, offset: 12985},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 13262},
+				pos: position{line: 444, col: 5, offset: 12998},
 				run: (*parser).callonPoolBody1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 13262},
+					pos: position{line: 444, col: 5, offset: 12998},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 13262},
+							pos:   position{line: 444, col: 5, offset: 12998},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 10, offset: 13267},
+								pos:  position{line: 444, col: 10, offset: 13003},
 								name: "PoolSpec",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 19, offset: 13276},
+							pos:   position{line: 444, col: 19, offset: 13012},
 							label: "at",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 22, offset: 13279},
+								pos: position{line: 444, col: 22, offset: 13015},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 22, offset: 13279},
+									pos:  position{line: 444, col: 22, offset: 13015},
 									name: "PoolAt",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 30, offset: 13287},
+							pos:   position{line: 444, col: 30, offset: 13023},
 							label: "over",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 35, offset: 13292},
+								pos: position{line: 444, col: 35, offset: 13028},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 35, offset: 13292},
+									pos:  position{line: 444, col: 35, offset: 13028},
 									name: "PoolRange",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 451, col: 46, offset: 13303},
+							pos:   position{line: 444, col: 46, offset: 13039},
 							label: "order",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 451, col: 52, offset: 13309},
+								pos: position{line: 444, col: 52, offset: 13045},
 								expr: &ruleRefExpr{
-									pos:  position{line: 451, col: 52, offset: 13309},
+									pos:  position{line: 444, col: 52, offset: 13045},
 									name: "OrderArg",
 								},
 							},
@@ -3464,48 +3418,48 @@ var g = &grammar{
 		},
 		{
 			name: "Get",
-			pos:  position{line: 455, col: 1, offset: 13445},
+			pos:  position{line: 448, col: 1, offset: 13181},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 5, offset: 13453},
+				pos: position{line: 449, col: 5, offset: 13189},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 456, col: 5, offset: 13453},
+					pos: position{line: 449, col: 5, offset: 13189},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 456, col: 5, offset: 13453},
+							pos:        position{line: 449, col: 5, offset: 13189},
 							val:        "get",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 456, col: 11, offset: 13459},
+							pos:  position{line: 449, col: 11, offset: 13195},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 13, offset: 13461},
+							pos:   position{line: 449, col: 13, offset: 13197},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 456, col: 17, offset: 13465},
+								pos:  position{line: 449, col: 17, offset: 13201},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 21, offset: 13469},
+							pos:   position{line: 449, col: 21, offset: 13205},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 456, col: 28, offset: 13476},
+								pos: position{line: 449, col: 28, offset: 13212},
 								expr: &ruleRefExpr{
-									pos:  position{line: 456, col: 28, offset: 13476},
+									pos:  position{line: 449, col: 28, offset: 13212},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 39, offset: 13487},
+							pos:   position{line: 449, col: 39, offset: 13223},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 456, col: 46, offset: 13494},
+								pos: position{line: 449, col: 46, offset: 13230},
 								expr: &ruleRefExpr{
-									pos:  position{line: 456, col: 46, offset: 13494},
+									pos:  position{line: 449, col: 46, offset: 13230},
 									name: "LayoutArg",
 								},
 							},
@@ -3516,30 +3470,30 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 460, col: 1, offset: 13620},
+			pos:  position{line: 453, col: 1, offset: 13356},
 			expr: &actionExpr{
-				pos: position{line: 460, col: 7, offset: 13626},
+				pos: position{line: 453, col: 7, offset: 13362},
 				run: (*parser).callonURL1,
 				expr: &seqExpr{
-					pos: position{line: 460, col: 7, offset: 13626},
+					pos: position{line: 453, col: 7, offset: 13362},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 460, col: 8, offset: 13627},
+							pos: position{line: 453, col: 8, offset: 13363},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 460, col: 8, offset: 13627},
+									pos:        position{line: 453, col: 8, offset: 13363},
 									val:        "http:",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 460, col: 18, offset: 13637},
+									pos:        position{line: 453, col: 18, offset: 13373},
 									val:        "https:",
 									ignoreCase: false,
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 460, col: 28, offset: 13647},
+							pos:  position{line: 453, col: 28, offset: 13383},
 							name: "Path",
 						},
 					},
@@ -3548,29 +3502,29 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 462, col: 1, offset: 13684},
+			pos:  position{line: 455, col: 1, offset: 13420},
 			expr: &choiceExpr{
-				pos: position{line: 463, col: 5, offset: 13693},
+				pos: position{line: 456, col: 5, offset: 13429},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 463, col: 5, offset: 13693},
+						pos: position{line: 456, col: 5, offset: 13429},
 						run: (*parser).callonPath2,
 						expr: &labeledExpr{
-							pos:   position{line: 463, col: 5, offset: 13693},
+							pos:   position{line: 456, col: 5, offset: 13429},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 463, col: 7, offset: 13695},
+								pos:  position{line: 456, col: 7, offset: 13431},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 464, col: 5, offset: 13730},
+						pos: position{line: 457, col: 5, offset: 13466},
 						run: (*parser).callonPath5,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 464, col: 5, offset: 13730},
+							pos: position{line: 457, col: 5, offset: 13466},
 							expr: &charClassMatcher{
-								pos:        position{line: 464, col: 5, offset: 13730},
+								pos:        position{line: 457, col: 5, offset: 13466},
 								val:        "[0-9a-zA-Z!@$%^&*()_=<>,./?:[\\]{}~|+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '(', ')', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '|', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -3584,31 +3538,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 467, col: 1, offset: 13835},
+			pos:  position{line: 460, col: 1, offset: 13571},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 5, offset: 13846},
+				pos: position{line: 461, col: 5, offset: 13582},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 468, col: 5, offset: 13846},
+					pos: position{line: 461, col: 5, offset: 13582},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 5, offset: 13846},
+							pos:  position{line: 461, col: 5, offset: 13582},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 468, col: 7, offset: 13848},
+							pos:        position{line: 461, col: 7, offset: 13584},
 							val:        "at",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 12, offset: 13853},
+							pos:  position{line: 461, col: 12, offset: 13589},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 14, offset: 13855},
+							pos:   position{line: 461, col: 14, offset: 13591},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 17, offset: 13858},
+								pos:  position{line: 461, col: 17, offset: 13594},
 								name: "KSUID",
 							},
 						},
@@ -3618,14 +3572,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 471, col: 1, offset: 13924},
+			pos:  position{line: 464, col: 1, offset: 13660},
 			expr: &actionExpr{
-				pos: position{line: 471, col: 9, offset: 13932},
+				pos: position{line: 464, col: 9, offset: 13668},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 471, col: 9, offset: 13932},
+					pos: position{line: 464, col: 9, offset: 13668},
 					expr: &charClassMatcher{
-						pos:        position{line: 471, col: 10, offset: 13933},
+						pos:        position{line: 464, col: 10, offset: 13669},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -3636,52 +3590,52 @@ var g = &grammar{
 		},
 		{
 			name: "PoolRange",
-			pos:  position{line: 473, col: 1, offset: 13979},
+			pos:  position{line: 466, col: 1, offset: 13715},
 			expr: &actionExpr{
-				pos: position{line: 474, col: 5, offset: 13993},
+				pos: position{line: 467, col: 5, offset: 13729},
 				run: (*parser).callonPoolRange1,
 				expr: &seqExpr{
-					pos: position{line: 474, col: 5, offset: 13993},
+					pos: position{line: 467, col: 5, offset: 13729},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 5, offset: 13993},
+							pos:  position{line: 467, col: 5, offset: 13729},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 7, offset: 13995},
+							pos:        position{line: 467, col: 7, offset: 13731},
 							val:        "range",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 15, offset: 14003},
+							pos:  position{line: 467, col: 15, offset: 13739},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 17, offset: 14005},
+							pos:   position{line: 467, col: 17, offset: 13741},
 							label: "lower",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 23, offset: 14011},
+								pos:  position{line: 467, col: 23, offset: 13747},
 								name: "Literal",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 31, offset: 14019},
+							pos:  position{line: 467, col: 31, offset: 13755},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 33, offset: 14021},
+							pos:        position{line: 467, col: 33, offset: 13757},
 							val:        "to",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 474, col: 38, offset: 14026},
+							pos:  position{line: 467, col: 38, offset: 13762},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 40, offset: 14028},
+							pos:   position{line: 467, col: 40, offset: 13764},
 							label: "upper",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 46, offset: 14034},
+								pos:  position{line: 467, col: 46, offset: 13770},
 								name: "Literal",
 							},
 						},
@@ -3691,42 +3645,42 @@ var g = &grammar{
 		},
 		{
 			name: "PoolSpec",
-			pos:  position{line: 478, col: 1, offset: 14139},
+			pos:  position{line: 471, col: 1, offset: 13875},
 			expr: &choiceExpr{
-				pos: position{line: 479, col: 5, offset: 14152},
+				pos: position{line: 472, col: 5, offset: 13888},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 479, col: 5, offset: 14152},
+						pos: position{line: 472, col: 5, offset: 13888},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 479, col: 5, offset: 14152},
+							pos: position{line: 472, col: 5, offset: 13888},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 479, col: 5, offset: 14152},
+									pos:   position{line: 472, col: 5, offset: 13888},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 10, offset: 14157},
+										pos:  position{line: 472, col: 10, offset: 13893},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 19, offset: 14166},
+									pos:   position{line: 472, col: 19, offset: 13902},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 479, col: 26, offset: 14173},
+										pos: position{line: 472, col: 26, offset: 13909},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 26, offset: 14173},
+											pos:  position{line: 472, col: 26, offset: 13909},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 38, offset: 14185},
+									pos:   position{line: 472, col: 38, offset: 13921},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 479, col: 43, offset: 14190},
+										pos: position{line: 472, col: 43, offset: 13926},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 43, offset: 14190},
+											pos:  position{line: 472, col: 43, offset: 13926},
 											name: "PoolMeta",
 										},
 									},
@@ -3735,13 +3689,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 14299},
+						pos: position{line: 475, col: 5, offset: 14035},
 						run: (*parser).callonPoolSpec12,
 						expr: &labeledExpr{
-							pos:   position{line: 482, col: 5, offset: 14299},
+							pos:   position{line: 475, col: 5, offset: 14035},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 482, col: 10, offset: 14304},
+								pos:  position{line: 475, col: 10, offset: 14040},
 								name: "PoolMeta",
 							},
 						},
@@ -3751,23 +3705,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 486, col: 1, offset: 14405},
+			pos:  position{line: 479, col: 1, offset: 14141},
 			expr: &actionExpr{
-				pos: position{line: 487, col: 5, offset: 14420},
+				pos: position{line: 480, col: 5, offset: 14156},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 487, col: 5, offset: 14420},
+					pos: position{line: 480, col: 5, offset: 14156},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 487, col: 5, offset: 14420},
+							pos:        position{line: 480, col: 5, offset: 14156},
 							val:        "@",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 487, col: 9, offset: 14424},
+							pos:   position{line: 480, col: 9, offset: 14160},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 487, col: 16, offset: 14431},
+								pos:  position{line: 480, col: 16, offset: 14167},
 								name: "PoolName",
 							},
 						},
@@ -3777,23 +3731,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 489, col: 1, offset: 14464},
+			pos:  position{line: 482, col: 1, offset: 14200},
 			expr: &actionExpr{
-				pos: position{line: 490, col: 5, offset: 14477},
+				pos: position{line: 483, col: 5, offset: 14213},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 490, col: 5, offset: 14477},
+					pos: position{line: 483, col: 5, offset: 14213},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 490, col: 5, offset: 14477},
+							pos:        position{line: 483, col: 5, offset: 14213},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 490, col: 9, offset: 14481},
+							pos:   position{line: 483, col: 9, offset: 14217},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 490, col: 14, offset: 14486},
+								pos:  position{line: 483, col: 14, offset: 14222},
 								name: "PoolIdentifier",
 							},
 						},
@@ -3803,20 +3757,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 492, col: 1, offset: 14523},
+			pos:  position{line: 485, col: 1, offset: 14259},
 			expr: &choiceExpr{
-				pos: position{line: 493, col: 5, offset: 14536},
+				pos: position{line: 486, col: 5, offset: 14272},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 493, col: 5, offset: 14536},
+						pos:  position{line: 486, col: 5, offset: 14272},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 494, col: 5, offset: 14555},
+						pos:  position{line: 487, col: 5, offset: 14291},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 495, col: 5, offset: 14565},
+						pos:  position{line: 488, col: 5, offset: 14301},
 						name: "QuotedString",
 					},
 				},
@@ -3824,38 +3778,38 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 497, col: 1, offset: 14579},
+			pos:  position{line: 490, col: 1, offset: 14315},
 			expr: &actionExpr{
-				pos: position{line: 498, col: 5, offset: 14598},
+				pos: position{line: 491, col: 5, offset: 14334},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 498, col: 5, offset: 14598},
+					pos: position{line: 491, col: 5, offset: 14334},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 498, col: 6, offset: 14599},
+							pos: position{line: 491, col: 6, offset: 14335},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 498, col: 6, offset: 14599},
+									pos:  position{line: 491, col: 6, offset: 14335},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 498, col: 24, offset: 14617},
+									pos:        position{line: 491, col: 24, offset: 14353},
 									val:        ".",
 									ignoreCase: false,
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 498, col: 29, offset: 14622},
+							pos: position{line: 491, col: 29, offset: 14358},
 							expr: &choiceExpr{
-								pos: position{line: 498, col: 30, offset: 14623},
+								pos: position{line: 491, col: 30, offset: 14359},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 498, col: 30, offset: 14623},
+										pos:  position{line: 491, col: 30, offset: 14359},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 498, col: 47, offset: 14640},
+										pos:        position{line: 491, col: 47, offset: 14376},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -3868,39 +3822,39 @@ var g = &grammar{
 		},
 		{
 			name: "LayoutArg",
-			pos:  position{line: 500, col: 1, offset: 14679},
+			pos:  position{line: 493, col: 1, offset: 14415},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 14693},
+				pos: position{line: 494, col: 5, offset: 14429},
 				run: (*parser).callonLayoutArg1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 14693},
+					pos: position{line: 494, col: 5, offset: 14429},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 5, offset: 14693},
+							pos:  position{line: 494, col: 5, offset: 14429},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 7, offset: 14695},
+							pos:        position{line: 494, col: 7, offset: 14431},
 							val:        "order",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 15, offset: 14703},
+							pos:  position{line: 494, col: 15, offset: 14439},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 17, offset: 14705},
+							pos:   position{line: 494, col: 17, offset: 14441},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 22, offset: 14710},
+								pos:  position{line: 494, col: 22, offset: 14446},
 								name: "FieldExprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 33, offset: 14721},
+							pos:   position{line: 494, col: 33, offset: 14457},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 39, offset: 14727},
+								pos:  position{line: 494, col: 39, offset: 14463},
 								name: "OrderSuffix",
 							},
 						},
@@ -3910,31 +3864,31 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 505, col: 1, offset: 14837},
+			pos:  position{line: 498, col: 1, offset: 14573},
 			expr: &actionExpr{
-				pos: position{line: 506, col: 5, offset: 14851},
+				pos: position{line: 499, col: 5, offset: 14587},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 506, col: 5, offset: 14851},
+					pos: position{line: 499, col: 5, offset: 14587},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 5, offset: 14851},
+							pos:  position{line: 499, col: 5, offset: 14587},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 506, col: 7, offset: 14853},
+							pos:        position{line: 499, col: 7, offset: 14589},
 							val:        "format",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 16, offset: 14862},
+							pos:  position{line: 499, col: 16, offset: 14598},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 506, col: 18, offset: 14864},
+							pos:   position{line: 499, col: 18, offset: 14600},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 506, col: 22, offset: 14868},
+								pos:  position{line: 499, col: 22, offset: 14604},
 								name: "IdentifierName",
 							},
 						},
@@ -3944,33 +3898,33 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 508, col: 1, offset: 14904},
+			pos:  position{line: 501, col: 1, offset: 14640},
 			expr: &choiceExpr{
-				pos: position{line: 509, col: 5, offset: 14920},
+				pos: position{line: 502, col: 5, offset: 14656},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 509, col: 5, offset: 14920},
+						pos: position{line: 502, col: 5, offset: 14656},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 509, col: 5, offset: 14920},
+							pos:        position{line: 502, col: 5, offset: 14656},
 							val:        ":asc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 14954},
+						pos: position{line: 503, col: 5, offset: 14690},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 510, col: 5, offset: 14954},
+							pos:        position{line: 503, col: 5, offset: 14690},
 							val:        ":desc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 511, col: 5, offset: 14990},
+						pos: position{line: 504, col: 5, offset: 14726},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 511, col: 5, offset: 14990},
+							pos:        position{line: 504, col: 5, offset: 14726},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3980,31 +3934,31 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 513, col: 1, offset: 15016},
+			pos:  position{line: 506, col: 1, offset: 14752},
 			expr: &choiceExpr{
-				pos: position{line: 514, col: 5, offset: 15029},
+				pos: position{line: 507, col: 5, offset: 14765},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 15029},
+						pos: position{line: 507, col: 5, offset: 14765},
 						run: (*parser).callonOrderArg2,
 						expr: &seqExpr{
-							pos: position{line: 514, col: 5, offset: 15029},
+							pos: position{line: 507, col: 5, offset: 14765},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 5, offset: 15029},
+									pos:  position{line: 507, col: 5, offset: 14765},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 7, offset: 15031},
+									pos:        position{line: 507, col: 7, offset: 14767},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 15, offset: 15039},
+									pos:  position{line: 507, col: 15, offset: 14775},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 17, offset: 15041},
+									pos:        position{line: 507, col: 17, offset: 14777},
 									val:        "asc",
 									ignoreCase: false,
 								},
@@ -4012,26 +3966,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 515, col: 5, offset: 15074},
+						pos: position{line: 508, col: 5, offset: 14810},
 						run: (*parser).callonOrderArg8,
 						expr: &seqExpr{
-							pos: position{line: 515, col: 5, offset: 15074},
+							pos: position{line: 508, col: 5, offset: 14810},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 515, col: 5, offset: 15074},
+									pos:  position{line: 508, col: 5, offset: 14810},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 515, col: 7, offset: 15076},
+									pos:        position{line: 508, col: 7, offset: 14812},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 515, col: 15, offset: 15084},
+									pos:  position{line: 508, col: 15, offset: 14820},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 515, col: 17, offset: 15086},
+									pos:        position{line: 508, col: 17, offset: 14822},
 									val:        "desc",
 									ignoreCase: false,
 								},
@@ -4043,22 +3997,22 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 517, col: 1, offset: 15118},
+			pos:  position{line: 510, col: 1, offset: 14854},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 5, offset: 15129},
+				pos: position{line: 511, col: 5, offset: 14865},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 518, col: 5, offset: 15129},
+					pos: position{line: 511, col: 5, offset: 14865},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 518, col: 5, offset: 15129},
+							pos:        position{line: 511, col: 5, offset: 14865},
 							val:        "pass",
 							ignoreCase: false,
 						},
 						&andExpr{
-							pos: position{line: 518, col: 12, offset: 15136},
+							pos: position{line: 511, col: 12, offset: 14872},
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 13, offset: 15137},
+								pos:  position{line: 511, col: 13, offset: 14873},
 								name: "EOKW",
 							},
 						},
@@ -4068,45 +4022,45 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 524, col: 1, offset: 15329},
+			pos:  position{line: 517, col: 1, offset: 15065},
 			expr: &actionExpr{
-				pos: position{line: 525, col: 5, offset: 15343},
+				pos: position{line: 518, col: 5, offset: 15079},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 525, col: 5, offset: 15343},
+					pos: position{line: 518, col: 5, offset: 15079},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 525, col: 5, offset: 15343},
+							pos:        position{line: 518, col: 5, offset: 15079},
 							val:        "explode",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 525, col: 15, offset: 15353},
+							pos:  position{line: 518, col: 15, offset: 15089},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 17, offset: 15355},
+							pos:   position{line: 518, col: 17, offset: 15091},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 22, offset: 15360},
+								pos:  position{line: 518, col: 22, offset: 15096},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 28, offset: 15366},
+							pos:   position{line: 518, col: 28, offset: 15102},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 32, offset: 15370},
+								pos:  position{line: 518, col: 32, offset: 15106},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 40, offset: 15378},
+							pos:   position{line: 518, col: 40, offset: 15114},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 525, col: 43, offset: 15381},
+								pos: position{line: 518, col: 43, offset: 15117},
 								expr: &ruleRefExpr{
-									pos:  position{line: 525, col: 43, offset: 15381},
+									pos:  position{line: 518, col: 43, offset: 15117},
 									name: "AsArg",
 								},
 							},
@@ -4117,27 +4071,27 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 529, col: 1, offset: 15493},
+			pos:  position{line: 522, col: 1, offset: 15229},
 			expr: &actionExpr{
-				pos: position{line: 530, col: 5, offset: 15505},
+				pos: position{line: 523, col: 5, offset: 15241},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 530, col: 5, offset: 15505},
+					pos: position{line: 523, col: 5, offset: 15241},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 530, col: 5, offset: 15505},
+							pos:        position{line: 523, col: 5, offset: 15241},
 							val:        "merge",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 530, col: 13, offset: 15513},
+							pos:  position{line: 523, col: 13, offset: 15249},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 15, offset: 15515},
+							pos:   position{line: 523, col: 15, offset: 15251},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 20, offset: 15520},
+								pos:  position{line: 523, col: 20, offset: 15256},
 								name: "Expr",
 							},
 						},
@@ -4147,128 +4101,91 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 534, col: 1, offset: 15601},
-			expr: &choiceExpr{
-				pos: position{line: 535, col: 5, offset: 15612},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 535, col: 5, offset: 15612},
-						run: (*parser).callonOverOp2,
-						expr: &seqExpr{
-							pos: position{line: 535, col: 5, offset: 15612},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 535, col: 5, offset: 15612},
-									val:        "over",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 535, col: 12, offset: 15619},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 535, col: 14, offset: 15621},
-									label: "exprs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 535, col: 20, offset: 15627},
-										name: "Exprs",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 535, col: 26, offset: 15633},
-									name: "_",
-								},
-								&litMatcher{
-									pos:        position{line: 535, col: 28, offset: 15635},
-									val:        "with",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 535, col: 35, offset: 15642},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 535, col: 37, offset: 15644},
-									label: "locals",
-									expr: &ruleRefExpr{
-										pos:  position{line: 535, col: 44, offset: 15651},
-										name: "LetAssignments",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 535, col: 59, offset: 15666},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 535, col: 62, offset: 15669},
-									label: "scope",
-									expr: &ruleRefExpr{
-										pos:  position{line: 535, col: 68, offset: 15675},
-										name: "Scope",
+			pos:  position{line: 527, col: 1, offset: 15337},
+			expr: &actionExpr{
+				pos: position{line: 528, col: 5, offset: 15348},
+				run: (*parser).callonOverOp1,
+				expr: &seqExpr{
+					pos: position{line: 528, col: 5, offset: 15348},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 528, col: 5, offset: 15348},
+							val:        "over",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 528, col: 12, offset: 15355},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 528, col: 14, offset: 15357},
+							label: "exprs",
+							expr: &ruleRefExpr{
+								pos:  position{line: 528, col: 20, offset: 15363},
+								name: "Exprs",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 528, col: 26, offset: 15369},
+							label: "locals",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 528, col: 33, offset: 15376},
+								expr: &actionExpr{
+									pos: position{line: 528, col: 34, offset: 15377},
+									run: (*parser).callonOverOp9,
+									expr: &seqExpr{
+										pos: position{line: 528, col: 34, offset: 15377},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 528, col: 34, offset: 15377},
+												name: "_",
+											},
+											&litMatcher{
+												pos:        position{line: 528, col: 36, offset: 15379},
+												val:        "with",
+												ignoreCase: false,
+											},
+											&ruleRefExpr{
+												pos:  position{line: 528, col: 43, offset: 15386},
+												name: "_",
+											},
+											&labeledExpr{
+												pos:   position{line: 528, col: 45, offset: 15388},
+												label: "l",
+												expr: &ruleRefExpr{
+													pos:  position{line: 528, col: 47, offset: 15390},
+													name: "LetAssignments",
+												},
+											},
+										},
 									},
 								},
 							},
 						},
-					},
-					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 15841},
-						run: (*parser).callonOverOp16,
-						expr: &seqExpr{
-							pos: position{line: 538, col: 5, offset: 15841},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 538, col: 5, offset: 15841},
-									val:        "over",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 538, col: 12, offset: 15848},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 538, col: 14, offset: 15850},
-									label: "exprs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 538, col: 20, offset: 15856},
-										name: "Exprs",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 538, col: 26, offset: 15862},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 538, col: 29, offset: 15865},
-									label: "scope",
-									expr: &ruleRefExpr{
-										pos:  position{line: 538, col: 35, offset: 15871},
-										name: "Scope",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 15975},
-						run: (*parser).callonOverOp25,
-						expr: &seqExpr{
-							pos: position{line: 541, col: 5, offset: 15975},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 541, col: 5, offset: 15975},
-									val:        "over",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 541, col: 12, offset: 15982},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 541, col: 14, offset: 15984},
-									label: "exprs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 20, offset: 15990},
-										name: "Exprs",
+						&labeledExpr{
+							pos:   position{line: 528, col: 82, offset: 15425},
+							label: "scope",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 528, col: 88, offset: 15431},
+								expr: &actionExpr{
+									pos: position{line: 528, col: 89, offset: 15432},
+									run: (*parser).callonOverOp18,
+									expr: &seqExpr{
+										pos: position{line: 528, col: 89, offset: 15432},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 528, col: 89, offset: 15432},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 528, col: 92, offset: 15435},
+												label: "s",
+												expr: &ruleRefExpr{
+													pos:  position{line: 528, col: 94, offset: 15437},
+													name: "Scope",
+												},
+											},
+										},
 									},
 								},
 							},
@@ -4279,45 +4196,45 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 545, col: 1, offset: 16089},
+			pos:  position{line: 536, col: 1, offset: 15706},
 			expr: &actionExpr{
-				pos: position{line: 545, col: 9, offset: 16097},
+				pos: position{line: 536, col: 9, offset: 15714},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 545, col: 9, offset: 16097},
+					pos: position{line: 536, col: 9, offset: 15714},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 545, col: 9, offset: 16097},
+							pos:        position{line: 536, col: 9, offset: 15714},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 545, col: 14, offset: 16102},
+							pos:  position{line: 536, col: 14, offset: 15719},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 545, col: 17, offset: 16105},
+							pos:        position{line: 536, col: 17, offset: 15722},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 545, col: 21, offset: 16109},
+							pos:  position{line: 536, col: 21, offset: 15726},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 24, offset: 16112},
+							pos:   position{line: 536, col: 24, offset: 15729},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 28, offset: 16116},
+								pos:  position{line: 536, col: 28, offset: 15733},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 545, col: 39, offset: 16127},
+							pos:  position{line: 536, col: 39, offset: 15744},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 545, col: 42, offset: 16130},
+							pos:        position{line: 536, col: 42, offset: 15747},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4327,50 +4244,50 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignments",
-			pos:  position{line: 547, col: 1, offset: 16155},
+			pos:  position{line: 538, col: 1, offset: 15772},
 			expr: &actionExpr{
-				pos: position{line: 548, col: 5, offset: 16174},
+				pos: position{line: 539, col: 5, offset: 15791},
 				run: (*parser).callonLetAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 548, col: 5, offset: 16174},
+					pos: position{line: 539, col: 5, offset: 15791},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 548, col: 5, offset: 16174},
+							pos:   position{line: 539, col: 5, offset: 15791},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 11, offset: 16180},
+								pos:  position{line: 539, col: 11, offset: 15797},
 								name: "LetAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 548, col: 25, offset: 16194},
+							pos:   position{line: 539, col: 25, offset: 15811},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 548, col: 30, offset: 16199},
+								pos: position{line: 539, col: 30, offset: 15816},
 								expr: &actionExpr{
-									pos: position{line: 548, col: 31, offset: 16200},
+									pos: position{line: 539, col: 31, offset: 15817},
 									run: (*parser).callonLetAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 548, col: 31, offset: 16200},
+										pos: position{line: 539, col: 31, offset: 15817},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 548, col: 31, offset: 16200},
+												pos:  position{line: 539, col: 31, offset: 15817},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 548, col: 34, offset: 16203},
+												pos:        position{line: 539, col: 34, offset: 15820},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 548, col: 38, offset: 16207},
+												pos:  position{line: 539, col: 38, offset: 15824},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 548, col: 41, offset: 16210},
+												pos:   position{line: 539, col: 41, offset: 15827},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 548, col: 43, offset: 16212},
+													pos:  position{line: 539, col: 43, offset: 15829},
 													name: "LetAssignment",
 												},
 											},
@@ -4385,42 +4302,42 @@ var g = &grammar{
 		},
 		{
 			name: "LetAssignment",
-			pos:  position{line: 552, col: 1, offset: 16330},
+			pos:  position{line: 543, col: 1, offset: 15947},
 			expr: &choiceExpr{
-				pos: position{line: 553, col: 5, offset: 16348},
+				pos: position{line: 544, col: 5, offset: 15965},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 553, col: 5, offset: 16348},
+						pos: position{line: 544, col: 5, offset: 15965},
 						run: (*parser).callonLetAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 553, col: 5, offset: 16348},
+							pos: position{line: 544, col: 5, offset: 15965},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 553, col: 5, offset: 16348},
+									pos:   position{line: 544, col: 5, offset: 15965},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 553, col: 8, offset: 16351},
+										pos:  position{line: 544, col: 8, offset: 15968},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 23, offset: 16366},
+									pos:  position{line: 544, col: 23, offset: 15983},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 553, col: 26, offset: 16369},
+									pos:        position{line: 544, col: 26, offset: 15986},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 30, offset: 16373},
+									pos:  position{line: 544, col: 30, offset: 15990},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 553, col: 33, offset: 16376},
+									pos:   position{line: 544, col: 33, offset: 15993},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 553, col: 38, offset: 16381},
+										pos:  position{line: 544, col: 38, offset: 15998},
 										name: "Expr",
 									},
 								},
@@ -4428,13 +4345,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 556, col: 5, offset: 16463},
+						pos: position{line: 547, col: 5, offset: 16080},
 						run: (*parser).callonLetAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 556, col: 5, offset: 16463},
+							pos:   position{line: 547, col: 5, offset: 16080},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 556, col: 8, offset: 16466},
+								pos:  position{line: 547, col: 8, offset: 16083},
 								name: "IdentifierName",
 							},
 						},
@@ -4444,27 +4361,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 560, col: 1, offset: 16596},
+			pos:  position{line: 551, col: 1, offset: 16213},
 			expr: &actionExpr{
-				pos: position{line: 561, col: 5, offset: 16608},
+				pos: position{line: 552, col: 5, offset: 16225},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 561, col: 5, offset: 16608},
+					pos: position{line: 552, col: 5, offset: 16225},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 561, col: 5, offset: 16608},
+							pos:        position{line: 552, col: 5, offset: 16225},
 							val:        "yield",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 561, col: 13, offset: 16616},
+							pos:  position{line: 552, col: 13, offset: 16233},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 561, col: 15, offset: 16618},
+							pos:   position{line: 552, col: 15, offset: 16235},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 21, offset: 16624},
+								pos:  position{line: 552, col: 21, offset: 16241},
 								name: "Exprs",
 							},
 						},
@@ -4474,30 +4391,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 565, col: 1, offset: 16708},
+			pos:  position{line: 556, col: 1, offset: 16325},
 			expr: &actionExpr{
-				pos: position{line: 566, col: 5, offset: 16720},
+				pos: position{line: 557, col: 5, offset: 16337},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 566, col: 5, offset: 16720},
+					pos: position{line: 557, col: 5, offset: 16337},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 566, col: 5, offset: 16720},
+							pos:  position{line: 557, col: 5, offset: 16337},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 566, col: 7, offset: 16722},
+							pos:  position{line: 557, col: 7, offset: 16339},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 566, col: 10, offset: 16725},
+							pos:  position{line: 557, col: 10, offset: 16342},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 566, col: 12, offset: 16727},
+							pos:   position{line: 557, col: 12, offset: 16344},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 566, col: 16, offset: 16731},
+								pos:  position{line: 557, col: 16, offset: 16348},
 								name: "Type",
 							},
 						},
@@ -4507,30 +4424,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 568, col: 1, offset: 16756},
+			pos:  position{line: 559, col: 1, offset: 16373},
 			expr: &actionExpr{
-				pos: position{line: 569, col: 5, offset: 16766},
+				pos: position{line: 560, col: 5, offset: 16383},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 569, col: 5, offset: 16766},
+					pos: position{line: 560, col: 5, offset: 16383},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 569, col: 5, offset: 16766},
+							pos:  position{line: 560, col: 5, offset: 16383},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 569, col: 7, offset: 16768},
+							pos:  position{line: 560, col: 7, offset: 16385},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 569, col: 10, offset: 16771},
+							pos:  position{line: 560, col: 10, offset: 16388},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 569, col: 12, offset: 16773},
+							pos:   position{line: 560, col: 12, offset: 16390},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 569, col: 16, offset: 16777},
+								pos:  position{line: 560, col: 16, offset: 16394},
 								name: "Lval",
 							},
 						},
@@ -4540,58 +4457,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 573, col: 1, offset: 16828},
+			pos:  position{line: 564, col: 1, offset: 16445},
 			expr: &ruleRefExpr{
-				pos:  position{line: 573, col: 8, offset: 16835},
+				pos:  position{line: 564, col: 8, offset: 16452},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 575, col: 1, offset: 16846},
+			pos:  position{line: 566, col: 1, offset: 16463},
 			expr: &actionExpr{
-				pos: position{line: 576, col: 5, offset: 16856},
+				pos: position{line: 567, col: 5, offset: 16473},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 576, col: 5, offset: 16856},
+					pos: position{line: 567, col: 5, offset: 16473},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 576, col: 5, offset: 16856},
+							pos:   position{line: 567, col: 5, offset: 16473},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 576, col: 11, offset: 16862},
+								pos:  position{line: 567, col: 11, offset: 16479},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 576, col: 16, offset: 16867},
+							pos:   position{line: 567, col: 16, offset: 16484},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 576, col: 21, offset: 16872},
+								pos: position{line: 567, col: 21, offset: 16489},
 								expr: &actionExpr{
-									pos: position{line: 576, col: 22, offset: 16873},
+									pos: position{line: 567, col: 22, offset: 16490},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 576, col: 22, offset: 16873},
+										pos: position{line: 567, col: 22, offset: 16490},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 576, col: 22, offset: 16873},
+												pos:  position{line: 567, col: 22, offset: 16490},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 576, col: 25, offset: 16876},
+												pos:        position{line: 567, col: 25, offset: 16493},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 576, col: 29, offset: 16880},
+												pos:  position{line: 567, col: 29, offset: 16497},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 576, col: 32, offset: 16883},
+												pos:   position{line: 567, col: 32, offset: 16500},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 576, col: 37, offset: 16888},
+													pos:  position{line: 567, col: 37, offset: 16505},
 													name: "Lval",
 												},
 											},
@@ -4606,52 +4523,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 580, col: 1, offset: 17000},
+			pos:  position{line: 571, col: 1, offset: 16617},
 			expr: &ruleRefExpr{
-				pos:  position{line: 580, col: 13, offset: 17012},
+				pos:  position{line: 571, col: 13, offset: 16629},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 582, col: 1, offset: 17018},
+			pos:  position{line: 573, col: 1, offset: 16635},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 5, offset: 17033},
+				pos: position{line: 574, col: 5, offset: 16650},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 583, col: 5, offset: 17033},
+					pos: position{line: 574, col: 5, offset: 16650},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 583, col: 5, offset: 17033},
+							pos:   position{line: 574, col: 5, offset: 16650},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 11, offset: 17039},
+								pos:  position{line: 574, col: 11, offset: 16656},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 21, offset: 17049},
+							pos:   position{line: 574, col: 21, offset: 16666},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 583, col: 26, offset: 17054},
+								pos: position{line: 574, col: 26, offset: 16671},
 								expr: &seqExpr{
-									pos: position{line: 583, col: 27, offset: 17055},
+									pos: position{line: 574, col: 27, offset: 16672},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 583, col: 27, offset: 17055},
+											pos:  position{line: 574, col: 27, offset: 16672},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 583, col: 30, offset: 17058},
+											pos:        position{line: 574, col: 30, offset: 16675},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 583, col: 34, offset: 17062},
+											pos:  position{line: 574, col: 34, offset: 16679},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 583, col: 37, offset: 17065},
+											pos:  position{line: 574, col: 37, offset: 16682},
 											name: "FieldExpr",
 										},
 									},
@@ -4664,50 +4581,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 593, col: 1, offset: 17264},
+			pos:  position{line: 584, col: 1, offset: 16881},
 			expr: &actionExpr{
-				pos: position{line: 594, col: 5, offset: 17280},
+				pos: position{line: 585, col: 5, offset: 16897},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 594, col: 5, offset: 17280},
+					pos: position{line: 585, col: 5, offset: 16897},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 594, col: 5, offset: 17280},
+							pos:   position{line: 585, col: 5, offset: 16897},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 594, col: 11, offset: 17286},
+								pos:  position{line: 585, col: 11, offset: 16903},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 594, col: 22, offset: 17297},
+							pos:   position{line: 585, col: 22, offset: 16914},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 594, col: 27, offset: 17302},
+								pos: position{line: 585, col: 27, offset: 16919},
 								expr: &actionExpr{
-									pos: position{line: 594, col: 28, offset: 17303},
+									pos: position{line: 585, col: 28, offset: 16920},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 594, col: 28, offset: 17303},
+										pos: position{line: 585, col: 28, offset: 16920},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 594, col: 28, offset: 17303},
+												pos:  position{line: 585, col: 28, offset: 16920},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 594, col: 31, offset: 17306},
+												pos:        position{line: 585, col: 31, offset: 16923},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 594, col: 35, offset: 17310},
+												pos:  position{line: 585, col: 35, offset: 16927},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 594, col: 38, offset: 17313},
+												pos:   position{line: 585, col: 38, offset: 16930},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 594, col: 40, offset: 17315},
+													pos:  position{line: 585, col: 40, offset: 16932},
 													name: "Assignment",
 												},
 											},
@@ -4722,39 +4639,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 598, col: 1, offset: 17426},
+			pos:  position{line: 589, col: 1, offset: 17043},
 			expr: &actionExpr{
-				pos: position{line: 599, col: 5, offset: 17441},
+				pos: position{line: 590, col: 5, offset: 17058},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 599, col: 5, offset: 17441},
+					pos: position{line: 590, col: 5, offset: 17058},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 599, col: 5, offset: 17441},
+							pos:   position{line: 590, col: 5, offset: 17058},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 599, col: 9, offset: 17445},
+								pos:  position{line: 590, col: 9, offset: 17062},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 14, offset: 17450},
+							pos:  position{line: 590, col: 14, offset: 17067},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 599, col: 17, offset: 17453},
+							pos:        position{line: 590, col: 17, offset: 17070},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 22, offset: 17458},
+							pos:  position{line: 590, col: 22, offset: 17075},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 599, col: 25, offset: 17461},
+							pos:   position{line: 590, col: 25, offset: 17078},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 599, col: 29, offset: 17465},
+								pos:  position{line: 590, col: 29, offset: 17082},
 								name: "Expr",
 							},
 						},
@@ -4764,71 +4681,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 601, col: 1, offset: 17556},
+			pos:  position{line: 592, col: 1, offset: 17173},
 			expr: &ruleRefExpr{
-				pos:  position{line: 601, col: 8, offset: 17563},
+				pos:  position{line: 592, col: 8, offset: 17180},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 603, col: 1, offset: 17580},
+			pos:  position{line: 594, col: 1, offset: 17197},
 			expr: &choiceExpr{
-				pos: position{line: 604, col: 5, offset: 17600},
+				pos: position{line: 595, col: 5, offset: 17217},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 604, col: 5, offset: 17600},
+						pos: position{line: 595, col: 5, offset: 17217},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 604, col: 5, offset: 17600},
+							pos: position{line: 595, col: 5, offset: 17217},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 604, col: 5, offset: 17600},
+									pos:   position{line: 595, col: 5, offset: 17217},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 604, col: 15, offset: 17610},
+										pos:  position{line: 595, col: 15, offset: 17227},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 604, col: 29, offset: 17624},
+									pos:  position{line: 595, col: 29, offset: 17241},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 604, col: 32, offset: 17627},
+									pos:        position{line: 595, col: 32, offset: 17244},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 604, col: 36, offset: 17631},
+									pos:  position{line: 595, col: 36, offset: 17248},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 604, col: 39, offset: 17634},
+									pos:   position{line: 595, col: 39, offset: 17251},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 604, col: 50, offset: 17645},
+										pos:  position{line: 595, col: 50, offset: 17262},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 604, col: 55, offset: 17650},
+									pos:  position{line: 595, col: 55, offset: 17267},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 604, col: 58, offset: 17653},
+									pos:        position{line: 595, col: 58, offset: 17270},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 604, col: 62, offset: 17657},
+									pos:  position{line: 595, col: 62, offset: 17274},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 604, col: 65, offset: 17660},
+									pos:   position{line: 595, col: 65, offset: 17277},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 604, col: 76, offset: 17671},
+										pos:  position{line: 595, col: 76, offset: 17288},
 										name: "Expr",
 									},
 								},
@@ -4836,7 +4753,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 607, col: 5, offset: 17811},
+						pos:  position{line: 598, col: 5, offset: 17428},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -4844,53 +4761,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 609, col: 1, offset: 17826},
+			pos:  position{line: 600, col: 1, offset: 17443},
 			expr: &actionExpr{
-				pos: position{line: 610, col: 5, offset: 17844},
+				pos: position{line: 601, col: 5, offset: 17461},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 610, col: 5, offset: 17844},
+					pos: position{line: 601, col: 5, offset: 17461},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 610, col: 5, offset: 17844},
+							pos:   position{line: 601, col: 5, offset: 17461},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 610, col: 11, offset: 17850},
+								pos:  position{line: 601, col: 11, offset: 17467},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 5, offset: 17869},
+							pos:   position{line: 602, col: 5, offset: 17486},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 611, col: 10, offset: 17874},
+								pos: position{line: 602, col: 10, offset: 17491},
 								expr: &actionExpr{
-									pos: position{line: 611, col: 11, offset: 17875},
+									pos: position{line: 602, col: 11, offset: 17492},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 611, col: 11, offset: 17875},
+										pos: position{line: 602, col: 11, offset: 17492},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 11, offset: 17875},
+												pos:  position{line: 602, col: 11, offset: 17492},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 611, col: 14, offset: 17878},
+												pos:   position{line: 602, col: 14, offset: 17495},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 611, col: 17, offset: 17881},
+													pos:  position{line: 602, col: 17, offset: 17498},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 611, col: 25, offset: 17889},
+												pos:  position{line: 602, col: 25, offset: 17506},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 611, col: 28, offset: 17892},
+												pos:   position{line: 602, col: 28, offset: 17509},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 611, col: 33, offset: 17897},
+													pos:  position{line: 602, col: 33, offset: 17514},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4905,53 +4822,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 615, col: 1, offset: 18015},
+			pos:  position{line: 606, col: 1, offset: 17632},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 5, offset: 18034},
+				pos: position{line: 607, col: 5, offset: 17651},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 5, offset: 18034},
+					pos: position{line: 607, col: 5, offset: 17651},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 616, col: 5, offset: 18034},
+							pos:   position{line: 607, col: 5, offset: 17651},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 11, offset: 18040},
+								pos:  position{line: 607, col: 11, offset: 17657},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 617, col: 5, offset: 18059},
+							pos:   position{line: 608, col: 5, offset: 17676},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 617, col: 10, offset: 18064},
+								pos: position{line: 608, col: 10, offset: 17681},
 								expr: &actionExpr{
-									pos: position{line: 617, col: 11, offset: 18065},
+									pos: position{line: 608, col: 11, offset: 17682},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 617, col: 11, offset: 18065},
+										pos: position{line: 608, col: 11, offset: 17682},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 617, col: 11, offset: 18065},
+												pos:  position{line: 608, col: 11, offset: 17682},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 617, col: 14, offset: 18068},
+												pos:   position{line: 608, col: 14, offset: 17685},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 617, col: 17, offset: 18071},
+													pos:  position{line: 608, col: 17, offset: 17688},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 617, col: 26, offset: 18080},
+												pos:  position{line: 608, col: 26, offset: 17697},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 617, col: 29, offset: 18083},
+												pos:   position{line: 608, col: 29, offset: 17700},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 617, col: 34, offset: 18088},
+													pos:  position{line: 608, col: 34, offset: 17705},
 													name: "ComparisonExpr",
 												},
 											},
@@ -4966,145 +4883,133 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 621, col: 1, offset: 18206},
-			expr: &choiceExpr{
-				pos: position{line: 622, col: 5, offset: 18225},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 622, col: 5, offset: 18225},
-						run: (*parser).callonComparisonExpr2,
-						expr: &seqExpr{
-							pos: position{line: 622, col: 5, offset: 18225},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 622, col: 5, offset: 18225},
-									label: "lhs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 622, col: 9, offset: 18229},
-										name: "AdditiveExpr",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 622, col: 22, offset: 18242},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 622, col: 25, offset: 18245},
-									label: "op",
-									expr: &ruleRefExpr{
-										pos:  position{line: 622, col: 28, offset: 18248},
-										name: "Comparator",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 622, col: 39, offset: 18259},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 622, col: 42, offset: 18262},
-									label: "rhs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 622, col: 46, offset: 18266},
-										name: "AdditiveExpr",
+			pos:  position{line: 612, col: 1, offset: 17823},
+			expr: &actionExpr{
+				pos: position{line: 613, col: 5, offset: 17842},
+				run: (*parser).callonComparisonExpr1,
+				expr: &seqExpr{
+					pos: position{line: 613, col: 5, offset: 17842},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 613, col: 5, offset: 17842},
+							label: "lhs",
+							expr: &ruleRefExpr{
+								pos:  position{line: 613, col: 9, offset: 17846},
+								name: "AdditiveExpr",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 613, col: 22, offset: 17859},
+							label: "opAndRHS",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 613, col: 31, offset: 17868},
+								expr: &choiceExpr{
+									pos: position{line: 613, col: 32, offset: 17869},
+									alternatives: []interface{}{
+										&seqExpr{
+											pos: position{line: 613, col: 32, offset: 17869},
+											exprs: []interface{}{
+												&ruleRefExpr{
+													pos:  position{line: 613, col: 32, offset: 17869},
+													name: "__",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 613, col: 35, offset: 17872},
+													name: "Comparator",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 613, col: 46, offset: 17883},
+													name: "__",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 613, col: 49, offset: 17886},
+													name: "AdditiveExpr",
+												},
+											},
+										},
+										&seqExpr{
+											pos: position{line: 613, col: 64, offset: 17901},
+											exprs: []interface{}{
+												&ruleRefExpr{
+													pos:  position{line: 613, col: 64, offset: 17901},
+													name: "__",
+												},
+												&actionExpr{
+													pos: position{line: 613, col: 68, offset: 17905},
+													run: (*parser).callonComparisonExpr15,
+													expr: &litMatcher{
+														pos:        position{line: 613, col: 68, offset: 17905},
+														val:        "~",
+														ignoreCase: false,
+													},
+												},
+												&ruleRefExpr{
+													pos:  position{line: 613, col: 104, offset: 17941},
+													name: "__",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 613, col: 107, offset: 17944},
+													name: "Regexp",
+												},
+											},
+										},
 									},
 								},
 							},
 						},
-					},
-					&actionExpr{
-						pos: position{line: 625, col: 5, offset: 18390},
-						run: (*parser).callonComparisonExpr12,
-						expr: &seqExpr{
-							pos: position{line: 625, col: 5, offset: 18390},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 625, col: 5, offset: 18390},
-									label: "lhs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 625, col: 9, offset: 18394},
-										name: "AdditiveExpr",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 625, col: 22, offset: 18407},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 625, col: 25, offset: 18410},
-									val:        "~",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 625, col: 29, offset: 18414},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 625, col: 32, offset: 18417},
-									label: "rhs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 625, col: 36, offset: 18421},
-										name: "Regexp",
-									},
-								},
-							},
-						},
-					},
-					&ruleRefExpr{
-						pos:  position{line: 628, col: 5, offset: 18540},
-						name: "AdditiveExpr",
 					},
 				},
 			},
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 630, col: 1, offset: 18554},
+			pos:  position{line: 622, col: 1, offset: 18205},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 18571},
+				pos: position{line: 623, col: 5, offset: 18222},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 5, offset: 18571},
+					pos: position{line: 623, col: 5, offset: 18222},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 631, col: 5, offset: 18571},
+							pos:   position{line: 623, col: 5, offset: 18222},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 11, offset: 18577},
+								pos:  position{line: 623, col: 11, offset: 18228},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 632, col: 5, offset: 18600},
+							pos:   position{line: 624, col: 5, offset: 18251},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 632, col: 10, offset: 18605},
+								pos: position{line: 624, col: 10, offset: 18256},
 								expr: &actionExpr{
-									pos: position{line: 632, col: 11, offset: 18606},
+									pos: position{line: 624, col: 11, offset: 18257},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 632, col: 11, offset: 18606},
+										pos: position{line: 624, col: 11, offset: 18257},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 632, col: 11, offset: 18606},
+												pos:  position{line: 624, col: 11, offset: 18257},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 632, col: 14, offset: 18609},
+												pos:   position{line: 624, col: 14, offset: 18260},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 632, col: 17, offset: 18612},
+													pos:  position{line: 624, col: 17, offset: 18263},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 632, col: 34, offset: 18629},
+												pos:  position{line: 624, col: 34, offset: 18280},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 632, col: 37, offset: 18632},
+												pos:   position{line: 624, col: 37, offset: 18283},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 632, col: 42, offset: 18637},
+													pos:  position{line: 624, col: 42, offset: 18288},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5119,20 +5024,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 636, col: 1, offset: 18759},
+			pos:  position{line: 628, col: 1, offset: 18410},
 			expr: &actionExpr{
-				pos: position{line: 636, col: 20, offset: 18778},
+				pos: position{line: 628, col: 20, offset: 18429},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 636, col: 21, offset: 18779},
+					pos: position{line: 628, col: 21, offset: 18430},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 636, col: 21, offset: 18779},
+							pos:        position{line: 628, col: 21, offset: 18430},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 636, col: 27, offset: 18785},
+							pos:        position{line: 628, col: 27, offset: 18436},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5142,53 +5047,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 638, col: 1, offset: 18822},
+			pos:  position{line: 630, col: 1, offset: 18473},
 			expr: &actionExpr{
-				pos: position{line: 639, col: 5, offset: 18845},
+				pos: position{line: 631, col: 5, offset: 18496},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 639, col: 5, offset: 18845},
+					pos: position{line: 631, col: 5, offset: 18496},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 639, col: 5, offset: 18845},
+							pos:   position{line: 631, col: 5, offset: 18496},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 11, offset: 18851},
+								pos:  position{line: 631, col: 11, offset: 18502},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 640, col: 5, offset: 18863},
+							pos:   position{line: 632, col: 5, offset: 18514},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 640, col: 10, offset: 18868},
+								pos: position{line: 632, col: 10, offset: 18519},
 								expr: &actionExpr{
-									pos: position{line: 640, col: 11, offset: 18869},
+									pos: position{line: 632, col: 11, offset: 18520},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 640, col: 11, offset: 18869},
+										pos: position{line: 632, col: 11, offset: 18520},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 640, col: 11, offset: 18869},
+												pos:  position{line: 632, col: 11, offset: 18520},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 640, col: 14, offset: 18872},
+												pos:   position{line: 632, col: 14, offset: 18523},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 640, col: 17, offset: 18875},
+													pos:  position{line: 632, col: 17, offset: 18526},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 640, col: 40, offset: 18898},
+												pos:  position{line: 632, col: 40, offset: 18549},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 640, col: 43, offset: 18901},
+												pos:   position{line: 632, col: 43, offset: 18552},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 640, col: 48, offset: 18906},
+													pos:  position{line: 632, col: 48, offset: 18557},
 													name: "NotExpr",
 												},
 											},
@@ -5203,25 +5108,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 644, col: 1, offset: 19017},
+			pos:  position{line: 636, col: 1, offset: 18668},
 			expr: &actionExpr{
-				pos: position{line: 644, col: 26, offset: 19042},
+				pos: position{line: 636, col: 26, offset: 18693},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 644, col: 27, offset: 19043},
+					pos: position{line: 636, col: 27, offset: 18694},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 644, col: 27, offset: 19043},
+							pos:        position{line: 636, col: 27, offset: 18694},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 644, col: 33, offset: 19049},
+							pos:        position{line: 636, col: 33, offset: 18700},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 644, col: 39, offset: 19055},
+							pos:        position{line: 636, col: 39, offset: 18706},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5231,30 +5136,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 646, col: 1, offset: 19092},
+			pos:  position{line: 638, col: 1, offset: 18743},
 			expr: &choiceExpr{
-				pos: position{line: 647, col: 5, offset: 19104},
+				pos: position{line: 639, col: 5, offset: 18755},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 647, col: 5, offset: 19104},
+						pos: position{line: 639, col: 5, offset: 18755},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 647, col: 5, offset: 19104},
+							pos: position{line: 639, col: 5, offset: 18755},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 647, col: 5, offset: 19104},
+									pos:        position{line: 639, col: 5, offset: 18755},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 647, col: 9, offset: 19108},
+									pos:  position{line: 639, col: 9, offset: 18759},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 647, col: 12, offset: 19111},
+									pos:   position{line: 639, col: 12, offset: 18762},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 647, col: 14, offset: 19113},
+										pos:  position{line: 639, col: 14, offset: 18764},
 										name: "NotExpr",
 									},
 								},
@@ -5262,7 +5167,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 650, col: 5, offset: 19222},
+						pos:  position{line: 642, col: 5, offset: 18873},
 						name: "NegationExpr",
 					},
 				},
@@ -5270,37 +5175,37 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 652, col: 1, offset: 19236},
+			pos:  position{line: 644, col: 1, offset: 18887},
 			expr: &choiceExpr{
-				pos: position{line: 653, col: 5, offset: 19253},
+				pos: position{line: 645, col: 5, offset: 18904},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 653, col: 5, offset: 19253},
+						pos: position{line: 645, col: 5, offset: 18904},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 653, col: 5, offset: 19253},
+							pos: position{line: 645, col: 5, offset: 18904},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 653, col: 5, offset: 19253},
+									pos: position{line: 645, col: 5, offset: 18904},
 									expr: &ruleRefExpr{
-										pos:  position{line: 653, col: 6, offset: 19254},
+										pos:  position{line: 645, col: 6, offset: 18905},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 653, col: 14, offset: 19262},
+									pos:        position{line: 645, col: 14, offset: 18913},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 653, col: 18, offset: 19266},
+									pos:  position{line: 645, col: 18, offset: 18917},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 653, col: 21, offset: 19269},
+									pos:   position{line: 645, col: 21, offset: 18920},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 653, col: 23, offset: 19271},
+										pos:  position{line: 645, col: 23, offset: 18922},
 										name: "FuncExpr",
 									},
 								},
@@ -5308,7 +5213,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 656, col: 5, offset: 19381},
+						pos:  position{line: 648, col: 5, offset: 19032},
 						name: "FuncExpr",
 					},
 				},
@@ -5316,31 +5221,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 658, col: 1, offset: 19391},
+			pos:  position{line: 650, col: 1, offset: 19042},
 			expr: &choiceExpr{
-				pos: position{line: 659, col: 5, offset: 19404},
+				pos: position{line: 651, col: 5, offset: 19055},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19404},
+						pos: position{line: 651, col: 5, offset: 19055},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 19404},
+							pos: position{line: 651, col: 5, offset: 19055},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 659, col: 5, offset: 19404},
+									pos:   position{line: 651, col: 5, offset: 19055},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 11, offset: 19410},
+										pos:  position{line: 651, col: 11, offset: 19061},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 659, col: 16, offset: 19415},
+									pos:   position{line: 651, col: 16, offset: 19066},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 659, col: 21, offset: 19420},
+										pos: position{line: 651, col: 21, offset: 19071},
 										expr: &ruleRefExpr{
-											pos:  position{line: 659, col: 22, offset: 19421},
+											pos:  position{line: 651, col: 22, offset: 19072},
 											name: "Deref",
 										},
 									},
@@ -5349,26 +5254,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 662, col: 5, offset: 19492},
+						pos: position{line: 654, col: 5, offset: 19143},
 						run: (*parser).callonFuncExpr9,
 						expr: &seqExpr{
-							pos: position{line: 662, col: 5, offset: 19492},
+							pos: position{line: 654, col: 5, offset: 19143},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 662, col: 5, offset: 19492},
+									pos:   position{line: 654, col: 5, offset: 19143},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 662, col: 11, offset: 19498},
+										pos:  position{line: 654, col: 11, offset: 19149},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 662, col: 20, offset: 19507},
+									pos:   position{line: 654, col: 20, offset: 19158},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 662, col: 25, offset: 19512},
+										pos: position{line: 654, col: 25, offset: 19163},
 										expr: &ruleRefExpr{
-											pos:  position{line: 662, col: 26, offset: 19513},
+											pos:  position{line: 654, col: 26, offset: 19164},
 											name: "Deref",
 										},
 									},
@@ -5377,11 +5282,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 665, col: 5, offset: 19584},
+						pos:  position{line: 657, col: 5, offset: 19235},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 666, col: 5, offset: 19598},
+						pos:  position{line: 658, col: 5, offset: 19249},
 						name: "Primary",
 					},
 				},
@@ -5389,20 +5294,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 668, col: 1, offset: 19607},
+			pos:  position{line: 660, col: 1, offset: 19258},
 			expr: &seqExpr{
-				pos: position{line: 668, col: 13, offset: 19619},
+				pos: position{line: 660, col: 13, offset: 19270},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 668, col: 13, offset: 19619},
+						pos:  position{line: 660, col: 13, offset: 19270},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 668, col: 22, offset: 19628},
+						pos:  position{line: 660, col: 22, offset: 19279},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 668, col: 25, offset: 19631},
+						pos:        position{line: 660, col: 25, offset: 19282},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5411,17 +5316,17 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 670, col: 1, offset: 19636},
+			pos:  position{line: 662, col: 1, offset: 19287},
 			expr: &choiceExpr{
-				pos: position{line: 671, col: 5, offset: 19649},
+				pos: position{line: 663, col: 5, offset: 19300},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 671, col: 5, offset: 19649},
+						pos:        position{line: 663, col: 5, offset: 19300},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 672, col: 5, offset: 19659},
+						pos:        position{line: 664, col: 5, offset: 19310},
 						val:        "select",
 						ignoreCase: false,
 					},
@@ -5430,48 +5335,48 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 674, col: 1, offset: 19669},
+			pos:  position{line: 666, col: 1, offset: 19320},
 			expr: &actionExpr{
-				pos: position{line: 675, col: 5, offset: 19678},
+				pos: position{line: 667, col: 5, offset: 19329},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 675, col: 5, offset: 19678},
+					pos: position{line: 667, col: 5, offset: 19329},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 675, col: 5, offset: 19678},
+							pos:   position{line: 667, col: 5, offset: 19329},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 675, col: 9, offset: 19682},
+								pos:  position{line: 667, col: 9, offset: 19333},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 675, col: 18, offset: 19691},
+							pos:  position{line: 667, col: 18, offset: 19342},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 675, col: 21, offset: 19694},
+							pos:        position{line: 667, col: 21, offset: 19345},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 675, col: 25, offset: 19698},
+							pos:  position{line: 667, col: 25, offset: 19349},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 675, col: 28, offset: 19701},
+							pos:   position{line: 667, col: 28, offset: 19352},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 675, col: 33, offset: 19706},
+								pos:  position{line: 667, col: 33, offset: 19357},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 675, col: 38, offset: 19711},
+							pos:  position{line: 667, col: 38, offset: 19362},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 675, col: 41, offset: 19714},
+							pos:        position{line: 667, col: 41, offset: 19365},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5481,72 +5386,72 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 679, col: 1, offset: 19811},
+			pos:  position{line: 671, col: 1, offset: 19462},
 			expr: &choiceExpr{
-				pos: position{line: 680, col: 5, offset: 19824},
+				pos: position{line: 672, col: 5, offset: 19475},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 680, col: 5, offset: 19824},
+						pos:  position{line: 672, col: 5, offset: 19475},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 19833},
+						pos: position{line: 673, col: 5, offset: 19484},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 5, offset: 19833},
+							pos: position{line: 673, col: 5, offset: 19484},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 681, col: 5, offset: 19833},
+									pos: position{line: 673, col: 5, offset: 19484},
 									expr: &ruleRefExpr{
-										pos:  position{line: 681, col: 6, offset: 19834},
+										pos:  position{line: 673, col: 6, offset: 19485},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 681, col: 16, offset: 19844},
+									pos:   position{line: 673, col: 16, offset: 19495},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 681, col: 19, offset: 19847},
+										pos:  position{line: 673, col: 19, offset: 19498},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 34, offset: 19862},
+									pos:  position{line: 673, col: 34, offset: 19513},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 681, col: 37, offset: 19865},
+									pos:        position{line: 673, col: 37, offset: 19516},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 41, offset: 19869},
+									pos:  position{line: 673, col: 41, offset: 19520},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 681, col: 44, offset: 19872},
+									pos:   position{line: 673, col: 44, offset: 19523},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 681, col: 49, offset: 19877},
+										pos:  position{line: 673, col: 49, offset: 19528},
 										name: "OptionalExprs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 63, offset: 19891},
+									pos:  position{line: 673, col: 63, offset: 19542},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 681, col: 66, offset: 19894},
+									pos:        position{line: 673, col: 66, offset: 19545},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 681, col: 70, offset: 19898},
+									pos:   position{line: 673, col: 70, offset: 19549},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 681, col: 76, offset: 19904},
+										pos: position{line: 673, col: 76, offset: 19555},
 										expr: &ruleRefExpr{
-											pos:  position{line: 681, col: 76, offset: 19904},
+											pos:  position{line: 673, col: 76, offset: 19555},
 											name: "WhereClause",
 										},
 									},
@@ -5559,48 +5464,48 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 685, col: 1, offset: 20025},
+			pos:  position{line: 677, col: 1, offset: 19676},
 			expr: &choiceExpr{
-				pos: position{line: 686, col: 5, offset: 20034},
+				pos: position{line: 678, col: 5, offset: 19685},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 686, col: 5, offset: 20034},
+						pos: position{line: 678, col: 5, offset: 19685},
 						run: (*parser).callonGrep2,
 						expr: &seqExpr{
-							pos: position{line: 686, col: 5, offset: 20034},
+							pos: position{line: 678, col: 5, offset: 19685},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 686, col: 5, offset: 20034},
+									pos:        position{line: 678, col: 5, offset: 19685},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 686, col: 12, offset: 20041},
+									pos:  position{line: 678, col: 12, offset: 19692},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 686, col: 15, offset: 20044},
+									pos:        position{line: 678, col: 15, offset: 19695},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 686, col: 19, offset: 20048},
+									pos:  position{line: 678, col: 19, offset: 19699},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 686, col: 22, offset: 20051},
+									pos:   position{line: 678, col: 22, offset: 19702},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 686, col: 30, offset: 20059},
+										pos:  position{line: 678, col: 30, offset: 19710},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 686, col: 38, offset: 20067},
+									pos:  position{line: 678, col: 38, offset: 19718},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 686, col: 41, offset: 20070},
+									pos:        position{line: 678, col: 41, offset: 19721},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5608,64 +5513,64 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 689, col: 5, offset: 20225},
+						pos: position{line: 681, col: 5, offset: 19876},
 						run: (*parser).callonGrep12,
 						expr: &seqExpr{
-							pos: position{line: 689, col: 5, offset: 20225},
+							pos: position{line: 681, col: 5, offset: 19876},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 689, col: 5, offset: 20225},
+									pos:        position{line: 681, col: 5, offset: 19876},
 									val:        "grep",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 12, offset: 20232},
+									pos:  position{line: 681, col: 12, offset: 19883},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 689, col: 15, offset: 20235},
+									pos:        position{line: 681, col: 15, offset: 19886},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 19, offset: 20239},
+									pos:  position{line: 681, col: 19, offset: 19890},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 689, col: 22, offset: 20242},
+									pos:   position{line: 681, col: 22, offset: 19893},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 689, col: 30, offset: 20250},
+										pos:  position{line: 681, col: 30, offset: 19901},
 										name: "Pattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 38, offset: 20258},
+									pos:  position{line: 681, col: 38, offset: 19909},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 689, col: 42, offset: 20262},
+									pos:        position{line: 681, col: 42, offset: 19913},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 46, offset: 20266},
+									pos:  position{line: 681, col: 46, offset: 19917},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 689, col: 49, offset: 20269},
+									pos:   position{line: 681, col: 49, offset: 19920},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 689, col: 54, offset: 20274},
+										pos:  position{line: 681, col: 54, offset: 19925},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 59, offset: 20279},
+									pos:  position{line: 681, col: 59, offset: 19930},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 689, col: 62, offset: 20282},
+									pos:        position{line: 681, col: 62, offset: 19933},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5677,26 +5582,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 693, col: 1, offset: 20386},
+			pos:  position{line: 685, col: 1, offset: 20037},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 20398},
+				pos: position{line: 686, col: 5, offset: 20049},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 694, col: 5, offset: 20398},
+						pos:  position{line: 686, col: 5, offset: 20049},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 695, col: 5, offset: 20409},
+						pos:  position{line: 687, col: 5, offset: 20060},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 696, col: 5, offset: 20418},
+						pos: position{line: 688, col: 5, offset: 20069},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 696, col: 5, offset: 20418},
+							pos:   position{line: 688, col: 5, offset: 20069},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 696, col: 7, offset: 20420},
+								pos:  position{line: 688, col: 7, offset: 20071},
 								name: "QuotedString",
 							},
 						},
@@ -5706,19 +5611,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 700, col: 1, offset: 20512},
+			pos:  position{line: 692, col: 1, offset: 20163},
 			expr: &choiceExpr{
-				pos: position{line: 701, col: 5, offset: 20530},
+				pos: position{line: 693, col: 5, offset: 20181},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 701, col: 5, offset: 20530},
+						pos:  position{line: 693, col: 5, offset: 20181},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 702, col: 5, offset: 20540},
+						pos: position{line: 694, col: 5, offset: 20191},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 702, col: 5, offset: 20540},
+							pos:  position{line: 694, col: 5, offset: 20191},
 							name: "__",
 						},
 					},
@@ -5727,50 +5632,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 704, col: 1, offset: 20576},
+			pos:  position{line: 696, col: 1, offset: 20227},
 			expr: &actionExpr{
-				pos: position{line: 705, col: 5, offset: 20586},
+				pos: position{line: 697, col: 5, offset: 20237},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 705, col: 5, offset: 20586},
+					pos: position{line: 697, col: 5, offset: 20237},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 705, col: 5, offset: 20586},
+							pos:   position{line: 697, col: 5, offset: 20237},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 705, col: 11, offset: 20592},
+								pos:  position{line: 697, col: 11, offset: 20243},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 705, col: 16, offset: 20597},
+							pos:   position{line: 697, col: 16, offset: 20248},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 705, col: 21, offset: 20602},
+								pos: position{line: 697, col: 21, offset: 20253},
 								expr: &actionExpr{
-									pos: position{line: 705, col: 22, offset: 20603},
+									pos: position{line: 697, col: 22, offset: 20254},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 705, col: 22, offset: 20603},
+										pos: position{line: 697, col: 22, offset: 20254},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 705, col: 22, offset: 20603},
+												pos:  position{line: 697, col: 22, offset: 20254},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 705, col: 25, offset: 20606},
+												pos:        position{line: 697, col: 25, offset: 20257},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 705, col: 29, offset: 20610},
+												pos:  position{line: 697, col: 29, offset: 20261},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 705, col: 32, offset: 20613},
+												pos:   position{line: 697, col: 32, offset: 20264},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 705, col: 34, offset: 20615},
+													pos:  position{line: 697, col: 34, offset: 20266},
 													name: "Expr",
 												},
 											},
@@ -5785,35 +5690,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 709, col: 1, offset: 20724},
+			pos:  position{line: 701, col: 1, offset: 20375},
 			expr: &actionExpr{
-				pos: position{line: 710, col: 5, offset: 20738},
+				pos: position{line: 702, col: 5, offset: 20389},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 710, col: 5, offset: 20738},
+					pos: position{line: 702, col: 5, offset: 20389},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 710, col: 5, offset: 20738},
+							pos: position{line: 702, col: 5, offset: 20389},
 							expr: &ruleRefExpr{
-								pos:  position{line: 710, col: 6, offset: 20739},
+								pos:  position{line: 702, col: 6, offset: 20390},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 710, col: 10, offset: 20743},
+							pos:   position{line: 702, col: 10, offset: 20394},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 710, col: 16, offset: 20749},
+								pos:  position{line: 702, col: 16, offset: 20400},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 710, col: 27, offset: 20760},
+							pos:   position{line: 702, col: 27, offset: 20411},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 710, col: 32, offset: 20765},
+								pos: position{line: 702, col: 32, offset: 20416},
 								expr: &ruleRefExpr{
-									pos:  position{line: 710, col: 33, offset: 20766},
+									pos:  position{line: 702, col: 33, offset: 20417},
 									name: "Deref",
 								},
 							},
@@ -5824,52 +5729,95 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 714, col: 1, offset: 20834},
+			pos:  position{line: 706, col: 1, offset: 20485},
 			expr: &choiceExpr{
-				pos: position{line: 715, col: 5, offset: 20844},
+				pos: position{line: 707, col: 5, offset: 20495},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 715, col: 5, offset: 20844},
+						pos: position{line: 707, col: 5, offset: 20495},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 715, col: 5, offset: 20844},
+							pos: position{line: 707, col: 5, offset: 20495},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 715, col: 5, offset: 20844},
+									pos:        position{line: 707, col: 5, offset: 20495},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 715, col: 9, offset: 20848},
+									pos:   position{line: 707, col: 9, offset: 20499},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 715, col: 14, offset: 20853},
+										pos:  position{line: 707, col: 14, offset: 20504},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 715, col: 27, offset: 20866},
+									pos:  position{line: 707, col: 27, offset: 20517},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 715, col: 30, offset: 20869},
+									pos:        position{line: 707, col: 30, offset: 20520},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 715, col: 34, offset: 20873},
+									pos:  position{line: 707, col: 34, offset: 20524},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 715, col: 37, offset: 20876},
+									pos:   position{line: 707, col: 37, offset: 20527},
+									label: "to",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 707, col: 40, offset: 20530},
+										expr: &ruleRefExpr{
+											pos:  position{line: 707, col: 40, offset: 20530},
+											name: "AdditiveExpr",
+										},
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 707, col: 54, offset: 20544},
+									val:        "]",
+									ignoreCase: false,
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 713, col: 5, offset: 20715},
+						run: (*parser).callonDeref14,
+						expr: &seqExpr{
+							pos: position{line: 713, col: 5, offset: 20715},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 713, col: 5, offset: 20715},
+									val:        "[",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 713, col: 9, offset: 20719},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 713, col: 12, offset: 20722},
+									val:        ":",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 713, col: 16, offset: 20726},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 713, col: 19, offset: 20729},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 715, col: 40, offset: 20879},
+										pos:  position{line: 713, col: 22, offset: 20732},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 715, col: 53, offset: 20892},
+									pos:        position{line: 713, col: 35, offset: 20745},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5877,106 +5825,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 721, col: 5, offset: 21063},
-						run: (*parser).callonDeref13,
+						pos: position{line: 719, col: 5, offset: 20916},
+						run: (*parser).callonDeref23,
 						expr: &seqExpr{
-							pos: position{line: 721, col: 5, offset: 21063},
+							pos: position{line: 719, col: 5, offset: 20916},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 721, col: 5, offset: 21063},
-									val:        "[",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 721, col: 9, offset: 21067},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 721, col: 12, offset: 21070},
-									val:        ":",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 721, col: 16, offset: 21074},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 721, col: 19, offset: 21077},
-									label: "to",
-									expr: &ruleRefExpr{
-										pos:  position{line: 721, col: 22, offset: 21080},
-										name: "AdditiveExpr",
-									},
-								},
-								&litMatcher{
-									pos:        position{line: 721, col: 35, offset: 21093},
-									val:        "]",
-									ignoreCase: false,
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 727, col: 5, offset: 21264},
-						run: (*parser).callonDeref22,
-						expr: &seqExpr{
-							pos: position{line: 727, col: 5, offset: 21264},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 727, col: 5, offset: 21264},
+									pos:        position{line: 719, col: 5, offset: 20916},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 727, col: 9, offset: 21268},
-									label: "from",
-									expr: &ruleRefExpr{
-										pos:  position{line: 727, col: 14, offset: 21273},
-										name: "AdditiveExpr",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 727, col: 27, offset: 21286},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 727, col: 30, offset: 21289},
-									val:        ":",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 727, col: 34, offset: 21293},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 727, col: 37, offset: 21296},
-									val:        "]",
-									ignoreCase: false,
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 733, col: 5, offset: 21469},
-						run: (*parser).callonDeref31,
-						expr: &seqExpr{
-							pos: position{line: 733, col: 5, offset: 21469},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 733, col: 5, offset: 21469},
-									val:        "[",
-									ignoreCase: false,
-								},
-								&labeledExpr{
-									pos:   position{line: 733, col: 9, offset: 21473},
+									pos:   position{line: 719, col: 9, offset: 20920},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 733, col: 14, offset: 21478},
+										pos:  position{line: 719, col: 14, offset: 20925},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 733, col: 19, offset: 21483},
+									pos:        position{line: 719, col: 19, offset: 20930},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5984,21 +5852,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 734, col: 5, offset: 21532},
-						run: (*parser).callonDeref37,
+						pos: position{line: 720, col: 5, offset: 20979},
+						run: (*parser).callonDeref29,
 						expr: &seqExpr{
-							pos: position{line: 734, col: 5, offset: 21532},
+							pos: position{line: 720, col: 5, offset: 20979},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 734, col: 5, offset: 21532},
+									pos:        position{line: 720, col: 5, offset: 20979},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 734, col: 9, offset: 21536},
+									pos:   position{line: 720, col: 9, offset: 20983},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 734, col: 12, offset: 21539},
+										pos:  position{line: 720, col: 12, offset: 20986},
 										name: "Identifier",
 									},
 								},
@@ -6010,59 +5878,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 736, col: 1, offset: 21590},
+			pos:  position{line: 722, col: 1, offset: 21037},
 			expr: &choiceExpr{
-				pos: position{line: 737, col: 5, offset: 21602},
+				pos: position{line: 723, col: 5, offset: 21049},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 737, col: 5, offset: 21602},
+						pos:  position{line: 723, col: 5, offset: 21049},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 738, col: 5, offset: 21613},
+						pos:  position{line: 724, col: 5, offset: 21060},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 739, col: 5, offset: 21623},
+						pos:  position{line: 725, col: 5, offset: 21070},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 740, col: 5, offset: 21631},
+						pos:  position{line: 726, col: 5, offset: 21078},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 741, col: 5, offset: 21639},
+						pos:  position{line: 727, col: 5, offset: 21086},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 742, col: 5, offset: 21651},
+						pos: position{line: 728, col: 5, offset: 21098},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 742, col: 5, offset: 21651},
+							pos: position{line: 728, col: 5, offset: 21098},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 742, col: 5, offset: 21651},
+									pos:        position{line: 728, col: 5, offset: 21098},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 742, col: 9, offset: 21655},
+									pos:  position{line: 728, col: 9, offset: 21102},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 742, col: 12, offset: 21658},
+									pos:   position{line: 728, col: 12, offset: 21105},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 17, offset: 21663},
+										pos:  position{line: 728, col: 17, offset: 21110},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 742, col: 26, offset: 21672},
+									pos:  position{line: 728, col: 26, offset: 21119},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 742, col: 29, offset: 21675},
+									pos:        position{line: 728, col: 29, offset: 21122},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6070,34 +5938,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 743, col: 5, offset: 21705},
+						pos: position{line: 729, col: 5, offset: 21152},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 743, col: 5, offset: 21705},
+							pos: position{line: 729, col: 5, offset: 21152},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 743, col: 5, offset: 21705},
+									pos:        position{line: 729, col: 5, offset: 21152},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 743, col: 9, offset: 21709},
+									pos:  position{line: 729, col: 9, offset: 21156},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 743, col: 12, offset: 21712},
+									pos:   position{line: 729, col: 12, offset: 21159},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 743, col: 17, offset: 21717},
+										pos:  position{line: 729, col: 17, offset: 21164},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 743, col: 22, offset: 21722},
+									pos:  position{line: 729, col: 22, offset: 21169},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 743, col: 25, offset: 21725},
+									pos:        position{line: 729, col: 25, offset: 21172},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6109,122 +5977,86 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 745, col: 1, offset: 21751},
-			expr: &choiceExpr{
-				pos: position{line: 746, col: 5, offset: 21764},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 746, col: 5, offset: 21764},
-						run: (*parser).callonOverExpr2,
-						expr: &seqExpr{
-							pos: position{line: 746, col: 5, offset: 21764},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 746, col: 5, offset: 21764},
-									val:        "over",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 746, col: 12, offset: 21771},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 746, col: 14, offset: 21773},
-									label: "exprs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 746, col: 20, offset: 21779},
-										name: "Exprs",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 746, col: 26, offset: 21785},
-									name: "_",
-								},
-								&litMatcher{
-									pos:        position{line: 746, col: 28, offset: 21787},
-									val:        "with",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 746, col: 35, offset: 21794},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 746, col: 37, offset: 21796},
-									label: "locals",
-									expr: &ruleRefExpr{
-										pos:  position{line: 746, col: 44, offset: 21803},
-										name: "LetAssignments",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 746, col: 59, offset: 21818},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 746, col: 62, offset: 21821},
-									val:        "|",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 746, col: 66, offset: 21825},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 746, col: 69, offset: 21828},
-									label: "scope",
-									expr: &ruleRefExpr{
-										pos:  position{line: 746, col: 75, offset: 21834},
-										name: "Sequential",
+			pos:  position{line: 731, col: 1, offset: 21198},
+			expr: &actionExpr{
+				pos: position{line: 732, col: 5, offset: 21211},
+				run: (*parser).callonOverExpr1,
+				expr: &seqExpr{
+					pos: position{line: 732, col: 5, offset: 21211},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 732, col: 5, offset: 21211},
+							val:        "over",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 732, col: 12, offset: 21218},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 732, col: 14, offset: 21220},
+							label: "exprs",
+							expr: &ruleRefExpr{
+								pos:  position{line: 732, col: 20, offset: 21226},
+								name: "Exprs",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 732, col: 26, offset: 21232},
+							label: "locals",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 732, col: 33, offset: 21239},
+								expr: &actionExpr{
+									pos: position{line: 732, col: 34, offset: 21240},
+									run: (*parser).callonOverExpr9,
+									expr: &seqExpr{
+										pos: position{line: 732, col: 34, offset: 21240},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 732, col: 34, offset: 21240},
+												name: "_",
+											},
+											&litMatcher{
+												pos:        position{line: 732, col: 36, offset: 21242},
+												val:        "with",
+												ignoreCase: false,
+											},
+											&ruleRefExpr{
+												pos:  position{line: 732, col: 43, offset: 21249},
+												name: "_",
+											},
+											&labeledExpr{
+												pos:   position{line: 732, col: 45, offset: 21251},
+												label: "l",
+												expr: &ruleRefExpr{
+													pos:  position{line: 732, col: 47, offset: 21253},
+													name: "LetAssignments",
+												},
+											},
+										},
 									},
 								},
 							},
 						},
-					},
-					&actionExpr{
-						pos: position{line: 749, col: 5, offset: 21968},
-						run: (*parser).callonOverExpr18,
-						expr: &seqExpr{
-							pos: position{line: 749, col: 5, offset: 21968},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 749, col: 5, offset: 21968},
-									val:        "over",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 749, col: 12, offset: 21975},
-									name: "_",
-								},
-								&labeledExpr{
-									pos:   position{line: 749, col: 14, offset: 21977},
-									label: "exprs",
-									expr: &ruleRefExpr{
-										pos:  position{line: 749, col: 20, offset: 21983},
-										name: "Exprs",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 749, col: 26, offset: 21989},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 749, col: 29, offset: 21992},
-									val:        "|",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 749, col: 33, offset: 21996},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 749, col: 36, offset: 21999},
-									label: "scope",
-									expr: &ruleRefExpr{
-										pos:  position{line: 749, col: 42, offset: 22005},
-										name: "Sequential",
-									},
-								},
+						&ruleRefExpr{
+							pos:  position{line: 732, col: 82, offset: 21288},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 732, col: 85, offset: 21291},
+							val:        "|",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 732, col: 89, offset: 21295},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 732, col: 92, offset: 21298},
+							label: "scope",
+							expr: &ruleRefExpr{
+								pos:  position{line: 732, col: 98, offset: 21304},
+								name: "Sequential",
 							},
 						},
 					},
@@ -6233,36 +6065,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 753, col: 1, offset: 22132},
+			pos:  position{line: 736, col: 1, offset: 21435},
 			expr: &actionExpr{
-				pos: position{line: 754, col: 5, offset: 22143},
+				pos: position{line: 737, col: 5, offset: 21446},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 754, col: 5, offset: 22143},
+					pos: position{line: 737, col: 5, offset: 21446},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 754, col: 5, offset: 22143},
+							pos:        position{line: 737, col: 5, offset: 21446},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 754, col: 9, offset: 22147},
+							pos:  position{line: 737, col: 9, offset: 21450},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 754, col: 12, offset: 22150},
+							pos:   position{line: 737, col: 12, offset: 21453},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 754, col: 18, offset: 22156},
+								pos:  position{line: 737, col: 18, offset: 21459},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 754, col: 30, offset: 22168},
+							pos:  position{line: 737, col: 30, offset: 21471},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 754, col: 33, offset: 22171},
+							pos:        position{line: 737, col: 33, offset: 21474},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6272,31 +6104,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 758, col: 1, offset: 22261},
+			pos:  position{line: 741, col: 1, offset: 21564},
 			expr: &choiceExpr{
-				pos: position{line: 759, col: 5, offset: 22277},
+				pos: position{line: 742, col: 5, offset: 21580},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 759, col: 5, offset: 22277},
+						pos: position{line: 742, col: 5, offset: 21580},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 759, col: 5, offset: 22277},
+							pos: position{line: 742, col: 5, offset: 21580},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 759, col: 5, offset: 22277},
+									pos:   position{line: 742, col: 5, offset: 21580},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 759, col: 11, offset: 22283},
+										pos:  position{line: 742, col: 11, offset: 21586},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 759, col: 22, offset: 22294},
+									pos:   position{line: 742, col: 22, offset: 21597},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 759, col: 27, offset: 22299},
+										pos: position{line: 742, col: 27, offset: 21602},
 										expr: &ruleRefExpr{
-											pos:  position{line: 759, col: 27, offset: 22299},
+											pos:  position{line: 742, col: 27, offset: 21602},
 											name: "RecordElemTail",
 										},
 									},
@@ -6305,10 +6137,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 762, col: 5, offset: 22398},
+						pos: position{line: 745, col: 5, offset: 21701},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 762, col: 5, offset: 22398},
+							pos:  position{line: 745, col: 5, offset: 21701},
 							name: "__",
 						},
 					},
@@ -6317,31 +6149,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 764, col: 1, offset: 22434},
+			pos:  position{line: 747, col: 1, offset: 21737},
 			expr: &actionExpr{
-				pos: position{line: 764, col: 18, offset: 22451},
+				pos: position{line: 747, col: 18, offset: 21754},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 764, col: 18, offset: 22451},
+					pos: position{line: 747, col: 18, offset: 21754},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 764, col: 18, offset: 22451},
+							pos:  position{line: 747, col: 18, offset: 21754},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 764, col: 21, offset: 22454},
+							pos:        position{line: 747, col: 21, offset: 21757},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 764, col: 25, offset: 22458},
+							pos:  position{line: 747, col: 25, offset: 21761},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 764, col: 28, offset: 22461},
+							pos:   position{line: 747, col: 28, offset: 21764},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 764, col: 33, offset: 22466},
+								pos:  position{line: 747, col: 33, offset: 21769},
 								name: "RecordElem",
 							},
 						},
@@ -6351,20 +6183,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 766, col: 1, offset: 22499},
+			pos:  position{line: 749, col: 1, offset: 21802},
 			expr: &choiceExpr{
-				pos: position{line: 767, col: 5, offset: 22514},
+				pos: position{line: 750, col: 5, offset: 21817},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 767, col: 5, offset: 22514},
+						pos:  position{line: 750, col: 5, offset: 21817},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 768, col: 5, offset: 22525},
+						pos:  position{line: 751, col: 5, offset: 21828},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 769, col: 5, offset: 22535},
+						pos:  position{line: 752, col: 5, offset: 21838},
 						name: "Identifier",
 					},
 				},
@@ -6372,27 +6204,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 771, col: 1, offset: 22547},
+			pos:  position{line: 754, col: 1, offset: 21850},
 			expr: &actionExpr{
-				pos: position{line: 772, col: 5, offset: 22558},
+				pos: position{line: 755, col: 5, offset: 21861},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 772, col: 5, offset: 22558},
+					pos: position{line: 755, col: 5, offset: 21861},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 772, col: 5, offset: 22558},
+							pos:        position{line: 755, col: 5, offset: 21861},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 772, col: 11, offset: 22564},
+							pos:  position{line: 755, col: 11, offset: 21867},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 772, col: 14, offset: 22567},
+							pos:   position{line: 755, col: 14, offset: 21870},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 772, col: 19, offset: 22572},
+								pos:  position{line: 755, col: 19, offset: 21875},
 								name: "Expr",
 							},
 						},
@@ -6402,39 +6234,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 776, col: 1, offset: 22658},
+			pos:  position{line: 759, col: 1, offset: 21961},
 			expr: &actionExpr{
-				pos: position{line: 777, col: 5, offset: 22668},
+				pos: position{line: 760, col: 5, offset: 21971},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 777, col: 5, offset: 22668},
+					pos: position{line: 760, col: 5, offset: 21971},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 777, col: 5, offset: 22668},
+							pos:   position{line: 760, col: 5, offset: 21971},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 777, col: 10, offset: 22673},
+								pos:  position{line: 760, col: 10, offset: 21976},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 777, col: 20, offset: 22683},
+							pos:  position{line: 760, col: 20, offset: 21986},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 777, col: 23, offset: 22686},
+							pos:        position{line: 760, col: 23, offset: 21989},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 777, col: 27, offset: 22690},
+							pos:  position{line: 760, col: 27, offset: 21993},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 777, col: 30, offset: 22693},
+							pos:   position{line: 760, col: 30, offset: 21996},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 777, col: 36, offset: 22699},
+								pos:  position{line: 760, col: 36, offset: 22002},
 								name: "Expr",
 							},
 						},
@@ -6444,36 +6276,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 781, col: 1, offset: 22799},
+			pos:  position{line: 764, col: 1, offset: 22102},
 			expr: &actionExpr{
-				pos: position{line: 782, col: 5, offset: 22809},
+				pos: position{line: 765, col: 5, offset: 22112},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 782, col: 5, offset: 22809},
+					pos: position{line: 765, col: 5, offset: 22112},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 782, col: 5, offset: 22809},
+							pos:        position{line: 765, col: 5, offset: 22112},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 782, col: 9, offset: 22813},
+							pos:  position{line: 765, col: 9, offset: 22116},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 782, col: 12, offset: 22816},
+							pos:   position{line: 765, col: 12, offset: 22119},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 782, col: 18, offset: 22822},
+								pos:  position{line: 765, col: 18, offset: 22125},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 782, col: 32, offset: 22836},
+							pos:  position{line: 765, col: 32, offset: 22139},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 782, col: 35, offset: 22839},
+							pos:        position{line: 765, col: 35, offset: 22142},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6483,36 +6315,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 786, col: 1, offset: 22929},
+			pos:  position{line: 769, col: 1, offset: 22232},
 			expr: &actionExpr{
-				pos: position{line: 787, col: 5, offset: 22937},
+				pos: position{line: 770, col: 5, offset: 22240},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 787, col: 5, offset: 22937},
+					pos: position{line: 770, col: 5, offset: 22240},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 787, col: 5, offset: 22937},
+							pos:        position{line: 770, col: 5, offset: 22240},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 787, col: 10, offset: 22942},
+							pos:  position{line: 770, col: 10, offset: 22245},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 787, col: 13, offset: 22945},
+							pos:   position{line: 770, col: 13, offset: 22248},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 787, col: 19, offset: 22951},
+								pos:  position{line: 770, col: 19, offset: 22254},
 								name: "OptionalExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 787, col: 33, offset: 22965},
+							pos:  position{line: 770, col: 33, offset: 22268},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 787, col: 36, offset: 22968},
+							pos:        position{line: 770, col: 36, offset: 22271},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6522,36 +6354,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 791, col: 1, offset: 23057},
+			pos:  position{line: 774, col: 1, offset: 22360},
 			expr: &actionExpr{
-				pos: position{line: 792, col: 5, offset: 23065},
+				pos: position{line: 775, col: 5, offset: 22368},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 792, col: 5, offset: 23065},
+					pos: position{line: 775, col: 5, offset: 22368},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 792, col: 5, offset: 23065},
+							pos:        position{line: 775, col: 5, offset: 22368},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 10, offset: 23070},
+							pos:  position{line: 775, col: 10, offset: 22373},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 792, col: 13, offset: 23073},
+							pos:   position{line: 775, col: 13, offset: 22376},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 792, col: 19, offset: 23079},
+								pos:  position{line: 775, col: 19, offset: 22382},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 27, offset: 23087},
+							pos:  position{line: 775, col: 27, offset: 22390},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 792, col: 30, offset: 23090},
+							pos:        position{line: 775, col: 30, offset: 22393},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6561,31 +6393,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 796, col: 1, offset: 23181},
+			pos:  position{line: 779, col: 1, offset: 22484},
 			expr: &choiceExpr{
-				pos: position{line: 797, col: 5, offset: 23193},
+				pos: position{line: 780, col: 5, offset: 22496},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 797, col: 5, offset: 23193},
+						pos: position{line: 780, col: 5, offset: 22496},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 797, col: 5, offset: 23193},
+							pos: position{line: 780, col: 5, offset: 22496},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 797, col: 5, offset: 23193},
+									pos:   position{line: 780, col: 5, offset: 22496},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 797, col: 11, offset: 23199},
+										pos:  position{line: 780, col: 11, offset: 22502},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 797, col: 17, offset: 23205},
+									pos:   position{line: 780, col: 17, offset: 22508},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 797, col: 22, offset: 23210},
+										pos: position{line: 780, col: 22, offset: 22513},
 										expr: &ruleRefExpr{
-											pos:  position{line: 797, col: 22, offset: 23210},
+											pos:  position{line: 780, col: 22, offset: 22513},
 											name: "EntryTail",
 										},
 									},
@@ -6594,10 +6426,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 800, col: 5, offset: 23304},
+						pos: position{line: 783, col: 5, offset: 22607},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 800, col: 5, offset: 23304},
+							pos:  position{line: 783, col: 5, offset: 22607},
 							name: "__",
 						},
 					},
@@ -6606,31 +6438,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 803, col: 1, offset: 23341},
+			pos:  position{line: 786, col: 1, offset: 22644},
 			expr: &actionExpr{
-				pos: position{line: 803, col: 13, offset: 23353},
+				pos: position{line: 786, col: 13, offset: 22656},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 803, col: 13, offset: 23353},
+					pos: position{line: 786, col: 13, offset: 22656},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 13, offset: 23353},
+							pos:  position{line: 786, col: 13, offset: 22656},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 803, col: 16, offset: 23356},
+							pos:        position{line: 786, col: 16, offset: 22659},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 20, offset: 23360},
+							pos:  position{line: 786, col: 20, offset: 22663},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 23, offset: 23363},
+							pos:   position{line: 786, col: 23, offset: 22666},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 25, offset: 23365},
+								pos:  position{line: 786, col: 25, offset: 22668},
 								name: "Entry",
 							},
 						},
@@ -6640,39 +6472,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 805, col: 1, offset: 23390},
+			pos:  position{line: 788, col: 1, offset: 22693},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 5, offset: 23400},
+				pos: position{line: 789, col: 5, offset: 22703},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 806, col: 5, offset: 23400},
+					pos: position{line: 789, col: 5, offset: 22703},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 806, col: 5, offset: 23400},
+							pos:   position{line: 789, col: 5, offset: 22703},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 806, col: 9, offset: 23404},
+								pos:  position{line: 789, col: 9, offset: 22707},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 14, offset: 23409},
+							pos:  position{line: 789, col: 14, offset: 22712},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 806, col: 17, offset: 23412},
+							pos:        position{line: 789, col: 17, offset: 22715},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 21, offset: 23416},
+							pos:  position{line: 789, col: 21, offset: 22719},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 806, col: 24, offset: 23419},
+							pos:   position{line: 789, col: 24, offset: 22722},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 806, col: 30, offset: 23425},
+								pos:  position{line: 789, col: 30, offset: 22728},
 								name: "Expr",
 							},
 						},
@@ -6682,92 +6514,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 812, col: 1, offset: 23532},
+			pos:  position{line: 795, col: 1, offset: 22835},
 			expr: &actionExpr{
-				pos: position{line: 813, col: 5, offset: 23542},
+				pos: position{line: 796, col: 5, offset: 22845},
 				run: (*parser).callonSQLOp1,
 				expr: &seqExpr{
-					pos: position{line: 813, col: 5, offset: 23542},
+					pos: position{line: 796, col: 5, offset: 22845},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 813, col: 5, offset: 23542},
+							pos:   position{line: 796, col: 5, offset: 22845},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 813, col: 15, offset: 23552},
+								pos:  position{line: 796, col: 15, offset: 22855},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 814, col: 5, offset: 23566},
+							pos:   position{line: 797, col: 5, offset: 22869},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 814, col: 10, offset: 23571},
+								pos: position{line: 797, col: 10, offset: 22874},
 								expr: &ruleRefExpr{
-									pos:  position{line: 814, col: 10, offset: 23571},
+									pos:  position{line: 797, col: 10, offset: 22874},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 5, offset: 23584},
+							pos:   position{line: 798, col: 5, offset: 22887},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 815, col: 11, offset: 23590},
+								pos: position{line: 798, col: 11, offset: 22893},
 								expr: &ruleRefExpr{
-									pos:  position{line: 815, col: 11, offset: 23590},
+									pos:  position{line: 798, col: 11, offset: 22893},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 816, col: 5, offset: 23604},
+							pos:   position{line: 799, col: 5, offset: 22907},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 816, col: 11, offset: 23610},
+								pos: position{line: 799, col: 11, offset: 22913},
 								expr: &ruleRefExpr{
-									pos:  position{line: 816, col: 11, offset: 23610},
+									pos:  position{line: 799, col: 11, offset: 22913},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 817, col: 5, offset: 23624},
+							pos:   position{line: 800, col: 5, offset: 22927},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 817, col: 13, offset: 23632},
+								pos: position{line: 800, col: 13, offset: 22935},
 								expr: &ruleRefExpr{
-									pos:  position{line: 817, col: 13, offset: 23632},
+									pos:  position{line: 800, col: 13, offset: 22935},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 5, offset: 23648},
+							pos:   position{line: 801, col: 5, offset: 22951},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 818, col: 12, offset: 23655},
+								pos: position{line: 801, col: 12, offset: 22958},
 								expr: &ruleRefExpr{
-									pos:  position{line: 818, col: 12, offset: 23655},
+									pos:  position{line: 801, col: 12, offset: 22958},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 819, col: 5, offset: 23670},
+							pos:   position{line: 802, col: 5, offset: 22973},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 819, col: 13, offset: 23678},
+								pos: position{line: 802, col: 13, offset: 22981},
 								expr: &ruleRefExpr{
-									pos:  position{line: 819, col: 13, offset: 23678},
+									pos:  position{line: 802, col: 13, offset: 22981},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 820, col: 5, offset: 23694},
+							pos:   position{line: 803, col: 5, offset: 22997},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 820, col: 11, offset: 23700},
+								pos:  position{line: 803, col: 11, offset: 23003},
 								name: "SQLLimit",
 							},
 						},
@@ -6777,26 +6609,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 844, col: 1, offset: 24067},
+			pos:  position{line: 827, col: 1, offset: 23370},
 			expr: &choiceExpr{
-				pos: position{line: 845, col: 5, offset: 24081},
+				pos: position{line: 828, col: 5, offset: 23384},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 845, col: 5, offset: 24081},
+						pos: position{line: 828, col: 5, offset: 23384},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 845, col: 5, offset: 24081},
+							pos: position{line: 828, col: 5, offset: 23384},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 845, col: 5, offset: 24081},
+									pos:  position{line: 828, col: 5, offset: 23384},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 845, col: 12, offset: 24088},
+									pos:  position{line: 828, col: 12, offset: 23391},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 845, col: 14, offset: 24090},
+									pos:        position{line: 828, col: 14, offset: 23393},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6804,24 +6636,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 846, col: 5, offset: 24118},
+						pos: position{line: 829, col: 5, offset: 23421},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 846, col: 5, offset: 24118},
+							pos: position{line: 829, col: 5, offset: 23421},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 846, col: 5, offset: 24118},
+									pos:  position{line: 829, col: 5, offset: 23421},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 846, col: 12, offset: 24125},
+									pos:  position{line: 829, col: 12, offset: 23428},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 846, col: 14, offset: 24127},
+									pos:   position{line: 829, col: 14, offset: 23430},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 846, col: 26, offset: 24139},
+										pos:  position{line: 829, col: 26, offset: 23442},
 										name: "SQLAssignments",
 									},
 								},
@@ -6833,41 +6665,41 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 848, col: 1, offset: 24183},
+			pos:  position{line: 831, col: 1, offset: 23486},
 			expr: &choiceExpr{
-				pos: position{line: 849, col: 5, offset: 24201},
+				pos: position{line: 832, col: 5, offset: 23504},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 849, col: 5, offset: 24201},
+						pos: position{line: 832, col: 5, offset: 23504},
 						run: (*parser).callonSQLAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 849, col: 5, offset: 24201},
+							pos: position{line: 832, col: 5, offset: 23504},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 849, col: 5, offset: 24201},
+									pos:   position{line: 832, col: 5, offset: 23504},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 849, col: 9, offset: 24205},
+										pos:  position{line: 832, col: 9, offset: 23508},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 849, col: 14, offset: 24210},
+									pos:  position{line: 832, col: 14, offset: 23513},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 849, col: 16, offset: 24212},
+									pos:  position{line: 832, col: 16, offset: 23515},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 849, col: 19, offset: 24215},
+									pos:  position{line: 832, col: 19, offset: 23518},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 849, col: 21, offset: 24217},
+									pos:   position{line: 832, col: 21, offset: 23520},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 849, col: 25, offset: 24221},
+										pos:  position{line: 832, col: 25, offset: 23524},
 										name: "Lval",
 									},
 								},
@@ -6875,13 +6707,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 850, col: 5, offset: 24315},
+						pos: position{line: 833, col: 5, offset: 23618},
 						run: (*parser).callonSQLAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 850, col: 5, offset: 24315},
+							pos:   position{line: 833, col: 5, offset: 23618},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 850, col: 10, offset: 24320},
+								pos:  position{line: 833, col: 10, offset: 23623},
 								name: "Expr",
 							},
 						},
@@ -6891,50 +6723,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 852, col: 1, offset: 24412},
+			pos:  position{line: 835, col: 1, offset: 23715},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 5, offset: 24431},
+				pos: position{line: 836, col: 5, offset: 23734},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 853, col: 5, offset: 24431},
+					pos: position{line: 836, col: 5, offset: 23734},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 853, col: 5, offset: 24431},
+							pos:   position{line: 836, col: 5, offset: 23734},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 11, offset: 24437},
+								pos:  position{line: 836, col: 11, offset: 23740},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 25, offset: 24451},
+							pos:   position{line: 836, col: 25, offset: 23754},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 853, col: 30, offset: 24456},
+								pos: position{line: 836, col: 30, offset: 23759},
 								expr: &actionExpr{
-									pos: position{line: 853, col: 31, offset: 24457},
+									pos: position{line: 836, col: 31, offset: 23760},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 853, col: 31, offset: 24457},
+										pos: position{line: 836, col: 31, offset: 23760},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 853, col: 31, offset: 24457},
+												pos:  position{line: 836, col: 31, offset: 23760},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 853, col: 34, offset: 24460},
+												pos:        position{line: 836, col: 34, offset: 23763},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 853, col: 38, offset: 24464},
+												pos:  position{line: 836, col: 38, offset: 23767},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 853, col: 41, offset: 24467},
+												pos:   position{line: 836, col: 41, offset: 23770},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 853, col: 46, offset: 24472},
+													pos:  position{line: 836, col: 46, offset: 23775},
 													name: "SQLAssignment",
 												},
 											},
@@ -6949,43 +6781,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 857, col: 1, offset: 24593},
+			pos:  position{line: 840, col: 1, offset: 23896},
 			expr: &choiceExpr{
-				pos: position{line: 858, col: 5, offset: 24605},
+				pos: position{line: 841, col: 5, offset: 23908},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 858, col: 5, offset: 24605},
+						pos: position{line: 841, col: 5, offset: 23908},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 858, col: 5, offset: 24605},
+							pos: position{line: 841, col: 5, offset: 23908},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 858, col: 5, offset: 24605},
+									pos:  position{line: 841, col: 5, offset: 23908},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 858, col: 7, offset: 24607},
+									pos:  position{line: 841, col: 7, offset: 23910},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 858, col: 12, offset: 24612},
+									pos:  position{line: 841, col: 12, offset: 23915},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 858, col: 14, offset: 24614},
+									pos:   position{line: 841, col: 14, offset: 23917},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 858, col: 20, offset: 24620},
+										pos:  position{line: 841, col: 20, offset: 23923},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 858, col: 29, offset: 24629},
+									pos:   position{line: 841, col: 29, offset: 23932},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 858, col: 35, offset: 24635},
+										pos: position{line: 841, col: 35, offset: 23938},
 										expr: &ruleRefExpr{
-											pos:  position{line: 858, col: 35, offset: 24635},
+											pos:  position{line: 841, col: 35, offset: 23938},
 											name: "SQLAlias",
 										},
 									},
@@ -6994,25 +6826,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 861, col: 5, offset: 24730},
+						pos: position{line: 844, col: 5, offset: 24033},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 861, col: 5, offset: 24730},
+							pos: position{line: 844, col: 5, offset: 24033},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 5, offset: 24730},
+									pos:  position{line: 844, col: 5, offset: 24033},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 7, offset: 24732},
+									pos:  position{line: 844, col: 7, offset: 24035},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 12, offset: 24737},
+									pos:  position{line: 844, col: 12, offset: 24040},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 861, col: 14, offset: 24739},
+									pos:        position{line: 844, col: 14, offset: 24042},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -7024,33 +6856,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 863, col: 1, offset: 24764},
+			pos:  position{line: 846, col: 1, offset: 24067},
 			expr: &choiceExpr{
-				pos: position{line: 864, col: 5, offset: 24777},
+				pos: position{line: 847, col: 5, offset: 24080},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 864, col: 5, offset: 24777},
+						pos: position{line: 847, col: 5, offset: 24080},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 864, col: 5, offset: 24777},
+							pos: position{line: 847, col: 5, offset: 24080},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 5, offset: 24777},
+									pos:  position{line: 847, col: 5, offset: 24080},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 7, offset: 24779},
+									pos:  position{line: 847, col: 7, offset: 24082},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 10, offset: 24782},
+									pos:  position{line: 847, col: 10, offset: 24085},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 864, col: 12, offset: 24784},
+									pos:   position{line: 847, col: 12, offset: 24087},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 864, col: 15, offset: 24787},
+										pos:  position{line: 847, col: 15, offset: 24090},
 										name: "Lval",
 									},
 								},
@@ -7058,36 +6890,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 865, col: 5, offset: 24815},
+						pos: position{line: 848, col: 5, offset: 24118},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 865, col: 5, offset: 24815},
+							pos: position{line: 848, col: 5, offset: 24118},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 865, col: 5, offset: 24815},
+									pos:  position{line: 848, col: 5, offset: 24118},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 865, col: 7, offset: 24817},
+									pos: position{line: 848, col: 7, offset: 24120},
 									expr: &seqExpr{
-										pos: position{line: 865, col: 9, offset: 24819},
+										pos: position{line: 848, col: 9, offset: 24122},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 865, col: 9, offset: 24819},
+												pos:  position{line: 848, col: 9, offset: 24122},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 865, col: 27, offset: 24837},
+												pos:  position{line: 848, col: 27, offset: 24140},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 865, col: 30, offset: 24840},
+									pos:   position{line: 848, col: 30, offset: 24143},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 865, col: 33, offset: 24843},
+										pos:  position{line: 848, col: 33, offset: 24146},
 										name: "Lval",
 									},
 								},
@@ -7099,42 +6931,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 867, col: 1, offset: 24868},
+			pos:  position{line: 850, col: 1, offset: 24171},
 			expr: &ruleRefExpr{
-				pos:  position{line: 868, col: 5, offset: 24881},
+				pos:  position{line: 851, col: 5, offset: 24184},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 870, col: 1, offset: 24887},
+			pos:  position{line: 853, col: 1, offset: 24190},
 			expr: &actionExpr{
-				pos: position{line: 871, col: 5, offset: 24900},
+				pos: position{line: 854, col: 5, offset: 24203},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 871, col: 5, offset: 24900},
+					pos: position{line: 854, col: 5, offset: 24203},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 871, col: 5, offset: 24900},
+							pos:   position{line: 854, col: 5, offset: 24203},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 871, col: 11, offset: 24906},
+								pos:  position{line: 854, col: 11, offset: 24209},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 871, col: 19, offset: 24914},
+							pos:   position{line: 854, col: 19, offset: 24217},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 871, col: 24, offset: 24919},
+								pos: position{line: 854, col: 24, offset: 24222},
 								expr: &actionExpr{
-									pos: position{line: 871, col: 25, offset: 24920},
+									pos: position{line: 854, col: 25, offset: 24223},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 871, col: 25, offset: 24920},
+										pos:   position{line: 854, col: 25, offset: 24223},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 871, col: 30, offset: 24925},
+											pos:  position{line: 854, col: 30, offset: 24228},
 											name: "SQLJoin",
 										},
 									},
@@ -7147,90 +6979,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 875, col: 1, offset: 25040},
+			pos:  position{line: 858, col: 1, offset: 24343},
 			expr: &actionExpr{
-				pos: position{line: 876, col: 5, offset: 25052},
+				pos: position{line: 859, col: 5, offset: 24355},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 876, col: 5, offset: 25052},
+					pos: position{line: 859, col: 5, offset: 24355},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 876, col: 5, offset: 25052},
+							pos:   position{line: 859, col: 5, offset: 24355},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 876, col: 11, offset: 25058},
+								pos:  position{line: 859, col: 11, offset: 24361},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 24, offset: 25071},
+							pos:  position{line: 859, col: 24, offset: 24374},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 26, offset: 25073},
+							pos:  position{line: 859, col: 26, offset: 24376},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 31, offset: 25078},
+							pos:  position{line: 859, col: 31, offset: 24381},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 33, offset: 25080},
+							pos:   position{line: 859, col: 33, offset: 24383},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 876, col: 39, offset: 25086},
+								pos:  position{line: 859, col: 39, offset: 24389},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 48, offset: 25095},
+							pos:   position{line: 859, col: 48, offset: 24398},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 876, col: 54, offset: 25101},
+								pos: position{line: 859, col: 54, offset: 24404},
 								expr: &ruleRefExpr{
-									pos:  position{line: 876, col: 54, offset: 25101},
+									pos:  position{line: 859, col: 54, offset: 24404},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 64, offset: 25111},
+							pos:  position{line: 859, col: 64, offset: 24414},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 66, offset: 25113},
+							pos:  position{line: 859, col: 66, offset: 24416},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 69, offset: 25116},
+							pos:  position{line: 859, col: 69, offset: 24419},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 71, offset: 25118},
+							pos:   position{line: 859, col: 71, offset: 24421},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 876, col: 79, offset: 25126},
+								pos:  position{line: 859, col: 79, offset: 24429},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 87, offset: 25134},
+							pos:  position{line: 859, col: 87, offset: 24437},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 876, col: 90, offset: 25137},
+							pos:        position{line: 859, col: 90, offset: 24440},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 94, offset: 25141},
+							pos:  position{line: 859, col: 94, offset: 24444},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 97, offset: 25144},
+							pos:   position{line: 859, col: 97, offset: 24447},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 876, col: 106, offset: 25153},
+								pos:  position{line: 859, col: 106, offset: 24456},
 								name: "JoinKey",
 							},
 						},
@@ -7240,40 +7072,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 895, col: 1, offset: 25388},
+			pos:  position{line: 874, col: 1, offset: 24687},
 			expr: &choiceExpr{
-				pos: position{line: 896, col: 5, offset: 25405},
+				pos: position{line: 875, col: 5, offset: 24704},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 896, col: 5, offset: 25405},
+						pos: position{line: 875, col: 5, offset: 24704},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 896, col: 5, offset: 25405},
+							pos: position{line: 875, col: 5, offset: 24704},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 896, col: 5, offset: 25405},
+									pos:  position{line: 875, col: 5, offset: 24704},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 896, col: 7, offset: 25407},
+									pos:   position{line: 875, col: 7, offset: 24706},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 896, col: 14, offset: 25414},
+										pos: position{line: 875, col: 14, offset: 24713},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 896, col: 14, offset: 25414},
+												pos:  position{line: 875, col: 14, offset: 24713},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 896, col: 21, offset: 25421},
+												pos:  position{line: 875, col: 21, offset: 24720},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 896, col: 29, offset: 25429},
+												pos:  position{line: 875, col: 29, offset: 24728},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 896, col: 36, offset: 25436},
+												pos:  position{line: 875, col: 36, offset: 24735},
 												name: "RIGHT",
 											},
 										},
@@ -7283,10 +7115,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 897, col: 5, offset: 25469},
+						pos: position{line: 876, col: 5, offset: 24768},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 897, col: 5, offset: 25469},
+							pos:        position{line: 876, col: 5, offset: 24768},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7296,30 +7128,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 899, col: 1, offset: 25497},
+			pos:  position{line: 878, col: 1, offset: 24796},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 25510},
+				pos: position{line: 879, col: 5, offset: 24809},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 25510},
+					pos: position{line: 879, col: 5, offset: 24809},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 900, col: 5, offset: 25510},
+							pos:  position{line: 879, col: 5, offset: 24809},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 900, col: 7, offset: 25512},
+							pos:  position{line: 879, col: 7, offset: 24811},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 900, col: 13, offset: 25518},
+							pos:  position{line: 879, col: 13, offset: 24817},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 900, col: 15, offset: 25520},
+							pos:   position{line: 879, col: 15, offset: 24819},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 20, offset: 25525},
+								pos:  position{line: 879, col: 20, offset: 24824},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7329,38 +7161,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 902, col: 1, offset: 25561},
+			pos:  position{line: 881, col: 1, offset: 24860},
 			expr: &actionExpr{
-				pos: position{line: 903, col: 5, offset: 25576},
+				pos: position{line: 882, col: 5, offset: 24875},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 903, col: 5, offset: 25576},
+					pos: position{line: 882, col: 5, offset: 24875},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 903, col: 5, offset: 25576},
+							pos:  position{line: 882, col: 5, offset: 24875},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 903, col: 7, offset: 25578},
+							pos:  position{line: 882, col: 7, offset: 24877},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 903, col: 13, offset: 25584},
+							pos:  position{line: 882, col: 13, offset: 24883},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 903, col: 15, offset: 25586},
+							pos:  position{line: 882, col: 15, offset: 24885},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 903, col: 18, offset: 25589},
+							pos:  position{line: 882, col: 18, offset: 24888},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 903, col: 20, offset: 25591},
+							pos:   position{line: 882, col: 20, offset: 24890},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 903, col: 28, offset: 25599},
+								pos:  position{line: 882, col: 28, offset: 24898},
 								name: "FieldExprs",
 							},
 						},
@@ -7370,30 +7202,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 905, col: 1, offset: 25635},
+			pos:  position{line: 884, col: 1, offset: 24934},
 			expr: &actionExpr{
-				pos: position{line: 906, col: 5, offset: 25649},
+				pos: position{line: 885, col: 5, offset: 24948},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 906, col: 5, offset: 25649},
+					pos: position{line: 885, col: 5, offset: 24948},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 5, offset: 25649},
+							pos:  position{line: 885, col: 5, offset: 24948},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 7, offset: 25651},
+							pos:  position{line: 885, col: 7, offset: 24950},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 14, offset: 25658},
+							pos:  position{line: 885, col: 14, offset: 24957},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 906, col: 16, offset: 25660},
+							pos:   position{line: 885, col: 16, offset: 24959},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 906, col: 21, offset: 25665},
+								pos:  position{line: 885, col: 21, offset: 24964},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7403,46 +7235,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 908, col: 1, offset: 25701},
+			pos:  position{line: 887, col: 1, offset: 25000},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 5, offset: 25716},
+				pos: position{line: 888, col: 5, offset: 25015},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 909, col: 5, offset: 25716},
+					pos: position{line: 888, col: 5, offset: 25015},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 5, offset: 25716},
+							pos:  position{line: 888, col: 5, offset: 25015},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 7, offset: 25718},
+							pos:  position{line: 888, col: 7, offset: 25017},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 13, offset: 25724},
+							pos:  position{line: 888, col: 13, offset: 25023},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 15, offset: 25726},
+							pos:  position{line: 888, col: 15, offset: 25025},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 18, offset: 25729},
+							pos:  position{line: 888, col: 18, offset: 25028},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 20, offset: 25731},
+							pos:   position{line: 888, col: 20, offset: 25030},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 909, col: 25, offset: 25736},
+								pos:  position{line: 888, col: 25, offset: 25035},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 31, offset: 25742},
+							pos:   position{line: 888, col: 31, offset: 25041},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 909, col: 37, offset: 25748},
+								pos:  position{line: 888, col: 37, offset: 25047},
 								name: "SQLOrder",
 							},
 						},
@@ -7452,32 +7284,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 913, col: 1, offset: 25858},
+			pos:  position{line: 892, col: 1, offset: 25157},
 			expr: &choiceExpr{
-				pos: position{line: 914, col: 5, offset: 25871},
+				pos: position{line: 893, col: 5, offset: 25170},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 914, col: 5, offset: 25871},
+						pos: position{line: 893, col: 5, offset: 25170},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 914, col: 5, offset: 25871},
+							pos: position{line: 893, col: 5, offset: 25170},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 914, col: 5, offset: 25871},
+									pos:  position{line: 893, col: 5, offset: 25170},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 914, col: 7, offset: 25873},
+									pos:   position{line: 893, col: 7, offset: 25172},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 914, col: 12, offset: 25878},
+										pos: position{line: 893, col: 12, offset: 25177},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 914, col: 12, offset: 25878},
+												pos:  position{line: 893, col: 12, offset: 25177},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 914, col: 18, offset: 25884},
+												pos:  position{line: 893, col: 18, offset: 25183},
 												name: "DESC",
 											},
 										},
@@ -7487,10 +7319,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 915, col: 5, offset: 25914},
+						pos: position{line: 894, col: 5, offset: 25213},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 915, col: 5, offset: 25914},
+							pos:        position{line: 894, col: 5, offset: 25213},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7500,33 +7332,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 917, col: 1, offset: 25940},
+			pos:  position{line: 896, col: 1, offset: 25239},
 			expr: &choiceExpr{
-				pos: position{line: 918, col: 5, offset: 25953},
+				pos: position{line: 897, col: 5, offset: 25252},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 918, col: 5, offset: 25953},
+						pos: position{line: 897, col: 5, offset: 25252},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 918, col: 5, offset: 25953},
+							pos: position{line: 897, col: 5, offset: 25252},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 918, col: 5, offset: 25953},
+									pos:  position{line: 897, col: 5, offset: 25252},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 918, col: 7, offset: 25955},
+									pos:  position{line: 897, col: 7, offset: 25254},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 918, col: 13, offset: 25961},
+									pos:  position{line: 897, col: 13, offset: 25260},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 918, col: 15, offset: 25963},
+									pos:   position{line: 897, col: 15, offset: 25262},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 918, col: 21, offset: 25969},
+										pos:  position{line: 897, col: 21, offset: 25268},
 										name: "UInt",
 									},
 								},
@@ -7534,10 +7366,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 919, col: 5, offset: 26000},
+						pos: position{line: 898, col: 5, offset: 25299},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 919, col: 5, offset: 26000},
+							pos:        position{line: 898, col: 5, offset: 25299},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7547,12 +7379,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 921, col: 1, offset: 26022},
+			pos:  position{line: 900, col: 1, offset: 25321},
 			expr: &actionExpr{
-				pos: position{line: 921, col: 10, offset: 26031},
+				pos: position{line: 900, col: 10, offset: 25330},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 921, col: 10, offset: 26031},
+					pos:        position{line: 900, col: 10, offset: 25330},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7560,12 +7392,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 922, col: 1, offset: 26066},
+			pos:  position{line: 901, col: 1, offset: 25365},
 			expr: &actionExpr{
-				pos: position{line: 922, col: 6, offset: 26071},
+				pos: position{line: 901, col: 6, offset: 25370},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 922, col: 6, offset: 26071},
+					pos:        position{line: 901, col: 6, offset: 25370},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7573,12 +7405,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 923, col: 1, offset: 26098},
+			pos:  position{line: 902, col: 1, offset: 25397},
 			expr: &actionExpr{
-				pos: position{line: 923, col: 8, offset: 26105},
+				pos: position{line: 902, col: 8, offset: 25404},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 923, col: 8, offset: 26105},
+					pos:        position{line: 902, col: 8, offset: 25404},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7586,12 +7418,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 924, col: 1, offset: 26136},
+			pos:  position{line: 903, col: 1, offset: 25435},
 			expr: &actionExpr{
-				pos: position{line: 924, col: 8, offset: 26143},
+				pos: position{line: 903, col: 8, offset: 25442},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 924, col: 8, offset: 26143},
+					pos:        position{line: 903, col: 8, offset: 25442},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7599,12 +7431,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 925, col: 1, offset: 26174},
+			pos:  position{line: 904, col: 1, offset: 25473},
 			expr: &actionExpr{
-				pos: position{line: 925, col: 9, offset: 26182},
+				pos: position{line: 904, col: 9, offset: 25481},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 925, col: 9, offset: 26182},
+					pos:        position{line: 904, col: 9, offset: 25481},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7612,12 +7444,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 926, col: 1, offset: 26215},
+			pos:  position{line: 905, col: 1, offset: 25514},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 9, offset: 26223},
+				pos: position{line: 905, col: 9, offset: 25522},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 926, col: 9, offset: 26223},
+					pos:        position{line: 905, col: 9, offset: 25522},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7625,12 +7457,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 927, col: 1, offset: 26256},
+			pos:  position{line: 906, col: 1, offset: 25555},
 			expr: &actionExpr{
-				pos: position{line: 927, col: 6, offset: 26261},
+				pos: position{line: 906, col: 6, offset: 25560},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 927, col: 6, offset: 26261},
+					pos:        position{line: 906, col: 6, offset: 25560},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7638,12 +7470,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 928, col: 1, offset: 26288},
+			pos:  position{line: 907, col: 1, offset: 25587},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 10, offset: 26297},
+				pos: position{line: 907, col: 10, offset: 25596},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 928, col: 10, offset: 26297},
+					pos:        position{line: 907, col: 10, offset: 25596},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7651,12 +7483,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 929, col: 1, offset: 26332},
+			pos:  position{line: 908, col: 1, offset: 25631},
 			expr: &actionExpr{
-				pos: position{line: 929, col: 9, offset: 26340},
+				pos: position{line: 908, col: 9, offset: 25639},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 929, col: 9, offset: 26340},
+					pos:        position{line: 908, col: 9, offset: 25639},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7664,12 +7496,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 930, col: 1, offset: 26373},
+			pos:  position{line: 909, col: 1, offset: 25672},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 6, offset: 26378},
+				pos: position{line: 909, col: 6, offset: 25677},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 930, col: 6, offset: 26378},
+					pos:        position{line: 909, col: 6, offset: 25677},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7677,12 +7509,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 931, col: 1, offset: 26405},
+			pos:  position{line: 910, col: 1, offset: 25704},
 			expr: &actionExpr{
-				pos: position{line: 931, col: 9, offset: 26413},
+				pos: position{line: 910, col: 9, offset: 25712},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 931, col: 9, offset: 26413},
+					pos:        position{line: 910, col: 9, offset: 25712},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7690,12 +7522,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 932, col: 1, offset: 26446},
+			pos:  position{line: 911, col: 1, offset: 25745},
 			expr: &actionExpr{
-				pos: position{line: 932, col: 7, offset: 26452},
+				pos: position{line: 911, col: 7, offset: 25751},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 932, col: 7, offset: 26452},
+					pos:        position{line: 911, col: 7, offset: 25751},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7703,12 +7535,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 933, col: 1, offset: 26481},
+			pos:  position{line: 912, col: 1, offset: 25780},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 8, offset: 26488},
+				pos: position{line: 912, col: 8, offset: 25787},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 933, col: 8, offset: 26488},
+					pos:        position{line: 912, col: 8, offset: 25787},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7716,12 +7548,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 934, col: 1, offset: 26519},
+			pos:  position{line: 913, col: 1, offset: 25818},
 			expr: &actionExpr{
-				pos: position{line: 934, col: 8, offset: 26526},
+				pos: position{line: 913, col: 8, offset: 25825},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 934, col: 8, offset: 26526},
+					pos:        position{line: 913, col: 8, offset: 25825},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7729,12 +7561,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 935, col: 1, offset: 26557},
+			pos:  position{line: 914, col: 1, offset: 25856},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 8, offset: 26564},
+				pos: position{line: 914, col: 8, offset: 25863},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 935, col: 8, offset: 26564},
+					pos:        position{line: 914, col: 8, offset: 25863},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7742,12 +7574,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 936, col: 1, offset: 26595},
+			pos:  position{line: 915, col: 1, offset: 25894},
 			expr: &actionExpr{
-				pos: position{line: 936, col: 9, offset: 26603},
+				pos: position{line: 915, col: 9, offset: 25902},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 936, col: 9, offset: 26603},
+					pos:        position{line: 915, col: 9, offset: 25902},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7755,12 +7587,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 937, col: 1, offset: 26636},
+			pos:  position{line: 916, col: 1, offset: 25935},
 			expr: &actionExpr{
-				pos: position{line: 937, col: 9, offset: 26644},
+				pos: position{line: 916, col: 9, offset: 25943},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 937, col: 9, offset: 26644},
+					pos:        position{line: 916, col: 9, offset: 25943},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7768,48 +7600,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 939, col: 1, offset: 26678},
+			pos:  position{line: 918, col: 1, offset: 25977},
 			expr: &choiceExpr{
-				pos: position{line: 940, col: 5, offset: 26700},
+				pos: position{line: 919, col: 5, offset: 25999},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 5, offset: 26700},
+						pos:  position{line: 919, col: 5, offset: 25999},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 14, offset: 26709},
+						pos:  position{line: 919, col: 14, offset: 26008},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 19, offset: 26714},
+						pos:  position{line: 919, col: 19, offset: 26013},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 27, offset: 26722},
+						pos:  position{line: 919, col: 27, offset: 26021},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 34, offset: 26729},
+						pos:  position{line: 919, col: 34, offset: 26028},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 42, offset: 26737},
+						pos:  position{line: 919, col: 42, offset: 26036},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 50, offset: 26745},
+						pos:  position{line: 919, col: 50, offset: 26044},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 59, offset: 26754},
+						pos:  position{line: 919, col: 59, offset: 26053},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 67, offset: 26762},
+						pos:  position{line: 919, col: 67, offset: 26061},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 75, offset: 26770},
+						pos:  position{line: 919, col: 75, offset: 26069},
 						name: "ON",
 					},
 				},
@@ -7817,52 +7649,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 944, col: 1, offset: 26796},
+			pos:  position{line: 923, col: 1, offset: 26095},
 			expr: &choiceExpr{
-				pos: position{line: 945, col: 5, offset: 26808},
+				pos: position{line: 924, col: 5, offset: 26107},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 5, offset: 26808},
+						pos:  position{line: 924, col: 5, offset: 26107},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 946, col: 5, offset: 26824},
+						pos:  position{line: 925, col: 5, offset: 26123},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 947, col: 5, offset: 26844},
+						pos:  position{line: 926, col: 5, offset: 26143},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 948, col: 5, offset: 26862},
+						pos:  position{line: 927, col: 5, offset: 26161},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 949, col: 5, offset: 26881},
+						pos:  position{line: 928, col: 5, offset: 26180},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 950, col: 5, offset: 26898},
+						pos:  position{line: 929, col: 5, offset: 26197},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 951, col: 5, offset: 26911},
+						pos:  position{line: 930, col: 5, offset: 26210},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 952, col: 5, offset: 26920},
+						pos:  position{line: 931, col: 5, offset: 26219},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 953, col: 5, offset: 26937},
+						pos:  position{line: 932, col: 5, offset: 26236},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 954, col: 5, offset: 26956},
+						pos:  position{line: 933, col: 5, offset: 26255},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 955, col: 5, offset: 26975},
+						pos:  position{line: 934, col: 5, offset: 26274},
 						name: "NullLiteral",
 					},
 				},
@@ -7870,28 +7702,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 957, col: 1, offset: 26988},
+			pos:  position{line: 936, col: 1, offset: 26287},
 			expr: &choiceExpr{
-				pos: position{line: 958, col: 5, offset: 27006},
+				pos: position{line: 937, col: 5, offset: 26305},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 958, col: 5, offset: 27006},
+						pos: position{line: 937, col: 5, offset: 26305},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 958, col: 5, offset: 27006},
+							pos: position{line: 937, col: 5, offset: 26305},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 958, col: 5, offset: 27006},
+									pos:   position{line: 937, col: 5, offset: 26305},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 7, offset: 27008},
+										pos:  position{line: 937, col: 7, offset: 26307},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 958, col: 14, offset: 27015},
+									pos: position{line: 937, col: 14, offset: 26314},
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 15, offset: 27016},
+										pos:  position{line: 937, col: 15, offset: 26315},
 										name: "IdentifierRest",
 									},
 								},
@@ -7899,13 +7731,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 961, col: 5, offset: 27131},
+						pos: position{line: 940, col: 5, offset: 26430},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 961, col: 5, offset: 27131},
+							pos:   position{line: 940, col: 5, offset: 26430},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 961, col: 7, offset: 27133},
+								pos:  position{line: 940, col: 7, offset: 26432},
 								name: "IP4Net",
 							},
 						},
@@ -7915,28 +7747,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 965, col: 1, offset: 27237},
+			pos:  position{line: 944, col: 1, offset: 26536},
 			expr: &choiceExpr{
-				pos: position{line: 966, col: 5, offset: 27256},
+				pos: position{line: 945, col: 5, offset: 26555},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 966, col: 5, offset: 27256},
+						pos: position{line: 945, col: 5, offset: 26555},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 966, col: 5, offset: 27256},
+							pos: position{line: 945, col: 5, offset: 26555},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 966, col: 5, offset: 27256},
+									pos:   position{line: 945, col: 5, offset: 26555},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 966, col: 7, offset: 27258},
+										pos:  position{line: 945, col: 7, offset: 26557},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 966, col: 11, offset: 27262},
+									pos: position{line: 945, col: 11, offset: 26561},
 									expr: &ruleRefExpr{
-										pos:  position{line: 966, col: 12, offset: 27263},
+										pos:  position{line: 945, col: 12, offset: 26562},
 										name: "IdentifierRest",
 									},
 								},
@@ -7944,13 +7776,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 969, col: 5, offset: 27377},
+						pos: position{line: 948, col: 5, offset: 26676},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 969, col: 5, offset: 27377},
+							pos:   position{line: 948, col: 5, offset: 26676},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 969, col: 7, offset: 27379},
+								pos:  position{line: 948, col: 7, offset: 26678},
 								name: "IP",
 							},
 						},
@@ -7960,15 +7792,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 973, col: 1, offset: 27478},
+			pos:  position{line: 952, col: 1, offset: 26777},
 			expr: &actionExpr{
-				pos: position{line: 974, col: 5, offset: 27495},
+				pos: position{line: 953, col: 5, offset: 26794},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 974, col: 5, offset: 27495},
+					pos:   position{line: 953, col: 5, offset: 26794},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 974, col: 7, offset: 27497},
+						pos:  position{line: 953, col: 7, offset: 26796},
 						name: "FloatString",
 					},
 				},
@@ -7976,15 +7808,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 978, col: 1, offset: 27610},
+			pos:  position{line: 957, col: 1, offset: 26909},
 			expr: &actionExpr{
-				pos: position{line: 979, col: 5, offset: 27629},
+				pos: position{line: 958, col: 5, offset: 26928},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 979, col: 5, offset: 27629},
+					pos:   position{line: 958, col: 5, offset: 26928},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 979, col: 7, offset: 27631},
+						pos:  position{line: 958, col: 7, offset: 26930},
 						name: "IntString",
 					},
 				},
@@ -7992,24 +7824,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 983, col: 1, offset: 27740},
+			pos:  position{line: 962, col: 1, offset: 27039},
 			expr: &choiceExpr{
-				pos: position{line: 984, col: 5, offset: 27759},
+				pos: position{line: 963, col: 5, offset: 27058},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 984, col: 5, offset: 27759},
+						pos: position{line: 963, col: 5, offset: 27058},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 984, col: 5, offset: 27759},
+							pos:        position{line: 963, col: 5, offset: 27058},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 985, col: 5, offset: 27872},
+						pos: position{line: 964, col: 5, offset: 27171},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 985, col: 5, offset: 27872},
+							pos:        position{line: 964, col: 5, offset: 27171},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -8019,12 +7851,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 987, col: 1, offset: 27983},
+			pos:  position{line: 966, col: 1, offset: 27282},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 5, offset: 27999},
+				pos: position{line: 967, col: 5, offset: 27298},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 988, col: 5, offset: 27999},
+					pos:        position{line: 967, col: 5, offset: 27298},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -8032,22 +7864,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 990, col: 1, offset: 28105},
+			pos:  position{line: 969, col: 1, offset: 27404},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 5, offset: 28122},
+				pos: position{line: 970, col: 5, offset: 27421},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 991, col: 5, offset: 28122},
+					pos: position{line: 970, col: 5, offset: 27421},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 991, col: 5, offset: 28122},
+							pos:        position{line: 970, col: 5, offset: 27421},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 991, col: 10, offset: 28127},
+							pos: position{line: 970, col: 10, offset: 27426},
 							expr: &ruleRefExpr{
-								pos:  position{line: 991, col: 10, offset: 28127},
+								pos:  position{line: 970, col: 10, offset: 27426},
 								name: "HexDigit",
 							},
 						},
@@ -8057,28 +7889,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 995, col: 1, offset: 28242},
+			pos:  position{line: 974, col: 1, offset: 27541},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 5, offset: 28258},
+				pos: position{line: 975, col: 5, offset: 27557},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 996, col: 5, offset: 28258},
+					pos: position{line: 975, col: 5, offset: 27557},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 996, col: 5, offset: 28258},
+							pos:        position{line: 975, col: 5, offset: 27557},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 996, col: 9, offset: 28262},
+							pos:   position{line: 975, col: 9, offset: 27561},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 996, col: 13, offset: 28266},
+								pos:  position{line: 975, col: 13, offset: 27565},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 996, col: 18, offset: 28271},
+							pos:        position{line: 975, col: 18, offset: 27570},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -8088,22 +7920,22 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1000, col: 1, offset: 28360},
+			pos:  position{line: 979, col: 1, offset: 27659},
 			expr: &choiceExpr{
-				pos: position{line: 1001, col: 5, offset: 28373},
+				pos: position{line: 980, col: 5, offset: 27672},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1001, col: 5, offset: 28373},
+						pos:  position{line: 980, col: 5, offset: 27672},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 1002, col: 5, offset: 28389},
+						pos: position{line: 981, col: 5, offset: 27688},
 						run: (*parser).callonCastType3,
 						expr: &labeledExpr{
-							pos:   position{line: 1002, col: 5, offset: 28389},
+							pos:   position{line: 981, col: 5, offset: 27688},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1002, col: 9, offset: 28393},
+								pos:  position{line: 981, col: 9, offset: 27692},
 								name: "PrimitiveType",
 							},
 						},
@@ -8113,20 +7945,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1006, col: 1, offset: 28492},
+			pos:  position{line: 985, col: 1, offset: 27791},
 			expr: &choiceExpr{
-				pos: position{line: 1007, col: 5, offset: 28501},
+				pos: position{line: 986, col: 5, offset: 27800},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 28501},
+						pos:  position{line: 986, col: 5, offset: 27800},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 28517},
+						pos:  position{line: 987, col: 5, offset: 27816},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 28535},
+						pos:  position{line: 988, col: 5, offset: 27834},
 						name: "ComplexType",
 					},
 				},
@@ -8134,28 +7966,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1011, col: 1, offset: 28548},
+			pos:  position{line: 990, col: 1, offset: 27847},
 			expr: &choiceExpr{
-				pos: position{line: 1012, col: 5, offset: 28566},
+				pos: position{line: 991, col: 5, offset: 27865},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 28566},
+						pos: position{line: 991, col: 5, offset: 27865},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1012, col: 5, offset: 28566},
+							pos: position{line: 991, col: 5, offset: 27865},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1012, col: 5, offset: 28566},
+									pos:   position{line: 991, col: 5, offset: 27865},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1012, col: 10, offset: 28571},
+										pos:  position{line: 991, col: 10, offset: 27870},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1012, col: 24, offset: 28585},
+									pos: position{line: 991, col: 24, offset: 27884},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1012, col: 25, offset: 28586},
+										pos:  position{line: 991, col: 25, offset: 27885},
 										name: "IdentifierRest",
 									},
 								},
@@ -8163,37 +7995,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1013, col: 5, offset: 28626},
+						pos: position{line: 992, col: 5, offset: 27925},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1013, col: 5, offset: 28626},
+							pos: position{line: 992, col: 5, offset: 27925},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1013, col: 5, offset: 28626},
+									pos:   position{line: 992, col: 5, offset: 27925},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 10, offset: 28631},
+										pos:  position{line: 992, col: 10, offset: 27930},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 25, offset: 28646},
+									pos:  position{line: 992, col: 25, offset: 27945},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1013, col: 28, offset: 28649},
+									pos:        position{line: 992, col: 28, offset: 27948},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 32, offset: 28653},
+									pos:  position{line: 992, col: 32, offset: 27952},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 35, offset: 28656},
+									pos:   position{line: 992, col: 35, offset: 27955},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 39, offset: 28660},
+										pos:  position{line: 992, col: 39, offset: 27959},
 										name: "Type",
 									},
 								},
@@ -8201,42 +8033,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1016, col: 5, offset: 28762},
+						pos: position{line: 995, col: 5, offset: 28061},
 						run: (*parser).callonAmbiguousType17,
 						expr: &labeledExpr{
-							pos:   position{line: 1016, col: 5, offset: 28762},
+							pos:   position{line: 995, col: 5, offset: 28061},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1016, col: 10, offset: 28767},
+								pos:  position{line: 995, col: 10, offset: 28066},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 28869},
+						pos: position{line: 998, col: 5, offset: 28168},
 						run: (*parser).callonAmbiguousType20,
 						expr: &seqExpr{
-							pos: position{line: 1019, col: 5, offset: 28869},
+							pos: position{line: 998, col: 5, offset: 28168},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1019, col: 5, offset: 28869},
+									pos:        position{line: 998, col: 5, offset: 28168},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 9, offset: 28873},
+									pos:  position{line: 998, col: 9, offset: 28172},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1019, col: 12, offset: 28876},
+									pos:   position{line: 998, col: 12, offset: 28175},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 14, offset: 28878},
+										pos:  position{line: 998, col: 14, offset: 28177},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 25, offset: 28889},
+									pos:        position{line: 998, col: 25, offset: 28188},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8248,15 +8080,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1021, col: 1, offset: 28912},
+			pos:  position{line: 1000, col: 1, offset: 28211},
 			expr: &actionExpr{
-				pos: position{line: 1022, col: 5, offset: 28926},
+				pos: position{line: 1001, col: 5, offset: 28225},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1022, col: 5, offset: 28926},
+					pos:   position{line: 1001, col: 5, offset: 28225},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1022, col: 11, offset: 28932},
+						pos:  position{line: 1001, col: 11, offset: 28231},
 						name: "TypeList",
 					},
 				},
@@ -8264,28 +8096,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1026, col: 1, offset: 29028},
+			pos:  position{line: 1005, col: 1, offset: 28327},
 			expr: &actionExpr{
-				pos: position{line: 1027, col: 5, offset: 29041},
+				pos: position{line: 1006, col: 5, offset: 28340},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1027, col: 5, offset: 29041},
+					pos: position{line: 1006, col: 5, offset: 28340},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1027, col: 5, offset: 29041},
+							pos:   position{line: 1006, col: 5, offset: 28340},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1027, col: 11, offset: 29047},
+								pos:  position{line: 1006, col: 11, offset: 28346},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1027, col: 16, offset: 29052},
+							pos:   position{line: 1006, col: 16, offset: 28351},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1027, col: 21, offset: 29057},
+								pos: position{line: 1006, col: 21, offset: 28356},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1027, col: 21, offset: 29057},
+									pos:  position{line: 1006, col: 21, offset: 28356},
 									name: "TypeListTail",
 								},
 							},
@@ -8296,31 +8128,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1031, col: 1, offset: 29151},
+			pos:  position{line: 1010, col: 1, offset: 28450},
 			expr: &actionExpr{
-				pos: position{line: 1031, col: 16, offset: 29166},
+				pos: position{line: 1010, col: 16, offset: 28465},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1031, col: 16, offset: 29166},
+					pos: position{line: 1010, col: 16, offset: 28465},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1031, col: 16, offset: 29166},
+							pos:  position{line: 1010, col: 16, offset: 28465},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1031, col: 19, offset: 29169},
+							pos:        position{line: 1010, col: 19, offset: 28468},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1031, col: 23, offset: 29173},
+							pos:  position{line: 1010, col: 23, offset: 28472},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1031, col: 26, offset: 29176},
+							pos:   position{line: 1010, col: 26, offset: 28475},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1031, col: 30, offset: 29180},
+								pos:  position{line: 1010, col: 30, offset: 28479},
 								name: "Type",
 							},
 						},
@@ -8330,39 +8162,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1033, col: 1, offset: 29206},
+			pos:  position{line: 1012, col: 1, offset: 28505},
 			expr: &choiceExpr{
-				pos: position{line: 1034, col: 5, offset: 29222},
+				pos: position{line: 1013, col: 5, offset: 28521},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1034, col: 5, offset: 29222},
+						pos: position{line: 1013, col: 5, offset: 28521},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1034, col: 5, offset: 29222},
+							pos: position{line: 1013, col: 5, offset: 28521},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1034, col: 5, offset: 29222},
+									pos:        position{line: 1013, col: 5, offset: 28521},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1034, col: 9, offset: 29226},
+									pos:  position{line: 1013, col: 9, offset: 28525},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1034, col: 12, offset: 29229},
+									pos:   position{line: 1013, col: 12, offset: 28528},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1034, col: 19, offset: 29236},
+										pos:  position{line: 1013, col: 19, offset: 28535},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1034, col: 33, offset: 29250},
+									pos:  position{line: 1013, col: 33, offset: 28549},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1034, col: 36, offset: 29253},
+									pos:        position{line: 1013, col: 36, offset: 28552},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8370,34 +8202,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1037, col: 5, offset: 29348},
+						pos: position{line: 1016, col: 5, offset: 28647},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1037, col: 5, offset: 29348},
+							pos: position{line: 1016, col: 5, offset: 28647},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1037, col: 5, offset: 29348},
+									pos:        position{line: 1016, col: 5, offset: 28647},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 9, offset: 29352},
+									pos:  position{line: 1016, col: 9, offset: 28651},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1037, col: 12, offset: 29355},
+									pos:   position{line: 1016, col: 12, offset: 28654},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1037, col: 16, offset: 29359},
+										pos:  position{line: 1016, col: 16, offset: 28658},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 21, offset: 29364},
+									pos:  position{line: 1016, col: 21, offset: 28663},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1037, col: 24, offset: 29367},
+									pos:        position{line: 1016, col: 24, offset: 28666},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8405,34 +8237,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1040, col: 5, offset: 29456},
+						pos: position{line: 1019, col: 5, offset: 28755},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1040, col: 5, offset: 29456},
+							pos: position{line: 1019, col: 5, offset: 28755},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1040, col: 5, offset: 29456},
+									pos:        position{line: 1019, col: 5, offset: 28755},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1040, col: 10, offset: 29461},
+									pos:  position{line: 1019, col: 10, offset: 28760},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1040, col: 14, offset: 29465},
+									pos:   position{line: 1019, col: 14, offset: 28764},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1040, col: 18, offset: 29469},
+										pos:  position{line: 1019, col: 18, offset: 28768},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1040, col: 23, offset: 29474},
+									pos:  position{line: 1019, col: 23, offset: 28773},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1040, col: 26, offset: 29477},
+									pos:        position{line: 1019, col: 26, offset: 28776},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8440,55 +8272,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 29565},
+						pos: position{line: 1022, col: 5, offset: 28864},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1043, col: 5, offset: 29565},
+							pos: position{line: 1022, col: 5, offset: 28864},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1043, col: 5, offset: 29565},
+									pos:        position{line: 1022, col: 5, offset: 28864},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 10, offset: 29570},
+									pos:  position{line: 1022, col: 10, offset: 28869},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 13, offset: 29573},
+									pos:   position{line: 1022, col: 13, offset: 28872},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 21, offset: 29581},
+										pos:  position{line: 1022, col: 21, offset: 28880},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 26, offset: 29586},
+									pos:  position{line: 1022, col: 26, offset: 28885},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 29, offset: 29589},
+									pos:        position{line: 1022, col: 29, offset: 28888},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 33, offset: 29593},
+									pos:  position{line: 1022, col: 33, offset: 28892},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 36, offset: 29596},
+									pos:   position{line: 1022, col: 36, offset: 28895},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 44, offset: 29604},
+										pos:  position{line: 1022, col: 44, offset: 28903},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 49, offset: 29609},
+									pos:  position{line: 1022, col: 49, offset: 28908},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 52, offset: 29612},
+									pos:        position{line: 1022, col: 52, offset: 28911},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8500,15 +8332,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1047, col: 1, offset: 29726},
+			pos:  position{line: 1026, col: 1, offset: 29025},
 			expr: &actionExpr{
-				pos: position{line: 1048, col: 5, offset: 29746},
+				pos: position{line: 1027, col: 5, offset: 29045},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1048, col: 5, offset: 29746},
+					pos:   position{line: 1027, col: 5, offset: 29045},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1048, col: 7, offset: 29748},
+						pos:  position{line: 1027, col: 7, offset: 29047},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8516,34 +8348,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1055, col: 1, offset: 29964},
+			pos:  position{line: 1034, col: 1, offset: 29263},
 			expr: &choiceExpr{
-				pos: position{line: 1056, col: 5, offset: 29989},
+				pos: position{line: 1035, col: 5, offset: 29288},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1056, col: 5, offset: 29989},
+						pos: position{line: 1035, col: 5, offset: 29288},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1056, col: 5, offset: 29989},
+							pos: position{line: 1035, col: 5, offset: 29288},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1056, col: 5, offset: 29989},
+									pos:        position{line: 1035, col: 5, offset: 29288},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1056, col: 9, offset: 29993},
+									pos:   position{line: 1035, col: 9, offset: 29292},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1056, col: 11, offset: 29995},
+										pos: position{line: 1035, col: 11, offset: 29294},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1056, col: 11, offset: 29995},
+											pos:  position{line: 1035, col: 11, offset: 29294},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1056, col: 37, offset: 30021},
+									pos:        position{line: 1035, col: 37, offset: 29320},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8551,29 +8383,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 30047},
+						pos: position{line: 1036, col: 5, offset: 29346},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 30047},
+							pos: position{line: 1036, col: 5, offset: 29346},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1057, col: 5, offset: 30047},
+									pos:        position{line: 1036, col: 5, offset: 29346},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 9, offset: 30051},
+									pos:   position{line: 1036, col: 9, offset: 29350},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1057, col: 11, offset: 30053},
+										pos: position{line: 1036, col: 11, offset: 29352},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1057, col: 11, offset: 30053},
+											pos:  position{line: 1036, col: 11, offset: 29352},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 37, offset: 30079},
+									pos:        position{line: 1036, col: 37, offset: 29378},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8585,24 +8417,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1059, col: 1, offset: 30102},
+			pos:  position{line: 1038, col: 1, offset: 29401},
 			expr: &choiceExpr{
-				pos: position{line: 1060, col: 5, offset: 30131},
+				pos: position{line: 1039, col: 5, offset: 29430},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1060, col: 5, offset: 30131},
+						pos:  position{line: 1039, col: 5, offset: 29430},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1061, col: 5, offset: 30148},
+						pos: position{line: 1040, col: 5, offset: 29447},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1061, col: 5, offset: 30148},
+							pos:   position{line: 1040, col: 5, offset: 29447},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1061, col: 7, offset: 30150},
+								pos: position{line: 1040, col: 7, offset: 29449},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1061, col: 7, offset: 30150},
+									pos:  position{line: 1040, col: 7, offset: 29449},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8613,26 +8445,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1065, col: 1, offset: 30287},
+			pos:  position{line: 1044, col: 1, offset: 29586},
 			expr: &choiceExpr{
-				pos: position{line: 1066, col: 5, offset: 30316},
+				pos: position{line: 1045, col: 5, offset: 29615},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 30316},
+						pos: position{line: 1045, col: 5, offset: 29615},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1066, col: 5, offset: 30316},
+							pos: position{line: 1045, col: 5, offset: 29615},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1066, col: 5, offset: 30316},
+									pos:        position{line: 1045, col: 5, offset: 29615},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 10, offset: 30321},
+									pos:   position{line: 1045, col: 10, offset: 29620},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1066, col: 12, offset: 30323},
+										pos:        position{line: 1045, col: 12, offset: 29622},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8641,24 +8473,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 30350},
+						pos: position{line: 1046, col: 5, offset: 29649},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1067, col: 5, offset: 30350},
+							pos: position{line: 1046, col: 5, offset: 29649},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1067, col: 5, offset: 30350},
+									pos: position{line: 1046, col: 5, offset: 29649},
 									expr: &litMatcher{
-										pos:        position{line: 1067, col: 8, offset: 30353},
+										pos:        position{line: 1046, col: 8, offset: 29652},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1067, col: 15, offset: 30360},
+									pos:   position{line: 1046, col: 15, offset: 29659},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1067, col: 17, offset: 30362},
+										pos:  position{line: 1046, col: 17, offset: 29661},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8670,24 +8502,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1069, col: 1, offset: 30398},
+			pos:  position{line: 1048, col: 1, offset: 29697},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 5, offset: 30427},
+				pos: position{line: 1049, col: 5, offset: 29726},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1070, col: 5, offset: 30427},
+						pos:  position{line: 1049, col: 5, offset: 29726},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 30444},
+						pos: position{line: 1050, col: 5, offset: 29743},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1071, col: 5, offset: 30444},
+							pos:   position{line: 1050, col: 5, offset: 29743},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1071, col: 7, offset: 30446},
+								pos: position{line: 1050, col: 7, offset: 29745},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1071, col: 7, offset: 30446},
+									pos:  position{line: 1050, col: 7, offset: 29745},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8698,26 +8530,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1075, col: 1, offset: 30583},
+			pos:  position{line: 1054, col: 1, offset: 29882},
 			expr: &choiceExpr{
-				pos: position{line: 1076, col: 5, offset: 30612},
+				pos: position{line: 1055, col: 5, offset: 29911},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1076, col: 5, offset: 30612},
+						pos: position{line: 1055, col: 5, offset: 29911},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1076, col: 5, offset: 30612},
+							pos: position{line: 1055, col: 5, offset: 29911},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1076, col: 5, offset: 30612},
+									pos:        position{line: 1055, col: 5, offset: 29911},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1076, col: 10, offset: 30617},
+									pos:   position{line: 1055, col: 10, offset: 29916},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1076, col: 12, offset: 30619},
+										pos:        position{line: 1055, col: 12, offset: 29918},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8726,24 +8558,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 30646},
+						pos: position{line: 1056, col: 5, offset: 29945},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 30646},
+							pos: position{line: 1056, col: 5, offset: 29945},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1077, col: 5, offset: 30646},
+									pos: position{line: 1056, col: 5, offset: 29945},
 									expr: &litMatcher{
-										pos:        position{line: 1077, col: 8, offset: 30649},
+										pos:        position{line: 1056, col: 8, offset: 29948},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 15, offset: 30656},
+									pos:   position{line: 1056, col: 15, offset: 29955},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 17, offset: 30658},
+										pos:  position{line: 1056, col: 17, offset: 29957},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8755,36 +8587,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1079, col: 1, offset: 30694},
+			pos:  position{line: 1058, col: 1, offset: 29993},
 			expr: &actionExpr{
-				pos: position{line: 1080, col: 5, offset: 30711},
+				pos: position{line: 1059, col: 5, offset: 30010},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1080, col: 5, offset: 30711},
+					pos: position{line: 1059, col: 5, offset: 30010},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1080, col: 5, offset: 30711},
+							pos:        position{line: 1059, col: 5, offset: 30010},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1080, col: 10, offset: 30716},
+							pos:  position{line: 1059, col: 10, offset: 30015},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1080, col: 13, offset: 30719},
+							pos:   position{line: 1059, col: 13, offset: 30018},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1080, col: 15, offset: 30721},
+								pos:  position{line: 1059, col: 15, offset: 30020},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1080, col: 20, offset: 30726},
+							pos:  position{line: 1059, col: 20, offset: 30025},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1080, col: 23, offset: 30729},
+							pos:        position{line: 1059, col: 23, offset: 30028},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8794,105 +8626,105 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1099, col: 1, offset: 31029},
+			pos:  position{line: 1074, col: 1, offset: 30324},
 			expr: &actionExpr{
-				pos: position{line: 1100, col: 5, offset: 31047},
+				pos: position{line: 1075, col: 5, offset: 30342},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1100, col: 9, offset: 31051},
+					pos: position{line: 1075, col: 9, offset: 30346},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1100, col: 9, offset: 31051},
+							pos:        position{line: 1075, col: 9, offset: 30346},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 19, offset: 31061},
+							pos:        position{line: 1075, col: 19, offset: 30356},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 30, offset: 31072},
+							pos:        position{line: 1075, col: 30, offset: 30367},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1100, col: 41, offset: 31083},
+							pos:        position{line: 1075, col: 41, offset: 30378},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1101, col: 9, offset: 31100},
+							pos:        position{line: 1076, col: 9, offset: 30395},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1101, col: 18, offset: 31109},
+							pos:        position{line: 1076, col: 18, offset: 30404},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1101, col: 28, offset: 31119},
+							pos:        position{line: 1076, col: 28, offset: 30414},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1101, col: 38, offset: 31129},
+							pos:        position{line: 1076, col: 38, offset: 30424},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1102, col: 9, offset: 31145},
+							pos:        position{line: 1077, col: 9, offset: 30440},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1102, col: 21, offset: 31157},
+							pos:        position{line: 1077, col: 21, offset: 30452},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 9, offset: 31175},
+							pos:        position{line: 1078, col: 9, offset: 30470},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 18, offset: 31184},
+							pos:        position{line: 1078, col: 18, offset: 30479},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1104, col: 9, offset: 31201},
+							pos:        position{line: 1079, col: 9, offset: 30496},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1104, col: 22, offset: 31214},
+							pos:        position{line: 1079, col: 22, offset: 30509},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1105, col: 9, offset: 31229},
+							pos:        position{line: 1080, col: 9, offset: 30524},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1106, col: 9, offset: 31245},
+							pos:        position{line: 1081, col: 9, offset: 30540},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1106, col: 16, offset: 31252},
+							pos:        position{line: 1081, col: 16, offset: 30547},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1107, col: 9, offset: 31266},
+							pos:        position{line: 1082, col: 9, offset: 30561},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1107, col: 18, offset: 31275},
+							pos:        position{line: 1082, col: 18, offset: 30570},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8902,31 +8734,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1111, col: 1, offset: 31391},
+			pos:  position{line: 1086, col: 1, offset: 30686},
 			expr: &choiceExpr{
-				pos: position{line: 1112, col: 5, offset: 31409},
+				pos: position{line: 1087, col: 5, offset: 30704},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1112, col: 5, offset: 31409},
+						pos: position{line: 1087, col: 5, offset: 30704},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1112, col: 5, offset: 31409},
+							pos: position{line: 1087, col: 5, offset: 30704},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1112, col: 5, offset: 31409},
+									pos:   position{line: 1087, col: 5, offset: 30704},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1112, col: 11, offset: 31415},
+										pos:  position{line: 1087, col: 11, offset: 30710},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1112, col: 21, offset: 31425},
+									pos:   position{line: 1087, col: 21, offset: 30720},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1112, col: 26, offset: 31430},
+										pos: position{line: 1087, col: 26, offset: 30725},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1112, col: 26, offset: 31430},
+											pos:  position{line: 1087, col: 26, offset: 30725},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -8935,10 +8767,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1115, col: 5, offset: 31532},
+						pos: position{line: 1090, col: 5, offset: 30827},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1115, col: 5, offset: 31532},
+							pos:        position{line: 1090, col: 5, offset: 30827},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8948,31 +8780,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1117, col: 1, offset: 31556},
+			pos:  position{line: 1092, col: 1, offset: 30851},
 			expr: &actionExpr{
-				pos: position{line: 1117, col: 21, offset: 31576},
+				pos: position{line: 1092, col: 21, offset: 30871},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1117, col: 21, offset: 31576},
+					pos: position{line: 1092, col: 21, offset: 30871},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1117, col: 21, offset: 31576},
+							pos:  position{line: 1092, col: 21, offset: 30871},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1117, col: 24, offset: 31579},
+							pos:        position{line: 1092, col: 24, offset: 30874},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1117, col: 28, offset: 31583},
+							pos:  position{line: 1092, col: 28, offset: 30878},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1117, col: 31, offset: 31586},
+							pos:   position{line: 1092, col: 31, offset: 30881},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1117, col: 35, offset: 31590},
+								pos:  position{line: 1092, col: 35, offset: 30885},
 								name: "TypeField",
 							},
 						},
@@ -8982,39 +8814,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1119, col: 1, offset: 31621},
+			pos:  position{line: 1094, col: 1, offset: 30916},
 			expr: &actionExpr{
-				pos: position{line: 1120, col: 5, offset: 31635},
+				pos: position{line: 1095, col: 5, offset: 30930},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1120, col: 5, offset: 31635},
+					pos: position{line: 1095, col: 5, offset: 30930},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1120, col: 5, offset: 31635},
+							pos:   position{line: 1095, col: 5, offset: 30930},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1120, col: 10, offset: 31640},
+								pos:  position{line: 1095, col: 10, offset: 30935},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1120, col: 20, offset: 31650},
+							pos:  position{line: 1095, col: 20, offset: 30945},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1120, col: 23, offset: 31653},
+							pos:        position{line: 1095, col: 23, offset: 30948},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1120, col: 27, offset: 31657},
+							pos:  position{line: 1095, col: 27, offset: 30952},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1120, col: 30, offset: 31660},
+							pos:   position{line: 1095, col: 30, offset: 30955},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1120, col: 34, offset: 31664},
+								pos:  position{line: 1095, col: 34, offset: 30959},
 								name: "Type",
 							},
 						},
@@ -9024,16 +8856,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1124, col: 1, offset: 31746},
+			pos:  position{line: 1099, col: 1, offset: 31041},
 			expr: &choiceExpr{
-				pos: position{line: 1125, col: 5, offset: 31760},
+				pos: position{line: 1100, col: 5, offset: 31055},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1125, col: 5, offset: 31760},
+						pos:  position{line: 1100, col: 5, offset: 31055},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1126, col: 5, offset: 31779},
+						pos:  position{line: 1101, col: 5, offset: 31074},
 						name: "QuotedString",
 					},
 				},
@@ -9041,32 +8873,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1128, col: 1, offset: 31793},
+			pos:  position{line: 1103, col: 1, offset: 31088},
 			expr: &actionExpr{
-				pos: position{line: 1128, col: 12, offset: 31804},
+				pos: position{line: 1103, col: 12, offset: 31099},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1128, col: 12, offset: 31804},
+					pos: position{line: 1103, col: 12, offset: 31099},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1128, col: 13, offset: 31805},
+							pos: position{line: 1103, col: 13, offset: 31100},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1128, col: 13, offset: 31805},
+									pos:        position{line: 1103, col: 13, offset: 31100},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1128, col: 21, offset: 31813},
+									pos:        position{line: 1103, col: 21, offset: 31108},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1128, col: 28, offset: 31820},
+							pos: position{line: 1103, col: 28, offset: 31115},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1128, col: 29, offset: 31821},
+								pos:  position{line: 1103, col: 29, offset: 31116},
 								name: "IdentifierRest",
 							},
 						},
@@ -9076,32 +8908,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1129, col: 1, offset: 31858},
+			pos:  position{line: 1104, col: 1, offset: 31153},
 			expr: &actionExpr{
-				pos: position{line: 1129, col: 11, offset: 31868},
+				pos: position{line: 1104, col: 11, offset: 31163},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1129, col: 11, offset: 31868},
+					pos: position{line: 1104, col: 11, offset: 31163},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1129, col: 12, offset: 31869},
+							pos: position{line: 1104, col: 12, offset: 31164},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1129, col: 12, offset: 31869},
+									pos:        position{line: 1104, col: 12, offset: 31164},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1129, col: 19, offset: 31876},
+									pos:        position{line: 1104, col: 19, offset: 31171},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1129, col: 25, offset: 31882},
+							pos: position{line: 1104, col: 25, offset: 31177},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1129, col: 26, offset: 31883},
+								pos:  position{line: 1104, col: 26, offset: 31178},
 								name: "IdentifierRest",
 							},
 						},
@@ -9111,22 +8943,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1130, col: 1, offset: 31919},
+			pos:  position{line: 1105, col: 1, offset: 31214},
 			expr: &actionExpr{
-				pos: position{line: 1130, col: 11, offset: 31929},
+				pos: position{line: 1105, col: 11, offset: 31224},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1130, col: 11, offset: 31929},
+					pos: position{line: 1105, col: 11, offset: 31224},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1130, col: 11, offset: 31929},
+							pos:        position{line: 1105, col: 11, offset: 31224},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1130, col: 16, offset: 31934},
+							pos: position{line: 1105, col: 16, offset: 31229},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1130, col: 17, offset: 31935},
+								pos:  position{line: 1105, col: 17, offset: 31230},
 								name: "IdentifierRest",
 							},
 						},
@@ -9136,32 +8968,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1131, col: 1, offset: 31971},
+			pos:  position{line: 1106, col: 1, offset: 31266},
 			expr: &actionExpr{
-				pos: position{line: 1131, col: 12, offset: 31982},
+				pos: position{line: 1106, col: 12, offset: 31277},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1131, col: 12, offset: 31982},
+					pos: position{line: 1106, col: 12, offset: 31277},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1131, col: 13, offset: 31983},
+							pos: position{line: 1106, col: 13, offset: 31278},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1131, col: 13, offset: 31983},
+									pos:        position{line: 1106, col: 13, offset: 31278},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1131, col: 21, offset: 31991},
+									pos:        position{line: 1106, col: 21, offset: 31286},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1131, col: 28, offset: 31998},
+							pos: position{line: 1106, col: 28, offset: 31293},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1131, col: 29, offset: 31999},
+								pos:  position{line: 1106, col: 29, offset: 31294},
 								name: "IdentifierRest",
 							},
 						},
@@ -9171,22 +9003,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1132, col: 1, offset: 32036},
+			pos:  position{line: 1107, col: 1, offset: 31331},
 			expr: &actionExpr{
-				pos: position{line: 1132, col: 11, offset: 32046},
+				pos: position{line: 1107, col: 11, offset: 31341},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1132, col: 11, offset: 32046},
+					pos: position{line: 1107, col: 11, offset: 31341},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1132, col: 11, offset: 32046},
+							pos:        position{line: 1107, col: 11, offset: 31341},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1132, col: 16, offset: 32051},
+							pos: position{line: 1107, col: 16, offset: 31346},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1132, col: 17, offset: 32052},
+								pos:  position{line: 1107, col: 17, offset: 31347},
 								name: "IdentifierRest",
 							},
 						},
@@ -9196,9 +9028,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1134, col: 1, offset: 32089},
+			pos:  position{line: 1109, col: 1, offset: 31384},
 			expr: &charClassMatcher{
-				pos:        position{line: 1134, col: 19, offset: 32107},
+				pos:        position{line: 1109, col: 19, offset: 31402},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9208,16 +9040,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1136, col: 1, offset: 32119},
+			pos:  position{line: 1111, col: 1, offset: 31414},
 			expr: &choiceExpr{
-				pos: position{line: 1136, col: 18, offset: 32136},
+				pos: position{line: 1111, col: 18, offset: 31431},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1136, col: 18, offset: 32136},
+						pos:  position{line: 1111, col: 18, offset: 31431},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1136, col: 36, offset: 32154},
+						pos:        position{line: 1111, col: 36, offset: 31449},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9228,15 +9060,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1138, col: 1, offset: 32161},
+			pos:  position{line: 1113, col: 1, offset: 31456},
 			expr: &actionExpr{
-				pos: position{line: 1139, col: 5, offset: 32176},
+				pos: position{line: 1114, col: 5, offset: 31471},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1139, col: 5, offset: 32176},
+					pos:   position{line: 1114, col: 5, offset: 31471},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1139, col: 8, offset: 32179},
+						pos:  position{line: 1114, col: 8, offset: 31474},
 						name: "IdentifierName",
 					},
 				},
@@ -9244,29 +9076,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1141, col: 1, offset: 32260},
+			pos:  position{line: 1116, col: 1, offset: 31555},
 			expr: &choiceExpr{
-				pos: position{line: 1142, col: 5, offset: 32279},
+				pos: position{line: 1117, col: 5, offset: 31574},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1142, col: 5, offset: 32279},
+						pos: position{line: 1117, col: 5, offset: 31574},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1142, col: 5, offset: 32279},
+							pos: position{line: 1117, col: 5, offset: 31574},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1142, col: 5, offset: 32279},
+									pos: position{line: 1117, col: 5, offset: 31574},
 									expr: &seqExpr{
-										pos: position{line: 1142, col: 7, offset: 32281},
+										pos: position{line: 1117, col: 7, offset: 31576},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1142, col: 7, offset: 32281},
+												pos:  position{line: 1117, col: 7, offset: 31576},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1142, col: 15, offset: 32289},
+												pos: position{line: 1117, col: 15, offset: 31584},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1142, col: 16, offset: 32290},
+													pos:  position{line: 1117, col: 16, offset: 31585},
 													name: "IdentifierRest",
 												},
 											},
@@ -9274,13 +9106,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1142, col: 32, offset: 32306},
+									pos:  position{line: 1117, col: 32, offset: 31601},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1142, col: 48, offset: 32322},
+									pos: position{line: 1117, col: 48, offset: 31617},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1142, col: 48, offset: 32322},
+										pos:  position{line: 1117, col: 48, offset: 31617},
 										name: "IdentifierRest",
 									},
 								},
@@ -9288,30 +9120,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1143, col: 5, offset: 32374},
+						pos: position{line: 1118, col: 5, offset: 31669},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1143, col: 5, offset: 32374},
+							pos:        position{line: 1118, col: 5, offset: 31669},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1144, col: 5, offset: 32413},
+						pos: position{line: 1119, col: 5, offset: 31708},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1144, col: 5, offset: 32413},
+							pos: position{line: 1119, col: 5, offset: 31708},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1144, col: 5, offset: 32413},
+									pos:        position{line: 1119, col: 5, offset: 31708},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1144, col: 10, offset: 32418},
+									pos:   position{line: 1119, col: 10, offset: 31713},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1144, col: 13, offset: 32421},
+										pos:  position{line: 1119, col: 13, offset: 31716},
 										name: "IDGuard",
 									},
 								},
@@ -9319,39 +9151,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1146, col: 5, offset: 32512},
+						pos: position{line: 1121, col: 5, offset: 31807},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1146, col: 5, offset: 32512},
+							pos:        position{line: 1121, col: 5, offset: 31807},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1147, col: 5, offset: 32554},
+						pos: position{line: 1122, col: 5, offset: 31849},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1147, col: 5, offset: 32554},
+							pos: position{line: 1122, col: 5, offset: 31849},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1147, col: 5, offset: 32554},
+									pos:   position{line: 1122, col: 5, offset: 31849},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1147, col: 8, offset: 32557},
+										pos:  position{line: 1122, col: 8, offset: 31852},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1147, col: 26, offset: 32575},
+									pos: position{line: 1122, col: 26, offset: 31870},
 									expr: &seqExpr{
-										pos: position{line: 1147, col: 28, offset: 32577},
+										pos: position{line: 1122, col: 28, offset: 31872},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1147, col: 28, offset: 32577},
+												pos:  position{line: 1122, col: 28, offset: 31872},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1147, col: 31, offset: 32580},
+												pos:        position{line: 1122, col: 31, offset: 31875},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9366,24 +9198,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1149, col: 1, offset: 32605},
+			pos:  position{line: 1124, col: 1, offset: 31900},
 			expr: &choiceExpr{
-				pos: position{line: 1150, col: 5, offset: 32617},
+				pos: position{line: 1125, col: 5, offset: 31912},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1150, col: 5, offset: 32617},
+						pos:  position{line: 1125, col: 5, offset: 31912},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1151, col: 5, offset: 32636},
+						pos:  position{line: 1126, col: 5, offset: 31931},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1152, col: 5, offset: 32652},
+						pos:  position{line: 1127, col: 5, offset: 31947},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1153, col: 5, offset: 32660},
+						pos:  position{line: 1128, col: 5, offset: 31955},
 						name: "Infinity",
 					},
 				},
@@ -9391,24 +9223,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1155, col: 1, offset: 32670},
+			pos:  position{line: 1130, col: 1, offset: 31965},
 			expr: &actionExpr{
-				pos: position{line: 1156, col: 5, offset: 32679},
+				pos: position{line: 1131, col: 5, offset: 31974},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1156, col: 5, offset: 32679},
+					pos: position{line: 1131, col: 5, offset: 31974},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 5, offset: 32679},
+							pos:  position{line: 1131, col: 5, offset: 31974},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1156, col: 14, offset: 32688},
+							pos:        position{line: 1131, col: 14, offset: 31983},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 18, offset: 32692},
+							pos:  position{line: 1131, col: 18, offset: 31987},
 							name: "FullTime",
 						},
 					},
@@ -9417,30 +9249,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1160, col: 1, offset: 32812},
+			pos:  position{line: 1135, col: 1, offset: 32107},
 			expr: &seqExpr{
-				pos: position{line: 1160, col: 12, offset: 32823},
+				pos: position{line: 1135, col: 12, offset: 32118},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 12, offset: 32823},
+						pos:  position{line: 1135, col: 12, offset: 32118},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1160, col: 15, offset: 32826},
+						pos:        position{line: 1135, col: 15, offset: 32121},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 19, offset: 32830},
+						pos:  position{line: 1135, col: 19, offset: 32125},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1160, col: 22, offset: 32833},
+						pos:        position{line: 1135, col: 22, offset: 32128},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 26, offset: 32837},
+						pos:  position{line: 1135, col: 26, offset: 32132},
 						name: "D2",
 					},
 				},
@@ -9448,33 +9280,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1162, col: 1, offset: 32841},
+			pos:  position{line: 1137, col: 1, offset: 32136},
 			expr: &seqExpr{
-				pos: position{line: 1162, col: 6, offset: 32846},
+				pos: position{line: 1137, col: 6, offset: 32141},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1162, col: 6, offset: 32846},
+						pos:        position{line: 1137, col: 6, offset: 32141},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1162, col: 11, offset: 32851},
+						pos:        position{line: 1137, col: 11, offset: 32146},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1162, col: 16, offset: 32856},
+						pos:        position{line: 1137, col: 16, offset: 32151},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1162, col: 21, offset: 32861},
+						pos:        position{line: 1137, col: 21, offset: 32156},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9485,19 +9317,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1163, col: 1, offset: 32867},
+			pos:  position{line: 1138, col: 1, offset: 32162},
 			expr: &seqExpr{
-				pos: position{line: 1163, col: 6, offset: 32872},
+				pos: position{line: 1138, col: 6, offset: 32167},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1163, col: 6, offset: 32872},
+						pos:        position{line: 1138, col: 6, offset: 32167},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1163, col: 11, offset: 32877},
+						pos:        position{line: 1138, col: 11, offset: 32172},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9508,16 +9340,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1165, col: 1, offset: 32884},
+			pos:  position{line: 1140, col: 1, offset: 32179},
 			expr: &seqExpr{
-				pos: position{line: 1165, col: 12, offset: 32895},
+				pos: position{line: 1140, col: 12, offset: 32190},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 12, offset: 32895},
+						pos:  position{line: 1140, col: 12, offset: 32190},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 24, offset: 32907},
+						pos:  position{line: 1140, col: 24, offset: 32202},
 						name: "TimeOffset",
 					},
 				},
@@ -9525,46 +9357,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1167, col: 1, offset: 32919},
+			pos:  position{line: 1142, col: 1, offset: 32214},
 			expr: &seqExpr{
-				pos: position{line: 1167, col: 15, offset: 32933},
+				pos: position{line: 1142, col: 15, offset: 32228},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 15, offset: 32933},
+						pos:  position{line: 1142, col: 15, offset: 32228},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1167, col: 18, offset: 32936},
+						pos:        position{line: 1142, col: 18, offset: 32231},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 22, offset: 32940},
+						pos:  position{line: 1142, col: 22, offset: 32235},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1167, col: 25, offset: 32943},
+						pos:        position{line: 1142, col: 25, offset: 32238},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 29, offset: 32947},
+						pos:  position{line: 1142, col: 29, offset: 32242},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1167, col: 32, offset: 32950},
+						pos: position{line: 1142, col: 32, offset: 32245},
 						expr: &seqExpr{
-							pos: position{line: 1167, col: 33, offset: 32951},
+							pos: position{line: 1142, col: 33, offset: 32246},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1167, col: 33, offset: 32951},
+									pos:        position{line: 1142, col: 33, offset: 32246},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1167, col: 37, offset: 32955},
+									pos: position{line: 1142, col: 37, offset: 32250},
 									expr: &charClassMatcher{
-										pos:        position{line: 1167, col: 37, offset: 32955},
+										pos:        position{line: 1142, col: 37, offset: 32250},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9579,60 +9411,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1169, col: 1, offset: 32965},
+			pos:  position{line: 1144, col: 1, offset: 32260},
 			expr: &choiceExpr{
-				pos: position{line: 1170, col: 5, offset: 32980},
+				pos: position{line: 1145, col: 5, offset: 32275},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1170, col: 5, offset: 32980},
+						pos:        position{line: 1145, col: 5, offset: 32275},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1171, col: 5, offset: 32988},
+						pos: position{line: 1146, col: 5, offset: 32283},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1171, col: 6, offset: 32989},
+								pos: position{line: 1146, col: 6, offset: 32284},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1171, col: 6, offset: 32989},
+										pos:        position{line: 1146, col: 6, offset: 32284},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1171, col: 12, offset: 32995},
+										pos:        position{line: 1146, col: 12, offset: 32290},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1171, col: 17, offset: 33000},
+								pos:  position{line: 1146, col: 17, offset: 32295},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1171, col: 20, offset: 33003},
+								pos:        position{line: 1146, col: 20, offset: 32298},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1171, col: 24, offset: 33007},
+								pos:  position{line: 1146, col: 24, offset: 32302},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1171, col: 27, offset: 33010},
+								pos: position{line: 1146, col: 27, offset: 32305},
 								expr: &seqExpr{
-									pos: position{line: 1171, col: 28, offset: 33011},
+									pos: position{line: 1146, col: 28, offset: 32306},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1171, col: 28, offset: 33011},
+											pos:        position{line: 1146, col: 28, offset: 32306},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1171, col: 32, offset: 33015},
+											pos: position{line: 1146, col: 32, offset: 32310},
 											expr: &charClassMatcher{
-												pos:        position{line: 1171, col: 32, offset: 33015},
+												pos:        position{line: 1146, col: 32, offset: 32310},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9649,32 +9481,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1173, col: 1, offset: 33025},
+			pos:  position{line: 1148, col: 1, offset: 32320},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 5, offset: 33038},
+				pos: position{line: 1149, col: 5, offset: 32333},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1174, col: 5, offset: 33038},
+					pos: position{line: 1149, col: 5, offset: 32333},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1174, col: 5, offset: 33038},
+							pos: position{line: 1149, col: 5, offset: 32333},
 							expr: &litMatcher{
-								pos:        position{line: 1174, col: 5, offset: 33038},
+								pos:        position{line: 1149, col: 5, offset: 32333},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1174, col: 10, offset: 33043},
+							pos: position{line: 1149, col: 10, offset: 32338},
 							expr: &seqExpr{
-								pos: position{line: 1174, col: 11, offset: 33044},
+								pos: position{line: 1149, col: 11, offset: 32339},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1174, col: 11, offset: 33044},
+										pos:  position{line: 1149, col: 11, offset: 32339},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1174, col: 19, offset: 33052},
+										pos:  position{line: 1149, col: 19, offset: 32347},
 										name: "TimeUnit",
 									},
 								},
@@ -9686,26 +9518,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1178, col: 1, offset: 33178},
+			pos:  position{line: 1153, col: 1, offset: 32473},
 			expr: &seqExpr{
-				pos: position{line: 1178, col: 11, offset: 33188},
+				pos: position{line: 1153, col: 11, offset: 32483},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1178, col: 11, offset: 33188},
+						pos:  position{line: 1153, col: 11, offset: 32483},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1178, col: 16, offset: 33193},
+						pos: position{line: 1153, col: 16, offset: 32488},
 						expr: &seqExpr{
-							pos: position{line: 1178, col: 17, offset: 33194},
+							pos: position{line: 1153, col: 17, offset: 32489},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1178, col: 17, offset: 33194},
+									pos:        position{line: 1153, col: 17, offset: 32489},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1178, col: 21, offset: 33198},
+									pos:  position{line: 1153, col: 21, offset: 32493},
 									name: "UInt",
 								},
 							},
@@ -9716,52 +9548,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1180, col: 1, offset: 33206},
+			pos:  position{line: 1155, col: 1, offset: 32501},
 			expr: &choiceExpr{
-				pos: position{line: 1181, col: 5, offset: 33219},
+				pos: position{line: 1156, col: 5, offset: 32514},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1181, col: 5, offset: 33219},
+						pos:        position{line: 1156, col: 5, offset: 32514},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1182, col: 5, offset: 33228},
+						pos:        position{line: 1157, col: 5, offset: 32523},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1183, col: 5, offset: 33237},
+						pos:        position{line: 1158, col: 5, offset: 32532},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1184, col: 5, offset: 33246},
+						pos:        position{line: 1159, col: 5, offset: 32541},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1185, col: 5, offset: 33254},
+						pos:        position{line: 1160, col: 5, offset: 32549},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1186, col: 5, offset: 33262},
+						pos:        position{line: 1161, col: 5, offset: 32557},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1187, col: 5, offset: 33270},
+						pos:        position{line: 1162, col: 5, offset: 32565},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1188, col: 5, offset: 33278},
+						pos:        position{line: 1163, col: 5, offset: 32573},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1189, col: 5, offset: 33286},
+						pos:        position{line: 1164, col: 5, offset: 32581},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9770,42 +9602,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1191, col: 1, offset: 33291},
+			pos:  position{line: 1166, col: 1, offset: 32586},
 			expr: &actionExpr{
-				pos: position{line: 1192, col: 5, offset: 33298},
+				pos: position{line: 1167, col: 5, offset: 32593},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1192, col: 5, offset: 33298},
+					pos: position{line: 1167, col: 5, offset: 32593},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 5, offset: 33298},
+							pos:  position{line: 1167, col: 5, offset: 32593},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1192, col: 10, offset: 33303},
+							pos:        position{line: 1167, col: 10, offset: 32598},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 14, offset: 33307},
+							pos:  position{line: 1167, col: 14, offset: 32602},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1192, col: 19, offset: 33312},
+							pos:        position{line: 1167, col: 19, offset: 32607},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 23, offset: 33316},
+							pos:  position{line: 1167, col: 23, offset: 32611},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1192, col: 28, offset: 33321},
+							pos:        position{line: 1167, col: 28, offset: 32616},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 32, offset: 33325},
+							pos:  position{line: 1167, col: 32, offset: 32620},
 							name: "UInt",
 						},
 					},
@@ -9814,42 +9646,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1194, col: 1, offset: 33362},
+			pos:  position{line: 1169, col: 1, offset: 32657},
 			expr: &actionExpr{
-				pos: position{line: 1195, col: 5, offset: 33370},
+				pos: position{line: 1170, col: 5, offset: 32665},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1195, col: 5, offset: 33370},
+					pos: position{line: 1170, col: 5, offset: 32665},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1195, col: 5, offset: 33370},
+							pos: position{line: 1170, col: 5, offset: 32665},
 							expr: &seqExpr{
-								pos: position{line: 1195, col: 8, offset: 33373},
+								pos: position{line: 1170, col: 8, offset: 32668},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1195, col: 8, offset: 33373},
+										pos:  position{line: 1170, col: 8, offset: 32668},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1195, col: 12, offset: 33377},
+										pos:        position{line: 1170, col: 12, offset: 32672},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1195, col: 16, offset: 33381},
+										pos:  position{line: 1170, col: 16, offset: 32676},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1195, col: 20, offset: 33385},
+										pos: position{line: 1170, col: 20, offset: 32680},
 										expr: &choiceExpr{
-											pos: position{line: 1195, col: 22, offset: 33387},
+											pos: position{line: 1170, col: 22, offset: 32682},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1195, col: 22, offset: 33387},
+													pos:  position{line: 1170, col: 22, offset: 32682},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1195, col: 33, offset: 33398},
+													pos:        position{line: 1170, col: 33, offset: 32693},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9860,10 +9692,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1195, col: 39, offset: 33404},
+							pos:   position{line: 1170, col: 39, offset: 32699},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1195, col: 41, offset: 33406},
+								pos:  position{line: 1170, col: 41, offset: 32701},
 								name: "IP6Variations",
 							},
 						},
@@ -9873,32 +9705,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1199, col: 1, offset: 33570},
+			pos:  position{line: 1174, col: 1, offset: 32865},
 			expr: &choiceExpr{
-				pos: position{line: 1200, col: 5, offset: 33588},
+				pos: position{line: 1175, col: 5, offset: 32883},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1200, col: 5, offset: 33588},
+						pos: position{line: 1175, col: 5, offset: 32883},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1200, col: 5, offset: 33588},
+							pos: position{line: 1175, col: 5, offset: 32883},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1200, col: 5, offset: 33588},
+									pos:   position{line: 1175, col: 5, offset: 32883},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1200, col: 7, offset: 33590},
+										pos: position{line: 1175, col: 7, offset: 32885},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1200, col: 7, offset: 33590},
+											pos:  position{line: 1175, col: 7, offset: 32885},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1200, col: 17, offset: 33600},
+									pos:   position{line: 1175, col: 17, offset: 32895},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1200, col: 19, offset: 33602},
+										pos:  position{line: 1175, col: 19, offset: 32897},
 										name: "IP6Tail",
 									},
 								},
@@ -9906,51 +9738,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1203, col: 5, offset: 33666},
+						pos: position{line: 1178, col: 5, offset: 32961},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1203, col: 5, offset: 33666},
+							pos: position{line: 1178, col: 5, offset: 32961},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1203, col: 5, offset: 33666},
+									pos:   position{line: 1178, col: 5, offset: 32961},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1203, col: 7, offset: 33668},
+										pos:  position{line: 1178, col: 7, offset: 32963},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 11, offset: 33672},
+									pos:   position{line: 1178, col: 11, offset: 32967},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1203, col: 13, offset: 33674},
+										pos: position{line: 1178, col: 13, offset: 32969},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1203, col: 13, offset: 33674},
+											pos:  position{line: 1178, col: 13, offset: 32969},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1203, col: 23, offset: 33684},
+									pos:        position{line: 1178, col: 23, offset: 32979},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 28, offset: 33689},
+									pos:   position{line: 1178, col: 28, offset: 32984},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1203, col: 30, offset: 33691},
+										pos: position{line: 1178, col: 30, offset: 32986},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1203, col: 30, offset: 33691},
+											pos:  position{line: 1178, col: 30, offset: 32986},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 40, offset: 33701},
+									pos:   position{line: 1178, col: 40, offset: 32996},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1203, col: 42, offset: 33703},
+										pos:  position{line: 1178, col: 42, offset: 32998},
 										name: "IP6Tail",
 									},
 								},
@@ -9958,32 +9790,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1206, col: 5, offset: 33802},
+						pos: position{line: 1181, col: 5, offset: 33097},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1206, col: 5, offset: 33802},
+							pos: position{line: 1181, col: 5, offset: 33097},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1206, col: 5, offset: 33802},
+									pos:        position{line: 1181, col: 5, offset: 33097},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1206, col: 10, offset: 33807},
+									pos:   position{line: 1181, col: 10, offset: 33102},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1206, col: 12, offset: 33809},
+										pos: position{line: 1181, col: 12, offset: 33104},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1206, col: 12, offset: 33809},
+											pos:  position{line: 1181, col: 12, offset: 33104},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1206, col: 22, offset: 33819},
+									pos:   position{line: 1181, col: 22, offset: 33114},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1206, col: 24, offset: 33821},
+										pos:  position{line: 1181, col: 24, offset: 33116},
 										name: "IP6Tail",
 									},
 								},
@@ -9991,32 +9823,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1209, col: 5, offset: 33892},
+						pos: position{line: 1184, col: 5, offset: 33187},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1209, col: 5, offset: 33892},
+							pos: position{line: 1184, col: 5, offset: 33187},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1209, col: 5, offset: 33892},
+									pos:   position{line: 1184, col: 5, offset: 33187},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1209, col: 7, offset: 33894},
+										pos:  position{line: 1184, col: 7, offset: 33189},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1209, col: 11, offset: 33898},
+									pos:   position{line: 1184, col: 11, offset: 33193},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1209, col: 13, offset: 33900},
+										pos: position{line: 1184, col: 13, offset: 33195},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1209, col: 13, offset: 33900},
+											pos:  position{line: 1184, col: 13, offset: 33195},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1209, col: 23, offset: 33910},
+									pos:        position{line: 1184, col: 23, offset: 33205},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -10024,10 +9856,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1212, col: 5, offset: 33978},
+						pos: position{line: 1187, col: 5, offset: 33273},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1212, col: 5, offset: 33978},
+							pos:        position{line: 1187, col: 5, offset: 33273},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -10037,16 +9869,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1216, col: 1, offset: 34015},
+			pos:  position{line: 1191, col: 1, offset: 33310},
 			expr: &choiceExpr{
-				pos: position{line: 1217, col: 5, offset: 34027},
+				pos: position{line: 1192, col: 5, offset: 33322},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 5, offset: 34027},
+						pos:  position{line: 1192, col: 5, offset: 33322},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1218, col: 5, offset: 34034},
+						pos:  position{line: 1193, col: 5, offset: 33329},
 						name: "Hex",
 					},
 				},
@@ -10054,23 +9886,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1220, col: 1, offset: 34039},
+			pos:  position{line: 1195, col: 1, offset: 33334},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 12, offset: 34050},
+				pos: position{line: 1195, col: 12, offset: 33345},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 12, offset: 34050},
+					pos: position{line: 1195, col: 12, offset: 33345},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1220, col: 12, offset: 34050},
+							pos:        position{line: 1195, col: 12, offset: 33345},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1220, col: 16, offset: 34054},
+							pos:   position{line: 1195, col: 16, offset: 33349},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 18, offset: 34056},
+								pos:  position{line: 1195, col: 18, offset: 33351},
 								name: "Hex",
 							},
 						},
@@ -10080,23 +9912,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1222, col: 1, offset: 34094},
+			pos:  position{line: 1197, col: 1, offset: 33389},
 			expr: &actionExpr{
-				pos: position{line: 1222, col: 12, offset: 34105},
+				pos: position{line: 1197, col: 12, offset: 33400},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1222, col: 12, offset: 34105},
+					pos: position{line: 1197, col: 12, offset: 33400},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1222, col: 12, offset: 34105},
+							pos:   position{line: 1197, col: 12, offset: 33400},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1222, col: 14, offset: 34107},
+								pos:  position{line: 1197, col: 14, offset: 33402},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1222, col: 18, offset: 34111},
+							pos:        position{line: 1197, col: 18, offset: 33406},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -10106,31 +9938,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1224, col: 1, offset: 34149},
+			pos:  position{line: 1199, col: 1, offset: 33444},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 34160},
+				pos: position{line: 1200, col: 5, offset: 33455},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 34160},
+					pos: position{line: 1200, col: 5, offset: 33455},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1225, col: 5, offset: 34160},
+							pos:   position{line: 1200, col: 5, offset: 33455},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 7, offset: 34162},
+								pos:  position{line: 1200, col: 7, offset: 33457},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1225, col: 10, offset: 34165},
+							pos:        position{line: 1200, col: 10, offset: 33460},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 14, offset: 34169},
+							pos:   position{line: 1200, col: 14, offset: 33464},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 16, offset: 34171},
+								pos:  position{line: 1200, col: 16, offset: 33466},
 								name: "UInt",
 							},
 						},
@@ -10140,31 +9972,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1229, col: 1, offset: 34244},
+			pos:  position{line: 1204, col: 1, offset: 33539},
 			expr: &actionExpr{
-				pos: position{line: 1230, col: 5, offset: 34255},
+				pos: position{line: 1205, col: 5, offset: 33550},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1230, col: 5, offset: 34255},
+					pos: position{line: 1205, col: 5, offset: 33550},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1230, col: 5, offset: 34255},
+							pos:   position{line: 1205, col: 5, offset: 33550},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1230, col: 7, offset: 34257},
+								pos:  position{line: 1205, col: 7, offset: 33552},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1230, col: 11, offset: 34261},
+							pos:        position{line: 1205, col: 11, offset: 33556},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1230, col: 15, offset: 34265},
+							pos:   position{line: 1205, col: 15, offset: 33560},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1230, col: 17, offset: 34267},
+								pos:  position{line: 1205, col: 17, offset: 33562},
 								name: "UInt",
 							},
 						},
@@ -10174,15 +10006,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1234, col: 1, offset: 34330},
+			pos:  position{line: 1209, col: 1, offset: 33625},
 			expr: &actionExpr{
-				pos: position{line: 1235, col: 4, offset: 34338},
+				pos: position{line: 1210, col: 4, offset: 33633},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1235, col: 4, offset: 34338},
+					pos:   position{line: 1210, col: 4, offset: 33633},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1235, col: 6, offset: 34340},
+						pos:  position{line: 1210, col: 6, offset: 33635},
 						name: "UIntString",
 					},
 				},
@@ -10190,16 +10022,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1237, col: 1, offset: 34380},
+			pos:  position{line: 1212, col: 1, offset: 33675},
 			expr: &choiceExpr{
-				pos: position{line: 1238, col: 5, offset: 34394},
+				pos: position{line: 1213, col: 5, offset: 33689},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1238, col: 5, offset: 34394},
+						pos:  position{line: 1213, col: 5, offset: 33689},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1239, col: 5, offset: 34409},
+						pos:  position{line: 1214, col: 5, offset: 33704},
 						name: "MinusIntString",
 					},
 				},
@@ -10207,14 +10039,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1241, col: 1, offset: 34425},
+			pos:  position{line: 1216, col: 1, offset: 33720},
 			expr: &actionExpr{
-				pos: position{line: 1241, col: 14, offset: 34438},
+				pos: position{line: 1216, col: 14, offset: 33733},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1241, col: 14, offset: 34438},
+					pos: position{line: 1216, col: 14, offset: 33733},
 					expr: &charClassMatcher{
-						pos:        position{line: 1241, col: 14, offset: 34438},
+						pos:        position{line: 1216, col: 14, offset: 33733},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10225,20 +10057,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1243, col: 1, offset: 34477},
+			pos:  position{line: 1218, col: 1, offset: 33772},
 			expr: &actionExpr{
-				pos: position{line: 1244, col: 5, offset: 34496},
+				pos: position{line: 1219, col: 5, offset: 33791},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1244, col: 5, offset: 34496},
+					pos: position{line: 1219, col: 5, offset: 33791},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1244, col: 5, offset: 34496},
+							pos:        position{line: 1219, col: 5, offset: 33791},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 9, offset: 34500},
+							pos:  position{line: 1219, col: 9, offset: 33795},
 							name: "UIntString",
 						},
 					},
@@ -10247,28 +10079,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1246, col: 1, offset: 34543},
+			pos:  position{line: 1221, col: 1, offset: 33838},
 			expr: &choiceExpr{
-				pos: position{line: 1247, col: 5, offset: 34559},
+				pos: position{line: 1222, col: 5, offset: 33854},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1247, col: 5, offset: 34559},
+						pos: position{line: 1222, col: 5, offset: 33854},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1247, col: 5, offset: 34559},
+							pos: position{line: 1222, col: 5, offset: 33854},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1247, col: 5, offset: 34559},
+									pos: position{line: 1222, col: 5, offset: 33854},
 									expr: &litMatcher{
-										pos:        position{line: 1247, col: 5, offset: 34559},
+										pos:        position{line: 1222, col: 5, offset: 33854},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1247, col: 10, offset: 34564},
+									pos: position{line: 1222, col: 10, offset: 33859},
 									expr: &charClassMatcher{
-										pos:        position{line: 1247, col: 10, offset: 34564},
+										pos:        position{line: 1222, col: 10, offset: 33859},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10276,14 +10108,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1247, col: 17, offset: 34571},
+									pos:        position{line: 1222, col: 17, offset: 33866},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1247, col: 21, offset: 34575},
+									pos: position{line: 1222, col: 21, offset: 33870},
 									expr: &charClassMatcher{
-										pos:        position{line: 1247, col: 21, offset: 34575},
+										pos:        position{line: 1222, col: 21, offset: 33870},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10291,9 +10123,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1247, col: 28, offset: 34582},
+									pos: position{line: 1222, col: 28, offset: 33877},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1247, col: 28, offset: 34582},
+										pos:  position{line: 1222, col: 28, offset: 33877},
 										name: "ExponentPart",
 									},
 								},
@@ -10301,28 +10133,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1250, col: 5, offset: 34641},
+						pos: position{line: 1225, col: 5, offset: 33936},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1250, col: 5, offset: 34641},
+							pos: position{line: 1225, col: 5, offset: 33936},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1250, col: 5, offset: 34641},
+									pos: position{line: 1225, col: 5, offset: 33936},
 									expr: &litMatcher{
-										pos:        position{line: 1250, col: 5, offset: 34641},
+										pos:        position{line: 1225, col: 5, offset: 33936},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1250, col: 10, offset: 34646},
+									pos:        position{line: 1225, col: 10, offset: 33941},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1250, col: 14, offset: 34650},
+									pos: position{line: 1225, col: 14, offset: 33945},
 									expr: &charClassMatcher{
-										pos:        position{line: 1250, col: 14, offset: 34650},
+										pos:        position{line: 1225, col: 14, offset: 33945},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10330,9 +10162,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1250, col: 21, offset: 34657},
+									pos: position{line: 1225, col: 21, offset: 33952},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1250, col: 21, offset: 34657},
+										pos:  position{line: 1225, col: 21, offset: 33952},
 										name: "ExponentPart",
 									},
 								},
@@ -10340,17 +10172,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1253, col: 5, offset: 34716},
+						pos: position{line: 1228, col: 5, offset: 34011},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1253, col: 7, offset: 34718},
+							pos: position{line: 1228, col: 7, offset: 34013},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1253, col: 7, offset: 34718},
+									pos:  position{line: 1228, col: 7, offset: 34013},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1253, col: 13, offset: 34724},
+									pos:  position{line: 1228, col: 13, offset: 34019},
 									name: "Infinity",
 								},
 							},
@@ -10361,19 +10193,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1256, col: 1, offset: 34768},
+			pos:  position{line: 1231, col: 1, offset: 34063},
 			expr: &seqExpr{
-				pos: position{line: 1256, col: 16, offset: 34783},
+				pos: position{line: 1231, col: 16, offset: 34078},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1256, col: 16, offset: 34783},
+						pos:        position{line: 1231, col: 16, offset: 34078},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1256, col: 21, offset: 34788},
+						pos: position{line: 1231, col: 21, offset: 34083},
 						expr: &charClassMatcher{
-							pos:        position{line: 1256, col: 21, offset: 34788},
+							pos:        position{line: 1231, col: 21, offset: 34083},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10381,7 +10213,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1256, col: 27, offset: 34794},
+						pos:  position{line: 1231, col: 27, offset: 34089},
 						name: "UIntString",
 					},
 				},
@@ -10389,31 +10221,31 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1258, col: 1, offset: 34806},
+			pos:  position{line: 1233, col: 1, offset: 34101},
 			expr: &litMatcher{
-				pos:        position{line: 1258, col: 7, offset: 34812},
+				pos:        position{line: 1233, col: 7, offset: 34107},
 				val:        "NaN",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1260, col: 1, offset: 34819},
+			pos:  position{line: 1235, col: 1, offset: 34114},
 			expr: &seqExpr{
-				pos: position{line: 1260, col: 12, offset: 34830},
+				pos: position{line: 1235, col: 12, offset: 34125},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 1260, col: 12, offset: 34830},
+						pos: position{line: 1235, col: 12, offset: 34125},
 						expr: &choiceExpr{
-							pos: position{line: 1260, col: 13, offset: 34831},
+							pos: position{line: 1235, col: 13, offset: 34126},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1260, col: 13, offset: 34831},
+									pos:        position{line: 1235, col: 13, offset: 34126},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1260, col: 19, offset: 34837},
+									pos:        position{line: 1235, col: 19, offset: 34132},
 									val:        "+",
 									ignoreCase: false,
 								},
@@ -10421,7 +10253,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1260, col: 25, offset: 34843},
+						pos:        position{line: 1235, col: 25, offset: 34138},
 						val:        "Inf",
 						ignoreCase: false,
 					},
@@ -10430,14 +10262,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1262, col: 1, offset: 34850},
+			pos:  position{line: 1237, col: 1, offset: 34145},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 7, offset: 34856},
+				pos: position{line: 1237, col: 7, offset: 34151},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1262, col: 7, offset: 34856},
+					pos: position{line: 1237, col: 7, offset: 34151},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1262, col: 7, offset: 34856},
+						pos:  position{line: 1237, col: 7, offset: 34151},
 						name: "HexDigit",
 					},
 				},
@@ -10445,9 +10277,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1264, col: 1, offset: 34898},
+			pos:  position{line: 1239, col: 1, offset: 34193},
 			expr: &charClassMatcher{
-				pos:        position{line: 1264, col: 12, offset: 34909},
+				pos:        position{line: 1239, col: 12, offset: 34204},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10456,34 +10288,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1266, col: 1, offset: 34922},
+			pos:  position{line: 1241, col: 1, offset: 34217},
 			expr: &choiceExpr{
-				pos: position{line: 1267, col: 5, offset: 34939},
+				pos: position{line: 1242, col: 5, offset: 34234},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 34939},
+						pos: position{line: 1242, col: 5, offset: 34234},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1267, col: 5, offset: 34939},
+							pos: position{line: 1242, col: 5, offset: 34234},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1267, col: 5, offset: 34939},
+									pos:        position{line: 1242, col: 5, offset: 34234},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 9, offset: 34943},
+									pos:   position{line: 1242, col: 9, offset: 34238},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1267, col: 11, offset: 34945},
+										pos: position{line: 1242, col: 11, offset: 34240},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1267, col: 11, offset: 34945},
+											pos:  position{line: 1242, col: 11, offset: 34240},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1267, col: 29, offset: 34963},
+									pos:        position{line: 1242, col: 29, offset: 34258},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10491,29 +10323,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1268, col: 5, offset: 35000},
+						pos: position{line: 1243, col: 5, offset: 34295},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1268, col: 5, offset: 35000},
+							pos: position{line: 1243, col: 5, offset: 34295},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1268, col: 5, offset: 35000},
+									pos:        position{line: 1243, col: 5, offset: 34295},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1268, col: 9, offset: 35004},
+									pos:   position{line: 1243, col: 9, offset: 34299},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1268, col: 11, offset: 35006},
+										pos: position{line: 1243, col: 11, offset: 34301},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1268, col: 11, offset: 35006},
+											pos:  position{line: 1243, col: 11, offset: 34301},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1268, col: 29, offset: 35024},
+									pos:        position{line: 1243, col: 29, offset: 34319},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10525,55 +10357,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1270, col: 1, offset: 35058},
+			pos:  position{line: 1245, col: 1, offset: 34353},
 			expr: &choiceExpr{
-				pos: position{line: 1271, col: 5, offset: 35079},
+				pos: position{line: 1246, col: 5, offset: 34374},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1271, col: 5, offset: 35079},
+						pos: position{line: 1246, col: 5, offset: 34374},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1271, col: 5, offset: 35079},
+							pos: position{line: 1246, col: 5, offset: 34374},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1271, col: 5, offset: 35079},
+									pos: position{line: 1246, col: 5, offset: 34374},
 									expr: &choiceExpr{
-										pos: position{line: 1271, col: 7, offset: 35081},
+										pos: position{line: 1246, col: 7, offset: 34376},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1271, col: 7, offset: 35081},
+												pos:        position{line: 1246, col: 7, offset: 34376},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1271, col: 13, offset: 35087},
+												pos:  position{line: 1246, col: 13, offset: 34382},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1271, col: 26, offset: 35100,
+									line: 1246, col: 26, offset: 34395,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1272, col: 5, offset: 35137},
+						pos: position{line: 1247, col: 5, offset: 34432},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1272, col: 5, offset: 35137},
+							pos: position{line: 1247, col: 5, offset: 34432},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1272, col: 5, offset: 35137},
+									pos:        position{line: 1247, col: 5, offset: 34432},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1272, col: 10, offset: 35142},
+									pos:   position{line: 1247, col: 10, offset: 34437},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1272, col: 12, offset: 35144},
+										pos:  position{line: 1247, col: 12, offset: 34439},
 										name: "EscapeSequence",
 									},
 								},
@@ -10585,28 +10417,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1274, col: 1, offset: 35178},
+			pos:  position{line: 1249, col: 1, offset: 34473},
 			expr: &actionExpr{
-				pos: position{line: 1275, col: 5, offset: 35190},
+				pos: position{line: 1250, col: 5, offset: 34485},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1275, col: 5, offset: 35190},
+					pos: position{line: 1250, col: 5, offset: 34485},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1275, col: 5, offset: 35190},
+							pos:   position{line: 1250, col: 5, offset: 34485},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1275, col: 10, offset: 35195},
+								pos:  position{line: 1250, col: 10, offset: 34490},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1275, col: 23, offset: 35208},
+							pos:   position{line: 1250, col: 23, offset: 34503},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1275, col: 28, offset: 35213},
+								pos: position{line: 1250, col: 28, offset: 34508},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1275, col: 28, offset: 35213},
+									pos:  position{line: 1250, col: 28, offset: 34508},
 									name: "KeyWordRest",
 								},
 							},
@@ -10617,16 +10449,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1277, col: 1, offset: 35275},
+			pos:  position{line: 1252, col: 1, offset: 34570},
 			expr: &choiceExpr{
-				pos: position{line: 1278, col: 5, offset: 35292},
+				pos: position{line: 1253, col: 5, offset: 34587},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 35292},
+						pos:  position{line: 1253, col: 5, offset: 34587},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 5, offset: 35309},
+						pos:  position{line: 1254, col: 5, offset: 34604},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10634,12 +10466,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1281, col: 1, offset: 35321},
+			pos:  position{line: 1256, col: 1, offset: 34616},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 16, offset: 35336},
+				pos: position{line: 1256, col: 16, offset: 34631},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1281, col: 16, offset: 35336},
+					pos:        position{line: 1256, col: 16, offset: 34631},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10650,16 +10482,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1283, col: 1, offset: 35385},
+			pos:  position{line: 1258, col: 1, offset: 34680},
 			expr: &choiceExpr{
-				pos: position{line: 1284, col: 5, offset: 35401},
+				pos: position{line: 1259, col: 5, offset: 34696},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1284, col: 5, offset: 35401},
+						pos:  position{line: 1259, col: 5, offset: 34696},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1285, col: 5, offset: 35418},
+						pos:        position{line: 1260, col: 5, offset: 34713},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10670,30 +10502,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1287, col: 1, offset: 35425},
+			pos:  position{line: 1262, col: 1, offset: 34720},
 			expr: &actionExpr{
-				pos: position{line: 1287, col: 14, offset: 35438},
+				pos: position{line: 1262, col: 14, offset: 34733},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1287, col: 14, offset: 35438},
+					pos: position{line: 1262, col: 14, offset: 34733},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1287, col: 14, offset: 35438},
+							pos:        position{line: 1262, col: 14, offset: 34733},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1287, col: 19, offset: 35443},
+							pos:   position{line: 1262, col: 19, offset: 34738},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1287, col: 22, offset: 35446},
+								pos: position{line: 1262, col: 22, offset: 34741},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1287, col: 22, offset: 35446},
+										pos:  position{line: 1262, col: 22, offset: 34741},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1287, col: 38, offset: 35462},
+										pos:  position{line: 1262, col: 38, offset: 34757},
 										name: "EscapeSequence",
 									},
 								},
@@ -10705,42 +10537,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1289, col: 1, offset: 35498},
+			pos:  position{line: 1264, col: 1, offset: 34793},
 			expr: &actionExpr{
-				pos: position{line: 1290, col: 5, offset: 35514},
+				pos: position{line: 1265, col: 5, offset: 34809},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1290, col: 5, offset: 35514},
+					pos: position{line: 1265, col: 5, offset: 34809},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1290, col: 5, offset: 35514},
+							pos: position{line: 1265, col: 5, offset: 34809},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1290, col: 6, offset: 35515},
+								pos:  position{line: 1265, col: 6, offset: 34810},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1290, col: 22, offset: 35531},
+							pos: position{line: 1265, col: 22, offset: 34826},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1290, col: 23, offset: 35532},
+								pos:  position{line: 1265, col: 23, offset: 34827},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1290, col: 35, offset: 35544},
+							pos:   position{line: 1265, col: 35, offset: 34839},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1290, col: 40, offset: 35549},
+								pos:  position{line: 1265, col: 40, offset: 34844},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1290, col: 50, offset: 35559},
+							pos:   position{line: 1265, col: 50, offset: 34854},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1290, col: 55, offset: 35564},
+								pos: position{line: 1265, col: 55, offset: 34859},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1290, col: 55, offset: 35564},
+									pos:  position{line: 1265, col: 55, offset: 34859},
 									name: "GlobRest",
 								},
 							},
@@ -10751,20 +10583,20 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1294, col: 1, offset: 35633},
+			pos:  position{line: 1269, col: 1, offset: 34928},
 			expr: &seqExpr{
-				pos: position{line: 1294, col: 19, offset: 35651},
+				pos: position{line: 1269, col: 19, offset: 34946},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1294, col: 19, offset: 35651},
+						pos: position{line: 1269, col: 19, offset: 34946},
 						expr: &litMatcher{
-							pos:        position{line: 1294, col: 19, offset: 35651},
+							pos:        position{line: 1269, col: 19, offset: 34946},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1294, col: 24, offset: 35656},
+						pos:  position{line: 1269, col: 24, offset: 34951},
 						name: "KeyWordStart",
 					},
 				},
@@ -10772,19 +10604,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1295, col: 1, offset: 35669},
+			pos:  position{line: 1270, col: 1, offset: 34964},
 			expr: &seqExpr{
-				pos: position{line: 1295, col: 15, offset: 35683},
+				pos: position{line: 1270, col: 15, offset: 34978},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1295, col: 15, offset: 35683},
+						pos: position{line: 1270, col: 15, offset: 34978},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1295, col: 15, offset: 35683},
+							pos:  position{line: 1270, col: 15, offset: 34978},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1295, col: 28, offset: 35696},
+						pos:        position{line: 1270, col: 28, offset: 34991},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10793,23 +10625,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1297, col: 1, offset: 35701},
+			pos:  position{line: 1272, col: 1, offset: 34996},
 			expr: &choiceExpr{
-				pos: position{line: 1298, col: 5, offset: 35715},
+				pos: position{line: 1273, col: 5, offset: 35010},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1298, col: 5, offset: 35715},
+						pos:  position{line: 1273, col: 5, offset: 35010},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1299, col: 5, offset: 35732},
+						pos:  position{line: 1274, col: 5, offset: 35027},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1300, col: 5, offset: 35744},
+						pos: position{line: 1275, col: 5, offset: 35039},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1300, col: 5, offset: 35744},
+							pos:        position{line: 1275, col: 5, offset: 35039},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10819,16 +10651,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1302, col: 1, offset: 35768},
+			pos:  position{line: 1277, col: 1, offset: 35063},
 			expr: &choiceExpr{
-				pos: position{line: 1303, col: 5, offset: 35781},
+				pos: position{line: 1278, col: 5, offset: 35076},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1303, col: 5, offset: 35781},
+						pos:  position{line: 1278, col: 5, offset: 35076},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1304, col: 5, offset: 35795},
+						pos:        position{line: 1279, col: 5, offset: 35090},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10839,30 +10671,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1306, col: 1, offset: 35802},
+			pos:  position{line: 1281, col: 1, offset: 35097},
 			expr: &actionExpr{
-				pos: position{line: 1306, col: 11, offset: 35812},
+				pos: position{line: 1281, col: 11, offset: 35107},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1306, col: 11, offset: 35812},
+					pos: position{line: 1281, col: 11, offset: 35107},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1306, col: 11, offset: 35812},
+							pos:        position{line: 1281, col: 11, offset: 35107},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1306, col: 16, offset: 35817},
+							pos:   position{line: 1281, col: 16, offset: 35112},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1306, col: 19, offset: 35820},
+								pos: position{line: 1281, col: 19, offset: 35115},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1306, col: 19, offset: 35820},
+										pos:  position{line: 1281, col: 19, offset: 35115},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1306, col: 32, offset: 35833},
+										pos:  position{line: 1281, col: 32, offset: 35128},
 										name: "EscapeSequence",
 									},
 								},
@@ -10874,30 +10706,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1308, col: 1, offset: 35869},
+			pos:  position{line: 1283, col: 1, offset: 35164},
 			expr: &choiceExpr{
-				pos: position{line: 1309, col: 5, offset: 35884},
+				pos: position{line: 1284, col: 5, offset: 35179},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 35884},
+						pos: position{line: 1284, col: 5, offset: 35179},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1309, col: 5, offset: 35884},
+							pos:        position{line: 1284, col: 5, offset: 35179},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 35912},
+						pos: position{line: 1285, col: 5, offset: 35207},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1310, col: 5, offset: 35912},
+							pos:        position{line: 1285, col: 5, offset: 35207},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1311, col: 5, offset: 35942},
+						pos:        position{line: 1286, col: 5, offset: 35237},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10908,55 +10740,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1314, col: 1, offset: 35949},
+			pos:  position{line: 1289, col: 1, offset: 35244},
 			expr: &choiceExpr{
-				pos: position{line: 1315, col: 5, offset: 35970},
+				pos: position{line: 1290, col: 5, offset: 35265},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1315, col: 5, offset: 35970},
+						pos: position{line: 1290, col: 5, offset: 35265},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1315, col: 5, offset: 35970},
+							pos: position{line: 1290, col: 5, offset: 35265},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1315, col: 5, offset: 35970},
+									pos: position{line: 1290, col: 5, offset: 35265},
 									expr: &choiceExpr{
-										pos: position{line: 1315, col: 7, offset: 35972},
+										pos: position{line: 1290, col: 7, offset: 35267},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1315, col: 7, offset: 35972},
+												pos:        position{line: 1290, col: 7, offset: 35267},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1315, col: 13, offset: 35978},
+												pos:  position{line: 1290, col: 13, offset: 35273},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1315, col: 26, offset: 35991,
+									line: 1290, col: 26, offset: 35286,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 36028},
+						pos: position{line: 1291, col: 5, offset: 35323},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 5, offset: 36028},
+							pos: position{line: 1291, col: 5, offset: 35323},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1316, col: 5, offset: 36028},
+									pos:        position{line: 1291, col: 5, offset: 35323},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1316, col: 10, offset: 36033},
+									pos:   position{line: 1291, col: 10, offset: 35328},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1316, col: 12, offset: 36035},
+										pos:  position{line: 1291, col: 12, offset: 35330},
 										name: "EscapeSequence",
 									},
 								},
@@ -10968,16 +10800,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1318, col: 1, offset: 36069},
+			pos:  position{line: 1293, col: 1, offset: 35364},
 			expr: &choiceExpr{
-				pos: position{line: 1319, col: 5, offset: 36088},
+				pos: position{line: 1294, col: 5, offset: 35383},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1319, col: 5, offset: 36088},
+						pos:  position{line: 1294, col: 5, offset: 35383},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 5, offset: 36109},
+						pos:  position{line: 1295, col: 5, offset: 35404},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10985,79 +10817,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1322, col: 1, offset: 36124},
+			pos:  position{line: 1297, col: 1, offset: 35419},
 			expr: &choiceExpr{
-				pos: position{line: 1323, col: 5, offset: 36145},
+				pos: position{line: 1298, col: 5, offset: 35440},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1323, col: 5, offset: 36145},
+						pos:        position{line: 1298, col: 5, offset: 35440},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1324, col: 5, offset: 36153},
+						pos: position{line: 1299, col: 5, offset: 35448},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1324, col: 5, offset: 36153},
+							pos:        position{line: 1299, col: 5, offset: 35448},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1325, col: 5, offset: 36193},
+						pos:        position{line: 1300, col: 5, offset: 35488},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1326, col: 5, offset: 36202},
+						pos: position{line: 1301, col: 5, offset: 35497},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1326, col: 5, offset: 36202},
+							pos:        position{line: 1301, col: 5, offset: 35497},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1327, col: 5, offset: 36231},
+						pos: position{line: 1302, col: 5, offset: 35526},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1327, col: 5, offset: 36231},
+							pos:        position{line: 1302, col: 5, offset: 35526},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1328, col: 5, offset: 36260},
+						pos: position{line: 1303, col: 5, offset: 35555},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1328, col: 5, offset: 36260},
+							pos:        position{line: 1303, col: 5, offset: 35555},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 36289},
+						pos: position{line: 1304, col: 5, offset: 35584},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1329, col: 5, offset: 36289},
+							pos:        position{line: 1304, col: 5, offset: 35584},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1330, col: 5, offset: 36318},
+						pos: position{line: 1305, col: 5, offset: 35613},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1330, col: 5, offset: 36318},
+							pos:        position{line: 1305, col: 5, offset: 35613},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1331, col: 5, offset: 36347},
+						pos: position{line: 1306, col: 5, offset: 35642},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1331, col: 5, offset: 36347},
+							pos:        position{line: 1306, col: 5, offset: 35642},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -11067,30 +10899,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1333, col: 1, offset: 36373},
+			pos:  position{line: 1308, col: 1, offset: 35668},
 			expr: &choiceExpr{
-				pos: position{line: 1334, col: 5, offset: 36391},
+				pos: position{line: 1309, col: 5, offset: 35686},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1334, col: 5, offset: 36391},
+						pos: position{line: 1309, col: 5, offset: 35686},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1334, col: 5, offset: 36391},
+							pos:        position{line: 1309, col: 5, offset: 35686},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1335, col: 5, offset: 36419},
+						pos: position{line: 1310, col: 5, offset: 35714},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1335, col: 5, offset: 36419},
+							pos:        position{line: 1310, col: 5, offset: 35714},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1336, col: 5, offset: 36447},
+						pos:        position{line: 1311, col: 5, offset: 35742},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11101,41 +10933,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1338, col: 1, offset: 36453},
+			pos:  position{line: 1313, col: 1, offset: 35748},
 			expr: &choiceExpr{
-				pos: position{line: 1339, col: 5, offset: 36471},
+				pos: position{line: 1314, col: 5, offset: 35766},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1339, col: 5, offset: 36471},
+						pos: position{line: 1314, col: 5, offset: 35766},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1339, col: 5, offset: 36471},
+							pos: position{line: 1314, col: 5, offset: 35766},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1339, col: 5, offset: 36471},
+									pos:        position{line: 1314, col: 5, offset: 35766},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1339, col: 9, offset: 36475},
+									pos:   position{line: 1314, col: 9, offset: 35770},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1339, col: 16, offset: 36482},
+										pos: position{line: 1314, col: 16, offset: 35777},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1339, col: 16, offset: 36482},
+												pos:  position{line: 1314, col: 16, offset: 35777},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1339, col: 25, offset: 36491},
+												pos:  position{line: 1314, col: 25, offset: 35786},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1339, col: 34, offset: 36500},
+												pos:  position{line: 1314, col: 34, offset: 35795},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1339, col: 43, offset: 36509},
+												pos:  position{line: 1314, col: 43, offset: 35804},
 												name: "HexDigit",
 											},
 										},
@@ -11145,63 +10977,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 36572},
+						pos: position{line: 1317, col: 5, offset: 35867},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1342, col: 5, offset: 36572},
+							pos: position{line: 1317, col: 5, offset: 35867},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1342, col: 5, offset: 36572},
+									pos:        position{line: 1317, col: 5, offset: 35867},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1342, col: 9, offset: 36576},
+									pos:        position{line: 1317, col: 9, offset: 35871},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1342, col: 13, offset: 36580},
+									pos:   position{line: 1317, col: 13, offset: 35875},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1342, col: 20, offset: 36587},
+										pos: position{line: 1317, col: 20, offset: 35882},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1342, col: 20, offset: 36587},
+												pos:  position{line: 1317, col: 20, offset: 35882},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 29, offset: 36596},
+												pos: position{line: 1317, col: 29, offset: 35891},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 29, offset: 36596},
+													pos:  position{line: 1317, col: 29, offset: 35891},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 39, offset: 36606},
+												pos: position{line: 1317, col: 39, offset: 35901},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 39, offset: 36606},
+													pos:  position{line: 1317, col: 39, offset: 35901},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 49, offset: 36616},
+												pos: position{line: 1317, col: 49, offset: 35911},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 49, offset: 36616},
+													pos:  position{line: 1317, col: 49, offset: 35911},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 59, offset: 36626},
+												pos: position{line: 1317, col: 59, offset: 35921},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 59, offset: 36626},
+													pos:  position{line: 1317, col: 59, offset: 35921},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1342, col: 69, offset: 36636},
+												pos: position{line: 1317, col: 69, offset: 35931},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1342, col: 69, offset: 36636},
+													pos:  position{line: 1317, col: 69, offset: 35931},
 													name: "HexDigit",
 												},
 											},
@@ -11209,7 +11041,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1342, col: 80, offset: 36647},
+									pos:        position{line: 1317, col: 80, offset: 35942},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11221,35 +11053,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1346, col: 1, offset: 36701},
+			pos:  position{line: 1321, col: 1, offset: 35996},
 			expr: &actionExpr{
-				pos: position{line: 1347, col: 5, offset: 36719},
+				pos: position{line: 1322, col: 5, offset: 36014},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1347, col: 5, offset: 36719},
+					pos: position{line: 1322, col: 5, offset: 36014},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1347, col: 5, offset: 36719},
+							pos:        position{line: 1322, col: 5, offset: 36014},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1347, col: 9, offset: 36723},
+							pos:   position{line: 1322, col: 9, offset: 36018},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1347, col: 14, offset: 36728},
+								pos:  position{line: 1322, col: 14, offset: 36023},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1347, col: 25, offset: 36739},
+							pos:        position{line: 1322, col: 25, offset: 36034},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1347, col: 29, offset: 36743},
+							pos: position{line: 1322, col: 29, offset: 36038},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1347, col: 30, offset: 36744},
+								pos:  position{line: 1322, col: 30, offset: 36039},
 								name: "KeyWordStart",
 							},
 						},
@@ -11259,32 +11091,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1349, col: 1, offset: 36779},
+			pos:  position{line: 1324, col: 1, offset: 36074},
 			expr: &actionExpr{
-				pos: position{line: 1350, col: 5, offset: 36794},
+				pos: position{line: 1325, col: 5, offset: 36089},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1350, col: 5, offset: 36794},
+					pos: position{line: 1325, col: 5, offset: 36089},
 					expr: &choiceExpr{
-						pos: position{line: 1350, col: 6, offset: 36795},
+						pos: position{line: 1325, col: 6, offset: 36090},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1350, col: 6, offset: 36795},
+								pos:        position{line: 1325, col: 6, offset: 36090},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1350, col: 15, offset: 36804},
+								pos: position{line: 1325, col: 15, offset: 36099},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1350, col: 15, offset: 36804},
+										pos:        position{line: 1325, col: 15, offset: 36099},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1350, col: 20, offset: 36809,
+										line: 1325, col: 20, offset: 36104,
 									},
 								},
 							},
@@ -11295,9 +11127,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1352, col: 1, offset: 36845},
+			pos:  position{line: 1327, col: 1, offset: 36140},
 			expr: &charClassMatcher{
-				pos:        position{line: 1353, col: 5, offset: 36861},
+				pos:        position{line: 1328, col: 5, offset: 36156},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11307,42 +11139,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1355, col: 1, offset: 36876},
+			pos:  position{line: 1330, col: 1, offset: 36171},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1355, col: 6, offset: 36881},
+				pos: position{line: 1330, col: 6, offset: 36176},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1355, col: 6, offset: 36881},
+					pos:  position{line: 1330, col: 6, offset: 36176},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1357, col: 1, offset: 36892},
+			pos:  position{line: 1332, col: 1, offset: 36187},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1357, col: 6, offset: 36897},
+				pos: position{line: 1332, col: 6, offset: 36192},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1357, col: 6, offset: 36897},
+					pos:  position{line: 1332, col: 6, offset: 36192},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1359, col: 1, offset: 36908},
+			pos:  position{line: 1334, col: 1, offset: 36203},
 			expr: &choiceExpr{
-				pos: position{line: 1360, col: 5, offset: 36921},
+				pos: position{line: 1335, col: 5, offset: 36216},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1360, col: 5, offset: 36921},
+						pos:  position{line: 1335, col: 5, offset: 36216},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1361, col: 5, offset: 36936},
+						pos:  position{line: 1336, col: 5, offset: 36231},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 5, offset: 36955},
+						pos:  position{line: 1337, col: 5, offset: 36250},
 						name: "Comment",
 					},
 				},
@@ -11350,45 +11182,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1364, col: 1, offset: 36964},
+			pos:  position{line: 1339, col: 1, offset: 36259},
 			expr: &anyMatcher{
-				line: 1365, col: 5, offset: 36984,
+				line: 1340, col: 5, offset: 36279,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1367, col: 1, offset: 36987},
+			pos:         position{line: 1342, col: 1, offset: 36282},
 			expr: &choiceExpr{
-				pos: position{line: 1368, col: 5, offset: 37015},
+				pos: position{line: 1343, col: 5, offset: 36310},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1368, col: 5, offset: 37015},
+						pos:        position{line: 1343, col: 5, offset: 36310},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1369, col: 5, offset: 37024},
+						pos:        position{line: 1344, col: 5, offset: 36319},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1370, col: 5, offset: 37033},
+						pos:        position{line: 1345, col: 5, offset: 36328},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1371, col: 5, offset: 37042},
+						pos:        position{line: 1346, col: 5, offset: 36337},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1372, col: 5, offset: 37050},
+						pos:        position{line: 1347, col: 5, offset: 36345},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1373, col: 5, offset: 37063},
+						pos:        position{line: 1348, col: 5, offset: 36358},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11397,9 +11229,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1375, col: 1, offset: 37073},
+			pos:  position{line: 1350, col: 1, offset: 36368},
 			expr: &charClassMatcher{
-				pos:        position{line: 1376, col: 5, offset: 37092},
+				pos:        position{line: 1351, col: 5, offset: 36387},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11409,45 +11241,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1382, col: 1, offset: 37422},
+			pos:         position{line: 1357, col: 1, offset: 36717},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1385, col: 5, offset: 37493},
+				pos:  position{line: 1360, col: 5, offset: 36788},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1387, col: 1, offset: 37512},
+			pos:  position{line: 1362, col: 1, offset: 36807},
 			expr: &seqExpr{
-				pos: position{line: 1388, col: 5, offset: 37533},
+				pos: position{line: 1363, col: 5, offset: 36828},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1388, col: 5, offset: 37533},
+						pos:        position{line: 1363, col: 5, offset: 36828},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1388, col: 10, offset: 37538},
+						pos: position{line: 1363, col: 10, offset: 36833},
 						expr: &seqExpr{
-							pos: position{line: 1388, col: 11, offset: 37539},
+							pos: position{line: 1363, col: 11, offset: 36834},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1388, col: 11, offset: 37539},
+									pos: position{line: 1363, col: 11, offset: 36834},
 									expr: &litMatcher{
-										pos:        position{line: 1388, col: 12, offset: 37540},
+										pos:        position{line: 1363, col: 12, offset: 36835},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1388, col: 17, offset: 37545},
+									pos:  position{line: 1363, col: 17, offset: 36840},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1388, col: 35, offset: 37563},
+						pos:        position{line: 1363, col: 35, offset: 36858},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11456,29 +11288,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1390, col: 1, offset: 37569},
+			pos:  position{line: 1365, col: 1, offset: 36864},
 			expr: &seqExpr{
-				pos: position{line: 1391, col: 5, offset: 37591},
+				pos: position{line: 1366, col: 5, offset: 36886},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1391, col: 5, offset: 37591},
+						pos:        position{line: 1366, col: 5, offset: 36886},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1391, col: 10, offset: 37596},
+						pos: position{line: 1366, col: 10, offset: 36891},
 						expr: &seqExpr{
-							pos: position{line: 1391, col: 11, offset: 37597},
+							pos: position{line: 1366, col: 11, offset: 36892},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1391, col: 11, offset: 37597},
+									pos: position{line: 1366, col: 11, offset: 36892},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1391, col: 12, offset: 37598},
+										pos:  position{line: 1366, col: 12, offset: 36893},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1391, col: 27, offset: 37613},
+									pos:  position{line: 1366, col: 27, offset: 36908},
 									name: "SourceCharacter",
 								},
 							},
@@ -11489,19 +11321,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1393, col: 1, offset: 37632},
+			pos:  position{line: 1368, col: 1, offset: 36927},
 			expr: &seqExpr{
-				pos: position{line: 1393, col: 7, offset: 37638},
+				pos: position{line: 1368, col: 7, offset: 36933},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1393, col: 7, offset: 37638},
+						pos: position{line: 1368, col: 7, offset: 36933},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1393, col: 7, offset: 37638},
+							pos:  position{line: 1368, col: 7, offset: 36933},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1393, col: 19, offset: 37650},
+						pos:  position{line: 1368, col: 19, offset: 36945},
 						name: "LineTerminator",
 					},
 				},
@@ -11509,16 +11341,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1395, col: 1, offset: 37666},
+			pos:  position{line: 1370, col: 1, offset: 36961},
 			expr: &choiceExpr{
-				pos: position{line: 1395, col: 7, offset: 37672},
+				pos: position{line: 1370, col: 7, offset: 36967},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1395, col: 7, offset: 37672},
+						pos:  position{line: 1370, col: 7, offset: 36967},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1395, col: 11, offset: 37676},
+						pos:  position{line: 1370, col: 11, offset: 36971},
 						name: "EOF",
 					},
 				},
@@ -11526,21 +11358,21 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1397, col: 1, offset: 37681},
+			pos:  position{line: 1372, col: 1, offset: 36976},
 			expr: &notExpr{
-				pos: position{line: 1397, col: 7, offset: 37687},
+				pos: position{line: 1372, col: 7, offset: 36982},
 				expr: &anyMatcher{
-					line: 1397, col: 8, offset: 37688,
+					line: 1372, col: 8, offset: 36983,
 				},
 			},
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1399, col: 1, offset: 37691},
+			pos:  position{line: 1374, col: 1, offset: 36986},
 			expr: &notExpr{
-				pos: position{line: 1399, col: 8, offset: 37698},
+				pos: position{line: 1374, col: 8, offset: 36993},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1399, col: 9, offset: 37699},
+					pos:  position{line: 1374, col: 9, offset: 36994},
 					name: "KeyWordChars",
 				},
 			},
@@ -11558,26 +11390,15 @@ func (p *parser) callonstart1() (interface{}, error) {
 	return p.cur.onstart1(stack["ast"])
 }
 
-func (c *current) onSequential2(consts, first, rest interface{}) (interface{}, error) {
+func (c *current) onSequential1(consts, first, rest interface{}) (interface{}, error) {
 	return map[string]interface{}{"kind": "Sequential", "ops": append([]interface{}{first}, (rest.([]interface{}))...), "consts": consts}, nil
 
 }
 
-func (p *parser) callonSequential2() (interface{}, error) {
+func (p *parser) callonSequential1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSequential2(stack["consts"], stack["first"], stack["rest"])
-}
-
-func (c *current) onSequential12(consts, op interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Sequential", "ops": []interface{}{op}, "consts": consts}, nil
-
-}
-
-func (p *parser) callonSequential12() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSequential12(stack["consts"], stack["op"])
+	return p.cur.onSequential1(stack["consts"], stack["first"], stack["rest"])
 }
 
 func (c *current) onSequentialTail1(p interface{}) (interface{}, error) {
@@ -11901,26 +11722,15 @@ func (p *parser) callonSearchExpr4() (interface{}, error) {
 	return p.cur.onSearchExpr4(stack["v"])
 }
 
-func (c *current) onSearchExpr12(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Term", "text": string(c.text), "value": v}, nil
-
-}
-
-func (p *parser) callonSearchExpr12() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSearchExpr12(stack["v"])
-}
-
-func (c *current) onSearchExpr18() (interface{}, error) {
+func (c *current) onSearchExpr15() (interface{}, error) {
 	return map[string]interface{}{"kind": "Primitive", "type": "bool", "text": "true"}, nil
 
 }
 
-func (p *parser) callonSearchExpr18() (interface{}, error) {
+func (p *parser) callonSearchExpr15() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchExpr18()
+	return p.cur.onSearchExpr15()
 }
 
 func (c *current) onSearchPredicate2(lhs, op, rhs interface{}) (interface{}, error) {
@@ -12843,37 +12653,39 @@ func (p *parser) callonMergeOp1() (interface{}, error) {
 	return p.cur.onMergeOp1(stack["expr"])
 }
 
-func (c *current) onOverOp2(exprs, locals, scope interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Let", "locals": locals, "over": map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope}}, nil
-
+func (c *current) onOverOp9(l interface{}) (interface{}, error) {
+	return l, nil
 }
 
-func (p *parser) callonOverOp2() (interface{}, error) {
+func (p *parser) callonOverOp9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOverOp2(stack["exprs"], stack["locals"], stack["scope"])
+	return p.cur.onOverOp9(stack["l"])
 }
 
-func (c *current) onOverOp16(exprs, scope interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope}, nil
-
+func (c *current) onOverOp18(s interface{}) (interface{}, error) {
+	return s, nil
 }
 
-func (p *parser) callonOverOp16() (interface{}, error) {
+func (p *parser) callonOverOp18() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOverOp16(stack["exprs"], stack["scope"])
+	return p.cur.onOverOp18(stack["s"])
 }
 
-func (c *current) onOverOp25(exprs interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": nil}, nil
+func (c *current) onOverOp1(exprs, locals, scope interface{}) (interface{}, error) {
+	var over = map[string]interface{}{"kind": "Over", "exprs": exprs, "scope": scope}
+	if locals != nil {
+		return map[string]interface{}{"kind": "Let", "locals": locals, "over": over}, nil
+	}
+	return over, nil
 
 }
 
-func (p *parser) callonOverOp25() (interface{}, error) {
+func (p *parser) callonOverOp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOverOp25(stack["exprs"])
+	return p.cur.onOverOp1(stack["exprs"], stack["locals"], stack["scope"])
 }
 
 func (c *current) onScope1(seq interface{}) (interface{}, error) {
@@ -13082,26 +12894,30 @@ func (p *parser) callonLogicalAndExpr1() (interface{}, error) {
 	return p.cur.onLogicalAndExpr1(stack["first"], stack["rest"])
 }
 
-func (c *current) onComparisonExpr2(lhs, op, rhs interface{}) (interface{}, error) {
+func (c *current) onComparisonExpr15() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonComparisonExpr15() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onComparisonExpr15()
+}
+
+func (c *current) onComparisonExpr1(lhs, opAndRHS interface{}) (interface{}, error) {
+	if opAndRHS == nil {
+		return lhs, nil
+	}
+	var op = opAndRHS.([]interface{})[1]
+	var rhs = opAndRHS.([]interface{})[3]
 	return map[string]interface{}{"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}, nil
 
 }
 
-func (p *parser) callonComparisonExpr2() (interface{}, error) {
+func (p *parser) callonComparisonExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onComparisonExpr2(stack["lhs"], stack["op"], stack["rhs"])
-}
-
-func (c *current) onComparisonExpr12(lhs, rhs interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "BinaryExpr", "op": "~", "lhs": lhs, "rhs": rhs}, nil
-
-}
-
-func (p *parser) callonComparisonExpr12() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onComparisonExpr12(stack["lhs"], stack["rhs"])
+	return p.cur.onComparisonExpr1(stack["lhs"], stack["opAndRHS"])
 }
 
 func (c *current) onAdditiveExpr7(op, expr interface{}) (interface{}, error) {
@@ -13320,50 +13136,37 @@ func (p *parser) callonDeref2() (interface{}, error) {
 	return p.cur.onDeref2(stack["from"], stack["to"])
 }
 
-func (c *current) onDeref13(to interface{}) (interface{}, error) {
+func (c *current) onDeref14(to interface{}) (interface{}, error) {
 	return []interface{}{"[", map[string]interface{}{"kind": "BinaryExpr", "op": ":",
 
 		"lhs": nil, "rhs": to}}, nil
 
 }
 
-func (p *parser) callonDeref13() (interface{}, error) {
+func (p *parser) callonDeref14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDeref13(stack["to"])
+	return p.cur.onDeref14(stack["to"])
 }
 
-func (c *current) onDeref22(from interface{}) (interface{}, error) {
-	return []interface{}{"[", map[string]interface{}{"kind": "BinaryExpr", "op": ":",
-
-		"lhs": from, "rhs": nil}}, nil
-
-}
-
-func (p *parser) callonDeref22() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onDeref22(stack["from"])
-}
-
-func (c *current) onDeref31(expr interface{}) (interface{}, error) {
+func (c *current) onDeref23(expr interface{}) (interface{}, error) {
 	return []interface{}{"[", expr}, nil
 }
 
-func (p *parser) callonDeref31() (interface{}, error) {
+func (p *parser) callonDeref23() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDeref31(stack["expr"])
+	return p.cur.onDeref23(stack["expr"])
 }
 
-func (c *current) onDeref37(id interface{}) (interface{}, error) {
+func (c *current) onDeref29(id interface{}) (interface{}, error) {
 	return []interface{}{".", id}, nil
 }
 
-func (p *parser) callonDeref37() (interface{}, error) {
+func (p *parser) callonDeref29() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDeref37(stack["id"])
+	return p.cur.onDeref29(stack["id"])
 }
 
 func (c *current) onPrimary7(expr interface{}) (interface{}, error) {
@@ -13386,26 +13189,25 @@ func (p *parser) callonPrimary15() (interface{}, error) {
 	return p.cur.onPrimary15(stack["expr"])
 }
 
-func (c *current) onOverExpr2(exprs, locals, scope interface{}) (interface{}, error) {
+func (c *current) onOverExpr9(l interface{}) (interface{}, error) {
+	return l, nil
+}
+
+func (p *parser) callonOverExpr9() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOverExpr9(stack["l"])
+}
+
+func (c *current) onOverExpr1(exprs, locals, scope interface{}) (interface{}, error) {
 	return map[string]interface{}{"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}, nil
 
 }
 
-func (p *parser) callonOverExpr2() (interface{}, error) {
+func (p *parser) callonOverExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOverExpr2(stack["exprs"], stack["locals"], stack["scope"])
-}
-
-func (c *current) onOverExpr18(exprs, scope interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "OverExpr", "locals": nil, "exprs": exprs, "scope": scope}, nil
-
-}
-
-func (p *parser) callonOverExpr18() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOverExpr18(stack["exprs"], stack["scope"])
+	return p.cur.onOverExpr1(stack["exprs"], stack["locals"], stack["scope"])
 }
 
 func (c *current) onRecord1(elems interface{}) (interface{}, error) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -584,29 +584,27 @@ function peg$parse(input, options) {
           },
       peg$c251 = "over",
       peg$c252 = peg$literalExpectation("over", false),
-      peg$c253 = function(exprs, l) { return l },
-      peg$c254 = function(exprs, locals, s) { return s },
-      peg$c255 = function(exprs, locals, scope) {
+      peg$c253 = function(exprs, locals, scope) {
             let over = {"kind": "Over", "exprs": exprs, "scope": scope}
             if (locals) {
               return {"kind": "Let", "locals": locals, "over": over}
             }
             return over
           },
-      peg$c256 = function(seq) { return seq },
-      peg$c257 = function(first, a) { return a },
-      peg$c258 = function(id) {
+      peg$c254 = function(seq) { return seq },
+      peg$c255 = function(first, a) { return a },
+      peg$c256 = function(id) {
             return {"name":id, "expr":{"kind":"ID","name":id}}
           },
-      peg$c259 = "yield",
-      peg$c260 = peg$literalExpectation("yield", false),
-      peg$c261 = function(exprs) {
+      peg$c257 = "yield",
+      peg$c258 = peg$literalExpectation("yield", false),
+      peg$c259 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c262 = function(typ) { return typ},
-      peg$c263 = function(lhs) { return lhs },
-      peg$c264 = function(first, lval) { return lval },
-      peg$c265 = function(first, rest) {
+      peg$c260 = function(typ) { return typ},
+      peg$c261 = function(lhs) { return lhs },
+      peg$c262 = function(first, lval) { return lval },
+      peg$c263 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -615,21 +613,21 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c266 = function(first, rest) {
+      peg$c264 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c267 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c268 = "?",
-      peg$c269 = peg$literalExpectation("?", false),
-      peg$c270 = function(condition, thenClause, elseClause) {
+      peg$c265 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c266 = "?",
+      peg$c267 = peg$literalExpectation("?", false),
+      peg$c268 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c271 = function(first, op, expr) { return [op, expr] },
-      peg$c272 = function(first, rest) {
+      peg$c269 = function(first, op, expr) { return [op, expr] },
+      peg$c270 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c273 = function(lhs) { return text() },
-      peg$c274 = function(lhs, opAndRHS) {
+      peg$c271 = function(lhs) { return text() },
+      peg$c272 = function(lhs, opAndRHS) {
             if (!opAndRHS) {
               return lhs
             }
@@ -637,97 +635,97 @@ function peg$parse(input, options) {
             let rhs = opAndRHS[3]
             return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c275 = "+",
-      peg$c276 = peg$literalExpectation("+", false),
-      peg$c277 = "-",
-      peg$c278 = peg$literalExpectation("-", false),
-      peg$c279 = "/",
-      peg$c280 = peg$literalExpectation("/", false),
-      peg$c281 = "%",
-      peg$c282 = peg$literalExpectation("%", false),
-      peg$c283 = function(e) {
+      peg$c273 = "+",
+      peg$c274 = peg$literalExpectation("+", false),
+      peg$c275 = "-",
+      peg$c276 = peg$literalExpectation("-", false),
+      peg$c277 = "/",
+      peg$c278 = peg$literalExpectation("/", false),
+      peg$c279 = "%",
+      peg$c280 = peg$literalExpectation("%", false),
+      peg$c281 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c284 = function(e) {
+      peg$c282 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c285 = "not",
-      peg$c286 = peg$literalExpectation("not", false),
-      peg$c287 = "select",
-      peg$c288 = peg$literalExpectation("select", false),
-      peg$c289 = function(typ, expr) {
+      peg$c283 = "not",
+      peg$c284 = peg$literalExpectation("not", false),
+      peg$c285 = "select",
+      peg$c286 = peg$literalExpectation("select", false),
+      peg$c287 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c290 = function(fn, args, where) {
+      peg$c288 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c291 = "grep",
-      peg$c292 = peg$literalExpectation("grep", false),
-      peg$c293 = function(pattern) {
+      peg$c289 = "grep",
+      peg$c290 = peg$literalExpectation("grep", false),
+      peg$c291 = function(pattern) {
             return {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
           },
-      peg$c294 = function(pattern, expr) {
+      peg$c292 = function(pattern, expr) {
             return {"kind": "Grep", "pattern": pattern, "expr": expr}
           },
-      peg$c295 = function(s) {
+      peg$c293 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c296 = function(first, e) { return e },
-      peg$c297 = "]",
-      peg$c298 = peg$literalExpectation("]", false),
-      peg$c299 = function(from, to) {
+      peg$c294 = function(first, e) { return e },
+      peg$c295 = "]",
+      peg$c296 = peg$literalExpectation("]", false),
+      peg$c297 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c300 = function(to) {
+      peg$c298 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c301 = function(expr) { return ["[", expr] },
-      peg$c302 = function(id) { return [".", id] },
-      peg$c303 = function(exprs, locals, scope) {
+      peg$c299 = function(expr) { return ["[", expr] },
+      peg$c300 = function(id) { return [".", id] },
+      peg$c301 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c304 = "}",
-      peg$c305 = peg$literalExpectation("}", false),
-      peg$c306 = function(elems) {
+      peg$c302 = "}",
+      peg$c303 = peg$literalExpectation("}", false),
+      peg$c304 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c307 = function(elem) { return elem },
-      peg$c308 = "...",
-      peg$c309 = peg$literalExpectation("...", false),
-      peg$c310 = function(expr) {
+      peg$c305 = function(elem) { return elem },
+      peg$c306 = "...",
+      peg$c307 = peg$literalExpectation("...", false),
+      peg$c308 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c311 = function(name, value) {
+      peg$c309 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c312 = function(exprs) {
+      peg$c310 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c313 = "|[",
-      peg$c314 = peg$literalExpectation("|[", false),
-      peg$c315 = "]|",
-      peg$c316 = peg$literalExpectation("]|", false),
-      peg$c317 = function(exprs) {
+      peg$c311 = "|[",
+      peg$c312 = peg$literalExpectation("|[", false),
+      peg$c313 = "]|",
+      peg$c314 = peg$literalExpectation("]|", false),
+      peg$c315 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c318 = "|{",
-      peg$c319 = peg$literalExpectation("|{", false),
-      peg$c320 = "}|",
-      peg$c321 = peg$literalExpectation("}|", false),
-      peg$c322 = function(exprs) {
+      peg$c316 = "|{",
+      peg$c317 = peg$literalExpectation("|{", false),
+      peg$c318 = "}|",
+      peg$c319 = peg$literalExpectation("}|", false),
+      peg$c320 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c323 = function(e) { return e },
-      peg$c324 = function(key, value) {
+      peg$c321 = function(e) { return e },
+      peg$c322 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c325 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c323 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -749,13 +747,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c326 = function(assignments) { return assignments },
-      peg$c327 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c328 = function(table, alias) {
+      peg$c324 = function(assignments) { return assignments },
+      peg$c325 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c326 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c329 = function(first, join) { return join },
-      peg$c330 = function(style, table, alias, leftKey, rightKey) {
+      peg$c327 = function(first, join) { return join },
+      peg$c328 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -769,117 +767,117 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c331 = function(style) { return style },
-      peg$c332 = function(keys, order) {
+      peg$c329 = function(style) { return style },
+      peg$c330 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c333 = function(dir) { return dir },
-      peg$c334 = function(count) { return count },
-      peg$c335 = peg$literalExpectation("select", true),
-      peg$c336 = function() { return "select" },
-      peg$c337 = "as",
-      peg$c338 = peg$literalExpectation("as", true),
-      peg$c339 = function() { return "as" },
-      peg$c340 = peg$literalExpectation("from", true),
-      peg$c341 = function() { return "from" },
-      peg$c342 = peg$literalExpectation("join", true),
-      peg$c343 = function() { return "join" },
-      peg$c344 = peg$literalExpectation("where", true),
-      peg$c345 = function() { return "where" },
-      peg$c346 = "group",
-      peg$c347 = peg$literalExpectation("group", true),
-      peg$c348 = function() { return "group" },
-      peg$c349 = "by",
-      peg$c350 = peg$literalExpectation("by", true),
-      peg$c351 = function() { return "by" },
-      peg$c352 = "having",
-      peg$c353 = peg$literalExpectation("having", true),
-      peg$c354 = function() { return "having" },
-      peg$c355 = peg$literalExpectation("order", true),
-      peg$c356 = function() { return "order" },
-      peg$c357 = "on",
-      peg$c358 = peg$literalExpectation("on", true),
-      peg$c359 = function() { return "on" },
-      peg$c360 = "limit",
-      peg$c361 = peg$literalExpectation("limit", true),
-      peg$c362 = function() { return "limit" },
-      peg$c363 = peg$literalExpectation("asc", true),
-      peg$c364 = peg$literalExpectation("desc", true),
-      peg$c365 = peg$literalExpectation("anti", true),
-      peg$c366 = peg$literalExpectation("left", true),
-      peg$c367 = peg$literalExpectation("right", true),
-      peg$c368 = peg$literalExpectation("inner", true),
-      peg$c369 = function(v) {
+      peg$c331 = function(dir) { return dir },
+      peg$c332 = function(count) { return count },
+      peg$c333 = peg$literalExpectation("select", true),
+      peg$c334 = function() { return "select" },
+      peg$c335 = "as",
+      peg$c336 = peg$literalExpectation("as", true),
+      peg$c337 = function() { return "as" },
+      peg$c338 = peg$literalExpectation("from", true),
+      peg$c339 = function() { return "from" },
+      peg$c340 = peg$literalExpectation("join", true),
+      peg$c341 = function() { return "join" },
+      peg$c342 = peg$literalExpectation("where", true),
+      peg$c343 = function() { return "where" },
+      peg$c344 = "group",
+      peg$c345 = peg$literalExpectation("group", true),
+      peg$c346 = function() { return "group" },
+      peg$c347 = "by",
+      peg$c348 = peg$literalExpectation("by", true),
+      peg$c349 = function() { return "by" },
+      peg$c350 = "having",
+      peg$c351 = peg$literalExpectation("having", true),
+      peg$c352 = function() { return "having" },
+      peg$c353 = peg$literalExpectation("order", true),
+      peg$c354 = function() { return "order" },
+      peg$c355 = "on",
+      peg$c356 = peg$literalExpectation("on", true),
+      peg$c357 = function() { return "on" },
+      peg$c358 = "limit",
+      peg$c359 = peg$literalExpectation("limit", true),
+      peg$c360 = function() { return "limit" },
+      peg$c361 = peg$literalExpectation("asc", true),
+      peg$c362 = peg$literalExpectation("desc", true),
+      peg$c363 = peg$literalExpectation("anti", true),
+      peg$c364 = peg$literalExpectation("left", true),
+      peg$c365 = peg$literalExpectation("right", true),
+      peg$c366 = peg$literalExpectation("inner", true),
+      peg$c367 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c370 = function(v) {
+      peg$c368 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c371 = function(v) {
+      peg$c369 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c372 = function(v) {
+      peg$c370 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c373 = "true",
-      peg$c374 = peg$literalExpectation("true", false),
-      peg$c375 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c376 = "false",
-      peg$c377 = peg$literalExpectation("false", false),
-      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c379 = "null",
-      peg$c380 = peg$literalExpectation("null", false),
-      peg$c381 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c382 = "0x",
-      peg$c383 = peg$literalExpectation("0x", false),
-      peg$c384 = function() {
+      peg$c371 = "true",
+      peg$c372 = peg$literalExpectation("true", false),
+      peg$c373 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c374 = "false",
+      peg$c375 = peg$literalExpectation("false", false),
+      peg$c376 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c377 = "null",
+      peg$c378 = peg$literalExpectation("null", false),
+      peg$c379 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c380 = "0x",
+      peg$c381 = peg$literalExpectation("0x", false),
+      peg$c382 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c385 = function(typ) {
+      peg$c383 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c386 = function(name) { return name },
-      peg$c387 = function(name, typ) {
+      peg$c384 = function(name) { return name },
+      peg$c385 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c388 = function(name) {
+      peg$c386 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c389 = function(u) { return u },
-      peg$c390 = function(types) {
+      peg$c387 = function(u) { return u },
+      peg$c388 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c391 = function(typ) { return typ },
-      peg$c392 = function(fields) {
+      peg$c389 = function(typ) { return typ },
+      peg$c390 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c393 = function(typ) {
+      peg$c391 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c394 = function(typ) {
+      peg$c392 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c395 = function(keyType, valType) {
+      peg$c393 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c396 = function(v) {
+      peg$c394 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c397 = "\"",
-      peg$c398 = peg$literalExpectation("\"", false),
-      peg$c399 = "'",
-      peg$c400 = peg$literalExpectation("'", false),
-      peg$c401 = function(v) {
+      peg$c395 = "\"",
+      peg$c396 = peg$literalExpectation("\"", false),
+      peg$c397 = "'",
+      peg$c398 = peg$literalExpectation("'", false),
+      peg$c399 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c402 = "\\",
-      peg$c403 = peg$literalExpectation("\\", false),
-      peg$c404 = "${",
-      peg$c405 = peg$literalExpectation("${", false),
-      peg$c406 = function(e) {
+      peg$c400 = "\\",
+      peg$c401 = peg$literalExpectation("\\", false),
+      peg$c402 = "${",
+      peg$c403 = peg$literalExpectation("${", false),
+      peg$c404 = function(e) {
             return {
               
             "kind": "Cast",
@@ -893,196 +891,196 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c407 = "uint8",
-      peg$c408 = peg$literalExpectation("uint8", false),
-      peg$c409 = "uint16",
-      peg$c410 = peg$literalExpectation("uint16", false),
-      peg$c411 = "uint32",
-      peg$c412 = peg$literalExpectation("uint32", false),
-      peg$c413 = "uint64",
-      peg$c414 = peg$literalExpectation("uint64", false),
-      peg$c415 = "int8",
-      peg$c416 = peg$literalExpectation("int8", false),
-      peg$c417 = "int16",
-      peg$c418 = peg$literalExpectation("int16", false),
-      peg$c419 = "int32",
-      peg$c420 = peg$literalExpectation("int32", false),
-      peg$c421 = "int64",
-      peg$c422 = peg$literalExpectation("int64", false),
-      peg$c423 = "float32",
-      peg$c424 = peg$literalExpectation("float32", false),
-      peg$c425 = "float64",
-      peg$c426 = peg$literalExpectation("float64", false),
-      peg$c427 = "bool",
-      peg$c428 = peg$literalExpectation("bool", false),
-      peg$c429 = "string",
-      peg$c430 = peg$literalExpectation("string", false),
-      peg$c431 = "duration",
-      peg$c432 = peg$literalExpectation("duration", false),
-      peg$c433 = "time",
-      peg$c434 = peg$literalExpectation("time", false),
-      peg$c435 = "bytes",
-      peg$c436 = peg$literalExpectation("bytes", false),
-      peg$c437 = "ip",
-      peg$c438 = peg$literalExpectation("ip", false),
-      peg$c439 = "net",
-      peg$c440 = peg$literalExpectation("net", false),
-      peg$c441 = function() {
+      peg$c405 = "uint8",
+      peg$c406 = peg$literalExpectation("uint8", false),
+      peg$c407 = "uint16",
+      peg$c408 = peg$literalExpectation("uint16", false),
+      peg$c409 = "uint32",
+      peg$c410 = peg$literalExpectation("uint32", false),
+      peg$c411 = "uint64",
+      peg$c412 = peg$literalExpectation("uint64", false),
+      peg$c413 = "int8",
+      peg$c414 = peg$literalExpectation("int8", false),
+      peg$c415 = "int16",
+      peg$c416 = peg$literalExpectation("int16", false),
+      peg$c417 = "int32",
+      peg$c418 = peg$literalExpectation("int32", false),
+      peg$c419 = "int64",
+      peg$c420 = peg$literalExpectation("int64", false),
+      peg$c421 = "float32",
+      peg$c422 = peg$literalExpectation("float32", false),
+      peg$c423 = "float64",
+      peg$c424 = peg$literalExpectation("float64", false),
+      peg$c425 = "bool",
+      peg$c426 = peg$literalExpectation("bool", false),
+      peg$c427 = "string",
+      peg$c428 = peg$literalExpectation("string", false),
+      peg$c429 = "duration",
+      peg$c430 = peg$literalExpectation("duration", false),
+      peg$c431 = "time",
+      peg$c432 = peg$literalExpectation("time", false),
+      peg$c433 = "bytes",
+      peg$c434 = peg$literalExpectation("bytes", false),
+      peg$c435 = "ip",
+      peg$c436 = peg$literalExpectation("ip", false),
+      peg$c437 = "net",
+      peg$c438 = peg$literalExpectation("net", false),
+      peg$c439 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c442 = function(name, typ) {
+      peg$c440 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c443 = "and",
-      peg$c444 = peg$literalExpectation("and", false),
-      peg$c445 = "AND",
-      peg$c446 = peg$literalExpectation("AND", false),
-      peg$c447 = function() { return "and" },
-      peg$c448 = "or",
-      peg$c449 = peg$literalExpectation("or", false),
-      peg$c450 = "OR",
-      peg$c451 = peg$literalExpectation("OR", false),
-      peg$c452 = function() { return "or" },
-      peg$c453 = function() { return "in" },
-      peg$c454 = "NOT",
-      peg$c455 = peg$literalExpectation("NOT", false),
-      peg$c456 = function() { return "not" },
-      peg$c457 = peg$literalExpectation("by", false),
-      peg$c458 = /^[A-Za-z_$]/,
-      peg$c459 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c460 = /^[0-9]/,
-      peg$c461 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c462 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c463 = "$",
-      peg$c464 = peg$literalExpectation("$", false),
-      peg$c465 = "T",
-      peg$c466 = peg$literalExpectation("T", false),
-      peg$c467 = function() {
+      peg$c441 = "and",
+      peg$c442 = peg$literalExpectation("and", false),
+      peg$c443 = "AND",
+      peg$c444 = peg$literalExpectation("AND", false),
+      peg$c445 = function() { return "and" },
+      peg$c446 = "or",
+      peg$c447 = peg$literalExpectation("or", false),
+      peg$c448 = "OR",
+      peg$c449 = peg$literalExpectation("OR", false),
+      peg$c450 = function() { return "or" },
+      peg$c451 = function() { return "in" },
+      peg$c452 = "NOT",
+      peg$c453 = peg$literalExpectation("NOT", false),
+      peg$c454 = function() { return "not" },
+      peg$c455 = peg$literalExpectation("by", false),
+      peg$c456 = /^[A-Za-z_$]/,
+      peg$c457 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c458 = /^[0-9]/,
+      peg$c459 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c460 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c461 = "$",
+      peg$c462 = peg$literalExpectation("$", false),
+      peg$c463 = "T",
+      peg$c464 = peg$literalExpectation("T", false),
+      peg$c465 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c468 = "Z",
-      peg$c469 = peg$literalExpectation("Z", false),
-      peg$c470 = function() {
+      peg$c466 = "Z",
+      peg$c467 = peg$literalExpectation("Z", false),
+      peg$c468 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c471 = "ns",
-      peg$c472 = peg$literalExpectation("ns", false),
-      peg$c473 = "us",
-      peg$c474 = peg$literalExpectation("us", false),
-      peg$c475 = "ms",
-      peg$c476 = peg$literalExpectation("ms", false),
-      peg$c477 = "s",
-      peg$c478 = peg$literalExpectation("s", false),
-      peg$c479 = "m",
-      peg$c480 = peg$literalExpectation("m", false),
-      peg$c481 = "h",
-      peg$c482 = peg$literalExpectation("h", false),
-      peg$c483 = "d",
-      peg$c484 = peg$literalExpectation("d", false),
-      peg$c485 = "w",
-      peg$c486 = peg$literalExpectation("w", false),
-      peg$c487 = "y",
-      peg$c488 = peg$literalExpectation("y", false),
-      peg$c489 = function(a, b) {
+      peg$c469 = "ns",
+      peg$c470 = peg$literalExpectation("ns", false),
+      peg$c471 = "us",
+      peg$c472 = peg$literalExpectation("us", false),
+      peg$c473 = "ms",
+      peg$c474 = peg$literalExpectation("ms", false),
+      peg$c475 = "s",
+      peg$c476 = peg$literalExpectation("s", false),
+      peg$c477 = "m",
+      peg$c478 = peg$literalExpectation("m", false),
+      peg$c479 = "h",
+      peg$c480 = peg$literalExpectation("h", false),
+      peg$c481 = "d",
+      peg$c482 = peg$literalExpectation("d", false),
+      peg$c483 = "w",
+      peg$c484 = peg$literalExpectation("w", false),
+      peg$c485 = "y",
+      peg$c486 = peg$literalExpectation("y", false),
+      peg$c487 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c490 = "::",
-      peg$c491 = peg$literalExpectation("::", false),
-      peg$c492 = function(a, b, d, e) {
+      peg$c488 = "::",
+      peg$c489 = peg$literalExpectation("::", false),
+      peg$c490 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c493 = function(a, b) {
+      peg$c491 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c494 = function(a, b) {
+      peg$c492 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c495 = function() {
+      peg$c493 = function() {
             return "::"
           },
-      peg$c496 = function(v) { return ":" + v },
-      peg$c497 = function(v) { return v + ":" },
-      peg$c498 = function(a, m) {
+      peg$c494 = function(v) { return ":" + v },
+      peg$c495 = function(v) { return v + ":" },
+      peg$c496 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c499 = function(a, m) {
+      peg$c497 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c500 = function(s) { return parseInt(s) },
-      peg$c501 = function() {
+      peg$c498 = function(s) { return parseInt(s) },
+      peg$c499 = function() {
             return text()
           },
-      peg$c502 = "e",
-      peg$c503 = peg$literalExpectation("e", true),
-      peg$c504 = /^[+\-]/,
-      peg$c505 = peg$classExpectation(["+", "-"], false, false),
-      peg$c506 = "NaN",
-      peg$c507 = peg$literalExpectation("NaN", false),
-      peg$c508 = "Inf",
-      peg$c509 = peg$literalExpectation("Inf", false),
-      peg$c510 = /^[0-9a-fA-F]/,
-      peg$c511 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c512 = function(v) { return joinChars(v) },
-      peg$c513 = peg$anyExpectation(),
-      peg$c514 = function(head, tail) { return head + joinChars(tail) },
-      peg$c515 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c516 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c517 = function(head, tail) {
+      peg$c500 = "e",
+      peg$c501 = peg$literalExpectation("e", true),
+      peg$c502 = /^[+\-]/,
+      peg$c503 = peg$classExpectation(["+", "-"], false, false),
+      peg$c504 = "NaN",
+      peg$c505 = peg$literalExpectation("NaN", false),
+      peg$c506 = "Inf",
+      peg$c507 = peg$literalExpectation("Inf", false),
+      peg$c508 = /^[0-9a-fA-F]/,
+      peg$c509 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c510 = function(v) { return joinChars(v) },
+      peg$c511 = peg$anyExpectation(),
+      peg$c512 = function(head, tail) { return head + joinChars(tail) },
+      peg$c513 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c514 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c515 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c518 = function() { return "*"},
-      peg$c519 = function() { return "=" },
-      peg$c520 = function() { return "\\*" },
-      peg$c521 = "b",
-      peg$c522 = peg$literalExpectation("b", false),
-      peg$c523 = function() { return "\b" },
-      peg$c524 = "f",
-      peg$c525 = peg$literalExpectation("f", false),
-      peg$c526 = function() { return "\f" },
-      peg$c527 = "n",
-      peg$c528 = peg$literalExpectation("n", false),
-      peg$c529 = function() { return "\n" },
-      peg$c530 = "r",
-      peg$c531 = peg$literalExpectation("r", false),
-      peg$c532 = function() { return "\r" },
-      peg$c533 = "t",
-      peg$c534 = peg$literalExpectation("t", false),
-      peg$c535 = function() { return "\t" },
-      peg$c536 = "v",
-      peg$c537 = peg$literalExpectation("v", false),
-      peg$c538 = function() { return "\v" },
-      peg$c539 = function() { return "*" },
-      peg$c540 = "u",
-      peg$c541 = peg$literalExpectation("u", false),
-      peg$c542 = function(chars) {
+      peg$c516 = function() { return "*"},
+      peg$c517 = function() { return "=" },
+      peg$c518 = function() { return "\\*" },
+      peg$c519 = "b",
+      peg$c520 = peg$literalExpectation("b", false),
+      peg$c521 = function() { return "\b" },
+      peg$c522 = "f",
+      peg$c523 = peg$literalExpectation("f", false),
+      peg$c524 = function() { return "\f" },
+      peg$c525 = "n",
+      peg$c526 = peg$literalExpectation("n", false),
+      peg$c527 = function() { return "\n" },
+      peg$c528 = "r",
+      peg$c529 = peg$literalExpectation("r", false),
+      peg$c530 = function() { return "\r" },
+      peg$c531 = "t",
+      peg$c532 = peg$literalExpectation("t", false),
+      peg$c533 = function() { return "\t" },
+      peg$c534 = "v",
+      peg$c535 = peg$literalExpectation("v", false),
+      peg$c536 = function() { return "\v" },
+      peg$c537 = function() { return "*" },
+      peg$c538 = "u",
+      peg$c539 = peg$literalExpectation("u", false),
+      peg$c540 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c543 = /^[^\/\\]/,
-      peg$c544 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c545 = /^[\0-\x1F\\]/,
-      peg$c546 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c547 = peg$otherExpectation("whitespace"),
-      peg$c548 = "\t",
-      peg$c549 = peg$literalExpectation("\t", false),
-      peg$c550 = "\x0B",
-      peg$c551 = peg$literalExpectation("\x0B", false),
-      peg$c552 = "\f",
-      peg$c553 = peg$literalExpectation("\f", false),
-      peg$c554 = " ",
-      peg$c555 = peg$literalExpectation(" ", false),
-      peg$c556 = "\xA0",
-      peg$c557 = peg$literalExpectation("\xA0", false),
-      peg$c558 = "\uFEFF",
-      peg$c559 = peg$literalExpectation("\uFEFF", false),
-      peg$c560 = /^[\n\r\u2028\u2029]/,
-      peg$c561 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c562 = peg$otherExpectation("comment"),
-      peg$c563 = "/*",
-      peg$c564 = peg$literalExpectation("/*", false),
-      peg$c565 = "*/",
-      peg$c566 = peg$literalExpectation("*/", false),
-      peg$c567 = "//",
-      peg$c568 = peg$literalExpectation("//", false),
+      peg$c541 = /^[^\/\\]/,
+      peg$c542 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c543 = /^[\0-\x1F\\]/,
+      peg$c544 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c545 = peg$otherExpectation("whitespace"),
+      peg$c546 = "\t",
+      peg$c547 = peg$literalExpectation("\t", false),
+      peg$c548 = "\x0B",
+      peg$c549 = peg$literalExpectation("\x0B", false),
+      peg$c550 = "\f",
+      peg$c551 = peg$literalExpectation("\f", false),
+      peg$c552 = " ",
+      peg$c553 = peg$literalExpectation(" ", false),
+      peg$c554 = "\xA0",
+      peg$c555 = peg$literalExpectation("\xA0", false),
+      peg$c556 = "\uFEFF",
+      peg$c557 = peg$literalExpectation("\uFEFF", false),
+      peg$c558 = /^[\n\r\u2028\u2029]/,
+      peg$c559 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c560 = peg$otherExpectation("comment"),
+      peg$c561 = "/*",
+      peg$c562 = peg$literalExpectation("/*", false),
+      peg$c563 = "*/",
+      peg$c564 = peg$literalExpectation("*/", false),
+      peg$c565 = "//",
+      peg$c566 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -6044,7 +6042,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOverOp() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+    var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c251) {
@@ -6059,66 +6057,18 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$currPos;
-          s5 = peg$parse_();
-          if (s5 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c92) {
-              s6 = peg$c92;
-              peg$currPos += 4;
-            } else {
-              s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c93); }
-            }
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parse_();
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parseLetAssignments();
-                if (s8 !== peg$FAILED) {
-                  peg$savedPos = s4;
-                  s5 = peg$c253(s3, s8);
-                  s4 = s5;
-                } else {
-                  peg$currPos = s4;
-                  s4 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s4;
-                s4 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s4;
-              s4 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s4;
-            s4 = peg$FAILED;
-          }
+          s4 = peg$parseLocals();
           if (s4 === peg$FAILED) {
             s4 = null;
           }
           if (s4 !== peg$FAILED) {
-            s5 = peg$currPos;
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseScope();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s5;
-                s6 = peg$c254(s3, s4, s7);
-                s5 = s6;
-              } else {
-                peg$currPos = s5;
-                s5 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s5;
-              s5 = peg$FAILED;
-            }
+            s5 = peg$parseScope();
             if (s5 === peg$FAILED) {
               s5 = null;
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c255(s3, s4, s5);
+              s1 = peg$c253(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6145,44 +6095,50 @@ function peg$parse(input, options) {
   }
 
   function peg$parseScope() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c33) {
-      s1 = peg$c33;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c34); }
-    }
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
+      if (input.substr(peg$currPos, 2) === peg$c33) {
+        s2 = peg$c33;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c34); }
+      }
       if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c15;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
-        }
+        s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          if (input.charCodeAt(peg$currPos) === 40) {
+            s4 = peg$c15;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseSequential();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
+              s6 = peg$parseSequential();
               if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c17;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
-                }
+                s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c256(s5);
-                  s0 = s1;
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s8 = peg$c17;
+                    peg$currPos++;
+                  } else {
+                    s8 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                  }
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c254(s6);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -6215,88 +6171,112 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLetAssignments() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseLocals() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    s1 = peg$parseLetAssignment();
+    s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c100;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseLetAssignment();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c257(s1, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+      if (input.substr(peg$currPos, 4) === peg$c92) {
+        s2 = peg$c92;
+        peg$currPos += 4;
       } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c100;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseLetAssignment();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c257(s1, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c103(s1, s2);
-        s0 = s1;
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseLocalsAssignment();
+          if (s4 !== peg$FAILED) {
+            s5 = [];
+            s6 = peg$currPos;
+            s7 = peg$parse__();
+            if (s7 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 44) {
+                s8 = peg$c100;
+                peg$currPos++;
+              } else {
+                s8 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              }
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parse__();
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parseLocalsAssignment();
+                  if (s10 !== peg$FAILED) {
+                    peg$savedPos = s6;
+                    s7 = peg$c255(s4, s10);
+                    s6 = s7;
+                  } else {
+                    peg$currPos = s6;
+                    s6 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s6;
+                  s6 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s6;
+                s6 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s6;
+              s6 = peg$FAILED;
+            }
+            while (s6 !== peg$FAILED) {
+              s5.push(s6);
+              s6 = peg$currPos;
+              s7 = peg$parse__();
+              if (s7 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 44) {
+                  s8 = peg$c100;
+                  peg$currPos++;
+                } else {
+                  s8 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c101); }
+                }
+                if (s8 !== peg$FAILED) {
+                  s9 = peg$parse__();
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parseLocalsAssignment();
+                    if (s10 !== peg$FAILED) {
+                      peg$savedPos = s6;
+                      s7 = peg$c255(s4, s10);
+                      s6 = s7;
+                    } else {
+                      peg$currPos = s6;
+                      s6 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s6;
+                    s6 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s6;
+                  s6 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s6;
+                s6 = peg$FAILED;
+              }
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c103(s4, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -6309,7 +6289,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLetAssignment() {
+  function peg$parseLocalsAssignment() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
@@ -6357,7 +6337,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIdentifierName();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c258(s1);
+        s1 = peg$c256(s1);
       }
       s0 = s1;
     }
@@ -6369,12 +6349,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c259) {
-      s1 = peg$c259;
+    if (input.substr(peg$currPos, 5) === peg$c257) {
+      s1 = peg$c257;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c260); }
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6382,7 +6362,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c261(s3);
+          s1 = peg$c259(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6413,7 +6393,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s4);
+            s1 = peg$c260(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6448,7 +6428,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c263(s4);
+            s1 = peg$c261(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6493,7 +6473,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c264(s1, s7);
+              s4 = peg$c262(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6529,7 +6509,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c264(s1, s7);
+                s4 = peg$c262(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6642,7 +6622,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c263(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6679,7 +6659,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c257(s1, s7);
+              s4 = peg$c255(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6715,7 +6695,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c257(s1, s7);
+                s4 = peg$c255(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6736,7 +6716,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6771,7 +6751,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c267(s1, s5);
+              s1 = peg$c265(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6814,11 +6794,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c268;
+          s3 = peg$c266;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c269); }
+          if (peg$silentFails === 0) { peg$fail(peg$c267); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6840,7 +6820,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c270(s1, s5, s9);
+                      s1 = peg$c268(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6902,7 +6882,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c271(s1, s5, s7);
+              s4 = peg$c269(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6932,7 +6912,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c271(s1, s5, s7);
+                s4 = peg$c269(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6953,7 +6933,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6984,7 +6964,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c271(s1, s5, s7);
+              s4 = peg$c269(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7014,7 +6994,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c271(s1, s5, s7);
+                s4 = peg$c269(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7035,7 +7015,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7096,7 +7076,7 @@ function peg$parse(input, options) {
           }
           if (s5 !== peg$FAILED) {
             peg$savedPos = s4;
-            s5 = peg$c273(s1);
+            s5 = peg$c271(s1);
           }
           s4 = s5;
           if (s4 !== peg$FAILED) {
@@ -7128,7 +7108,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7159,7 +7139,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c271(s1, s5, s7);
+              s4 = peg$c269(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7189,7 +7169,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c271(s1, s5, s7);
+                s4 = peg$c269(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7210,7 +7190,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7229,19 +7209,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c275;
+      s1 = peg$c273;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c277;
+        s1 = peg$c275;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7270,7 +7250,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c271(s1, s5, s7);
+              s4 = peg$c269(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7300,7 +7280,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c271(s1, s5, s7);
+                s4 = peg$c269(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7321,7 +7301,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7348,19 +7328,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c279;
+        s1 = peg$c277;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c281;
+          s1 = peg$c279;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c282); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
       }
     }
@@ -7390,7 +7370,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c283(s3);
+          s1 = peg$c281(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7427,11 +7407,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c277;
+        s2 = peg$c275;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7439,7 +7419,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c284(s4);
+            s1 = peg$c282(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7558,20 +7538,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c285) {
-      s0 = peg$c285;
+    if (input.substr(peg$currPos, 3) === peg$c283) {
+      s0 = peg$c283;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c287) {
-        s0 = peg$c287;
+      if (input.substr(peg$currPos, 6) === peg$c285) {
+        s0 = peg$c285;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
     }
 
@@ -7609,7 +7589,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c289(s1, s5);
+                  s1 = peg$c287(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7692,7 +7672,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c290(s2, s6, s9);
+                        s1 = peg$c288(s2, s6, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7739,12 +7719,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c291) {
-      s1 = peg$c291;
+    if (input.substr(peg$currPos, 4) === peg$c289) {
+      s1 = peg$c289;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c290); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7772,7 +7752,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c293(s5);
+                  s1 = peg$c291(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7804,12 +7784,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c291) {
-        s1 = peg$c291;
+      if (input.substr(peg$currPos, 4) === peg$c289) {
+        s1 = peg$c289;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c292); }
+        if (peg$silentFails === 0) { peg$fail(peg$c290); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7851,7 +7831,7 @@ function peg$parse(input, options) {
                           }
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c294(s5, s9);
+                            s1 = peg$c292(s5, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7913,7 +7893,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c295(s1);
+          s1 = peg$c293(s1);
         }
         s0 = s1;
       }
@@ -7962,7 +7942,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c296(s1, s7);
+              s4 = peg$c294(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7998,7 +7978,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c296(s1, s7);
+                s4 = peg$c294(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8108,15 +8088,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c297;
+                  s7 = peg$c295;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c299(s2, s6);
+                  s1 = peg$c297(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8171,15 +8151,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c297;
+                  s6 = peg$c295;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c300(s5);
+                  s1 = peg$c298(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8218,15 +8198,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c297;
+              s3 = peg$c295;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c298); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c301(s2);
+              s1 = peg$c299(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8253,7 +8233,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c302(s2);
+              s1 = peg$c300(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8402,40 +8382,7 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$currPos;
-          s5 = peg$parse_();
-          if (s5 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c92) {
-              s6 = peg$c92;
-              peg$currPos += 4;
-            } else {
-              s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c93); }
-            }
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parse_();
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parseLetAssignments();
-                if (s8 !== peg$FAILED) {
-                  peg$savedPos = s4;
-                  s5 = peg$c253(s3, s8);
-                  s4 = s5;
-                } else {
-                  peg$currPos = s4;
-                  s4 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s4;
-                s4 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s4;
-              s4 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s4;
-            s4 = peg$FAILED;
-          }
+          s4 = peg$parseLocals();
           if (s4 === peg$FAILED) {
             s4 = null;
           }
@@ -8455,7 +8402,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c303(s3, s4, s8);
+                    s1 = peg$c301(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8512,15 +8459,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c304;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c306(s3);
+              s1 = peg$c304(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8560,7 +8507,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8602,7 +8549,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c307(s4);
+            s1 = peg$c305(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8642,12 +8589,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c308) {
-      s1 = peg$c308;
+    if (input.substr(peg$currPos, 3) === peg$c306) {
+      s1 = peg$c306;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c309); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8655,7 +8602,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c310(s3);
+          s1 = peg$c308(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8694,7 +8641,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s1, s5);
+              s1 = peg$c309(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8739,15 +8686,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c297;
+              s5 = peg$c295;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c298); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c312(s3);
+              s1 = peg$c310(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8777,12 +8724,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c313) {
-      s1 = peg$c313;
+    if (input.substr(peg$currPos, 2) === peg$c311) {
+      s1 = peg$c311;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8791,16 +8738,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c315) {
-              s5 = peg$c315;
+            if (input.substr(peg$currPos, 2) === peg$c313) {
+              s5 = peg$c313;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c316); }
+              if (peg$silentFails === 0) { peg$fail(peg$c314); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c317(s3);
+              s1 = peg$c315(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8830,12 +8777,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c318) {
-      s1 = peg$c318;
+    if (input.substr(peg$currPos, 2) === peg$c316) {
+      s1 = peg$c316;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c319); }
+      if (peg$silentFails === 0) { peg$fail(peg$c317); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8844,16 +8791,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c320) {
-              s5 = peg$c320;
+            if (input.substr(peg$currPos, 2) === peg$c318) {
+              s5 = peg$c318;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c321); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c322(s3);
+              s1 = peg$c320(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8893,7 +8840,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8935,7 +8882,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c323(s4);
+            s1 = peg$c321(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8978,7 +8925,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c324(s1, s5);
+              s1 = peg$c322(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9043,7 +8990,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c325(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c323(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9121,7 +9068,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s3);
+            s1 = peg$c324(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9155,7 +9102,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c327(s1, s5);
+              s1 = peg$c325(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9302,7 +9249,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c328(s4, s5);
+              s1 = peg$c326(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9457,7 +9404,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c329(s1, s4);
+        s4 = peg$c327(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9466,7 +9413,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c329(s1, s4);
+          s4 = peg$c327(s1, s4);
         }
         s3 = s4;
       }
@@ -9528,7 +9475,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c330(s1, s5, s6, s10, s14);
+                                s1 = peg$c328(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9608,7 +9555,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c331(s2);
+        s1 = peg$c329(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9767,7 +9714,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c332(s6, s7);
+                  s1 = peg$c330(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9813,7 +9760,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s2);
+        s1 = peg$c331(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9849,7 +9796,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334(s4);
+            s1 = peg$c332(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9884,16 +9831,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c287) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c285) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c333); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c336();
+      s1 = peg$c334();
     }
     s0 = s1;
 
@@ -9904,16 +9851,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c337) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c335) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c336); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339();
+      s1 = peg$c337();
     }
     s0 = s1;
 
@@ -9929,11 +9876,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341();
+      s1 = peg$c339();
     }
     s0 = s1;
 
@@ -9949,11 +9896,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c343();
+      s1 = peg$c341();
     }
     s0 = s1;
 
@@ -9969,11 +9916,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c345();
+      s1 = peg$c343();
     }
     s0 = s1;
 
@@ -9984,16 +9931,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c344) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -10004,16 +9951,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c349) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c347) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c348); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c349();
     }
     s0 = s1;
 
@@ -10024,16 +9971,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c352) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c350) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c351); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c354();
+      s1 = peg$c352();
     }
     s0 = s1;
 
@@ -10049,11 +9996,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c354();
     }
     s0 = s1;
 
@@ -10064,16 +10011,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c357) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c355) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c359();
+      s1 = peg$c357();
     }
     s0 = s1;
 
@@ -10084,16 +10031,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c360) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c358) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c359); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c360();
     }
     s0 = s1;
 
@@ -10109,7 +10056,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10129,7 +10076,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c362); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10149,7 +10096,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10169,7 +10116,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10189,7 +10136,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10209,7 +10156,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10311,7 +10258,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c369(s1);
+        s1 = peg$c367(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10326,7 +10273,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c369(s1);
+        s1 = peg$c367(s1);
       }
       s0 = s1;
     }
@@ -10352,7 +10299,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c370(s1);
+        s1 = peg$c368(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10367,7 +10314,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c370(s1);
+        s1 = peg$c368(s1);
       }
       s0 = s1;
     }
@@ -10382,7 +10329,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c371(s1);
+      s1 = peg$c369(s1);
     }
     s0 = s1;
 
@@ -10396,7 +10343,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c372(s1);
+      s1 = peg$c370(s1);
     }
     s0 = s1;
 
@@ -10407,30 +10354,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c373) {
-      s1 = peg$c373;
+    if (input.substr(peg$currPos, 4) === peg$c371) {
+      s1 = peg$c371;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c375();
+      s1 = peg$c373();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c376) {
-        s1 = peg$c376;
+      if (input.substr(peg$currPos, 5) === peg$c374) {
+        s1 = peg$c374;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c377); }
+        if (peg$silentFails === 0) { peg$fail(peg$c375); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c378();
+        s1 = peg$c376();
       }
       s0 = s1;
     }
@@ -10442,16 +10389,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c379) {
-      s1 = peg$c379;
+    if (input.substr(peg$currPos, 4) === peg$c377) {
+      s1 = peg$c377;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c378); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c381();
+      s1 = peg$c379();
     }
     s0 = s1;
 
@@ -10462,12 +10409,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c382) {
-      s1 = peg$c382;
+    if (input.substr(peg$currPos, 2) === peg$c380) {
+      s1 = peg$c380;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c383); }
+      if (peg$silentFails === 0) { peg$fail(peg$c381); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10478,7 +10425,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c384();
+        s1 = peg$c382();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10515,7 +10462,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c385(s2);
+          s1 = peg$c383(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10542,7 +10489,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c385(s1);
+        s1 = peg$c383(s1);
       }
       s0 = s1;
     }
@@ -10582,7 +10529,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c386(s1);
+        s1 = peg$c384(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10611,7 +10558,7 @@ function peg$parse(input, options) {
               s5 = peg$parseType();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c387(s1, s5);
+                s1 = peg$c385(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10638,7 +10585,7 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c388(s1);
+          s1 = peg$c386(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10664,7 +10611,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c389(s3);
+                  s1 = peg$c387(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10696,7 +10643,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c390(s1);
+      s1 = peg$c388(s1);
     }
     s0 = s1;
 
@@ -10721,7 +10668,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10754,7 +10701,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c391(s4);
+            s1 = peg$c389(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10795,15 +10742,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c304;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c392(s3);
+              s1 = peg$c390(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10842,15 +10789,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c297;
+                s5 = peg$c295;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                if (peg$silentFails === 0) { peg$fail(peg$c296); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c393(s3);
+                s1 = peg$c391(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10874,12 +10821,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c313) {
-          s1 = peg$c313;
+        if (input.substr(peg$currPos, 2) === peg$c311) {
+          s1 = peg$c311;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c314); }
+          if (peg$silentFails === 0) { peg$fail(peg$c312); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10888,16 +10835,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c315) {
-                  s5 = peg$c315;
+                if (input.substr(peg$currPos, 2) === peg$c313) {
+                  s5 = peg$c313;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c316); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c314); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c394(s3);
+                  s1 = peg$c392(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10921,12 +10868,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c318) {
-            s1 = peg$c318;
+          if (input.substr(peg$currPos, 2) === peg$c316) {
+            s1 = peg$c316;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c319); }
+            if (peg$silentFails === 0) { peg$fail(peg$c317); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10949,16 +10896,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c320) {
-                            s9 = peg$c320;
+                          if (input.substr(peg$currPos, 2) === peg$c318) {
+                            s9 = peg$c318;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c321); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c319); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c395(s3, s7);
+                            s1 = peg$c393(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11010,7 +10957,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c396(s1);
+      s1 = peg$c394(s1);
     }
     s0 = s1;
 
@@ -11022,11 +10969,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c397;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c398); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11037,11 +10984,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c397;
+          s3 = peg$c395;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c398); }
+          if (peg$silentFails === 0) { peg$fail(peg$c396); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11062,11 +11009,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c399;
+        s1 = peg$c397;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c400); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11077,11 +11024,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c399;
+            s3 = peg$c397;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c400); }
+            if (peg$silentFails === 0) { peg$fail(peg$c398); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11122,7 +11069,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c401(s1);
+        s1 = peg$c399(s1);
       }
       s0 = s1;
     }
@@ -11135,19 +11082,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c402;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c404) {
-        s2 = peg$c404;
+      if (input.substr(peg$currPos, 2) === peg$c402) {
+        s2 = peg$c402;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11165,12 +11112,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c404) {
-        s2 = peg$c404;
+      if (input.substr(peg$currPos, 2) === peg$c402) {
+        s2 = peg$c402;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11216,7 +11163,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c401(s1);
+        s1 = peg$c399(s1);
       }
       s0 = s1;
     }
@@ -11229,19 +11176,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c402;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c404) {
-        s2 = peg$c404;
+      if (input.substr(peg$currPos, 2) === peg$c402) {
+        s2 = peg$c402;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11259,12 +11206,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c404) {
-        s2 = peg$c404;
+      if (input.substr(peg$currPos, 2) === peg$c402) {
+        s2 = peg$c402;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11296,12 +11243,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c404) {
-      s1 = peg$c404;
+    if (input.substr(peg$currPos, 2) === peg$c402) {
+      s1 = peg$c402;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11311,15 +11258,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c304;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c406(s3);
+              s1 = peg$c404(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11349,140 +11296,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c407) {
-      s1 = peg$c407;
+    if (input.substr(peg$currPos, 5) === peg$c405) {
+      s1 = peg$c405;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c409) {
-        s1 = peg$c409;
+      if (input.substr(peg$currPos, 6) === peg$c407) {
+        s1 = peg$c407;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c410); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c411) {
-          s1 = peg$c411;
+        if (input.substr(peg$currPos, 6) === peg$c409) {
+          s1 = peg$c409;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c412); }
+          if (peg$silentFails === 0) { peg$fail(peg$c410); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c413) {
-            s1 = peg$c413;
+          if (input.substr(peg$currPos, 6) === peg$c411) {
+            s1 = peg$c411;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c414); }
+            if (peg$silentFails === 0) { peg$fail(peg$c412); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c415) {
-              s1 = peg$c415;
+            if (input.substr(peg$currPos, 4) === peg$c413) {
+              s1 = peg$c413;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c416); }
+              if (peg$silentFails === 0) { peg$fail(peg$c414); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c417) {
-                s1 = peg$c417;
+              if (input.substr(peg$currPos, 5) === peg$c415) {
+                s1 = peg$c415;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c418); }
+                if (peg$silentFails === 0) { peg$fail(peg$c416); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c419) {
-                  s1 = peg$c419;
+                if (input.substr(peg$currPos, 5) === peg$c417) {
+                  s1 = peg$c417;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c420); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c418); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c421) {
-                    s1 = peg$c421;
+                  if (input.substr(peg$currPos, 5) === peg$c419) {
+                    s1 = peg$c419;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c422); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c420); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c423) {
-                      s1 = peg$c423;
+                    if (input.substr(peg$currPos, 7) === peg$c421) {
+                      s1 = peg$c421;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c424); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c422); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c425) {
-                        s1 = peg$c425;
+                      if (input.substr(peg$currPos, 7) === peg$c423) {
+                        s1 = peg$c423;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c424); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c427) {
-                          s1 = peg$c427;
+                        if (input.substr(peg$currPos, 4) === peg$c425) {
+                          s1 = peg$c425;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c428); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c426); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c429) {
-                            s1 = peg$c429;
+                          if (input.substr(peg$currPos, 6) === peg$c427) {
+                            s1 = peg$c427;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c430); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c428); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c431) {
-                              s1 = peg$c431;
+                            if (input.substr(peg$currPos, 8) === peg$c429) {
+                              s1 = peg$c429;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c432); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c430); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c433) {
-                                s1 = peg$c433;
+                              if (input.substr(peg$currPos, 4) === peg$c431) {
+                                s1 = peg$c431;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c434); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c432); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c435) {
-                                  s1 = peg$c435;
+                                if (input.substr(peg$currPos, 5) === peg$c433) {
+                                  s1 = peg$c433;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c434); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c437) {
-                                    s1 = peg$c437;
+                                  if (input.substr(peg$currPos, 2) === peg$c435) {
+                                    s1 = peg$c435;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c436); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c439) {
-                                      s1 = peg$c439;
+                                    if (input.substr(peg$currPos, 3) === peg$c437) {
+                                      s1 = peg$c437;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c438); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11493,12 +11440,12 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c379) {
-                                          s1 = peg$c379;
+                                        if (input.substr(peg$currPos, 4) === peg$c377) {
+                                          s1 = peg$c377;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c380); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c378); }
                                         }
                                       }
                                     }
@@ -11520,7 +11467,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c441();
+      s1 = peg$c439();
     }
     s0 = s1;
 
@@ -11541,7 +11488,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11583,7 +11530,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c391(s4);
+            s1 = peg$c389(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11626,7 +11573,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c442(s1, s5);
+              s1 = peg$c440(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11667,20 +11614,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c443) {
-      s1 = peg$c443;
+    if (input.substr(peg$currPos, 3) === peg$c441) {
+      s1 = peg$c441;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c444); }
+      if (peg$silentFails === 0) { peg$fail(peg$c442); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c445) {
-        s1 = peg$c445;
+      if (input.substr(peg$currPos, 3) === peg$c443) {
+        s1 = peg$c443;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c446); }
+        if (peg$silentFails === 0) { peg$fail(peg$c444); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11696,7 +11643,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c447();
+        s1 = peg$c445();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11714,20 +11661,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c448) {
-      s1 = peg$c448;
+    if (input.substr(peg$currPos, 2) === peg$c446) {
+      s1 = peg$c446;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c449); }
+      if (peg$silentFails === 0) { peg$fail(peg$c447); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c450) {
-        s1 = peg$c450;
+      if (input.substr(peg$currPos, 2) === peg$c448) {
+        s1 = peg$c448;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c451); }
+        if (peg$silentFails === 0) { peg$fail(peg$c449); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11743,7 +11690,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c452();
+        s1 = peg$c450();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11781,7 +11728,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c453();
+        s1 = peg$c451();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11799,20 +11746,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c285) {
-      s1 = peg$c285;
+    if (input.substr(peg$currPos, 3) === peg$c283) {
+      s1 = peg$c283;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c454) {
-        s1 = peg$c454;
+      if (input.substr(peg$currPos, 3) === peg$c452) {
+        s1 = peg$c452;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c455); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11828,7 +11775,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c456();
+        s1 = peg$c454();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11846,12 +11793,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c349) {
-      s1 = peg$c349;
+    if (input.substr(peg$currPos, 2) === peg$c347) {
+      s1 = peg$c347;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c457); }
+      if (peg$silentFails === 0) { peg$fail(peg$c455); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11866,7 +11813,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351();
+        s1 = peg$c349();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11883,12 +11830,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c458.test(input.charAt(peg$currPos))) {
+    if (peg$c456.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c459); }
+      if (peg$silentFails === 0) { peg$fail(peg$c457); }
     }
 
     return s0;
@@ -11899,12 +11846,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
     }
 
@@ -11918,7 +11865,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c462(s1);
+      s1 = peg$c460(s1);
     }
     s0 = s1;
 
@@ -11990,11 +11937,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c463;
+        s1 = peg$c461;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c462); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12004,11 +11951,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c402;
+          s1 = peg$c400;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c403); }
+          if (peg$silentFails === 0) { peg$fail(peg$c401); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12116,17 +12063,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c465;
+        s2 = peg$c463;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c467();
+          s1 = peg$c465();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12151,21 +12098,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c277;
+        s2 = peg$c275;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c277;
+            s4 = peg$c275;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c278); }
+            if (peg$silentFails === 0) { peg$fail(peg$c276); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12200,36 +12147,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c460.test(input.charAt(peg$currPos))) {
+    if (peg$c458.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c459); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c460.test(input.charAt(peg$currPos))) {
+        if (peg$c458.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c461); }
+          if (peg$silentFails === 0) { peg$fail(peg$c459); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c460.test(input.charAt(peg$currPos))) {
+          if (peg$c458.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c461); }
+            if (peg$silentFails === 0) { peg$fail(peg$c459); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12258,20 +12205,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c460.test(input.charAt(peg$currPos))) {
+    if (peg$c458.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c459); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12346,22 +12293,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c460.test(input.charAt(peg$currPos))) {
+                if (peg$c458.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c459); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c460.test(input.charAt(peg$currPos))) {
+                    if (peg$c458.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c459); }
                     }
                   }
                 } else {
@@ -12416,28 +12363,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c468;
+      s0 = peg$c466;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c469); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c275;
+        s1 = peg$c273;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c276); }
+        if (peg$silentFails === 0) { peg$fail(peg$c274); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c277;
+          s1 = peg$c275;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c278); }
+          if (peg$silentFails === 0) { peg$fail(peg$c276); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12463,22 +12410,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c460.test(input.charAt(peg$currPos))) {
+                if (peg$c458.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c459); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c460.test(input.charAt(peg$currPos))) {
+                    if (peg$c458.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c459); }
                     }
                   }
                 } else {
@@ -12531,11 +12478,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c277;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12581,7 +12528,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c470();
+        s1 = peg$c468();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12643,76 +12590,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c471) {
-      s0 = peg$c471;
+    if (input.substr(peg$currPos, 2) === peg$c469) {
+      s0 = peg$c469;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c470); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c473) {
-        s0 = peg$c473;
+      if (input.substr(peg$currPos, 2) === peg$c471) {
+        s0 = peg$c471;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c474); }
+        if (peg$silentFails === 0) { peg$fail(peg$c472); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c475) {
-          s0 = peg$c475;
+        if (input.substr(peg$currPos, 2) === peg$c473) {
+          s0 = peg$c473;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c476); }
+          if (peg$silentFails === 0) { peg$fail(peg$c474); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c477;
+            s0 = peg$c475;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c478); }
+            if (peg$silentFails === 0) { peg$fail(peg$c476); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c479;
+              s0 = peg$c477;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c480); }
+              if (peg$silentFails === 0) { peg$fail(peg$c478); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c481;
+                s0 = peg$c479;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c482); }
+                if (peg$silentFails === 0) { peg$fail(peg$c480); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c483;
+                  s0 = peg$c481;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c484); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c482); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c485;
+                    s0 = peg$c483;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c486); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c484); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c487;
+                      s0 = peg$c485;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c488); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c486); }
                     }
                   }
                 }
@@ -12897,7 +12844,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c489(s1, s2);
+        s1 = peg$c487(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12918,12 +12865,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c490) {
-            s3 = peg$c490;
+          if (input.substr(peg$currPos, 2) === peg$c488) {
+            s3 = peg$c488;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c491); }
+            if (peg$silentFails === 0) { peg$fail(peg$c489); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12936,7 +12883,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c492(s1, s2, s4, s5);
+                s1 = peg$c490(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12960,12 +12907,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c490) {
-          s1 = peg$c490;
+        if (input.substr(peg$currPos, 2) === peg$c488) {
+          s1 = peg$c488;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c491); }
+          if (peg$silentFails === 0) { peg$fail(peg$c489); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12978,7 +12925,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c493(s2, s3);
+              s1 = peg$c491(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13003,16 +12950,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c490) {
-                s3 = peg$c490;
+              if (input.substr(peg$currPos, 2) === peg$c488) {
+                s3 = peg$c488;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c491); }
+                if (peg$silentFails === 0) { peg$fail(peg$c489); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c494(s1, s2);
+                s1 = peg$c492(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13028,16 +12975,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c490) {
-              s1 = peg$c490;
+            if (input.substr(peg$currPos, 2) === peg$c488) {
+              s1 = peg$c488;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c491); }
+              if (peg$silentFails === 0) { peg$fail(peg$c489); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c495();
+              s1 = peg$c493();
             }
             s0 = s1;
           }
@@ -13074,7 +13021,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c496(s2);
+        s1 = peg$c494(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13103,7 +13050,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c497(s1);
+        s1 = peg$c495(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13124,17 +13071,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c279;
+        s2 = peg$c277;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c498(s1, s3);
+          s1 = peg$c496(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13159,17 +13106,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c279;
+        s2 = peg$c277;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c499(s1, s3);
+          s1 = peg$c497(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13194,7 +13141,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c500(s1);
+      s1 = peg$c498(s1);
     }
     s0 = s1;
 
@@ -13217,22 +13164,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c460.test(input.charAt(peg$currPos))) {
+    if (peg$c458.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c459); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c460.test(input.charAt(peg$currPos))) {
+        if (peg$c458.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c461); }
+          if (peg$silentFails === 0) { peg$fail(peg$c459); }
         }
       }
     } else {
@@ -13252,11 +13199,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c277;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13281,33 +13228,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c277;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c460.test(input.charAt(peg$currPos))) {
+          if (peg$c458.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c461); }
+            if (peg$silentFails === 0) { peg$fail(peg$c459); }
           }
         }
       } else {
@@ -13323,21 +13270,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c460.test(input.charAt(peg$currPos))) {
+          if (peg$c458.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c461); }
+            if (peg$silentFails === 0) { peg$fail(peg$c459); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c460.test(input.charAt(peg$currPos))) {
+            if (peg$c458.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c461); }
+              if (peg$silentFails === 0) { peg$fail(peg$c459); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13347,7 +13294,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c501();
+              s1 = peg$c499();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13372,11 +13319,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c277;
+        s1 = peg$c275;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13391,22 +13338,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c460.test(input.charAt(peg$currPos))) {
+          if (peg$c458.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c461); }
+            if (peg$silentFails === 0) { peg$fail(peg$c459); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c460.test(input.charAt(peg$currPos))) {
+              if (peg$c458.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                if (peg$silentFails === 0) { peg$fail(peg$c459); }
               }
             }
           } else {
@@ -13419,7 +13366,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c501();
+              s1 = peg$c499();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13458,20 +13405,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c502) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c500) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c503); }
+      if (peg$silentFails === 0) { peg$fail(peg$c501); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c504.test(input.charAt(peg$currPos))) {
+      if (peg$c502.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c505); }
+        if (peg$silentFails === 0) { peg$fail(peg$c503); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13500,12 +13447,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c506) {
-      s0 = peg$c506;
+    if (input.substr(peg$currPos, 3) === peg$c504) {
+      s0 = peg$c504;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c507); }
+      if (peg$silentFails === 0) { peg$fail(peg$c505); }
     }
 
     return s0;
@@ -13516,31 +13463,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c277;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c278); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c275;
+        s1 = peg$c273;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c276); }
+        if (peg$silentFails === 0) { peg$fail(peg$c274); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c508) {
-        s2 = peg$c508;
+      if (input.substr(peg$currPos, 3) === peg$c506) {
+        s2 = peg$c506;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c509); }
+        if (peg$silentFails === 0) { peg$fail(peg$c507); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13583,12 +13530,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c510.test(input.charAt(peg$currPos))) {
+    if (peg$c508.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c511); }
+      if (peg$silentFails === 0) { peg$fail(peg$c509); }
     }
 
     return s0;
@@ -13599,11 +13546,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c397;
+      s1 = peg$c395;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c398); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13614,15 +13561,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c397;
+          s3 = peg$c395;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c398); }
+          if (peg$silentFails === 0) { peg$fail(peg$c396); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c512(s2);
+          s1 = peg$c510(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13639,11 +13586,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c399;
+        s1 = peg$c397;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c400); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13654,15 +13601,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c399;
+            s3 = peg$c397;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c400); }
+            if (peg$silentFails === 0) { peg$fail(peg$c398); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c512(s2);
+            s1 = peg$c510(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13688,11 +13635,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c397;
+      s2 = peg$c395;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c398); }
+      if (peg$silentFails === 0) { peg$fail(peg$c396); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13710,7 +13657,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c513); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13727,11 +13674,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c402;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13766,7 +13713,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c514(s1, s2);
+        s1 = peg$c512(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13795,12 +13742,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c515.test(input.charAt(peg$currPos))) {
+    if (peg$c513.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c516); }
+      if (peg$silentFails === 0) { peg$fail(peg$c514); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13816,12 +13763,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
     }
 
@@ -13833,11 +13780,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c402;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13896,7 +13843,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c517(s3, s4);
+            s1 = peg$c515(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14007,7 +13954,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c518();
+          s1 = peg$c516();
         }
         s0 = s1;
       }
@@ -14021,12 +13968,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c460.test(input.charAt(peg$currPos))) {
+      if (peg$c458.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
     }
 
@@ -14038,11 +13985,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c402;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14078,7 +14025,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c519();
+      s1 = peg$c517();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14092,16 +14039,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c520();
+        s1 = peg$c518();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c504.test(input.charAt(peg$currPos))) {
+        if (peg$c502.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c505); }
+          if (peg$silentFails === 0) { peg$fail(peg$c503); }
         }
       }
     }
@@ -14116,11 +14063,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c399;
+      s2 = peg$c397;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14138,7 +14085,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c513); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14155,11 +14102,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c402;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14195,20 +14142,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c399;
+      s0 = peg$c397;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c397;
+        s1 = peg$c395;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c398); }
+        if (peg$silentFails === 0) { peg$fail(peg$c396); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14217,94 +14164,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c402;
+          s0 = peg$c400;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c403); }
+          if (peg$silentFails === 0) { peg$fail(peg$c401); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c521;
+            s1 = peg$c519;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c522); }
+            if (peg$silentFails === 0) { peg$fail(peg$c520); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c523();
+            s1 = peg$c521();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c524;
+              s1 = peg$c522;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c525); }
+              if (peg$silentFails === 0) { peg$fail(peg$c523); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c526();
+              s1 = peg$c524();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c527;
+                s1 = peg$c525;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c528); }
+                if (peg$silentFails === 0) { peg$fail(peg$c526); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c529();
+                s1 = peg$c527();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c530;
+                  s1 = peg$c528;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c531); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c529); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c532();
+                  s1 = peg$c530();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c533;
+                    s1 = peg$c531;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c534); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c532); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c535();
+                    s1 = peg$c533();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c536;
+                      s1 = peg$c534;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c537); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c535); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c538();
+                      s1 = peg$c536();
                     }
                     s0 = s1;
                   }
@@ -14332,7 +14279,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c519();
+      s1 = peg$c517();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14346,16 +14293,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c539();
+        s1 = peg$c537();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c504.test(input.charAt(peg$currPos))) {
+        if (peg$c502.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c505); }
+          if (peg$silentFails === 0) { peg$fail(peg$c503); }
         }
       }
     }
@@ -14368,11 +14315,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c540;
+      s1 = peg$c538;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c541); }
+      if (peg$silentFails === 0) { peg$fail(peg$c539); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14404,7 +14351,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c542(s2);
+        s1 = peg$c540(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14417,11 +14364,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c540;
+        s1 = peg$c538;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c541); }
+        if (peg$silentFails === 0) { peg$fail(peg$c539); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14488,15 +14435,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c304;
+              s4 = peg$c302;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c542(s3);
+              s1 = peg$c540(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14524,21 +14471,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c279;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c279;
+          s3 = peg$c277;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c280); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14580,21 +14527,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c543.test(input.charAt(peg$currPos))) {
+    if (peg$c541.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c544); }
+      if (peg$silentFails === 0) { peg$fail(peg$c542); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c402;
+        s3 = peg$c400;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14602,7 +14549,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c513); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14619,21 +14566,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c543.test(input.charAt(peg$currPos))) {
+        if (peg$c541.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c544); }
+          if (peg$silentFails === 0) { peg$fail(peg$c542); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c402;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14641,7 +14588,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c513); }
+              if (peg$silentFails === 0) { peg$fail(peg$c511); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14671,12 +14618,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c545.test(input.charAt(peg$currPos))) {
+    if (peg$c543.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c546); }
+      if (peg$silentFails === 0) { peg$fail(peg$c544); }
     }
 
     return s0;
@@ -14734,7 +14681,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
 
     return s0;
@@ -14745,51 +14692,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c548;
+      s0 = peg$c546;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c549); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c550;
+        s0 = peg$c548;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c551); }
+        if (peg$silentFails === 0) { peg$fail(peg$c549); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c552;
+          s0 = peg$c550;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c553); }
+          if (peg$silentFails === 0) { peg$fail(peg$c551); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c554;
+            s0 = peg$c552;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c555); }
+            if (peg$silentFails === 0) { peg$fail(peg$c553); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c556;
+              s0 = peg$c554;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c557); }
+              if (peg$silentFails === 0) { peg$fail(peg$c555); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c558;
+                s0 = peg$c556;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c559); }
+                if (peg$silentFails === 0) { peg$fail(peg$c557); }
               }
             }
           }
@@ -14799,7 +14746,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c545); }
     }
 
     return s0;
@@ -14808,12 +14755,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c560.test(input.charAt(peg$currPos))) {
+    if (peg$c558.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c561); }
+      if (peg$silentFails === 0) { peg$fail(peg$c559); }
     }
 
     return s0;
@@ -14827,7 +14774,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c562); }
+      if (peg$silentFails === 0) { peg$fail(peg$c560); }
     }
 
     return s0;
@@ -14837,24 +14784,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c563) {
-      s1 = peg$c563;
+    if (input.substr(peg$currPos, 2) === peg$c561) {
+      s1 = peg$c561;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c564); }
+      if (peg$silentFails === 0) { peg$fail(peg$c562); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c565) {
-        s5 = peg$c565;
+      if (input.substr(peg$currPos, 2) === peg$c563) {
+        s5 = peg$c563;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c566); }
+        if (peg$silentFails === 0) { peg$fail(peg$c564); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -14881,12 +14828,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c565) {
-          s5 = peg$c565;
+        if (input.substr(peg$currPos, 2) === peg$c563) {
+          s5 = peg$c563;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c566); }
+          if (peg$silentFails === 0) { peg$fail(peg$c564); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -14910,12 +14857,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c565) {
-          s3 = peg$c565;
+        if (input.substr(peg$currPos, 2) === peg$c563) {
+          s3 = peg$c563;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c566); }
+          if (peg$silentFails === 0) { peg$fail(peg$c564); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -14940,12 +14887,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c567) {
-      s1 = peg$c567;
+    if (input.substr(peg$currPos, 2) === peg$c565) {
+      s1 = peg$c565;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c568); }
+      if (peg$silentFails === 0) { peg$fail(peg$c566); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15063,7 +15010,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -145,201 +145,197 @@ function peg$parse(input, options) {
       peg$c1 = function(consts, first, rest) {
             return {"kind": "Sequential", "ops": [first, ... rest], "consts":consts}
           },
-      peg$c2 = function(consts, op) {
-            return {"kind": "Sequential", "ops": [op], "consts":consts}
-          },
-      peg$c3 = function(p) { return p },
-      peg$c4 = function() { return [] },
-      peg$c5 = function(v) { return v },
-      peg$c6 = "const",
-      peg$c7 = peg$literalExpectation("const", false),
-      peg$c8 = "=",
-      peg$c9 = peg$literalExpectation("=", false),
-      peg$c10 = function(id, expr) {
+      peg$c2 = function(p) { return p },
+      peg$c3 = function() { return [] },
+      peg$c4 = function(v) { return v },
+      peg$c5 = "const",
+      peg$c6 = peg$literalExpectation("const", false),
+      peg$c7 = "=",
+      peg$c8 = peg$literalExpectation("=", false),
+      peg$c9 = function(id, expr) {
             return {"name":id, "expr":expr}
           },
-      peg$c11 = "type",
-      peg$c12 = peg$literalExpectation("type", false),
-      peg$c13 = function(id, typ) {
+      peg$c10 = "type",
+      peg$c11 = peg$literalExpectation("type", false),
+      peg$c12 = function(id, typ) {
             return {
               
             "name":id,
               
             "expr":{"kind":"TypeValue","value":{"kind":"TypeDef","name":id,"type":typ}}}
           
-
           },
-      peg$c14 = "fork",
-      peg$c15 = peg$literalExpectation("fork", false),
-      peg$c16 = "(",
-      peg$c17 = peg$literalExpectation("(", false),
-      peg$c18 = ")",
-      peg$c19 = peg$literalExpectation(")", false),
-      peg$c20 = function(ops) {
+      peg$c13 = "fork",
+      peg$c14 = peg$literalExpectation("fork", false),
+      peg$c15 = "(",
+      peg$c16 = peg$literalExpectation("(", false),
+      peg$c17 = ")",
+      peg$c18 = peg$literalExpectation(")", false),
+      peg$c19 = function(ops) {
             return {"kind": "Parallel", "ops": ops}
           },
-      peg$c21 = "switch",
-      peg$c22 = peg$literalExpectation("switch", false),
-      peg$c23 = function(expr, cases) {
+      peg$c20 = "switch",
+      peg$c21 = peg$literalExpectation("switch", false),
+      peg$c22 = function(expr, cases) {
             return {"kind": "Switch", "expr": expr, "cases": cases}
           },
-      peg$c24 = function(cases) {
+      peg$c23 = function(cases) {
             return {"kind": "Switch", "expr": null, "cases": cases}
           },
-      peg$c25 = "from",
-      peg$c26 = peg$literalExpectation("from", false),
-      peg$c27 = function(trunks) {
+      peg$c24 = "from",
+      peg$c25 = peg$literalExpectation("from", false),
+      peg$c26 = function(trunks) {
             return {"kind": "From", "trunks": trunks}
           },
-      peg$c28 = function(a) { return a },
-      peg$c29 = "search",
-      peg$c30 = peg$literalExpectation("search", false),
-      peg$c31 = function(expr) {
+      peg$c27 = function(a) { return a },
+      peg$c28 = "search",
+      peg$c29 = peg$literalExpectation("search", false),
+      peg$c30 = function(expr) {
             return {"kind": "Search", "expr": expr}
+          },
+      peg$c31 = function(expr) {
+            return {"kind": "OpExpr", "expr": expr}
           },
       peg$c32 = function(expr) {
             return {"kind": "OpExpr", "expr": expr}
-          },
-      peg$c33 = function(expr) {
-            return {"kind": "OpExpr", "expr": expr}
         },
-      peg$c34 = "=>",
-      peg$c35 = peg$literalExpectation("=>", false),
-      peg$c36 = "|",
-      peg$c37 = peg$literalExpectation("|", false),
-      peg$c38 = "{",
-      peg$c39 = peg$literalExpectation("{", false),
-      peg$c40 = "[",
-      peg$c41 = peg$literalExpectation("[", false),
-      peg$c42 = function(s) { return s },
-      peg$c43 = function(expr, op) {
+      peg$c33 = "=>",
+      peg$c34 = peg$literalExpectation("=>", false),
+      peg$c35 = "|",
+      peg$c36 = peg$literalExpectation("|", false),
+      peg$c37 = "{",
+      peg$c38 = peg$literalExpectation("{", false),
+      peg$c39 = "[",
+      peg$c40 = peg$literalExpectation("[", false),
+      peg$c41 = function(s) { return s },
+      peg$c42 = function(expr, op) {
             return {"expr": expr, "op": op}
           },
-      peg$c44 = "case",
-      peg$c45 = peg$literalExpectation("case", false),
-      peg$c46 = function(expr) { return expr },
-      peg$c47 = "default",
-      peg$c48 = peg$literalExpectation("default", false),
-      peg$c49 = function() { return null },
-      peg$c50 = function(source, seq) {
+      peg$c43 = "case",
+      peg$c44 = peg$literalExpectation("case", false),
+      peg$c45 = function(expr) { return expr },
+      peg$c46 = "default",
+      peg$c47 = peg$literalExpectation("default", false),
+      peg$c48 = function() { return null },
+      peg$c49 = function(source, seq) {
             return {"kind": "Trunk", "source": source, "seq": seq}
           },
-      peg$c51 = function(source) {
+      peg$c50 = function(source) {
             return {"kind": "Trunk", "source": source, "seq": null}
           },
-      peg$c52 = function(src) { return src },
-      peg$c53 = ":",
-      peg$c54 = peg$literalExpectation(":", false),
-      peg$c55 = "~",
-      peg$c56 = peg$literalExpectation("~", false),
-      peg$c57 = "==",
-      peg$c58 = peg$literalExpectation("==", false),
-      peg$c59 = "!=",
-      peg$c60 = peg$literalExpectation("!=", false),
-      peg$c61 = "in",
-      peg$c62 = peg$literalExpectation("in", false),
-      peg$c63 = "<=",
-      peg$c64 = peg$literalExpectation("<=", false),
-      peg$c65 = "<",
-      peg$c66 = peg$literalExpectation("<", false),
-      peg$c67 = ">=",
-      peg$c68 = peg$literalExpectation(">=", false),
-      peg$c69 = ">",
-      peg$c70 = peg$literalExpectation(">", false),
-      peg$c71 = function() { return text() },
-      peg$c72 = function(first, rest) {
+      peg$c51 = function(src) { return src },
+      peg$c52 = ":",
+      peg$c53 = peg$literalExpectation(":", false),
+      peg$c54 = "~",
+      peg$c55 = peg$literalExpectation("~", false),
+      peg$c56 = "==",
+      peg$c57 = peg$literalExpectation("==", false),
+      peg$c58 = "!=",
+      peg$c59 = peg$literalExpectation("!=", false),
+      peg$c60 = "in",
+      peg$c61 = peg$literalExpectation("in", false),
+      peg$c62 = "<=",
+      peg$c63 = peg$literalExpectation("<=", false),
+      peg$c64 = "<",
+      peg$c65 = peg$literalExpectation("<", false),
+      peg$c66 = ">=",
+      peg$c67 = peg$literalExpectation(">=", false),
+      peg$c68 = ">",
+      peg$c69 = peg$literalExpectation(">", false),
+      peg$c70 = function() { return text() },
+      peg$c71 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c73 = function(t) { return ["or", t] },
-      peg$c74 = function(first, expr) { return ["and", expr] },
-      peg$c75 = function(first, rest) {
+      peg$c72 = function(t) { return ["or", t] },
+      peg$c73 = function(first, expr) { return ["and", expr] },
+      peg$c74 = function(first, rest) {
             return makeBinaryExprChain(first,rest)
           },
-      peg$c76 = "!",
-      peg$c77 = peg$literalExpectation("!", false),
-      peg$c78 = function(e) {
+      peg$c75 = "!",
+      peg$c76 = peg$literalExpectation("!", false),
+      peg$c77 = function(e) {
             return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c79 = function(v) {
+      peg$c78 = function(v) {
             return {"kind": "Term", "text": text(), "value": v}
           },
-      peg$c80 = "*",
-      peg$c81 = peg$literalExpectation("*", false),
-      peg$c82 = function() {
+      peg$c79 = "*",
+      peg$c80 = peg$literalExpectation("*", false),
+      peg$c81 = function() {
             return {"kind": "Primitive", "type": "bool", "text": "true"}
           },
-      peg$c83 = function(lhs, op, rhs) {
+      peg$c82 = function(lhs, op, rhs) {
             return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c84 = function(first, rest) {
+      peg$c83 = function(first, rest) {
                return makeBinaryExprChain(first, rest)
            },
-      peg$c85 = function(v) {
+      peg$c84 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": v}
           },
-      peg$c86 = function(pattern) {
+      peg$c85 = function(pattern) {
             return {"kind": "Glob", "pattern": pattern}
         },
-      peg$c87 = function(pattern) {
+      peg$c86 = function(pattern) {
             return {"kind": "Regexp", "pattern": pattern}
         },
-      peg$c88 = function(keys, limit) {
+      peg$c87 = function(keys, limit) {
             return {"kind": "Summarize", "keys": keys, "aggs": null, "limit": limit}
           },
-      peg$c89 = function(aggs, keys, limit) {
+      peg$c88 = function(aggs, keys, limit) {
             let p = {"kind": "Summarize", "keys": null, "aggs": aggs, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
             }
             return p
           },
-      peg$c90 = "summarize",
-      peg$c91 = peg$literalExpectation("summarize", false),
-      peg$c92 = function(columns) { return columns },
-      peg$c93 = "with",
-      peg$c94 = peg$literalExpectation("with", false),
-      peg$c95 = "-limit",
-      peg$c96 = peg$literalExpectation("-limit", false),
-      peg$c97 = function(limit) { return limit },
-      peg$c98 = "",
-      peg$c99 = function() { return 0 },
-      peg$c100 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c101 = ",",
-      peg$c102 = peg$literalExpectation(",", false),
-      peg$c103 = function(first, expr) { return expr },
-      peg$c104 = function(first, rest) {
+      peg$c89 = "summarize",
+      peg$c90 = peg$literalExpectation("summarize", false),
+      peg$c91 = function(columns) { return columns },
+      peg$c92 = "with",
+      peg$c93 = peg$literalExpectation("with", false),
+      peg$c94 = "-limit",
+      peg$c95 = peg$literalExpectation("-limit", false),
+      peg$c96 = function(limit) { return limit },
+      peg$c97 = "",
+      peg$c98 = function() { return 0 },
+      peg$c99 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c100 = ",",
+      peg$c101 = peg$literalExpectation(",", false),
+      peg$c102 = function(first, expr) { return expr },
+      peg$c103 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c105 = ":=",
-      peg$c106 = peg$literalExpectation(":=", false),
-      peg$c107 = function(lval, agg) {
+      peg$c104 = ":=",
+      peg$c105 = peg$literalExpectation(":=", false),
+      peg$c106 = function(lval, agg) {
             return {"kind": "Assignment", "lhs": lval, "rhs": agg}
           },
-      peg$c108 = function(agg) {
+      peg$c107 = function(agg) {
             return {"kind": "Assignment", "lhs": null, "rhs": agg}
           },
-      peg$c109 = ".",
-      peg$c110 = peg$literalExpectation(".", false),
-      peg$c111 = function(op, expr, where) {
+      peg$c108 = ".",
+      peg$c109 = peg$literalExpectation(".", false),
+      peg$c110 = function(op, expr, where) {
             let r = {"kind": "Agg", "name": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c112 = "where",
-      peg$c113 = peg$literalExpectation("where", false),
-      peg$c114 = function(first, rest) {
+      peg$c111 = "where",
+      peg$c112 = peg$literalExpectation("where", false),
+      peg$c113 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c115 = "sort",
-      peg$c116 = peg$literalExpectation("sort", false),
-      peg$c117 = function(args, l) { return l },
-      peg$c118 = function(args, list) {
+      peg$c114 = "sort",
+      peg$c115 = peg$literalExpectation("sort", false),
+      peg$c116 = function(args, l) { return l },
+      peg$c117 = function(args, list) {
             let argm = args
             let op = {"kind": "Sort", "args": list, "order": "asc", "nullsfirst": false}
             if ( "r" in argm) {
@@ -352,24 +348,24 @@ function peg$parse(input, options) {
             }
             return op
           },
-      peg$c119 = function(args) { return makeArgMap(args) },
-      peg$c120 = "-r",
-      peg$c121 = peg$literalExpectation("-r", false),
-      peg$c122 = function() { return {"name": "r", "value": null} },
-      peg$c123 = "-nulls",
-      peg$c124 = peg$literalExpectation("-nulls", false),
-      peg$c125 = "first",
-      peg$c126 = peg$literalExpectation("first", false),
-      peg$c127 = "last",
-      peg$c128 = peg$literalExpectation("last", false),
-      peg$c129 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c130 = "top",
-      peg$c131 = peg$literalExpectation("top", false),
-      peg$c132 = function(n) { return n},
-      peg$c133 = "-flush",
-      peg$c134 = peg$literalExpectation("-flush", false),
-      peg$c135 = function(limit, flush, f) { return f },
-      peg$c136 = function(limit, flush, fields) {
+      peg$c118 = function(args) { return makeArgMap(args) },
+      peg$c119 = "-r",
+      peg$c120 = peg$literalExpectation("-r", false),
+      peg$c121 = function() { return {"name": "r", "value": null} },
+      peg$c122 = "-nulls",
+      peg$c123 = peg$literalExpectation("-nulls", false),
+      peg$c124 = "first",
+      peg$c125 = peg$literalExpectation("first", false),
+      peg$c126 = "last",
+      peg$c127 = peg$literalExpectation("last", false),
+      peg$c128 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c129 = "top",
+      peg$c130 = peg$literalExpectation("top", false),
+      peg$c131 = function(n) { return n},
+      peg$c132 = "-flush",
+      peg$c133 = peg$literalExpectation("-flush", false),
+      peg$c134 = function(limit, flush, f) { return f },
+      peg$c135 = function(limit, flush, fields) {
             let op = {"kind": "Top", "limit": 0, "args": null, "flush": false}
             if (limit) {
               op["limit"] = limit
@@ -382,89 +378,89 @@ function peg$parse(input, options) {
             }
             return op
           },
-      peg$c137 = "cut",
-      peg$c138 = peg$literalExpectation("cut", false),
-      peg$c139 = function(args) {
+      peg$c136 = "cut",
+      peg$c137 = peg$literalExpectation("cut", false),
+      peg$c138 = function(args) {
             return {"kind": "Cut", "args": args}
           },
-      peg$c140 = "drop",
-      peg$c141 = peg$literalExpectation("drop", false),
-      peg$c142 = function(args) {
+      peg$c139 = "drop",
+      peg$c140 = peg$literalExpectation("drop", false),
+      peg$c141 = function(args) {
             return {"kind": "Drop", "args": args}
           },
-      peg$c143 = "head",
-      peg$c144 = peg$literalExpectation("head", false),
-      peg$c145 = function(count) { return {"kind": "Head", "count": count} },
-      peg$c146 = function() { return {"kind": "Head", "count": 1} },
-      peg$c147 = "tail",
-      peg$c148 = peg$literalExpectation("tail", false),
-      peg$c149 = function(count) { return {"kind": "Tail", "count": count} },
-      peg$c150 = function() { return {"kind": "Tail", "count": 1} },
-      peg$c151 = function(expr) {
+      peg$c142 = "head",
+      peg$c143 = peg$literalExpectation("head", false),
+      peg$c144 = function(count) { return {"kind": "Head", "count": count} },
+      peg$c145 = function() { return {"kind": "Head", "count": 1} },
+      peg$c146 = "tail",
+      peg$c147 = peg$literalExpectation("tail", false),
+      peg$c148 = function(count) { return {"kind": "Tail", "count": count} },
+      peg$c149 = function() { return {"kind": "Tail", "count": 1} },
+      peg$c150 = function(expr) {
             return {"kind": "Where", "expr": expr}
           },
-      peg$c152 = "uniq",
-      peg$c153 = peg$literalExpectation("uniq", false),
-      peg$c154 = "-c",
-      peg$c155 = peg$literalExpectation("-c", false),
-      peg$c156 = function() {
+      peg$c151 = "uniq",
+      peg$c152 = peg$literalExpectation("uniq", false),
+      peg$c153 = "-c",
+      peg$c154 = peg$literalExpectation("-c", false),
+      peg$c155 = function() {
             return {"kind": "Uniq", "cflag": true}
           },
-      peg$c157 = function() {
+      peg$c156 = function() {
             return {"kind": "Uniq", "cflag": false}
           },
-      peg$c158 = "put",
-      peg$c159 = peg$literalExpectation("put", false),
-      peg$c160 = function(args) {
+      peg$c157 = "put",
+      peg$c158 = peg$literalExpectation("put", false),
+      peg$c159 = function(args) {
             return {"kind": "Put", "args": args}
           },
-      peg$c161 = "rename",
-      peg$c162 = peg$literalExpectation("rename", false),
-      peg$c163 = function(first, cl) { return cl },
-      peg$c164 = function(first, rest) {
+      peg$c160 = "rename",
+      peg$c161 = peg$literalExpectation("rename", false),
+      peg$c162 = function(first, cl) { return cl },
+      peg$c163 = function(first, rest) {
             return {"kind": "Rename", "args": [first, ... rest]}
           },
-      peg$c165 = "fuse",
-      peg$c166 = peg$literalExpectation("fuse", false),
-      peg$c167 = function() {
+      peg$c164 = "fuse",
+      peg$c165 = peg$literalExpectation("fuse", false),
+      peg$c166 = function() {
             return {"kind": "Fuse"}
           },
-      peg$c168 = "shape",
-      peg$c169 = peg$literalExpectation("shape", false),
-      peg$c170 = function() {
+      peg$c167 = "shape",
+      peg$c168 = peg$literalExpectation("shape", false),
+      peg$c169 = function() {
             return {"kind": "Shape"}
           },
-      peg$c171 = "join",
-      peg$c172 = peg$literalExpectation("join", false),
-      peg$c173 = function(style, leftKey, rightKey, columns) {
+      peg$c170 = "join",
+      peg$c171 = peg$literalExpectation("join", false),
+      peg$c172 = function(style, leftKey, rightKey, columns) {
             let op = {"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": null}
             if (columns) {
               op["args"] = columns[1]
             }
             return op
           },
-      peg$c174 = function(style, key, columns) {
+      peg$c173 = function(style, key, columns) {
             let op = {"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": null}
             if (columns) {
               op["args"] = columns[1]
             }
             return op
           },
-      peg$c175 = "anti",
-      peg$c176 = peg$literalExpectation("anti", false),
-      peg$c177 = function() { return "anti" },
-      peg$c178 = "inner",
-      peg$c179 = peg$literalExpectation("inner", false),
-      peg$c180 = function() { return "inner" },
-      peg$c181 = "left",
-      peg$c182 = peg$literalExpectation("left", false),
-      peg$c183 = function() { return "left" },
-      peg$c184 = "right",
-      peg$c185 = peg$literalExpectation("right", false),
-      peg$c186 = function() { return "right" },
-      peg$c187 = "sample",
-      peg$c188 = peg$literalExpectation("sample", false),
-      peg$c189 = function(e) {
+      peg$c174 = "anti",
+      peg$c175 = peg$literalExpectation("anti", false),
+      peg$c176 = function() { return "anti" },
+      peg$c177 = "inner",
+      peg$c178 = peg$literalExpectation("inner", false),
+      peg$c179 = function() { return "inner" },
+      peg$c180 = "left",
+      peg$c181 = peg$literalExpectation("left", false),
+      peg$c182 = function() { return "left" },
+      peg$c183 = "right",
+      peg$c184 = peg$literalExpectation("right", false),
+      peg$c185 = function() { return "right" },
+      peg$c186 = "sample",
+      peg$c187 = peg$literalExpectation("sample", false),
+      peg$c188 = function(e) {
             return {"kind": "Sequential", "consts": [], "ops": [
               
             {"kind": "Summarize",
@@ -500,117 +496,117 @@ function peg$parse(input, options) {
             {"kind": "ID", "name": "sample"}]}]}
           
           },
-      peg$c190 = function(a) {
+      peg$c189 = function(a) {
           return {"kind": "OpAssignment", "assignments": a}
         },
-      peg$c191 = function(lval) { return lval},
-      peg$c192 = function() { return {"kind":"ID", "name":"this"} },
-      peg$c193 = function(source) {
+      peg$c190 = function(lval) { return lval},
+      peg$c191 = function() { return {"kind":"ID", "name":"this"} },
+      peg$c192 = function(source) {
             return {"kind":"From", "trunks": [{"kind": "Trunk","source": source}]}
           },
-      peg$c194 = "file",
-      peg$c195 = peg$literalExpectation("file", false),
-      peg$c196 = function(path, format, layout) {
+      peg$c193 = "file",
+      peg$c194 = peg$literalExpectation("file", false),
+      peg$c195 = function(path, format, layout) {
             return {"kind": "File", "path": path, "format": format, "layout": layout }
           },
-      peg$c197 = function(body) { return body },
-      peg$c198 = "pool",
-      peg$c199 = peg$literalExpectation("pool", false),
-      peg$c200 = function(spec, at, over, order) {
+      peg$c196 = function(body) { return body },
+      peg$c197 = "pool",
+      peg$c198 = peg$literalExpectation("pool", false),
+      peg$c199 = function(spec, at, over, order) {
             return {"kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order}
           },
-      peg$c201 = "get",
-      peg$c202 = peg$literalExpectation("get", false),
-      peg$c203 = function(url, format, layout) {
+      peg$c200 = "get",
+      peg$c201 = peg$literalExpectation("get", false),
+      peg$c202 = function(url, format, layout) {
             return {"kind": "HTTP", "url": url, "format": format, "layout": layout }
           },
-      peg$c204 = "http:",
-      peg$c205 = peg$literalExpectation("http:", false),
-      peg$c206 = "https:",
-      peg$c207 = peg$literalExpectation("https:", false),
-      peg$c208 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
-      peg$c209 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
-      peg$c210 = "at",
-      peg$c211 = peg$literalExpectation("at", false),
-      peg$c212 = function(id) { return id },
-      peg$c213 = /^[0-9a-zA-Z]/,
-      peg$c214 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
-      peg$c215 = "range",
-      peg$c216 = peg$literalExpectation("range", false),
-      peg$c217 = "to",
-      peg$c218 = peg$literalExpectation("to", false),
-      peg$c219 = function(lower, upper) {
+      peg$c203 = "http:",
+      peg$c204 = peg$literalExpectation("http:", false),
+      peg$c205 = "https:",
+      peg$c206 = peg$literalExpectation("https:", false),
+      peg$c207 = /^[0-9a-zA-Z!@$%\^&*()_=<>,.\/?:[\]{}~|+\-]/,
+      peg$c208 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "!", "@", "$", "%", "^", "&", "*", "(", ")", "_", "=", "<", ">", ",", ".", "/", "?", ":", "[", "]", "{", "}", "~", "|", "+", "-"], false, false),
+      peg$c209 = "at",
+      peg$c210 = peg$literalExpectation("at", false),
+      peg$c211 = function(id) { return id },
+      peg$c212 = /^[0-9a-zA-Z]/,
+      peg$c213 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
+      peg$c214 = "range",
+      peg$c215 = peg$literalExpectation("range", false),
+      peg$c216 = "to",
+      peg$c217 = peg$literalExpectation("to", false),
+      peg$c218 = function(lower, upper) {
             return {"kind":"Range","lower": lower, "upper": upper}
           },
-      peg$c220 = function(pool, commit, meta) {
+      peg$c219 = function(pool, commit, meta) {
             return {"pool": pool, "commit": commit, "meta": meta}
           },
-      peg$c221 = function(meta) {
+      peg$c220 = function(meta) {
             return {"pool": null, "commit": null, "meta": meta}
           },
-      peg$c222 = "@",
-      peg$c223 = peg$literalExpectation("@", false),
-      peg$c224 = function(commit) { return commit },
-      peg$c225 = function(meta) { return meta },
-      peg$c226 = function() {  return text() },
-      peg$c227 = "order",
-      peg$c228 = peg$literalExpectation("order", false),
-      peg$c229 = function(keys, order) {
+      peg$c221 = "@",
+      peg$c222 = peg$literalExpectation("@", false),
+      peg$c223 = function(commit) { return commit },
+      peg$c224 = function(meta) { return meta },
+      peg$c225 = function() {  return text() },
+      peg$c226 = "order",
+      peg$c227 = peg$literalExpectation("order", false),
+      peg$c228 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c230 = "format",
-      peg$c231 = peg$literalExpectation("format", false),
-      peg$c232 = function(val) { return val },
-      peg$c233 = ":asc",
-      peg$c234 = peg$literalExpectation(":asc", false),
-      peg$c235 = function() { return "asc" },
-      peg$c236 = ":desc",
-      peg$c237 = peg$literalExpectation(":desc", false),
-      peg$c238 = function() { return "desc" },
-      peg$c239 = "asc",
-      peg$c240 = peg$literalExpectation("asc", false),
-      peg$c241 = "desc",
-      peg$c242 = peg$literalExpectation("desc", false),
-      peg$c243 = "pass",
-      peg$c244 = peg$literalExpectation("pass", false),
-      peg$c245 = function() {
+      peg$c229 = "format",
+      peg$c230 = peg$literalExpectation("format", false),
+      peg$c231 = function(val) { return val },
+      peg$c232 = ":asc",
+      peg$c233 = peg$literalExpectation(":asc", false),
+      peg$c234 = function() { return "asc" },
+      peg$c235 = ":desc",
+      peg$c236 = peg$literalExpectation(":desc", false),
+      peg$c237 = function() { return "desc" },
+      peg$c238 = "asc",
+      peg$c239 = peg$literalExpectation("asc", false),
+      peg$c240 = "desc",
+      peg$c241 = peg$literalExpectation("desc", false),
+      peg$c242 = "pass",
+      peg$c243 = peg$literalExpectation("pass", false),
+      peg$c244 = function() {
             return {"kind":"Pass"}
           },
-      peg$c246 = "explode",
-      peg$c247 = peg$literalExpectation("explode", false),
-      peg$c248 = function(args, typ, as) {
+      peg$c245 = "explode",
+      peg$c246 = peg$literalExpectation("explode", false),
+      peg$c247 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c249 = "merge",
-      peg$c250 = peg$literalExpectation("merge", false),
-      peg$c251 = function(expr) {
+      peg$c248 = "merge",
+      peg$c249 = peg$literalExpectation("merge", false),
+      peg$c250 = function(expr) {
       	  return {"kind":"Merge", "expr":expr}
           },
-      peg$c252 = "over",
-      peg$c253 = peg$literalExpectation("over", false),
-      peg$c254 = function(exprs, locals, scope) {
-            return {"kind":"Let", "locals":locals, "over":{"kind":"Over", "exprs":exprs, "scope":scope}}
+      peg$c251 = "over",
+      peg$c252 = peg$literalExpectation("over", false),
+      peg$c253 = function(exprs, l) { return l },
+      peg$c254 = function(exprs, locals, s) { return s },
+      peg$c255 = function(exprs, locals, scope) {
+            let over = {"kind": "Over", "exprs": exprs, "scope": scope}
+            if (locals) {
+              return {"kind": "Let", "locals": locals, "over": over}
+            }
+            return over
           },
-      peg$c255 = function(exprs, scope) {
-            return {"kind":"Over", "exprs":exprs, "scope":scope}
-          },
-      peg$c256 = function(exprs) {
-            return {"kind":"Over", "exprs":exprs, "scope":null}
-          },
-      peg$c257 = function(seq) { return seq },
-      peg$c258 = function(first, a) { return a },
-      peg$c259 = function(id) {
+      peg$c256 = function(seq) { return seq },
+      peg$c257 = function(first, a) { return a },
+      peg$c258 = function(id) {
             return {"name":id, "expr":{"kind":"ID","name":id}}
           },
-      peg$c260 = "yield",
-      peg$c261 = peg$literalExpectation("yield", false),
-      peg$c262 = function(exprs) {
+      peg$c259 = "yield",
+      peg$c260 = peg$literalExpectation("yield", false),
+      peg$c261 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c263 = function(typ) { return typ},
-      peg$c264 = function(lhs) { return lhs },
-      peg$c265 = function(first, lval) { return lval },
-      peg$c266 = function(first, rest) {
+      peg$c262 = function(typ) { return typ},
+      peg$c263 = function(lhs) { return lhs },
+      peg$c264 = function(first, lval) { return lval },
+      peg$c265 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -619,125 +615,119 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c267 = function(first, rest) {
+      peg$c266 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c268 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c269 = "?",
-      peg$c270 = peg$literalExpectation("?", false),
-      peg$c271 = function(condition, thenClause, elseClause) {
+      peg$c267 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c268 = "?",
+      peg$c269 = peg$literalExpectation("?", false),
+      peg$c270 = function(condition, thenClause, elseClause) {
             return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c272 = function(first, op, expr) { return [op, expr] },
-      peg$c273 = function(first, rest) {
+      peg$c271 = function(first, op, expr) { return [op, expr] },
+      peg$c272 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c274 = function(lhs, op, rhs) {
-              return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
+      peg$c273 = function(lhs) { return text() },
+      peg$c274 = function(lhs, opAndRHS) {
+            if (!opAndRHS) {
+              return lhs
+            }
+            let op = opAndRHS[1]
+            let rhs = opAndRHS[3]
+            return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c275 = function(lhs, rhs) {
-              return {"kind": "BinaryExpr", "op": "~", "lhs": lhs, "rhs": rhs}
-          },
-      peg$c276 = "+",
-      peg$c277 = peg$literalExpectation("+", false),
-      peg$c278 = "-",
-      peg$c279 = peg$literalExpectation("-", false),
-      peg$c280 = "/",
-      peg$c281 = peg$literalExpectation("/", false),
-      peg$c282 = "%",
-      peg$c283 = peg$literalExpectation("%", false),
-      peg$c284 = function(e) {
+      peg$c275 = "+",
+      peg$c276 = peg$literalExpectation("+", false),
+      peg$c277 = "-",
+      peg$c278 = peg$literalExpectation("-", false),
+      peg$c279 = "/",
+      peg$c280 = peg$literalExpectation("/", false),
+      peg$c281 = "%",
+      peg$c282 = peg$literalExpectation("%", false),
+      peg$c283 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c285 = function(e) {
+      peg$c284 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c286 = "not",
-      peg$c287 = peg$literalExpectation("not", false),
-      peg$c288 = "select",
-      peg$c289 = peg$literalExpectation("select", false),
-      peg$c290 = function(typ, expr) {
+      peg$c285 = "not",
+      peg$c286 = peg$literalExpectation("not", false),
+      peg$c287 = "select",
+      peg$c288 = peg$literalExpectation("select", false),
+      peg$c289 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c291 = function(fn, args, where) {
+      peg$c290 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c292 = "grep",
-      peg$c293 = peg$literalExpectation("grep", false),
-      peg$c294 = function(pattern) {
+      peg$c291 = "grep",
+      peg$c292 = peg$literalExpectation("grep", false),
+      peg$c293 = function(pattern) {
             return {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
           },
-      peg$c295 = function(pattern, expr) {
+      peg$c294 = function(pattern, expr) {
             return {"kind": "Grep", "pattern": pattern, "expr": expr}
           },
-      peg$c296 = function(s) {
+      peg$c295 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c297 = function(first, e) { return e },
-      peg$c298 = "]",
-      peg$c299 = peg$literalExpectation("]", false),
-      peg$c300 = function(from, to) {
+      peg$c296 = function(first, e) { return e },
+      peg$c297 = "]",
+      peg$c298 = peg$literalExpectation("]", false),
+      peg$c299 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c301 = function(to) {
+      peg$c300 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c302 = function(from) {
-            return ["[", {"kind": "BinaryExpr", "op":":",
-                                  
-            "lhs":from, "rhs": null}]
-          
-          },
-      peg$c303 = function(expr) { return ["[", expr] },
-      peg$c304 = function(id) { return [".", id] },
-      peg$c305 = function(exprs, locals, scope) {
+      peg$c301 = function(expr) { return ["[", expr] },
+      peg$c302 = function(id) { return [".", id] },
+      peg$c303 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c306 = function(exprs, scope) {
-            return {"kind": "OverExpr", "locals":null, "exprs": exprs, "scope": scope}
-          },
-      peg$c307 = "}",
-      peg$c308 = peg$literalExpectation("}", false),
-      peg$c309 = function(elems) {
+      peg$c304 = "}",
+      peg$c305 = peg$literalExpectation("}", false),
+      peg$c306 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c310 = function(elem) { return elem },
-      peg$c311 = "...",
-      peg$c312 = peg$literalExpectation("...", false),
-      peg$c313 = function(expr) {
+      peg$c307 = function(elem) { return elem },
+      peg$c308 = "...",
+      peg$c309 = peg$literalExpectation("...", false),
+      peg$c310 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c314 = function(name, value) {
+      peg$c311 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c315 = function(exprs) {
+      peg$c312 = function(exprs) {
             return {"kind":"ArrayExpr", "exprs":exprs }
           },
-      peg$c316 = "|[",
-      peg$c317 = peg$literalExpectation("|[", false),
-      peg$c318 = "]|",
-      peg$c319 = peg$literalExpectation("]|", false),
-      peg$c320 = function(exprs) {
+      peg$c313 = "|[",
+      peg$c314 = peg$literalExpectation("|[", false),
+      peg$c315 = "]|",
+      peg$c316 = peg$literalExpectation("]|", false),
+      peg$c317 = function(exprs) {
             return {"kind":"SetExpr", "exprs":exprs }
           },
-      peg$c321 = "|{",
-      peg$c322 = peg$literalExpectation("|{", false),
-      peg$c323 = "}|",
-      peg$c324 = peg$literalExpectation("}|", false),
-      peg$c325 = function(exprs) {
+      peg$c318 = "|{",
+      peg$c319 = peg$literalExpectation("|{", false),
+      peg$c320 = "}|",
+      peg$c321 = peg$literalExpectation("}|", false),
+      peg$c322 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c326 = function(e) { return e },
-      peg$c327 = function(key, value) {
+      peg$c323 = function(e) { return e },
+      peg$c324 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c328 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c325 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -759,13 +749,13 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c329 = function(assignments) { return assignments },
-      peg$c330 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c331 = function(table, alias) {
+      peg$c326 = function(assignments) { return assignments },
+      peg$c327 = function(rhs, lhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c328 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c332 = function(first, join) { return join },
-      peg$c333 = function(style, table, alias, leftKey, rightKey) {
+      peg$c329 = function(first, join) { return join },
+      peg$c330 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -778,122 +768,118 @@ function peg$parse(input, options) {
               
             "alias": alias}
           
-
-
-
-
           },
-      peg$c334 = function(style) { return style },
-      peg$c335 = function(keys, order) {
+      peg$c331 = function(style) { return style },
+      peg$c332 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c336 = function(dir) { return dir },
-      peg$c337 = function(count) { return count },
-      peg$c338 = peg$literalExpectation("select", true),
-      peg$c339 = function() { return "select" },
-      peg$c340 = "as",
-      peg$c341 = peg$literalExpectation("as", true),
-      peg$c342 = function() { return "as" },
-      peg$c343 = peg$literalExpectation("from", true),
-      peg$c344 = function() { return "from" },
-      peg$c345 = peg$literalExpectation("join", true),
-      peg$c346 = function() { return "join" },
-      peg$c347 = peg$literalExpectation("where", true),
-      peg$c348 = function() { return "where" },
-      peg$c349 = "group",
-      peg$c350 = peg$literalExpectation("group", true),
-      peg$c351 = function() { return "group" },
-      peg$c352 = "by",
-      peg$c353 = peg$literalExpectation("by", true),
-      peg$c354 = function() { return "by" },
-      peg$c355 = "having",
-      peg$c356 = peg$literalExpectation("having", true),
-      peg$c357 = function() { return "having" },
-      peg$c358 = peg$literalExpectation("order", true),
-      peg$c359 = function() { return "order" },
-      peg$c360 = "on",
-      peg$c361 = peg$literalExpectation("on", true),
-      peg$c362 = function() { return "on" },
-      peg$c363 = "limit",
-      peg$c364 = peg$literalExpectation("limit", true),
-      peg$c365 = function() { return "limit" },
-      peg$c366 = peg$literalExpectation("asc", true),
-      peg$c367 = peg$literalExpectation("desc", true),
-      peg$c368 = peg$literalExpectation("anti", true),
-      peg$c369 = peg$literalExpectation("left", true),
-      peg$c370 = peg$literalExpectation("right", true),
-      peg$c371 = peg$literalExpectation("inner", true),
-      peg$c372 = function(v) {
+      peg$c333 = function(dir) { return dir },
+      peg$c334 = function(count) { return count },
+      peg$c335 = peg$literalExpectation("select", true),
+      peg$c336 = function() { return "select" },
+      peg$c337 = "as",
+      peg$c338 = peg$literalExpectation("as", true),
+      peg$c339 = function() { return "as" },
+      peg$c340 = peg$literalExpectation("from", true),
+      peg$c341 = function() { return "from" },
+      peg$c342 = peg$literalExpectation("join", true),
+      peg$c343 = function() { return "join" },
+      peg$c344 = peg$literalExpectation("where", true),
+      peg$c345 = function() { return "where" },
+      peg$c346 = "group",
+      peg$c347 = peg$literalExpectation("group", true),
+      peg$c348 = function() { return "group" },
+      peg$c349 = "by",
+      peg$c350 = peg$literalExpectation("by", true),
+      peg$c351 = function() { return "by" },
+      peg$c352 = "having",
+      peg$c353 = peg$literalExpectation("having", true),
+      peg$c354 = function() { return "having" },
+      peg$c355 = peg$literalExpectation("order", true),
+      peg$c356 = function() { return "order" },
+      peg$c357 = "on",
+      peg$c358 = peg$literalExpectation("on", true),
+      peg$c359 = function() { return "on" },
+      peg$c360 = "limit",
+      peg$c361 = peg$literalExpectation("limit", true),
+      peg$c362 = function() { return "limit" },
+      peg$c363 = peg$literalExpectation("asc", true),
+      peg$c364 = peg$literalExpectation("desc", true),
+      peg$c365 = peg$literalExpectation("anti", true),
+      peg$c366 = peg$literalExpectation("left", true),
+      peg$c367 = peg$literalExpectation("right", true),
+      peg$c368 = peg$literalExpectation("inner", true),
+      peg$c369 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c373 = function(v) {
+      peg$c370 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c374 = function(v) {
+      peg$c371 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c375 = function(v) {
+      peg$c372 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c376 = "true",
-      peg$c377 = peg$literalExpectation("true", false),
-      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c379 = "false",
-      peg$c380 = peg$literalExpectation("false", false),
-      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c382 = "null",
-      peg$c383 = peg$literalExpectation("null", false),
-      peg$c384 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c385 = "0x",
-      peg$c386 = peg$literalExpectation("0x", false),
-      peg$c387 = function() {
+      peg$c373 = "true",
+      peg$c374 = peg$literalExpectation("true", false),
+      peg$c375 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c376 = "false",
+      peg$c377 = peg$literalExpectation("false", false),
+      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c379 = "null",
+      peg$c380 = peg$literalExpectation("null", false),
+      peg$c381 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c382 = "0x",
+      peg$c383 = peg$literalExpectation("0x", false),
+      peg$c384 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c388 = function(typ) {
+      peg$c385 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c389 = function(name) { return name },
-      peg$c390 = function(name, typ) {
+      peg$c386 = function(name) { return name },
+      peg$c387 = function(name, typ) {
             return {"kind": "TypeDef", "name": name, "type": typ}
         },
-      peg$c391 = function(name) {
+      peg$c388 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c392 = function(u) { return u },
-      peg$c393 = function(types) {
+      peg$c389 = function(u) { return u },
+      peg$c390 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c394 = function(typ) { return typ },
-      peg$c395 = function(fields) {
+      peg$c391 = function(typ) { return typ },
+      peg$c392 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c396 = function(typ) {
+      peg$c393 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c397 = function(typ) {
+      peg$c394 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c398 = function(keyType, valType) {
+      peg$c395 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c399 = function(v) {
+      peg$c396 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c400 = "\"",
-      peg$c401 = peg$literalExpectation("\"", false),
-      peg$c402 = "'",
-      peg$c403 = peg$literalExpectation("'", false),
-      peg$c404 = function(v) {
+      peg$c397 = "\"",
+      peg$c398 = peg$literalExpectation("\"", false),
+      peg$c399 = "'",
+      peg$c400 = peg$literalExpectation("'", false),
+      peg$c401 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c405 = "\\",
-      peg$c406 = peg$literalExpectation("\\", false),
-      peg$c407 = "${",
-      peg$c408 = peg$literalExpectation("${", false),
-      peg$c409 = function(e) {
+      peg$c402 = "\\",
+      peg$c403 = peg$literalExpectation("\\", false),
+      peg$c404 = "${",
+      peg$c405 = peg$literalExpectation("${", false),
+      peg$c406 = function(e) {
             return {
               
             "kind": "Cast",
@@ -906,201 +892,197 @@ function peg$parse(input, options) {
                 
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
-
-
-
-
           },
-      peg$c410 = "uint8",
-      peg$c411 = peg$literalExpectation("uint8", false),
-      peg$c412 = "uint16",
-      peg$c413 = peg$literalExpectation("uint16", false),
-      peg$c414 = "uint32",
-      peg$c415 = peg$literalExpectation("uint32", false),
-      peg$c416 = "uint64",
-      peg$c417 = peg$literalExpectation("uint64", false),
-      peg$c418 = "int8",
-      peg$c419 = peg$literalExpectation("int8", false),
-      peg$c420 = "int16",
-      peg$c421 = peg$literalExpectation("int16", false),
-      peg$c422 = "int32",
-      peg$c423 = peg$literalExpectation("int32", false),
-      peg$c424 = "int64",
-      peg$c425 = peg$literalExpectation("int64", false),
-      peg$c426 = "float32",
-      peg$c427 = peg$literalExpectation("float32", false),
-      peg$c428 = "float64",
-      peg$c429 = peg$literalExpectation("float64", false),
-      peg$c430 = "bool",
-      peg$c431 = peg$literalExpectation("bool", false),
-      peg$c432 = "string",
-      peg$c433 = peg$literalExpectation("string", false),
-      peg$c434 = "duration",
-      peg$c435 = peg$literalExpectation("duration", false),
-      peg$c436 = "time",
-      peg$c437 = peg$literalExpectation("time", false),
-      peg$c438 = "bytes",
-      peg$c439 = peg$literalExpectation("bytes", false),
-      peg$c440 = "ip",
-      peg$c441 = peg$literalExpectation("ip", false),
-      peg$c442 = "net",
-      peg$c443 = peg$literalExpectation("net", false),
-      peg$c444 = function() {
+      peg$c407 = "uint8",
+      peg$c408 = peg$literalExpectation("uint8", false),
+      peg$c409 = "uint16",
+      peg$c410 = peg$literalExpectation("uint16", false),
+      peg$c411 = "uint32",
+      peg$c412 = peg$literalExpectation("uint32", false),
+      peg$c413 = "uint64",
+      peg$c414 = peg$literalExpectation("uint64", false),
+      peg$c415 = "int8",
+      peg$c416 = peg$literalExpectation("int8", false),
+      peg$c417 = "int16",
+      peg$c418 = peg$literalExpectation("int16", false),
+      peg$c419 = "int32",
+      peg$c420 = peg$literalExpectation("int32", false),
+      peg$c421 = "int64",
+      peg$c422 = peg$literalExpectation("int64", false),
+      peg$c423 = "float32",
+      peg$c424 = peg$literalExpectation("float32", false),
+      peg$c425 = "float64",
+      peg$c426 = peg$literalExpectation("float64", false),
+      peg$c427 = "bool",
+      peg$c428 = peg$literalExpectation("bool", false),
+      peg$c429 = "string",
+      peg$c430 = peg$literalExpectation("string", false),
+      peg$c431 = "duration",
+      peg$c432 = peg$literalExpectation("duration", false),
+      peg$c433 = "time",
+      peg$c434 = peg$literalExpectation("time", false),
+      peg$c435 = "bytes",
+      peg$c436 = peg$literalExpectation("bytes", false),
+      peg$c437 = "ip",
+      peg$c438 = peg$literalExpectation("ip", false),
+      peg$c439 = "net",
+      peg$c440 = peg$literalExpectation("net", false),
+      peg$c441 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c445 = function(name, typ) {
+      peg$c442 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c446 = "and",
-      peg$c447 = peg$literalExpectation("and", false),
-      peg$c448 = "AND",
-      peg$c449 = peg$literalExpectation("AND", false),
-      peg$c450 = function() { return "and" },
-      peg$c451 = "or",
-      peg$c452 = peg$literalExpectation("or", false),
-      peg$c453 = "OR",
-      peg$c454 = peg$literalExpectation("OR", false),
-      peg$c455 = function() { return "or" },
-      peg$c456 = function() { return "in" },
-      peg$c457 = "NOT",
-      peg$c458 = peg$literalExpectation("NOT", false),
-      peg$c459 = function() { return "not" },
-      peg$c460 = peg$literalExpectation("by", false),
-      peg$c461 = /^[A-Za-z_$]/,
-      peg$c462 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c463 = /^[0-9]/,
-      peg$c464 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c465 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c466 = "$",
-      peg$c467 = peg$literalExpectation("$", false),
-      peg$c468 = "T",
-      peg$c469 = peg$literalExpectation("T", false),
-      peg$c470 = function() {
+      peg$c443 = "and",
+      peg$c444 = peg$literalExpectation("and", false),
+      peg$c445 = "AND",
+      peg$c446 = peg$literalExpectation("AND", false),
+      peg$c447 = function() { return "and" },
+      peg$c448 = "or",
+      peg$c449 = peg$literalExpectation("or", false),
+      peg$c450 = "OR",
+      peg$c451 = peg$literalExpectation("OR", false),
+      peg$c452 = function() { return "or" },
+      peg$c453 = function() { return "in" },
+      peg$c454 = "NOT",
+      peg$c455 = peg$literalExpectation("NOT", false),
+      peg$c456 = function() { return "not" },
+      peg$c457 = peg$literalExpectation("by", false),
+      peg$c458 = /^[A-Za-z_$]/,
+      peg$c459 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c460 = /^[0-9]/,
+      peg$c461 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c462 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c463 = "$",
+      peg$c464 = peg$literalExpectation("$", false),
+      peg$c465 = "T",
+      peg$c466 = peg$literalExpectation("T", false),
+      peg$c467 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c471 = "Z",
-      peg$c472 = peg$literalExpectation("Z", false),
-      peg$c473 = function() {
+      peg$c468 = "Z",
+      peg$c469 = peg$literalExpectation("Z", false),
+      peg$c470 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c474 = "ns",
-      peg$c475 = peg$literalExpectation("ns", false),
-      peg$c476 = "us",
-      peg$c477 = peg$literalExpectation("us", false),
-      peg$c478 = "ms",
-      peg$c479 = peg$literalExpectation("ms", false),
-      peg$c480 = "s",
-      peg$c481 = peg$literalExpectation("s", false),
-      peg$c482 = "m",
-      peg$c483 = peg$literalExpectation("m", false),
-      peg$c484 = "h",
-      peg$c485 = peg$literalExpectation("h", false),
-      peg$c486 = "d",
-      peg$c487 = peg$literalExpectation("d", false),
-      peg$c488 = "w",
-      peg$c489 = peg$literalExpectation("w", false),
-      peg$c490 = "y",
-      peg$c491 = peg$literalExpectation("y", false),
-      peg$c492 = function(a, b) {
+      peg$c471 = "ns",
+      peg$c472 = peg$literalExpectation("ns", false),
+      peg$c473 = "us",
+      peg$c474 = peg$literalExpectation("us", false),
+      peg$c475 = "ms",
+      peg$c476 = peg$literalExpectation("ms", false),
+      peg$c477 = "s",
+      peg$c478 = peg$literalExpectation("s", false),
+      peg$c479 = "m",
+      peg$c480 = peg$literalExpectation("m", false),
+      peg$c481 = "h",
+      peg$c482 = peg$literalExpectation("h", false),
+      peg$c483 = "d",
+      peg$c484 = peg$literalExpectation("d", false),
+      peg$c485 = "w",
+      peg$c486 = peg$literalExpectation("w", false),
+      peg$c487 = "y",
+      peg$c488 = peg$literalExpectation("y", false),
+      peg$c489 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c493 = "::",
-      peg$c494 = peg$literalExpectation("::", false),
-      peg$c495 = function(a, b, d, e) {
+      peg$c490 = "::",
+      peg$c491 = peg$literalExpectation("::", false),
+      peg$c492 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c496 = function(a, b) {
+      peg$c493 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c497 = function(a, b) {
+      peg$c494 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c498 = function() {
+      peg$c495 = function() {
             return "::"
           },
-      peg$c499 = function(v) { return ":" + v },
-      peg$c500 = function(v) { return v + ":" },
-      peg$c501 = function(a, m) {
+      peg$c496 = function(v) { return ":" + v },
+      peg$c497 = function(v) { return v + ":" },
+      peg$c498 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c502 = function(a, m) {
+      peg$c499 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c503 = function(s) { return parseInt(s) },
-      peg$c504 = function() {
+      peg$c500 = function(s) { return parseInt(s) },
+      peg$c501 = function() {
             return text()
           },
-      peg$c505 = "e",
-      peg$c506 = peg$literalExpectation("e", true),
-      peg$c507 = /^[+\-]/,
-      peg$c508 = peg$classExpectation(["+", "-"], false, false),
-      peg$c509 = "NaN",
-      peg$c510 = peg$literalExpectation("NaN", false),
-      peg$c511 = "Inf",
-      peg$c512 = peg$literalExpectation("Inf", false),
-      peg$c513 = /^[0-9a-fA-F]/,
-      peg$c514 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c515 = function(v) { return joinChars(v) },
-      peg$c516 = peg$anyExpectation(),
-      peg$c517 = function(head, tail) { return head + joinChars(tail) },
-      peg$c518 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c519 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c520 = function(head, tail) {
+      peg$c502 = "e",
+      peg$c503 = peg$literalExpectation("e", true),
+      peg$c504 = /^[+\-]/,
+      peg$c505 = peg$classExpectation(["+", "-"], false, false),
+      peg$c506 = "NaN",
+      peg$c507 = peg$literalExpectation("NaN", false),
+      peg$c508 = "Inf",
+      peg$c509 = peg$literalExpectation("Inf", false),
+      peg$c510 = /^[0-9a-fA-F]/,
+      peg$c511 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c512 = function(v) { return joinChars(v) },
+      peg$c513 = peg$anyExpectation(),
+      peg$c514 = function(head, tail) { return head + joinChars(tail) },
+      peg$c515 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c516 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c517 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c521 = function() { return "*"},
-      peg$c522 = function() { return "=" },
-      peg$c523 = function() { return "\\*" },
-      peg$c524 = "b",
-      peg$c525 = peg$literalExpectation("b", false),
-      peg$c526 = function() { return "\b" },
-      peg$c527 = "f",
-      peg$c528 = peg$literalExpectation("f", false),
-      peg$c529 = function() { return "\f" },
-      peg$c530 = "n",
-      peg$c531 = peg$literalExpectation("n", false),
-      peg$c532 = function() { return "\n" },
-      peg$c533 = "r",
-      peg$c534 = peg$literalExpectation("r", false),
-      peg$c535 = function() { return "\r" },
-      peg$c536 = "t",
-      peg$c537 = peg$literalExpectation("t", false),
-      peg$c538 = function() { return "\t" },
-      peg$c539 = "v",
-      peg$c540 = peg$literalExpectation("v", false),
-      peg$c541 = function() { return "\v" },
-      peg$c542 = function() { return "*" },
-      peg$c543 = "u",
-      peg$c544 = peg$literalExpectation("u", false),
-      peg$c545 = function(chars) {
+      peg$c518 = function() { return "*"},
+      peg$c519 = function() { return "=" },
+      peg$c520 = function() { return "\\*" },
+      peg$c521 = "b",
+      peg$c522 = peg$literalExpectation("b", false),
+      peg$c523 = function() { return "\b" },
+      peg$c524 = "f",
+      peg$c525 = peg$literalExpectation("f", false),
+      peg$c526 = function() { return "\f" },
+      peg$c527 = "n",
+      peg$c528 = peg$literalExpectation("n", false),
+      peg$c529 = function() { return "\n" },
+      peg$c530 = "r",
+      peg$c531 = peg$literalExpectation("r", false),
+      peg$c532 = function() { return "\r" },
+      peg$c533 = "t",
+      peg$c534 = peg$literalExpectation("t", false),
+      peg$c535 = function() { return "\t" },
+      peg$c536 = "v",
+      peg$c537 = peg$literalExpectation("v", false),
+      peg$c538 = function() { return "\v" },
+      peg$c539 = function() { return "*" },
+      peg$c540 = "u",
+      peg$c541 = peg$literalExpectation("u", false),
+      peg$c542 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c546 = /^[^\/\\]/,
-      peg$c547 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c548 = /^[\0-\x1F\\]/,
-      peg$c549 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c550 = peg$otherExpectation("whitespace"),
-      peg$c551 = "\t",
-      peg$c552 = peg$literalExpectation("\t", false),
-      peg$c553 = "\x0B",
-      peg$c554 = peg$literalExpectation("\x0B", false),
-      peg$c555 = "\f",
-      peg$c556 = peg$literalExpectation("\f", false),
-      peg$c557 = " ",
-      peg$c558 = peg$literalExpectation(" ", false),
-      peg$c559 = "\xA0",
-      peg$c560 = peg$literalExpectation("\xA0", false),
-      peg$c561 = "\uFEFF",
-      peg$c562 = peg$literalExpectation("\uFEFF", false),
-      peg$c563 = /^[\n\r\u2028\u2029]/,
-      peg$c564 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c565 = peg$otherExpectation("comment"),
-      peg$c566 = "/*",
-      peg$c567 = peg$literalExpectation("/*", false),
-      peg$c568 = "*/",
-      peg$c569 = peg$literalExpectation("*/", false),
-      peg$c570 = "//",
-      peg$c571 = peg$literalExpectation("//", false),
+      peg$c543 = /^[^\/\\]/,
+      peg$c544 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c545 = /^[\0-\x1F\\]/,
+      peg$c546 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c547 = peg$otherExpectation("whitespace"),
+      peg$c548 = "\t",
+      peg$c549 = peg$literalExpectation("\t", false),
+      peg$c550 = "\x0B",
+      peg$c551 = peg$literalExpectation("\x0B", false),
+      peg$c552 = "\f",
+      peg$c553 = peg$literalExpectation("\f", false),
+      peg$c554 = " ",
+      peg$c555 = peg$literalExpectation(" ", false),
+      peg$c556 = "\xA0",
+      peg$c557 = peg$literalExpectation("\xA0", false),
+      peg$c558 = "\uFEFF",
+      peg$c559 = peg$literalExpectation("\uFEFF", false),
+      peg$c560 = /^[\n\r\u2028\u2029]/,
+      peg$c561 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c562 = peg$otherExpectation("comment"),
+      peg$c563 = "/*",
+      peg$c564 = peg$literalExpectation("/*", false),
+      peg$c565 = "*/",
+      peg$c566 = peg$literalExpectation("*/", false),
+      peg$c567 = "//",
+      peg$c568 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1285,13 +1267,9 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = [];
           s5 = peg$parseSequentialTail();
-          if (s5 !== peg$FAILED) {
-            while (s5 !== peg$FAILED) {
-              s4.push(s5);
-              s5 = peg$parseSequentialTail();
-            }
-          } else {
-            s4 = peg$FAILED;
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$parseSequentialTail();
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -1313,30 +1291,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseConsts();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseOperation();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c2(s1, s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
 
     return s0;
   }
@@ -1354,7 +1308,7 @@ function peg$parse(input, options) {
           s4 = peg$parseOperation();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c3(s4);
+            s1 = peg$c2(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1394,7 +1348,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4();
+        s1 = peg$c3();
       }
       s0 = s1;
     }
@@ -1411,7 +1365,7 @@ function peg$parse(input, options) {
       s2 = peg$parseConstDef();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s2);
+        s1 = peg$c4(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1429,12 +1383,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c6) {
-      s1 = peg$c6;
+    if (input.substr(peg$currPos, 5) === peg$c5) {
+      s1 = peg$c5;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c7); }
+      if (peg$silentFails === 0) { peg$fail(peg$c6); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1444,11 +1398,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s5 = peg$c8;
+              s5 = peg$c7;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c9); }
+              if (peg$silentFails === 0) { peg$fail(peg$c8); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -1456,7 +1410,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseConditionalExpr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c10(s3, s7);
+                  s1 = peg$c9(s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1488,12 +1442,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c11) {
-        s1 = peg$c11;
+      if (input.substr(peg$currPos, 4) === peg$c10) {
+        s1 = peg$c10;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+        if (peg$silentFails === 0) { peg$fail(peg$c11); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1503,11 +1457,11 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 61) {
-                s5 = peg$c8;
+                s5 = peg$c7;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c9); }
+                if (peg$silentFails === 0) { peg$fail(peg$c8); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse__();
@@ -1515,7 +1469,7 @@ function peg$parse(input, options) {
                   s7 = peg$parseType();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c13(s3, s7);
+                    s1 = peg$c12(s3, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1554,22 +1508,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c14) {
-      s1 = peg$c14;
+    if (input.substr(peg$currPos, 4) === peg$c13) {
+      s1 = peg$c13;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c15); }
+      if (peg$silentFails === 0) { peg$fail(peg$c14); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -1586,15 +1540,15 @@ function peg$parse(input, options) {
             s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s6 = peg$c18;
+                s6 = peg$c17;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                if (peg$silentFails === 0) { peg$fail(peg$c18); }
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c20(s4);
+                s1 = peg$c19(s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1622,12 +1576,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c21) {
-        s1 = peg$c21;
+      if (input.substr(peg$currPos, 6) === peg$c20) {
+        s1 = peg$c20;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c22); }
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1637,11 +1591,11 @@ function peg$parse(input, options) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s5 = peg$c16;
+                s5 = peg$c15;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = [];
@@ -1658,15 +1612,15 @@ function peg$parse(input, options) {
                   s7 = peg$parse__();
                   if (s7 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s8 = peg$c18;
+                      s8 = peg$c17;
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c18); }
                     }
                     if (s8 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c23(s3, s6);
+                      s1 = peg$c22(s3, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1702,22 +1656,22 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 6) === peg$c21) {
-          s1 = peg$c21;
+        if (input.substr(peg$currPos, 6) === peg$c20) {
+          s1 = peg$c20;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c22); }
+          if (peg$silentFails === 0) { peg$fail(peg$c21); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s3 = peg$c16;
+              s3 = peg$c15;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+              if (peg$silentFails === 0) { peg$fail(peg$c16); }
             }
             if (s3 !== peg$FAILED) {
               s4 = [];
@@ -1734,15 +1688,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s6 = peg$c18;
+                    s6 = peg$c17;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c24(s4);
+                    s1 = peg$c23(s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1770,22 +1724,22 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 4) === peg$c25) {
-            s1 = peg$c25;
+          if (input.substr(peg$currPos, 4) === peg$c24) {
+            s1 = peg$c24;
             peg$currPos += 4;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c26); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s3 = peg$c16;
+                s3 = peg$c15;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = [];
@@ -1802,15 +1756,15 @@ function peg$parse(input, options) {
                   s5 = peg$parse__();
                   if (s5 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s6 = peg$c18;
+                      s6 = peg$c17;
                       peg$currPos++;
                     } else {
                       s6 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c18); }
                     }
                     if (s6 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c27(s4);
+                      s1 = peg$c26(s4);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1854,7 +1808,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c28(s1);
+                  s1 = peg$c27(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1905,7 +1859,7 @@ function peg$parse(input, options) {
                     }
                     if (s3 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c28(s2);
+                      s1 = peg$c27(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1921,12 +1875,12 @@ function peg$parse(input, options) {
                 }
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 6) === peg$c29) {
-                    s1 = peg$c29;
+                  if (input.substr(peg$currPos, 6) === peg$c28) {
+                    s1 = peg$c28;
                     peg$currPos += 6;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c30); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c29); }
                   }
                   if (s1 !== peg$FAILED) {
                     s2 = peg$parse_();
@@ -1934,7 +1888,7 @@ function peg$parse(input, options) {
                       s3 = peg$parseSearchBoolean();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c31(s3);
+                        s1 = peg$c30(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1953,7 +1907,7 @@ function peg$parse(input, options) {
                     s1 = peg$parseSearchBoolean();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c32(s1);
+                      s1 = peg$c31(s1);
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
@@ -1961,7 +1915,7 @@ function peg$parse(input, options) {
                       s1 = peg$parseCast();
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c33(s1);
+                        s1 = peg$c32(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
@@ -1969,7 +1923,7 @@ function peg$parse(input, options) {
                         s1 = peg$parseConditionalExpr();
                         if (s1 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c32(s1);
+                          s1 = peg$c31(s1);
                         }
                         s0 = s1;
                       }
@@ -1996,20 +1950,20 @@ function peg$parse(input, options) {
       if (s2 === peg$FAILED) {
         s2 = peg$parseSearchKeywordGuard();
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c34) {
-            s2 = peg$c34;
+          if (input.substr(peg$currPos, 2) === peg$c33) {
+            s2 = peg$c33;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s2 = peg$c18;
+              s2 = peg$c17;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c19); }
+              if (peg$silentFails === 0) { peg$fail(peg$c18); }
             }
             if (s2 === peg$FAILED) {
               s2 = peg$parseEOF();
@@ -2037,29 +1991,29 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 124) {
-      s1 = peg$c36;
+      s1 = peg$c35;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c37); }
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s3 = peg$c38;
+        s3 = peg$c37;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        if (peg$silentFails === 0) { peg$fail(peg$c38); }
       }
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s3 = peg$c40;
+          s3 = peg$c39;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c40); }
         }
       }
       peg$silentFails--;
@@ -2090,12 +2044,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c34) {
-        s2 = peg$c34;
+      if (input.substr(peg$currPos, 2) === peg$c33) {
+        s2 = peg$c33;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c34); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2103,7 +2057,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequential();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c42(s4);
+            s1 = peg$c41(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2135,12 +2089,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c34) {
-            s4 = peg$c34;
+          if (input.substr(peg$currPos, 2) === peg$c33) {
+            s4 = peg$c33;
             peg$currPos += 2;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -2148,7 +2102,7 @@ function peg$parse(input, options) {
               s6 = peg$parseSequential();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c43(s2, s6);
+                s1 = peg$c42(s2, s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2182,12 +2136,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c44) {
-      s1 = peg$c44;
+    if (input.substr(peg$currPos, 4) === peg$c43) {
+      s1 = peg$c43;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c45); }
+      if (peg$silentFails === 0) { peg$fail(peg$c44); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2195,7 +2149,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c46(s3);
+          s1 = peg$c45(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2211,16 +2165,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c47) {
-        s1 = peg$c47;
+      if (input.substr(peg$currPos, 7) === peg$c46) {
+        s1 = peg$c46;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c48); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c49();
+        s1 = peg$c48();
       }
       s0 = s1;
     }
@@ -2241,7 +2195,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequential();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c50(s2, s4);
+            s1 = peg$c49(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2266,7 +2220,7 @@ function peg$parse(input, options) {
         s2 = peg$parseFromSource();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c51(s2);
+          s1 = peg$c50(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2289,16 +2243,16 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c34) {
-          s3 = peg$c34;
+        if (input.substr(peg$currPos, 2) === peg$c33) {
+          s3 = peg$c33;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c34); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c52(s1);
+          s1 = peg$c51(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2342,12 +2296,12 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c34) {
-        s4 = peg$c34;
+      if (input.substr(peg$currPos, 2) === peg$c33) {
+        s4 = peg$c33;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c34); }
       }
       peg$silentFails--;
       if (s4 === peg$FAILED) {
@@ -2375,35 +2329,35 @@ function peg$parse(input, options) {
           s2 = peg$parseMultiplicativeOperator();
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s2 = peg$c53;
+              s2 = peg$c52;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c54); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s2 = peg$c16;
+                s2 = peg$c15;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
               }
               if (s2 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s2 = peg$c40;
+                  s2 = peg$c39;
                   peg$currPos++;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c41); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c40); }
                 }
                 if (s2 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 126) {
-                    s2 = peg$c55;
+                    s2 = peg$c54;
                     peg$currPos++;
                   } else {
                     s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c56); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c55); }
                   }
                 }
               }
@@ -2430,29 +2384,29 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c57) {
-      s1 = peg$c57;
+    if (input.substr(peg$currPos, 2) === peg$c56) {
+      s1 = peg$c56;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c59) {
-        s1 = peg$c59;
+      if (input.substr(peg$currPos, 2) === peg$c58) {
+        s1 = peg$c58;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+        if (peg$silentFails === 0) { peg$fail(peg$c59); }
       }
       if (s1 === peg$FAILED) {
         s1 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c61) {
-          s2 = peg$c61;
+        if (input.substr(peg$currPos, 2) === peg$c60) {
+          s2 = peg$c60;
           peg$currPos += 2;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -2477,36 +2431,36 @@ function peg$parse(input, options) {
           s1 = peg$FAILED;
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c63) {
-            s1 = peg$c63;
+          if (input.substr(peg$currPos, 2) === peg$c62) {
+            s1 = peg$c62;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c64); }
+            if (peg$silentFails === 0) { peg$fail(peg$c63); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c65;
+              s1 = peg$c64;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c66); }
+              if (peg$silentFails === 0) { peg$fail(peg$c65); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c67) {
-                s1 = peg$c67;
+              if (input.substr(peg$currPos, 2) === peg$c66) {
+                s1 = peg$c66;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c68); }
+                if (peg$silentFails === 0) { peg$fail(peg$c67); }
               }
               if (s1 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 62) {
-                  s1 = peg$c69;
+                  s1 = peg$c68;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c70); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c69); }
                 }
               }
             }
@@ -2516,7 +2470,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -2537,7 +2491,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s1, s2);
+        s1 = peg$c71(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2564,7 +2518,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchAnd();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c73(s4);
+            s1 = peg$c72(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2632,7 +2586,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchFactor();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c74(s1, s7);
+              s4 = peg$c73(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2691,7 +2645,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchFactor();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c74(s1, s7);
+                s4 = peg$c73(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2712,7 +2666,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c75(s1, s2);
+        s1 = peg$c74(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2787,11 +2741,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c76;
+        s2 = peg$c75;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        if (peg$silentFails === 0) { peg$fail(peg$c76); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2811,7 +2765,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s2);
+        s1 = peg$c77(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2824,11 +2778,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c16;
+        s1 = peg$c15;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c16); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -2838,15 +2792,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s5 = peg$c18;
+                s5 = peg$c17;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                if (peg$silentFails === 0) { peg$fail(peg$c18); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c46(s3);
+                s1 = peg$c45(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2888,31 +2842,43 @@ function peg$parse(input, options) {
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
           peg$silentFails++;
-          s3 = peg$currPos;
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseGlob();
-            if (s5 !== peg$FAILED) {
-              s4 = [s4, s5];
-              s3 = s4;
+          s3 = peg$parseExprGuard();
+          peg$silentFails--;
+          if (s3 === peg$FAILED) {
+            s2 = void 0;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+          if (s2 === peg$FAILED) {
+            s2 = peg$currPos;
+            peg$silentFails++;
+            s3 = peg$currPos;
+            s4 = peg$parse_();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseGlob();
+              if (s5 !== peg$FAILED) {
+                s4 = [s4, s5];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
             } else {
               peg$currPos = s3;
               s3 = peg$FAILED;
             }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-          peg$silentFails--;
-          if (s3 !== peg$FAILED) {
-            peg$currPos = s2;
-            s2 = void 0;
-          } else {
-            s2 = peg$FAILED;
+            peg$silentFails--;
+            if (s3 !== peg$FAILED) {
+              peg$currPos = s2;
+              s2 = void 0;
+            } else {
+              s2 = peg$FAILED;
+            }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c79(s1);
+            s1 = peg$c78(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2924,7 +2890,13 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseSearchValue();
+          if (input.charCodeAt(peg$currPos) === 42) {
+            s1 = peg$c79;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          }
           if (s1 !== peg$FAILED) {
             s2 = peg$currPos;
             peg$silentFails++;
@@ -2938,7 +2910,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c79(s1);
+              s1 = peg$c81();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2949,40 +2921,7 @@ function peg$parse(input, options) {
             s0 = peg$FAILED;
           }
           if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.charCodeAt(peg$currPos) === 42) {
-              s1 = peg$c80;
-              peg$currPos++;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c81); }
-            }
-            if (s1 !== peg$FAILED) {
-              s2 = peg$currPos;
-              peg$silentFails++;
-              s3 = peg$parseExprGuard();
-              peg$silentFails--;
-              if (s3 === peg$FAILED) {
-                s2 = void 0;
-              } else {
-                peg$currPos = s2;
-                s2 = peg$FAILED;
-              }
-              if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c82();
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-              s0 = peg$parseSearchPredicate();
-            }
+            s0 = peg$parseSearchPredicate();
           }
         }
       }
@@ -3006,7 +2945,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAdditiveExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c83(s1, s3, s5);
+              s1 = peg$c82(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3040,7 +2979,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c84(s1, s2);
+          s1 = peg$c83(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3075,7 +3014,7 @@ function peg$parse(input, options) {
         s2 = peg$parseKeyWord();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c85(s2);
+          s1 = peg$c84(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3097,7 +3036,7 @@ function peg$parse(input, options) {
     s1 = peg$parseGlobPattern();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c86(s1);
+      s1 = peg$c85(s1);
     }
     s0 = s1;
 
@@ -3111,7 +3050,7 @@ function peg$parse(input, options) {
     s1 = peg$parseRegexpPattern();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c87(s1);
+      s1 = peg$c86(s1);
     }
     s0 = s1;
 
@@ -3132,7 +3071,7 @@ function peg$parse(input, options) {
         s3 = peg$parseLimitArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c88(s2, s3);
+          s1 = peg$c87(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3177,7 +3116,7 @@ function peg$parse(input, options) {
             s4 = peg$parseLimitArg();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c89(s2, s3, s4);
+              s1 = peg$c88(s2, s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3204,12 +3143,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c90) {
-      s1 = peg$c90;
+    if (input.substr(peg$currPos, 9) === peg$c89) {
+      s1 = peg$c89;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c91); }
+      if (peg$silentFails === 0) { peg$fail(peg$c90); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3239,7 +3178,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c92(s3);
+          s1 = peg$c91(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3263,22 +3202,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c93) {
-        s2 = peg$c93;
+      if (input.substr(peg$currPos, 4) === peg$c92) {
+        s2 = peg$c92;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c95) {
-            s4 = peg$c95;
+          if (input.substr(peg$currPos, 6) === peg$c94) {
+            s4 = peg$c94;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c96); }
+            if (peg$silentFails === 0) { peg$fail(peg$c95); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3286,7 +3225,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c97(s6);
+                s1 = peg$c96(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3314,10 +3253,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c99();
+        s1 = peg$c98();
       }
       s0 = s1;
     }
@@ -3334,7 +3273,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c100(s1);
+        s1 = peg$c99(s1);
       }
       s0 = s1;
     }
@@ -3353,11 +3292,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3365,7 +3304,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c103(s1, s7);
+              s4 = peg$c102(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3389,11 +3328,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3401,7 +3340,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c103(s1, s7);
+                s4 = peg$c102(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3422,7 +3361,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3444,12 +3383,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c105) {
-          s3 = peg$c105;
+        if (input.substr(peg$currPos, 2) === peg$c104) {
+          s3 = peg$c104;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c106); }
+          if (peg$silentFails === 0) { peg$fail(peg$c105); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3457,7 +3396,7 @@ function peg$parse(input, options) {
             s5 = peg$parseAgg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c107(s1, s5);
+              s1 = peg$c106(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3484,7 +3423,7 @@ function peg$parse(input, options) {
       s1 = peg$parseAgg();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108(s1);
+        s1 = peg$c107(s1);
       }
       s0 = s1;
     }
@@ -3512,11 +3451,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c16;
+            s4 = peg$c15;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -3529,11 +3468,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c18;
+                    s8 = peg$c17;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$currPos;
@@ -3542,11 +3481,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c109;
+                        s12 = peg$c108;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c109); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3573,7 +3512,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c111(s2, s6, s10);
+                        s1 = peg$c110(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3639,12 +3578,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c112) {
-        s2 = peg$c112;
+      if (input.substr(peg$currPos, 5) === peg$c111) {
+        s2 = peg$c111;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+        if (peg$silentFails === 0) { peg$fail(peg$c112); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3652,7 +3591,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLogicalOrExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s4);
+            s1 = peg$c45(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3685,11 +3624,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3720,11 +3659,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3752,7 +3691,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c113(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3838,12 +3777,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c115) {
-      s1 = peg$c115;
+    if (input.substr(peg$currPos, 4) === peg$c114) {
+      s1 = peg$c114;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c116); }
+      if (peg$silentFails === 0) { peg$fail(peg$c115); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3865,7 +3804,7 @@ function peg$parse(input, options) {
             s6 = peg$parseExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c117(s3, s6);
+              s5 = peg$c116(s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3880,7 +3819,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c118(s3, s4);
+            s1 = peg$c117(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3913,7 +3852,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c28(s4);
+        s3 = peg$c27(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3931,7 +3870,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c28(s4);
+          s3 = peg$c27(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3944,7 +3883,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c119(s1);
+      s1 = peg$c118(s1);
     }
     s0 = s1;
 
@@ -3955,55 +3894,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c120) {
-      s1 = peg$c120;
+    if (input.substr(peg$currPos, 2) === peg$c119) {
+      s1 = peg$c119;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c120); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c122();
+      s1 = peg$c121();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c123) {
-        s1 = peg$c123;
+      if (input.substr(peg$currPos, 6) === peg$c122) {
+        s1 = peg$c122;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c124); }
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c125) {
-            s4 = peg$c125;
+          if (input.substr(peg$currPos, 5) === peg$c124) {
+            s4 = peg$c124;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c126); }
+            if (peg$silentFails === 0) { peg$fail(peg$c125); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c127) {
-              s4 = peg$c127;
+            if (input.substr(peg$currPos, 4) === peg$c126) {
+              s4 = peg$c126;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c128); }
+              if (peg$silentFails === 0) { peg$fail(peg$c127); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c71();
+            s4 = peg$c70();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c129(s3);
+            s1 = peg$c128(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4026,12 +3965,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c130) {
-      s1 = peg$c130;
+    if (input.substr(peg$currPos, 3) === peg$c129) {
+      s1 = peg$c129;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c131); }
+      if (peg$silentFails === 0) { peg$fail(peg$c130); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4051,7 +3990,7 @@ function peg$parse(input, options) {
           s5 = peg$parseUInt();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c132(s5);
+            s4 = peg$c131(s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -4068,12 +4007,12 @@ function peg$parse(input, options) {
           s4 = peg$currPos;
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c133) {
-              s6 = peg$c133;
+            if (input.substr(peg$currPos, 6) === peg$c132) {
+              s6 = peg$c132;
               peg$currPos += 6;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c134); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -4096,7 +4035,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFieldExprs();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c135(s3, s4, s7);
+                s6 = peg$c134(s3, s4, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -4111,7 +4050,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c136(s3, s4, s5);
+              s1 = peg$c135(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4141,12 +4080,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c137) {
-      s1 = peg$c137;
+    if (input.substr(peg$currPos, 3) === peg$c136) {
+      s1 = peg$c136;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c138); }
+      if (peg$silentFails === 0) { peg$fail(peg$c137); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4154,7 +4093,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c139(s3);
+          s1 = peg$c138(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4176,12 +4115,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c140) {
-      s1 = peg$c140;
+    if (input.substr(peg$currPos, 4) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4189,7 +4128,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s3);
+          s1 = peg$c141(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4211,12 +4150,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c143) {
-      s1 = peg$c143;
+    if (input.substr(peg$currPos, 4) === peg$c142) {
+      s1 = peg$c142;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c144); }
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4224,7 +4163,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c145(s3);
+          s1 = peg$c144(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4240,16 +4179,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c143) {
-        s1 = peg$c143;
+      if (input.substr(peg$currPos, 4) === peg$c142) {
+        s1 = peg$c142;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c144); }
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c146();
+        s1 = peg$c145();
       }
       s0 = s1;
     }
@@ -4261,12 +4200,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c147) {
-      s1 = peg$c147;
+    if (input.substr(peg$currPos, 4) === peg$c146) {
+      s1 = peg$c146;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c147); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4274,7 +4213,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c149(s3);
+          s1 = peg$c148(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4290,16 +4229,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c147) {
-        s1 = peg$c147;
+      if (input.substr(peg$currPos, 4) === peg$c146) {
+        s1 = peg$c146;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+        if (peg$silentFails === 0) { peg$fail(peg$c147); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c150();
+        s1 = peg$c149();
       }
       s0 = s1;
     }
@@ -4311,12 +4250,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c112) {
-      s1 = peg$c112;
+    if (input.substr(peg$currPos, 5) === peg$c111) {
+      s1 = peg$c111;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c113); }
+      if (peg$silentFails === 0) { peg$fail(peg$c112); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4324,7 +4263,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c151(s3);
+          s1 = peg$c150(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4346,26 +4285,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c152) {
-      s1 = peg$c152;
+    if (input.substr(peg$currPos, 4) === peg$c151) {
+      s1 = peg$c151;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c153); }
+      if (peg$silentFails === 0) { peg$fail(peg$c152); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c154) {
-          s3 = peg$c154;
+        if (input.substr(peg$currPos, 2) === peg$c153) {
+          s3 = peg$c153;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c154); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c156();
+          s1 = peg$c155();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4381,16 +4320,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c152) {
-        s1 = peg$c152;
+      if (input.substr(peg$currPos, 4) === peg$c151) {
+        s1 = peg$c151;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c153); }
+        if (peg$silentFails === 0) { peg$fail(peg$c152); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c157();
+        s1 = peg$c156();
       }
       s0 = s1;
     }
@@ -4402,12 +4341,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c158) {
-      s1 = peg$c158;
+    if (input.substr(peg$currPos, 3) === peg$c157) {
+      s1 = peg$c157;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
+      if (peg$silentFails === 0) { peg$fail(peg$c158); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4415,7 +4354,7 @@ function peg$parse(input, options) {
         s3 = peg$parseAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c160(s3);
+          s1 = peg$c159(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4437,12 +4376,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c161) {
-      s1 = peg$c161;
+    if (input.substr(peg$currPos, 6) === peg$c160) {
+      s1 = peg$c160;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c162); }
+      if (peg$silentFails === 0) { peg$fail(peg$c161); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4454,11 +4393,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c101;
+              s7 = peg$c100;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c102); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -4466,7 +4405,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c163(s3, s9);
+                  s6 = peg$c162(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4490,11 +4429,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c101;
+                s7 = peg$c100;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -4502,7 +4441,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c163(s3, s9);
+                    s6 = peg$c162(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4523,7 +4462,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c164(s3, s4);
+            s1 = peg$c163(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4549,12 +4488,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c165) {
-      s1 = peg$c165;
+    if (input.substr(peg$currPos, 4) === peg$c164) {
+      s1 = peg$c164;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c166); }
+      if (peg$silentFails === 0) { peg$fail(peg$c165); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4563,11 +4502,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c16;
+          s5 = peg$c15;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4600,7 +4539,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c167();
+          s1 = peg$c166();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4622,12 +4561,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c168) {
-      s1 = peg$c168;
+    if (input.substr(peg$currPos, 5) === peg$c167) {
+      s1 = peg$c167;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c168); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4636,11 +4575,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c16;
+          s5 = peg$c15;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4673,7 +4612,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c170();
+          s1 = peg$c169();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4697,12 +4636,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseJoinStyle();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c171) {
-        s2 = peg$c171;
+      if (input.substr(peg$currPos, 4) === peg$c170) {
+        s2 = peg$c170;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c172); }
+        if (peg$silentFails === 0) { peg$fail(peg$c171); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4716,11 +4655,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 61) {
-                    s8 = peg$c8;
+                    s8 = peg$c7;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c9); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$parse__();
@@ -4747,7 +4686,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c173(s1, s6, s10, s11);
+                          s1 = peg$c172(s1, s6, s10, s11);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -4797,12 +4736,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parseJoinStyle();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c171) {
-          s2 = peg$c171;
+        if (input.substr(peg$currPos, 4) === peg$c170) {
+          s2 = peg$c170;
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c172); }
+          if (peg$silentFails === 0) { peg$fail(peg$c171); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4833,7 +4772,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c174(s1, s6, s7);
+                    s1 = peg$c173(s1, s6, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4872,18 +4811,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c175) {
-      s1 = peg$c175;
+    if (input.substr(peg$currPos, 4) === peg$c174) {
+      s1 = peg$c174;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c176); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c177();
+        s1 = peg$c176();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4895,18 +4834,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c178) {
-        s1 = peg$c178;
+      if (input.substr(peg$currPos, 5) === peg$c177) {
+        s1 = peg$c177;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c180();
+          s1 = peg$c179();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4918,18 +4857,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c181) {
-          s1 = peg$c181;
+        if (input.substr(peg$currPos, 4) === peg$c180) {
+          s1 = peg$c180;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c182); }
+          if (peg$silentFails === 0) { peg$fail(peg$c181); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c183();
+            s1 = peg$c182();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4941,18 +4880,18 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c184) {
-            s1 = peg$c184;
+          if (input.substr(peg$currPos, 5) === peg$c183) {
+            s1 = peg$c183;
             peg$currPos += 5;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c185); }
+            if (peg$silentFails === 0) { peg$fail(peg$c184); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c186();
+              s1 = peg$c185();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4964,10 +4903,10 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$c98;
+            s1 = peg$c97;
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c180();
+              s1 = peg$c179();
             }
             s0 = s1;
           }
@@ -4985,25 +4924,25 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c16;
+        s1 = peg$c15;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c16); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c18;
+            s3 = peg$c17;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c19); }
+            if (peg$silentFails === 0) { peg$fail(peg$c18); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s2);
+            s1 = peg$c45(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5026,12 +4965,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c187) {
-      s1 = peg$c187;
+    if (input.substr(peg$currPos, 6) === peg$c186) {
+      s1 = peg$c186;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+      if (peg$silentFails === 0) { peg$fail(peg$c187); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -5048,7 +4987,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSampleExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c189(s3);
+          s1 = peg$c188(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5073,7 +5012,7 @@ function peg$parse(input, options) {
     s1 = peg$parseAssignments();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c190(s1);
+      s1 = peg$c189(s1);
     }
     s0 = s1;
 
@@ -5089,7 +5028,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c191(s2);
+        s1 = peg$c190(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5101,10 +5040,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c192();
+        s1 = peg$c191();
       }
       s0 = s1;
     }
@@ -5119,7 +5058,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFromAny();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c193(s1);
+      s1 = peg$c192(s1);
     }
     s0 = s1;
 
@@ -5144,12 +5083,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c194) {
-      s1 = peg$c194;
+    if (input.substr(peg$currPos, 4) === peg$c193) {
+      s1 = peg$c193;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5167,7 +5106,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c196(s3, s4, s5);
+              s1 = peg$c195(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5197,12 +5136,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c25) {
-      s1 = peg$c25;
+    if (input.substr(peg$currPos, 4) === peg$c24) {
+      s1 = peg$c24;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c26); }
+      if (peg$silentFails === 0) { peg$fail(peg$c25); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5210,7 +5149,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePoolBody();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c197(s3);
+          s1 = peg$c196(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5232,12 +5171,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c198) {
-      s1 = peg$c198;
+    if (input.substr(peg$currPos, 4) === peg$c197) {
+      s1 = peg$c197;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c199); }
+      if (peg$silentFails === 0) { peg$fail(peg$c198); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5245,7 +5184,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePoolBody();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c197(s3);
+          s1 = peg$c196(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5285,7 +5224,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c200(s1, s2, s3, s4);
+            s1 = peg$c199(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5311,12 +5250,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c201) {
-      s1 = peg$c201;
+    if (input.substr(peg$currPos, 3) === peg$c200) {
+      s1 = peg$c200;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c202); }
+      if (peg$silentFails === 0) { peg$fail(peg$c201); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5334,7 +5273,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c203(s3, s4, s5);
+              s1 = peg$c202(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5364,27 +5303,27 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c204) {
-      s1 = peg$c204;
+    if (input.substr(peg$currPos, 5) === peg$c203) {
+      s1 = peg$c203;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c205); }
+      if (peg$silentFails === 0) { peg$fail(peg$c204); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c206) {
-        s1 = peg$c206;
+      if (input.substr(peg$currPos, 6) === peg$c205) {
+        s1 = peg$c205;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c207); }
+        if (peg$silentFails === 0) { peg$fail(peg$c206); }
       }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePath();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5405,28 +5344,28 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c5(s1);
+      s1 = peg$c4(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c208.test(input.charAt(peg$currPos))) {
+      if (peg$c207.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c209); }
+        if (peg$silentFails === 0) { peg$fail(peg$c208); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c208.test(input.charAt(peg$currPos))) {
+          if (peg$c207.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c209); }
+            if (peg$silentFails === 0) { peg$fail(peg$c208); }
           }
         }
       } else {
@@ -5434,7 +5373,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
       }
       s0 = s1;
     }
@@ -5448,12 +5387,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c210) {
-        s2 = peg$c210;
+      if (input.substr(peg$currPos, 2) === peg$c209) {
+        s2 = peg$c209;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c211); }
+        if (peg$silentFails === 0) { peg$fail(peg$c210); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5461,7 +5400,7 @@ function peg$parse(input, options) {
           s4 = peg$parseKSUID();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c212(s4);
+            s1 = peg$c211(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5488,22 +5427,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c213.test(input.charAt(peg$currPos))) {
+    if (peg$c212.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+      if (peg$silentFails === 0) { peg$fail(peg$c213); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c213.test(input.charAt(peg$currPos))) {
+        if (peg$c212.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+          if (peg$silentFails === 0) { peg$fail(peg$c213); }
         }
       }
     } else {
@@ -5511,7 +5450,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -5524,12 +5463,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c215) {
-        s2 = peg$c215;
+      if (input.substr(peg$currPos, 5) === peg$c214) {
+        s2 = peg$c214;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c216); }
+        if (peg$silentFails === 0) { peg$fail(peg$c215); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5538,12 +5477,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c217) {
-                s6 = peg$c217;
+              if (input.substr(peg$currPos, 2) === peg$c216) {
+                s6 = peg$c216;
                 peg$currPos += 2;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c218); }
+                if (peg$silentFails === 0) { peg$fail(peg$c217); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parse_();
@@ -5551,7 +5490,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseLiteral();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c219(s4, s8);
+                    s1 = peg$c218(s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5606,7 +5545,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c220(s1, s2, s3);
+          s1 = peg$c219(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5625,7 +5564,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePoolMeta();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c221(s1);
+        s1 = peg$c220(s1);
       }
       s0 = s1;
     }
@@ -5638,17 +5577,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 64) {
-      s1 = peg$c222;
+      s1 = peg$c221;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c223); }
+      if (peg$silentFails === 0) { peg$fail(peg$c222); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePoolName();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224(s2);
+        s1 = peg$c223(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5667,17 +5606,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c53;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePoolIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c225(s2);
+        s1 = peg$c224(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5712,11 +5651,11 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierStart();
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c109;
+        s1 = peg$c108;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -5724,11 +5663,11 @@ function peg$parse(input, options) {
       s3 = peg$parseIdentifierRest();
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c109;
+          s3 = peg$c108;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
       }
       while (s3 !== peg$FAILED) {
@@ -5736,17 +5675,17 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierRest();
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c109;
+            s3 = peg$c108;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c226();
+        s1 = peg$c225();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5766,12 +5705,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c227) {
-        s2 = peg$c227;
+      if (input.substr(peg$currPos, 5) === peg$c226) {
+        s2 = peg$c226;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c228); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5781,7 +5720,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c229(s4, s5);
+              s1 = peg$c228(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5813,12 +5752,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c230) {
-        s2 = peg$c230;
+      if (input.substr(peg$currPos, 6) === peg$c229) {
+        s2 = peg$c229;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c231); }
+        if (peg$silentFails === 0) { peg$fail(peg$c230); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5826,7 +5765,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c232(s4);
+            s1 = peg$c231(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5852,38 +5791,38 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c233) {
-      s1 = peg$c233;
+    if (input.substr(peg$currPos, 4) === peg$c232) {
+      s1 = peg$c232;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c235();
+      s1 = peg$c234();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c236) {
-        s1 = peg$c236;
+      if (input.substr(peg$currPos, 5) === peg$c235) {
+        s1 = peg$c235;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c237); }
+        if (peg$silentFails === 0) { peg$fail(peg$c236); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c238();
+        s1 = peg$c237();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$c98;
+        s1 = peg$c97;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c235();
+          s1 = peg$c234();
         }
         s0 = s1;
       }
@@ -5898,26 +5837,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c227) {
-        s2 = peg$c227;
+      if (input.substr(peg$currPos, 5) === peg$c226) {
+        s2 = peg$c226;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c228); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c239) {
-            s4 = peg$c239;
+          if (input.substr(peg$currPos, 3) === peg$c238) {
+            s4 = peg$c238;
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c235();
+            s1 = peg$c234();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5939,26 +5878,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c227) {
-          s2 = peg$c227;
+        if (input.substr(peg$currPos, 5) === peg$c226) {
+          s2 = peg$c226;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+          if (peg$silentFails === 0) { peg$fail(peg$c227); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c241) {
-              s4 = peg$c241;
+            if (input.substr(peg$currPos, 4) === peg$c240) {
+              s4 = peg$c240;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c242); }
+              if (peg$silentFails === 0) { peg$fail(peg$c241); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c238();
+              s1 = peg$c237();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5985,12 +5924,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c243) {
-      s1 = peg$c243;
+    if (input.substr(peg$currPos, 4) === peg$c242) {
+      s1 = peg$c242;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c243); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -6005,7 +5944,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245();
+        s1 = peg$c244();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6023,12 +5962,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7) === peg$c246) {
-      s1 = peg$c246;
+    if (input.substr(peg$currPos, 7) === peg$c245) {
+      s1 = peg$c245;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6043,7 +5982,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c248(s3, s4, s5);
+              s1 = peg$c247(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6073,12 +6012,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c249) {
-      s1 = peg$c249;
+    if (input.substr(peg$currPos, 5) === peg$c248) {
+      s1 = peg$c248;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c250); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6086,7 +6025,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c251(s3);
+          s1 = peg$c250(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6105,58 +6044,82 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOverOp() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c251) {
+      s1 = peg$c251;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c252); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c93) {
-              s5 = peg$c93;
+          s4 = peg$currPos;
+          s5 = peg$parse_();
+          if (s5 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 4) === peg$c92) {
+              s6 = peg$c92;
               peg$currPos += 4;
             } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c94); }
+              s6 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c93); }
             }
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse_();
-              if (s6 !== peg$FAILED) {
-                s7 = peg$parseLetAssignments();
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
-                  if (s8 !== peg$FAILED) {
-                    s9 = peg$parseScope();
-                    if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c254(s3, s7, s9);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parse_();
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parseLetAssignments();
+                if (s8 !== peg$FAILED) {
+                  peg$savedPos = s4;
+                  s5 = peg$c253(s3, s8);
+                  s4 = s5;
                 } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
+                  peg$currPos = s4;
+                  s4 = peg$FAILED;
                 }
               } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
+                peg$currPos = s4;
+                s4 = peg$FAILED;
               }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+          if (s4 === peg$FAILED) {
+            s4 = null;
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$currPos;
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseScope();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s5;
+                s6 = peg$c254(s3, s4, s7);
+                s5 = s6;
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c255(s3, s4, s5);
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -6177,78 +6140,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c252) {
-        s1 = peg$c252;
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c253); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseExprs();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parseScope();
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c255(s3, s5);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c252) {
-          s1 = peg$c252;
-          peg$currPos += 4;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c253); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse_();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parseExprs();
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c256(s3);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      }
-    }
 
     return s0;
   }
@@ -6257,22 +6148,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c34) {
-      s1 = peg$c34;
+    if (input.substr(peg$currPos, 2) === peg$c33) {
+      s1 = peg$c33;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c35); }
+      if (peg$silentFails === 0) { peg$fail(peg$c34); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6282,15 +6173,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c18;
+                  s7 = peg$c17;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c257(s5);
+                  s1 = peg$c256(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6335,11 +6226,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6347,7 +6238,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLetAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c258(s1, s7);
+              s4 = peg$c257(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6371,11 +6262,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6383,7 +6274,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLetAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c258(s1, s7);
+                s4 = peg$c257(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6404,7 +6295,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6427,11 +6318,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c8;
+          s3 = peg$c7;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c9); }
+          if (peg$silentFails === 0) { peg$fail(peg$c8); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6439,7 +6330,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c10(s1, s5);
+              s1 = peg$c9(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6466,7 +6357,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIdentifierName();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c259(s1);
+        s1 = peg$c258(s1);
       }
       s0 = s1;
     }
@@ -6478,12 +6369,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c260) {
-      s1 = peg$c260;
+    if (input.substr(peg$currPos, 5) === peg$c259) {
+      s1 = peg$c259;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c261); }
+      if (peg$silentFails === 0) { peg$fail(peg$c260); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6491,7 +6382,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c262(s3);
+          s1 = peg$c261(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6522,7 +6413,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c263(s4);
+            s1 = peg$c262(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6557,7 +6448,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c264(s4);
+            s1 = peg$c263(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6590,11 +6481,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6602,7 +6493,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c265(s1, s7);
+              s4 = peg$c264(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6626,11 +6517,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6638,7 +6529,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c265(s1, s7);
+                s4 = peg$c264(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6659,7 +6550,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6684,11 +6575,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6719,11 +6610,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6731,6 +6622,100 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 s4 = [s4, s5, s6, s7];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c265(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssignments() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseAssignment();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c100;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseAssignment();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c257(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c100;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseAssignment();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c257(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6765,100 +6750,6 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseAssignments() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseAssignment();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseAssignment();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c258(s1, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseAssignment();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c258(s1, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parseAssignment() {
     var s0, s1, s2, s3, s4, s5;
 
@@ -6867,12 +6758,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c105) {
-          s3 = peg$c105;
+        if (input.substr(peg$currPos, 2) === peg$c104) {
+          s3 = peg$c104;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c106); }
+          if (peg$silentFails === 0) { peg$fail(peg$c105); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6880,7 +6771,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c268(s1, s5);
+              s1 = peg$c267(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6923,11 +6814,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c269;
+          s3 = peg$c268;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c269); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6937,11 +6828,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c53;
+                  s7 = peg$c52;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -6949,7 +6840,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c271(s1, s5, s9);
+                      s1 = peg$c270(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7011,7 +6902,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s5, s7);
+              s4 = peg$c271(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7041,7 +6932,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s5, s7);
+                s4 = peg$c271(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7062,7 +6953,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7093,7 +6984,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s5, s7);
+              s4 = peg$c271(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7123,7 +7014,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s5, s7);
+                s4 = peg$c271(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7144,7 +7035,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7159,34 +7050,86 @@ function peg$parse(input, options) {
   }
 
   function peg$parseComparisonExpr() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     s1 = peg$parseAdditiveExpr();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseComparator();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseAdditiveExpr();
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c274(s1, s3, s5);
-              s0 = s1;
+      s2 = peg$currPos;
+      s3 = peg$parse__();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parseComparator();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parse__();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parseAdditiveExpr();
+            if (s6 !== peg$FAILED) {
+              s3 = [s3, s4, s5, s6];
+              s2 = s3;
             } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
+              peg$currPos = s2;
+              s2 = peg$FAILED;
             }
           } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
+            peg$currPos = s2;
+            s2 = peg$FAILED;
           }
         } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
+          peg$currPos = s2;
+          s2 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 === peg$FAILED) {
+        s2 = peg$currPos;
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 126) {
+            s5 = peg$c54;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          }
+          if (s5 !== peg$FAILED) {
+            peg$savedPos = s4;
+            s5 = peg$c273(s1);
+          }
+          s4 = s5;
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse__();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseRegexp();
+              if (s6 !== peg$FAILED) {
+                s3 = [s3, s4, s5, s6];
+                s2 = s3;
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      }
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c274(s1, s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -7194,51 +7137,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseAdditiveExpr();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 126) {
-            s3 = peg$c55;
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c56); }
-          }
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parseRegexp();
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c275(s1, s5);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseAdditiveExpr();
-      }
     }
 
     return s0;
@@ -7261,7 +7159,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s5, s7);
+              s4 = peg$c271(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7291,7 +7189,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s5, s7);
+                s4 = peg$c271(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7312,7 +7210,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7331,24 +7229,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c276;
+      s1 = peg$c275;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c278;
+        s1 = peg$c277;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7372,7 +7270,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c272(s1, s5, s7);
+              s4 = peg$c271(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7402,7 +7300,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c272(s1, s5, s7);
+                s4 = peg$c271(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7423,7 +7321,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c272(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7442,33 +7340,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c80;
+      s1 = peg$c79;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c81); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c280;
+        s1 = peg$c279;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+        if (peg$silentFails === 0) { peg$fail(peg$c280); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c282;
+          s1 = peg$c281;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+          if (peg$silentFails === 0) { peg$fail(peg$c282); }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7480,11 +7378,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c76;
+      s1 = peg$c75;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c77); }
+      if (peg$silentFails === 0) { peg$fail(peg$c76); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7492,7 +7390,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c284(s3);
+          s1 = peg$c283(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7529,11 +7427,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c278;
+        s2 = peg$c277;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7541,7 +7439,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c285(s4);
+            s1 = peg$c284(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7580,7 +7478,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s1, s2);
+        s1 = peg$c71(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7602,7 +7500,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c72(s1, s2);
+          s1 = peg$c71(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7632,11 +7530,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -7660,20 +7558,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c286) {
-      s0 = peg$c286;
+    if (input.substr(peg$currPos, 3) === peg$c285) {
+      s0 = peg$c285;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c287); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c288) {
-        s0 = peg$c288;
+      if (input.substr(peg$currPos, 6) === peg$c287) {
+        s0 = peg$c287;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c289); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
     }
 
@@ -7689,11 +7587,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7703,15 +7601,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c18;
+                  s7 = peg$c17;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c290(s1, s5);
+                  s1 = peg$c289(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7767,11 +7665,11 @@ function peg$parse(input, options) {
           s3 = peg$parse__();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s4 = peg$c16;
+              s4 = peg$c15;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+              if (peg$silentFails === 0) { peg$fail(peg$c16); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse__();
@@ -7781,11 +7679,11 @@ function peg$parse(input, options) {
                   s7 = peg$parse__();
                   if (s7 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s8 = peg$c18;
+                      s8 = peg$c17;
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c18); }
                     }
                     if (s8 !== peg$FAILED) {
                       s9 = peg$parseWhereClause();
@@ -7794,7 +7692,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c291(s2, s6, s9);
+                        s1 = peg$c290(s2, s6, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7841,22 +7739,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c292) {
-      s1 = peg$c292;
+    if (input.substr(peg$currPos, 4) === peg$c291) {
+      s1 = peg$c291;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c293); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c16;
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c17); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7866,15 +7764,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c18;
+                  s7 = peg$c17;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c294(s5);
+                  s1 = peg$c293(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7906,22 +7804,22 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c292) {
-        s1 = peg$c292;
+      if (input.substr(peg$currPos, 4) === peg$c291) {
+        s1 = peg$c291;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c293); }
+        if (peg$silentFails === 0) { peg$fail(peg$c292); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c16;
+            s3 = peg$c15;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -7931,11 +7829,11 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c101;
+                    s7 = peg$c100;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c101); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse__();
@@ -7945,15 +7843,15 @@ function peg$parse(input, options) {
                         s10 = peg$parse__();
                         if (s10 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 41) {
-                            s11 = peg$c18;
+                            s11 = peg$c17;
                             peg$currPos++;
                           } else {
                             s11 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c18); }
                           }
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c295(s5, s9);
+                            s1 = peg$c294(s5, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -8015,7 +7913,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c296(s1);
+          s1 = peg$c295(s1);
         }
         s0 = s1;
       }
@@ -8033,7 +7931,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4();
+        s1 = peg$c3();
       }
       s0 = s1;
     }
@@ -8052,11 +7950,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -8064,7 +7962,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c297(s1, s7);
+              s4 = peg$c296(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8088,11 +7986,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -8100,7 +7998,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c297(s1, s7);
+                s4 = peg$c296(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8121,7 +8019,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8160,7 +8058,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c72(s2, s3);
+          s1 = peg$c71(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8183,11 +8081,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c40;
+      s1 = peg$c39;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c41); }
+      if (peg$silentFails === 0) { peg$fail(peg$c40); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -8195,27 +8093,30 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c53;
+            s4 = peg$c52;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
               s6 = peg$parseAdditiveExpr();
+              if (s6 === peg$FAILED) {
+                s6 = null;
+              }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c298;
+                  s7 = peg$c297;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c300(s2, s6);
+                  s1 = peg$c299(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8248,21 +8149,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c40;
+        s1 = peg$c39;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c41); }
+        if (peg$silentFails === 0) { peg$fail(peg$c40); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c53;
+            s3 = peg$c52;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -8270,15 +8171,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c298;
+                  s6 = peg$c297;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c301(s5);
+                  s1 = peg$c300(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8307,50 +8208,26 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c40;
+          s1 = peg$c39;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c40); }
         }
         if (s1 !== peg$FAILED) {
-          s2 = peg$parseAdditiveExpr();
+          s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parse__();
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s3 = peg$c297;
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c298); }
+            }
             if (s3 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c53;
-                peg$currPos++;
-              } else {
-                s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c54); }
-              }
-              if (s4 !== peg$FAILED) {
-                s5 = peg$parse__();
-                if (s5 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c298;
-                    peg$currPos++;
-                  } else {
-                    s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c299); }
-                  }
-                  if (s6 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c302(s2);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
+              peg$savedPos = s0;
+              s1 = peg$c301(s2);
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -8365,31 +8242,19 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c40;
+          if (input.charCodeAt(peg$currPos) === 46) {
+            s1 = peg$c108;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c41); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
           if (s1 !== peg$FAILED) {
-            s2 = peg$parseConditionalExpr();
+            s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c298;
-                peg$currPos++;
-              } else {
-                s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c299); }
-              }
-              if (s3 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c303(s2);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
+              peg$savedPos = s0;
+              s1 = peg$c302(s2);
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -8397,30 +8262,6 @@ function peg$parse(input, options) {
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c109;
-              peg$currPos++;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c110); }
-            }
-            if (s1 !== peg$FAILED) {
-              s2 = peg$parseIdentifier();
-              if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c304(s2);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
           }
         }
       }
@@ -8444,11 +8285,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 40) {
-                s1 = peg$c16;
+                s1 = peg$c15;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -8458,15 +8299,15 @@ function peg$parse(input, options) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 41) {
-                        s5 = peg$c18;
+                        s5 = peg$c17;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c18); }
                       }
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c46(s3);
+                        s1 = peg$c45(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -8491,11 +8332,11 @@ function peg$parse(input, options) {
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s1 = peg$c16;
+                  s1 = peg$c15;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse__();
@@ -8505,15 +8346,15 @@ function peg$parse(input, options) {
                       s4 = peg$parse__();
                       if (s4 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 41) {
-                          s5 = peg$c18;
+                          s5 = peg$c17;
                           peg$currPos++;
                         } else {
                           s5 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c18); }
                         }
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c46(s3);
+                          s1 = peg$c45(s3);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -8546,64 +8387,76 @@ function peg$parse(input, options) {
   }
 
   function peg$parseOverExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c251) {
+      s1 = peg$c251;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c252); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c93) {
-              s5 = peg$c93;
+          s4 = peg$currPos;
+          s5 = peg$parse_();
+          if (s5 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 4) === peg$c92) {
+              s6 = peg$c92;
               peg$currPos += 4;
             } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c94); }
+              s6 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c93); }
             }
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parse_();
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parseLetAssignments();
+                if (s8 !== peg$FAILED) {
+                  peg$savedPos = s4;
+                  s5 = peg$c253(s3, s8);
+                  s4 = s5;
+                } else {
+                  peg$currPos = s4;
+                  s4 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s4;
+                s4 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+          if (s4 === peg$FAILED) {
+            s4 = null;
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse_();
+              if (input.charCodeAt(peg$currPos) === 124) {
+                s6 = peg$c35;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c36); }
+              }
               if (s6 !== peg$FAILED) {
-                s7 = peg$parseLetAssignments();
+                s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
+                  s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 124) {
-                      s9 = peg$c36;
-                      peg$currPos++;
-                    } else {
-                      s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c37); }
-                    }
-                    if (s9 !== peg$FAILED) {
-                      s10 = peg$parse__();
-                      if (s10 !== peg$FAILED) {
-                        s11 = peg$parseSequential();
-                        if (s11 !== peg$FAILED) {
-                          peg$savedPos = s0;
-                          s1 = peg$c305(s3, s7, s11);
-                          s0 = s1;
-                        } else {
-                          peg$currPos = s0;
-                          s0 = peg$FAILED;
-                        }
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
+                    peg$savedPos = s0;
+                    s1 = peg$c303(s3, s4, s8);
+                    s0 = s1;
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -8636,66 +8489,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c252) {
-        s1 = peg$c252;
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c253); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseExprs();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 124) {
-                s5 = peg$c36;
-                peg$currPos++;
-              } else {
-                s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c37); }
-              }
-              if (s5 !== peg$FAILED) {
-                s6 = peg$parse__();
-                if (s6 !== peg$FAILED) {
-                  s7 = peg$parseSequential();
-                  if (s7 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c306(s3, s7);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
 
     return s0;
   }
@@ -8705,11 +8498,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c38;
+      s1 = peg$c37;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c38); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8719,15 +8512,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c307;
+              s5 = peg$c304;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c308); }
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c309(s3);
+              s1 = peg$c306(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8767,7 +8560,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8782,7 +8575,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4();
+        s1 = peg$c3();
       }
       s0 = s1;
     }
@@ -8797,11 +8590,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c101;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8809,7 +8602,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c310(s4);
+            s1 = peg$c307(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8849,12 +8642,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c311) {
-      s1 = peg$c311;
+    if (input.substr(peg$currPos, 3) === peg$c308) {
+      s1 = peg$c308;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c312); }
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8862,7 +8655,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c313(s3);
+          s1 = peg$c310(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8889,11 +8682,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c53;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8901,7 +8694,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314(s1, s5);
+              s1 = peg$c311(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8932,11 +8725,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c40;
+      s1 = peg$c39;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c41); }
+      if (peg$silentFails === 0) { peg$fail(peg$c40); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8946,15 +8739,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c298;
+              s5 = peg$c297;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c299); }
+              if (peg$silentFails === 0) { peg$fail(peg$c298); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s3);
+              s1 = peg$c312(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8984,12 +8777,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c316) {
-      s1 = peg$c316;
+    if (input.substr(peg$currPos, 2) === peg$c313) {
+      s1 = peg$c313;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8998,16 +8791,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c318) {
-              s5 = peg$c318;
+            if (input.substr(peg$currPos, 2) === peg$c315) {
+              s5 = peg$c315;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c319); }
+              if (peg$silentFails === 0) { peg$fail(peg$c316); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s3);
+              s1 = peg$c317(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9037,12 +8830,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c321) {
-      s1 = peg$c321;
+    if (input.substr(peg$currPos, 2) === peg$c318) {
+      s1 = peg$c318;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9051,16 +8844,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c323) {
-              s5 = peg$c323;
+            if (input.substr(peg$currPos, 2) === peg$c320) {
+              s5 = peg$c320;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c324); }
+              if (peg$silentFails === 0) { peg$fail(peg$c321); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c325(s3);
+              s1 = peg$c322(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9100,7 +8893,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9115,7 +8908,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4();
+        s1 = peg$c3();
       }
       s0 = s1;
     }
@@ -9130,11 +8923,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c101;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -9142,7 +8935,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s4);
+            s1 = peg$c323(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9173,11 +8966,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c53;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -9185,7 +8978,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c327(s1, s5);
+              s1 = peg$c324(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9250,7 +9043,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c328(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c325(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9297,15 +9090,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 42) {
-          s3 = peg$c80;
+          s3 = peg$c79;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c49();
+          s1 = peg$c48();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9328,7 +9121,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c329(s3);
+            s1 = peg$c326(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9362,7 +9155,7 @@ function peg$parse(input, options) {
             s5 = peg$parseDerefExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s1, s5);
+              s1 = peg$c327(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9389,7 +9182,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c100(s1);
+        s1 = peg$c99(s1);
       }
       s0 = s1;
     }
@@ -9408,11 +9201,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c101;
+          s5 = peg$c100;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -9420,7 +9213,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSQLAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c103(s1, s7);
+              s4 = peg$c102(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9444,11 +9237,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c101;
+            s5 = peg$c100;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -9456,7 +9249,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSQLAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c103(s1, s7);
+                s4 = peg$c102(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9477,7 +9270,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9509,7 +9302,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331(s4, s5);
+              s1 = peg$c328(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9540,15 +9333,15 @@ function peg$parse(input, options) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 42) {
-              s4 = peg$c80;
+              s4 = peg$c79;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c81); }
+              if (peg$silentFails === 0) { peg$fail(peg$c80); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c49();
+              s1 = peg$c48();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9584,7 +9377,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c212(s4);
+            s1 = peg$c211(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9634,7 +9427,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDerefExpr();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c212(s3);
+            s1 = peg$c211(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9664,7 +9457,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c332(s1, s4);
+        s4 = peg$c329(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9673,13 +9466,13 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c332(s1, s4);
+          s4 = peg$c329(s1, s4);
         }
         s3 = s4;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c103(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9723,11 +9516,11 @@ function peg$parse(input, options) {
                         s11 = peg$parse__();
                         if (s11 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 61) {
-                            s12 = peg$c8;
+                            s12 = peg$c7;
                             peg$currPos++;
                           } else {
                             s12 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c9); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c8); }
                           }
                           if (s12 !== peg$FAILED) {
                             s13 = peg$parse__();
@@ -9735,7 +9528,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c333(s1, s5, s6, s10, s14);
+                                s1 = peg$c330(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9815,7 +9608,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c334(s2);
+        s1 = peg$c331(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9827,10 +9620,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c180();
+        s1 = peg$c179();
       }
       s0 = s1;
     }
@@ -9851,7 +9644,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLogicalOrExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s4);
+            s1 = peg$c45(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9890,7 +9683,7 @@ function peg$parse(input, options) {
               s6 = peg$parseFieldExprs();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c92(s6);
+                s1 = peg$c91(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9933,7 +9726,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLogicalOrExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s4);
+            s1 = peg$c45(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9974,7 +9767,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c335(s6, s7);
+                  s1 = peg$c332(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10020,7 +9813,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c336(s2);
+        s1 = peg$c333(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10032,10 +9825,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c235();
+        s1 = peg$c234();
       }
       s0 = s1;
     }
@@ -10056,7 +9849,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c337(s4);
+            s1 = peg$c334(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10076,10 +9869,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c99();
+        s1 = peg$c98();
       }
       s0 = s1;
     }
@@ -10091,9 +9884,29 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c288) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c287) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c336();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseAS() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c337) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c338); }
@@ -10107,40 +9920,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseAS() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c340) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c342();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
   function peg$parseFROM() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c25) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c24) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c344();
+      s1 = peg$c341();
     }
     s0 = s1;
 
@@ -10151,16 +9944,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c171) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c170) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c346();
+      s1 = peg$c343();
     }
     s0 = s1;
 
@@ -10171,7 +9964,27 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c112) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c111) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c345();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseGROUP() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c346) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
@@ -10187,13 +10000,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseGROUP() {
+  function peg$parseBY() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c349) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c350); }
@@ -10207,13 +10020,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseBY() {
+  function peg$parseHAVING() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c352) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c352) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c353); }
@@ -10227,33 +10040,33 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseHAVING() {
+  function peg$parseORDER() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c355) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c226) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c357();
+      s1 = peg$c356();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseORDER() {
+  function peg$parseON() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c227) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c357) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c358); }
@@ -10267,13 +10080,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseON() {
+  function peg$parseLIMIT() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c360) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c360) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c361); }
@@ -10287,40 +10100,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLIMIT() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c363) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c365();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
   function peg$parseASC() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c239) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c238) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c235();
+      s1 = peg$c234();
     }
     s0 = s1;
 
@@ -10331,16 +10124,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c238();
+      s1 = peg$c237();
     }
     s0 = s1;
 
@@ -10351,16 +10144,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c175) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c177();
+      s1 = peg$c176();
     }
     s0 = s1;
 
@@ -10371,16 +10164,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c181) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c183();
+      s1 = peg$c182();
     }
     s0 = s1;
 
@@ -10391,16 +10184,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c184) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c183) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c186();
+      s1 = peg$c185();
     }
     s0 = s1;
 
@@ -10411,16 +10204,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c178) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c177) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c180();
+      s1 = peg$c179();
     }
     s0 = s1;
 
@@ -10518,7 +10311,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c369(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10533,7 +10326,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c369(s1);
       }
       s0 = s1;
     }
@@ -10559,7 +10352,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s1);
+        s1 = peg$c370(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10574,7 +10367,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s1);
+        s1 = peg$c370(s1);
       }
       s0 = s1;
     }
@@ -10589,7 +10382,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374(s1);
+      s1 = peg$c371(s1);
     }
     s0 = s1;
 
@@ -10603,7 +10396,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c375(s1);
+      s1 = peg$c372(s1);
     }
     s0 = s1;
 
@@ -10614,30 +10407,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c376) {
-      s1 = peg$c376;
+    if (input.substr(peg$currPos, 4) === peg$c373) {
+      s1 = peg$c373;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c377); }
+      if (peg$silentFails === 0) { peg$fail(peg$c374); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c378();
+      s1 = peg$c375();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c379) {
-        s1 = peg$c379;
+      if (input.substr(peg$currPos, 5) === peg$c376) {
+        s1 = peg$c376;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c380); }
+        if (peg$silentFails === 0) { peg$fail(peg$c377); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c381();
+        s1 = peg$c378();
       }
       s0 = s1;
     }
@@ -10649,16 +10442,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c382) {
-      s1 = peg$c382;
+    if (input.substr(peg$currPos, 4) === peg$c379) {
+      s1 = peg$c379;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c383); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c384();
+      s1 = peg$c381();
     }
     s0 = s1;
 
@@ -10669,12 +10462,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c385) {
-      s1 = peg$c385;
+    if (input.substr(peg$currPos, 2) === peg$c382) {
+      s1 = peg$c382;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10685,7 +10478,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c387();
+        s1 = peg$c384();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10704,25 +10497,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 60) {
-      s1 = peg$c65;
+      s1 = peg$c64;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      if (peg$silentFails === 0) { peg$fail(peg$c65); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseType();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 62) {
-          s3 = peg$c69;
+          s3 = peg$c68;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c69); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c388(s2);
+          s1 = peg$c385(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10749,7 +10542,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c388(s1);
+        s1 = peg$c385(s1);
       }
       s0 = s1;
     }
@@ -10789,7 +10582,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c389(s1);
+        s1 = peg$c386(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10806,11 +10599,11 @@ function peg$parse(input, options) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 61) {
-            s3 = peg$c8;
+            s3 = peg$c7;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c9); }
+            if (peg$silentFails === 0) { peg$fail(peg$c8); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -10818,7 +10611,7 @@ function peg$parse(input, options) {
               s5 = peg$parseType();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c390(s1, s5);
+                s1 = peg$c387(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10845,17 +10638,17 @@ function peg$parse(input, options) {
         s1 = peg$parseIdentifierName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s1);
+          s1 = peg$c388(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c16;
+            s1 = peg$c15;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10863,15 +10656,15 @@ function peg$parse(input, options) {
               s3 = peg$parseTypeUnion();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s4 = peg$c18;
+                  s4 = peg$c17;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c392(s3);
+                  s1 = peg$c389(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10903,7 +10696,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c393(s1);
+      s1 = peg$c390(s1);
     }
     s0 = s1;
 
@@ -10928,7 +10721,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10949,11 +10742,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c101;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -10961,7 +10754,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c394(s4);
+            s1 = peg$c391(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10988,11 +10781,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c38;
+      s1 = peg$c37;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c38); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11002,15 +10795,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c307;
+              s5 = peg$c304;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c308); }
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c395(s3);
+              s1 = peg$c392(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11035,11 +10828,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c40;
+        s1 = peg$c39;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c41); }
+        if (peg$silentFails === 0) { peg$fail(peg$c40); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -11049,15 +10842,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c298;
+                s5 = peg$c297;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                if (peg$silentFails === 0) { peg$fail(peg$c298); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c396(s3);
+                s1 = peg$c393(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11081,12 +10874,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c316) {
-          s1 = peg$c316;
+        if (input.substr(peg$currPos, 2) === peg$c313) {
+          s1 = peg$c313;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c317); }
+          if (peg$silentFails === 0) { peg$fail(peg$c314); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11095,16 +10888,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c318) {
-                  s5 = peg$c318;
+                if (input.substr(peg$currPos, 2) === peg$c315) {
+                  s5 = peg$c315;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c316); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c397(s3);
+                  s1 = peg$c394(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11128,12 +10921,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c321) {
-            s1 = peg$c321;
+          if (input.substr(peg$currPos, 2) === peg$c318) {
+            s1 = peg$c318;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c322); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11143,11 +10936,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 58) {
-                    s5 = peg$c53;
+                    s5 = peg$c52;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c53); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -11156,16 +10949,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c323) {
-                            s9 = peg$c323;
+                          if (input.substr(peg$currPos, 2) === peg$c320) {
+                            s9 = peg$c320;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c321); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c398(s3, s7);
+                            s1 = peg$c395(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11217,7 +11010,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c399(s1);
+      s1 = peg$c396(s1);
     }
     s0 = s1;
 
@@ -11229,11 +11022,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c397;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11244,15 +11037,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c397;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c398); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c5(s2);
+          s1 = peg$c4(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11269,11 +11062,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c402;
+        s1 = peg$c399;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c400); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11284,15 +11077,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c402;
+            s3 = peg$c399;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c400); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c5(s2);
+            s1 = peg$c4(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11329,7 +11122,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c404(s1);
+        s1 = peg$c401(s1);
       }
       s0 = s1;
     }
@@ -11342,23 +11135,23 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s2 = peg$c404;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s2);
+        s1 = peg$c4(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11372,12 +11165,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s2 = peg$c404;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11390,7 +11183,7 @@ function peg$parse(input, options) {
         s2 = peg$parseDoubleQuotedChar();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c5(s2);
+          s1 = peg$c4(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11423,7 +11216,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c404(s1);
+        s1 = peg$c401(s1);
       }
       s0 = s1;
     }
@@ -11436,23 +11229,23 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s2 = peg$c404;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s2);
+        s1 = peg$c4(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11466,12 +11259,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s2 = peg$c404;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11484,7 +11277,7 @@ function peg$parse(input, options) {
         s2 = peg$parseSingleQuotedChar();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c5(s2);
+          s1 = peg$c4(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11503,12 +11296,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c407) {
-      s1 = peg$c407;
+    if (input.substr(peg$currPos, 2) === peg$c404) {
+      s1 = peg$c404;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c405); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11518,15 +11311,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c307;
+              s5 = peg$c304;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c308); }
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c409(s3);
+              s1 = peg$c406(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11556,156 +11349,156 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c410) {
-      s1 = peg$c410;
+    if (input.substr(peg$currPos, 5) === peg$c407) {
+      s1 = peg$c407;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c412) {
-        s1 = peg$c412;
+      if (input.substr(peg$currPos, 6) === peg$c409) {
+        s1 = peg$c409;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c414) {
-          s1 = peg$c414;
+        if (input.substr(peg$currPos, 6) === peg$c411) {
+          s1 = peg$c411;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c415); }
+          if (peg$silentFails === 0) { peg$fail(peg$c412); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c416) {
-            s1 = peg$c416;
+          if (input.substr(peg$currPos, 6) === peg$c413) {
+            s1 = peg$c413;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c417); }
+            if (peg$silentFails === 0) { peg$fail(peg$c414); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c418) {
-              s1 = peg$c418;
+            if (input.substr(peg$currPos, 4) === peg$c415) {
+              s1 = peg$c415;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c419); }
+              if (peg$silentFails === 0) { peg$fail(peg$c416); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c420) {
-                s1 = peg$c420;
+              if (input.substr(peg$currPos, 5) === peg$c417) {
+                s1 = peg$c417;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                if (peg$silentFails === 0) { peg$fail(peg$c418); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c422) {
-                  s1 = peg$c422;
+                if (input.substr(peg$currPos, 5) === peg$c419) {
+                  s1 = peg$c419;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c420); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c424) {
-                    s1 = peg$c424;
+                  if (input.substr(peg$currPos, 5) === peg$c421) {
+                    s1 = peg$c421;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c422); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c426) {
-                      s1 = peg$c426;
+                    if (input.substr(peg$currPos, 7) === peg$c423) {
+                      s1 = peg$c423;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c427); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c424); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c428) {
-                        s1 = peg$c428;
+                      if (input.substr(peg$currPos, 7) === peg$c425) {
+                        s1 = peg$c425;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c426); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c430) {
-                          s1 = peg$c430;
+                        if (input.substr(peg$currPos, 4) === peg$c427) {
+                          s1 = peg$c427;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c428); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c432) {
-                            s1 = peg$c432;
+                          if (input.substr(peg$currPos, 6) === peg$c429) {
+                            s1 = peg$c429;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c433); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c430); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c434) {
-                              s1 = peg$c434;
+                            if (input.substr(peg$currPos, 8) === peg$c431) {
+                              s1 = peg$c431;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c435); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c432); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c436) {
-                                s1 = peg$c436;
+                              if (input.substr(peg$currPos, 4) === peg$c433) {
+                                s1 = peg$c433;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c437); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c434); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c438) {
-                                  s1 = peg$c438;
+                                if (input.substr(peg$currPos, 5) === peg$c435) {
+                                  s1 = peg$c435;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c439); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c436); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c440) {
-                                    s1 = peg$c440;
+                                  if (input.substr(peg$currPos, 2) === peg$c437) {
+                                    s1 = peg$c437;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c441); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c438); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c442) {
-                                      s1 = peg$c442;
+                                    if (input.substr(peg$currPos, 3) === peg$c439) {
+                                      s1 = peg$c439;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c440); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 4) === peg$c11) {
-                                        s1 = peg$c11;
+                                      if (input.substr(peg$currPos, 4) === peg$c10) {
+                                        s1 = peg$c10;
                                         peg$currPos += 4;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c382) {
-                                          s1 = peg$c382;
+                                        if (input.substr(peg$currPos, 4) === peg$c379) {
+                                          s1 = peg$c379;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c383); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c380); }
                                         }
                                       }
                                     }
@@ -11727,7 +11520,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c444();
+      s1 = peg$c441();
     }
     s0 = s1;
 
@@ -11748,7 +11541,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c266(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11760,10 +11553,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c98;
+      s1 = peg$c97;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c49();
+        s1 = peg$c48();
       }
       s0 = s1;
     }
@@ -11778,11 +11571,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c101;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -11790,7 +11583,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c394(s4);
+            s1 = peg$c391(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11821,11 +11614,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c53;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -11833,7 +11626,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c445(s1, s5);
+              s1 = peg$c442(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11874,20 +11667,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c446) {
-      s1 = peg$c446;
+    if (input.substr(peg$currPos, 3) === peg$c443) {
+      s1 = peg$c443;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c447); }
+      if (peg$silentFails === 0) { peg$fail(peg$c444); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c448) {
-        s1 = peg$c448;
+      if (input.substr(peg$currPos, 3) === peg$c445) {
+        s1 = peg$c445;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c449); }
+        if (peg$silentFails === 0) { peg$fail(peg$c446); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11903,7 +11696,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c450();
+        s1 = peg$c447();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11921,20 +11714,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c451) {
-      s1 = peg$c451;
+    if (input.substr(peg$currPos, 2) === peg$c448) {
+      s1 = peg$c448;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c452); }
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c453) {
-        s1 = peg$c453;
+      if (input.substr(peg$currPos, 2) === peg$c450) {
+        s1 = peg$c450;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c454); }
+        if (peg$silentFails === 0) { peg$fail(peg$c451); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11950,7 +11743,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c455();
+        s1 = peg$c452();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11968,12 +11761,59 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c61) {
-      s1 = peg$c61;
+    if (input.substr(peg$currPos, 2) === peg$c60) {
+      s1 = peg$c60;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c61); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c453();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseNotToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c285) {
+      s1 = peg$c285;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 3) === peg$c454) {
+        s1 = peg$c454;
+        peg$currPos += 3;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c455); }
+      }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12002,63 +11842,16 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseNotToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c286) {
-      s1 = peg$c286;
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c287); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c457) {
-        s1 = peg$c457;
-        peg$currPos += 3;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c458); }
-      }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c459();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parseByToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c352) {
-      s1 = peg$c352;
+    if (input.substr(peg$currPos, 2) === peg$c349) {
+      s1 = peg$c349;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c460); }
+      if (peg$silentFails === 0) { peg$fail(peg$c457); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12073,7 +11866,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354();
+        s1 = peg$c351();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12090,12 +11883,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c461.test(input.charAt(peg$currPos))) {
+    if (peg$c458.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c462); }
+      if (peg$silentFails === 0) { peg$fail(peg$c459); }
     }
 
     return s0;
@@ -12106,12 +11899,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
     }
 
@@ -12125,7 +11918,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c465(s1);
+      s1 = peg$c462(s1);
     }
     s0 = s1;
 
@@ -12180,7 +11973,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c226();
+          s1 = peg$c225();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12197,31 +11990,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c466;
+        s1 = peg$c463;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c405;
+          s1 = peg$c402;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c212(s2);
+            s1 = peg$c211(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -12233,16 +12026,16 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 4) === peg$c11) {
-            s1 = peg$c11;
+          if (input.substr(peg$currPos, 4) === peg$c10) {
+            s1 = peg$c10;
             peg$currPos += 4;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c12); }
+            if (peg$silentFails === 0) { peg$fail(peg$c11); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c71();
+            s1 = peg$c70();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -12255,11 +12048,11 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s5 = peg$c16;
+                  s5 = peg$c15;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
                 }
                 if (s5 !== peg$FAILED) {
                   s4 = [s4, s5];
@@ -12281,7 +12074,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c212(s1);
+                s1 = peg$c211(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12323,17 +12116,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c468;
+        s2 = peg$c465;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c469); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c470();
+          s1 = peg$c467();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12358,21 +12151,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c278;
+        s2 = peg$c277;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c278;
+            s4 = peg$c277;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c279); }
+            if (peg$silentFails === 0) { peg$fail(peg$c278); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12407,36 +12200,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c463.test(input.charAt(peg$currPos))) {
+    if (peg$c460.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c463.test(input.charAt(peg$currPos))) {
+        if (peg$c460.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c464); }
+          if (peg$silentFails === 0) { peg$fail(peg$c461); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c463.test(input.charAt(peg$currPos))) {
+          if (peg$c460.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c464); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12465,20 +12258,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c463.test(input.charAt(peg$currPos))) {
+    if (peg$c460.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12524,51 +12317,51 @@ function peg$parse(input, options) {
     s1 = peg$parseD2();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c53;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c53;
+            s4 = peg$c52;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
             if (s5 !== peg$FAILED) {
               s6 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c109;
+                s7 = peg$c108;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c110); }
+                if (peg$silentFails === 0) { peg$fail(peg$c109); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c463.test(input.charAt(peg$currPos))) {
+                if (peg$c460.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c463.test(input.charAt(peg$currPos))) {
+                    if (peg$c460.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c461); }
                     }
                   }
                 } else {
@@ -12623,69 +12416,69 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c471;
+      s0 = peg$c468;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c469); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c276;
+        s1 = peg$c275;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c278;
+          s1 = peg$c277;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c279); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseD2();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c53;
+            s3 = peg$c52;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parseD2();
             if (s4 !== peg$FAILED) {
               s5 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c109;
+                s6 = peg$c108;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c110); }
+                if (peg$silentFails === 0) { peg$fail(peg$c109); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c463.test(input.charAt(peg$currPos))) {
+                if (peg$c460.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c463.test(input.charAt(peg$currPos))) {
+                    if (peg$c460.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c461); }
                     }
                   }
                 } else {
@@ -12738,11 +12531,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c278;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12788,7 +12581,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c473();
+        s1 = peg$c470();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12810,11 +12603,11 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c109;
+        s3 = peg$c108;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseUInt();
@@ -12850,76 +12643,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c474) {
-      s0 = peg$c474;
+    if (input.substr(peg$currPos, 2) === peg$c471) {
+      s0 = peg$c471;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c472); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c476) {
-        s0 = peg$c476;
+      if (input.substr(peg$currPos, 2) === peg$c473) {
+        s0 = peg$c473;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c477); }
+        if (peg$silentFails === 0) { peg$fail(peg$c474); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c478) {
-          s0 = peg$c478;
+        if (input.substr(peg$currPos, 2) === peg$c475) {
+          s0 = peg$c475;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c479); }
+          if (peg$silentFails === 0) { peg$fail(peg$c476); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c480;
+            s0 = peg$c477;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c481); }
+            if (peg$silentFails === 0) { peg$fail(peg$c478); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c482;
+              s0 = peg$c479;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c483); }
+              if (peg$silentFails === 0) { peg$fail(peg$c480); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c484;
+                s0 = peg$c481;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c485); }
+                if (peg$silentFails === 0) { peg$fail(peg$c482); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c486;
+                  s0 = peg$c483;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c487); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c484); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c488;
+                    s0 = peg$c485;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c489); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c486); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c490;
+                      s0 = peg$c487;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c491); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c488); }
                     }
                   }
                 }
@@ -12940,37 +12733,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c109;
+        s2 = peg$c108;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c109;
+            s4 = peg$c108;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c109;
+                s6 = peg$c108;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c110); }
+                if (peg$silentFails === 0) { peg$fail(peg$c109); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c71();
+                  s1 = peg$c70();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -13014,11 +12807,11 @@ function peg$parse(input, options) {
     s3 = peg$parseHex();
     if (s3 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s4 = peg$c53;
+        s4 = peg$c52;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parseHex();
@@ -13028,11 +12821,11 @@ function peg$parse(input, options) {
           s7 = peg$parseHexDigit();
           if (s7 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s7 = peg$c53;
+              s7 = peg$c52;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c54); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
           }
           peg$silentFails--;
@@ -13072,7 +12865,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Variations();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s2);
+        s1 = peg$c4(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13104,7 +12897,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c492(s1, s2);
+        s1 = peg$c489(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13125,12 +12918,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c493) {
-            s3 = peg$c493;
+          if (input.substr(peg$currPos, 2) === peg$c490) {
+            s3 = peg$c490;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c494); }
+            if (peg$silentFails === 0) { peg$fail(peg$c491); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13143,7 +12936,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c495(s1, s2, s4, s5);
+                s1 = peg$c492(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13167,12 +12960,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c493) {
-          s1 = peg$c493;
+        if (input.substr(peg$currPos, 2) === peg$c490) {
+          s1 = peg$c490;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c494); }
+          if (peg$silentFails === 0) { peg$fail(peg$c491); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13185,7 +12978,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c496(s2, s3);
+              s1 = peg$c493(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13210,16 +13003,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c493) {
-                s3 = peg$c493;
+              if (input.substr(peg$currPos, 2) === peg$c490) {
+                s3 = peg$c490;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c494); }
+                if (peg$silentFails === 0) { peg$fail(peg$c491); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c497(s1, s2);
+                s1 = peg$c494(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13235,16 +13028,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c493) {
-              s1 = peg$c493;
+            if (input.substr(peg$currPos, 2) === peg$c490) {
+              s1 = peg$c490;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c494); }
+              if (peg$silentFails === 0) { peg$fail(peg$c491); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c498();
+              s1 = peg$c495();
             }
             s0 = s1;
           }
@@ -13271,17 +13064,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c53;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c499(s2);
+        s1 = peg$c496(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13302,15 +13095,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c53;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c500(s1);
+        s1 = peg$c497(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13331,17 +13124,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c280;
+        s2 = peg$c279;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+        if (peg$silentFails === 0) { peg$fail(peg$c280); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c501(s1, s3);
+          s1 = peg$c498(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13366,17 +13159,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c280;
+        s2 = peg$c279;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+        if (peg$silentFails === 0) { peg$fail(peg$c280); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c502(s1, s3);
+          s1 = peg$c499(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13401,7 +13194,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c503(s1);
+      s1 = peg$c500(s1);
     }
     s0 = s1;
 
@@ -13424,22 +13217,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c463.test(input.charAt(peg$currPos))) {
+    if (peg$c460.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c463.test(input.charAt(peg$currPos))) {
+        if (peg$c460.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c464); }
+          if (peg$silentFails === 0) { peg$fail(peg$c461); }
         }
       }
     } else {
@@ -13447,7 +13240,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13459,17 +13252,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c278;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13488,33 +13281,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c278;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c463.test(input.charAt(peg$currPos))) {
+          if (peg$c460.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c464); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
         }
       } else {
@@ -13522,29 +13315,29 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c109;
+          s3 = peg$c108;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c463.test(input.charAt(peg$currPos))) {
+          if (peg$c460.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c464); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c463.test(input.charAt(peg$currPos))) {
+            if (peg$c460.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c464); }
+              if (peg$silentFails === 0) { peg$fail(peg$c461); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13554,7 +13347,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c504();
+              s1 = peg$c501();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13579,41 +13372,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c278;
+        s1 = peg$c277;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c109;
+          s2 = peg$c108;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c463.test(input.charAt(peg$currPos))) {
+          if (peg$c460.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c464); }
+            if (peg$silentFails === 0) { peg$fail(peg$c461); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c463.test(input.charAt(peg$currPos))) {
+              if (peg$c460.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c464); }
+                if (peg$silentFails === 0) { peg$fail(peg$c461); }
               }
             }
           } else {
@@ -13626,7 +13419,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c504();
+              s1 = peg$c501();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13652,7 +13445,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c71();
+          s1 = peg$c70();
         }
         s0 = s1;
       }
@@ -13665,20 +13458,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c505) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c502) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c506); }
+      if (peg$silentFails === 0) { peg$fail(peg$c503); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c507.test(input.charAt(peg$currPos))) {
+      if (peg$c504.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c508); }
+        if (peg$silentFails === 0) { peg$fail(peg$c505); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13707,12 +13500,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c509) {
-      s0 = peg$c509;
+    if (input.substr(peg$currPos, 3) === peg$c506) {
+      s0 = peg$c506;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c510); }
+      if (peg$silentFails === 0) { peg$fail(peg$c507); }
     }
 
     return s0;
@@ -13723,31 +13516,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c278;
+      s1 = peg$c277;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c276;
+        s1 = peg$c275;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c511) {
-        s2 = peg$c511;
+      if (input.substr(peg$currPos, 3) === peg$c508) {
+        s2 = peg$c508;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c512); }
+        if (peg$silentFails === 0) { peg$fail(peg$c509); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13780,7 +13573,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -13790,12 +13583,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c513.test(input.charAt(peg$currPos))) {
+    if (peg$c510.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
 
     return s0;
@@ -13806,11 +13599,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c397;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13821,15 +13614,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c397;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c398); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c515(s2);
+          s1 = peg$c512(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13846,11 +13639,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c402;
+        s1 = peg$c399;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c400); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13861,15 +13654,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c402;
+            s3 = peg$c399;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c400); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c515(s2);
+            s1 = peg$c512(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13895,11 +13688,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c400;
+      s2 = peg$c397;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13917,11 +13710,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c513); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13934,17 +13727,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c405;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c42(s2);
+          s1 = peg$c41(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13973,7 +13766,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c517(s1, s2);
+        s1 = peg$c514(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14002,16 +13795,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c518.test(input.charAt(peg$currPos))) {
+    if (peg$c515.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c516); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -14023,12 +13816,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
     }
 
@@ -14040,11 +13833,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -14053,7 +13846,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s2);
+        s1 = peg$c41(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14103,7 +13896,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c520(s3, s4);
+            s1 = peg$c517(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14131,20 +13924,20 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     if (input.charCodeAt(peg$currPos) === 42) {
-      s2 = peg$c80;
+      s2 = peg$c79;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c81); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c80;
+        s2 = peg$c79;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -14176,11 +13969,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c80;
+        s2 = peg$c79;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -14206,15 +13999,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c80;
+          s1 = peg$c79;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c521();
+          s1 = peg$c518();
         }
         s0 = s1;
       }
@@ -14228,12 +14021,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c463.test(input.charAt(peg$currPos))) {
+      if (peg$c460.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c464); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
     }
 
@@ -14245,11 +14038,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14258,7 +14051,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s2);
+        s1 = peg$c41(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14277,38 +14070,38 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c8;
+      s1 = peg$c7;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      if (peg$silentFails === 0) { peg$fail(peg$c8); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c522();
+      s1 = peg$c519();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c80;
+        s1 = peg$c79;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c523();
+        s1 = peg$c520();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c507.test(input.charAt(peg$currPos))) {
+        if (peg$c504.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c508); }
+          if (peg$silentFails === 0) { peg$fail(peg$c505); }
         }
       }
     }
@@ -14323,11 +14116,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c402;
+      s2 = peg$c399;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c400); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14345,11 +14138,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c513); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14362,17 +14155,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c405;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c42(s2);
+          s1 = peg$c41(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14402,116 +14195,116 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c402;
+      s0 = peg$c399;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c400); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c400;
+        s1 = peg$c397;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c401); }
+        if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71();
+        s1 = peg$c70();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c405;
+          s0 = peg$c402;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c524;
+            s1 = peg$c521;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c525); }
+            if (peg$silentFails === 0) { peg$fail(peg$c522); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c526();
+            s1 = peg$c523();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c527;
+              s1 = peg$c524;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c528); }
+              if (peg$silentFails === 0) { peg$fail(peg$c525); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c529();
+              s1 = peg$c526();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c530;
+                s1 = peg$c527;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c531); }
+                if (peg$silentFails === 0) { peg$fail(peg$c528); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c532();
+                s1 = peg$c529();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c533;
+                  s1 = peg$c530;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c534); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c531); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c535();
+                  s1 = peg$c532();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c536;
+                    s1 = peg$c533;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c537); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c534); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c538();
+                    s1 = peg$c535();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c539;
+                      s1 = peg$c536;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c540); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c537); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c541();
+                      s1 = peg$c538();
                     }
                     s0 = s1;
                   }
@@ -14531,38 +14324,38 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c8;
+      s1 = peg$c7;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      if (peg$silentFails === 0) { peg$fail(peg$c8); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c522();
+      s1 = peg$c519();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c80;
+        s1 = peg$c79;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c542();
+        s1 = peg$c539();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c507.test(input.charAt(peg$currPos))) {
+        if (peg$c504.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c508); }
+          if (peg$silentFails === 0) { peg$fail(peg$c505); }
         }
       }
     }
@@ -14575,11 +14368,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c543;
+      s1 = peg$c540;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c544); }
+      if (peg$silentFails === 0) { peg$fail(peg$c541); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14611,7 +14404,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c545(s2);
+        s1 = peg$c542(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14624,19 +14417,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c543;
+        s1 = peg$c540;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c544); }
+        if (peg$silentFails === 0) { peg$fail(peg$c541); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c38;
+          s2 = peg$c37;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c39); }
+          if (peg$silentFails === 0) { peg$fail(peg$c38); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -14695,15 +14488,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c307;
+              s4 = peg$c304;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c308); }
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c545(s3);
+              s1 = peg$c542(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14731,21 +14524,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c280;
+      s1 = peg$c279;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+      if (peg$silentFails === 0) { peg$fail(peg$c280); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c280;
+          s3 = peg$c279;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14760,7 +14553,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c197(s2);
+            s1 = peg$c196(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14787,21 +14580,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c546.test(input.charAt(peg$currPos))) {
+    if (peg$c543.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c544); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c405;
+        s3 = peg$c402;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14809,7 +14602,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c516); }
+          if (peg$silentFails === 0) { peg$fail(peg$c513); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14826,21 +14619,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c546.test(input.charAt(peg$currPos))) {
+        if (peg$c543.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c547); }
+          if (peg$silentFails === 0) { peg$fail(peg$c544); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c405;
+            s3 = peg$c402;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c406); }
+            if (peg$silentFails === 0) { peg$fail(peg$c403); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14848,7 +14641,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c516); }
+              if (peg$silentFails === 0) { peg$fail(peg$c513); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14868,7 +14661,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c71();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -14878,12 +14671,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c548.test(input.charAt(peg$currPos))) {
+    if (peg$c545.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c549); }
+      if (peg$silentFails === 0) { peg$fail(peg$c546); }
     }
 
     return s0;
@@ -14941,7 +14734,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c516); }
+      if (peg$silentFails === 0) { peg$fail(peg$c513); }
     }
 
     return s0;
@@ -14952,51 +14745,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c551;
+      s0 = peg$c548;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c552); }
+      if (peg$silentFails === 0) { peg$fail(peg$c549); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c553;
+        s0 = peg$c550;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c554); }
+        if (peg$silentFails === 0) { peg$fail(peg$c551); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c555;
+          s0 = peg$c552;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c556); }
+          if (peg$silentFails === 0) { peg$fail(peg$c553); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c557;
+            s0 = peg$c554;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c558); }
+            if (peg$silentFails === 0) { peg$fail(peg$c555); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c559;
+              s0 = peg$c556;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c560); }
+              if (peg$silentFails === 0) { peg$fail(peg$c557); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c561;
+                s0 = peg$c558;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c562); }
+                if (peg$silentFails === 0) { peg$fail(peg$c559); }
               }
             }
           }
@@ -15006,7 +14799,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c550); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
 
     return s0;
@@ -15015,12 +14808,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c563.test(input.charAt(peg$currPos))) {
+    if (peg$c560.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c564); }
+      if (peg$silentFails === 0) { peg$fail(peg$c561); }
     }
 
     return s0;
@@ -15034,7 +14827,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c565); }
+      if (peg$silentFails === 0) { peg$fail(peg$c562); }
     }
 
     return s0;
@@ -15044,24 +14837,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c566) {
-      s1 = peg$c566;
+    if (input.substr(peg$currPos, 2) === peg$c563) {
+      s1 = peg$c563;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c567); }
+      if (peg$silentFails === 0) { peg$fail(peg$c564); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c568) {
-        s5 = peg$c568;
+      if (input.substr(peg$currPos, 2) === peg$c565) {
+        s5 = peg$c565;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c569); }
+        if (peg$silentFails === 0) { peg$fail(peg$c566); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -15088,12 +14881,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c568) {
-          s5 = peg$c568;
+        if (input.substr(peg$currPos, 2) === peg$c565) {
+          s5 = peg$c565;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c569); }
+          if (peg$silentFails === 0) { peg$fail(peg$c566); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -15117,12 +14910,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c568) {
-          s3 = peg$c568;
+        if (input.substr(peg$currPos, 2) === peg$c565) {
+          s3 = peg$c565;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c569); }
+          if (peg$silentFails === 0) { peg$fail(peg$c566); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -15147,12 +14940,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c570) {
-      s1 = peg$c570;
+    if (input.substr(peg$currPos, 2) === peg$c567) {
+      s1 = peg$c567;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c571); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15270,7 +15063,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c516); }
+      if (peg$silentFails === 0) { peg$fail(peg$c513); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -49,11 +49,8 @@
 start = __ ast:Sequential __ EOF { RETURN(ast) }
 
 Sequential
-  = consts:Consts __ first:Operation rest:SequentialTail+ {
+  = consts:Consts __ first:Operation rest:SequentialTail* {
       RETURN(MAP("kind": "Sequential", "ops": PREPEND(first, rest), "consts":consts))
-    }
-  / consts:Consts __ op:Operation {
-      RETURN(MAP("kind": "Sequential", "ops": ARRAY(op), "consts":consts))
     }
 
 SequentialTail = __ Pipe __ p:Operation { RETURN(p) }
@@ -166,10 +163,7 @@ SearchFactor
 SearchExpr
   = Glob
   / Regexp
-  / v:SearchValue &(_ Glob) {
-      RETURN(MAP("kind": "Term", "text": TEXT, "value": v))
-    }
-  / v:SearchValue !ExprGuard {
+  / v:SearchValue (!ExprGuard / &(_ Glob)) {
       RETURN(MAP("kind": "Term", "text": TEXT, "value": v))
     }
   / "*" !ExprGuard {
@@ -553,14 +547,12 @@ MergeOp
     }
 
 OverOp
-  = "over" _ exprs:Exprs _ "with" _ locals:LetAssignments __ scope:Scope {
-      RETURN(MAP("kind":"Let", "locals":locals, "over":MAP("kind":"Over", "exprs":exprs, "scope":scope)))
-    }
-  / "over" _ exprs:Exprs __ scope:Scope {
-      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":scope))
-    }
-  / "over" _ exprs:Exprs {
-      RETURN(MAP("kind":"Over", "exprs":exprs, "scope":NULL))
+  = "over" _ exprs:Exprs locals:(_ "with" _ l:LetAssignments { RETURN(l) })? scope:(__ s:Scope { RETURN(s) })? {
+      VAR(over) = MAP("kind": "Over", "exprs": exprs, "scope": scope)
+      if ISNOTNULL(locals) {
+        RETURN(MAP("kind": "Let", "locals": locals, "over": over))
+      }
+      RETURN(over)
     }
 
 Scope = "=>" __ "(" __ seq:Sequential __ ")" { RETURN(seq) }
@@ -640,13 +632,14 @@ LogicalAndExpr
     }
 
 ComparisonExpr
-  = lhs:AdditiveExpr __ op:Comparator __ rhs:AdditiveExpr {
-        RETURN(MAP("kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs))
+  = lhs:AdditiveExpr opAndRHS:(__ Comparator __ AdditiveExpr / __ ("~" { RETURN(TEXT) }) __ Regexp)? {
+      if ISNULL(opAndRHS) {
+        RETURN(lhs)
+      }
+      VAR(op) = ASSERT_ARRAY(opAndRHS)[1]
+      VAR(rhs) = ASSERT_ARRAY(opAndRHS)[3]
+      RETURN(MAP("kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs))
     }
-  / lhs:AdditiveExpr __ "~" __ rhs:Regexp {
-        RETURN(MAP("kind": "BinaryExpr", "op": "~", "lhs": lhs, "rhs": rhs))
-    }
-  / AdditiveExpr
 
 AdditiveExpr
   = first:MultiplicativeExpr
@@ -733,17 +726,13 @@ DerefExpr
     }
 
 Deref
-  = "[" from:AdditiveExpr __ ":" __ to:AdditiveExpr "]" {
+  = "[" from:AdditiveExpr __ ":" __ to:AdditiveExpr? "]" {
       RETURN(ARRAY("[", MAP("kind": "BinaryExpr", "op":":",
                             "lhs":from, "rhs":to)))
     }
   / "[" __ ":" __ to:AdditiveExpr "]" {
       RETURN(ARRAY("[", MAP("kind": "BinaryExpr", "op":":",
                             "lhs": NULL, "rhs":to)))
-    }
-  / "[" from:AdditiveExpr __ ":" __ "]" {
-      RETURN(ARRAY("[", MAP("kind": "BinaryExpr", "op":":",
-                            "lhs":from, "rhs": NULL)))
     }
   / "[" expr:Expr "]" { RETURN(ARRAY("[", expr)) }
   / "." id:Identifier { RETURN(ARRAY(".", id)) }
@@ -758,11 +747,8 @@ Primary
   / "(" __ expr:Expr __ ")" { RETURN(expr) }
 
 OverExpr
-  = "over" _ exprs:Exprs _ "with" _ locals:LetAssignments __ "|" __ scope:Sequential {
+  = "over" _ exprs:Exprs locals:(_ "with" _ l:LetAssignments { RETURN(l) })? __ "|" __ scope:Sequential {
       RETURN(MAP("kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope))
-    }
-  / "over" _ exprs:Exprs __ "|" __ scope:Sequential {
-      RETURN(MAP("kind": "OverExpr", "locals": NULL, "exprs": exprs, "scope": scope))
     }
 
 Record

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -547,7 +547,7 @@ MergeOp
     }
 
 OverOp
-  = "over" _ exprs:Exprs locals:(_ "with" _ l:LetAssignments { RETURN(l) })? scope:(__ s:Scope { RETURN(s) })? {
+  = "over" _ exprs:Exprs locals:Locals? scope:Scope? {
       VAR(over) = MAP("kind": "Over", "exprs": exprs, "scope": scope)
       if ISNOTNULL(locals) {
         RETURN(MAP("kind": "Let", "locals": locals, "over": over))
@@ -555,14 +555,15 @@ OverOp
       RETURN(over)
     }
 
-Scope = "=>" __ "(" __ seq:Sequential __ ")" { RETURN(seq) }
+Scope
+  = __ "=>" __ "(" __ seq:Sequential __ ")" { RETURN(seq) }
 
-LetAssignments
-  = first:LetAssignment rest:(__ "," __ a:LetAssignment { RETURN(a) })* {
+Locals
+  = _ "with" _ first:LocalsAssignment rest:(__ "," __ a:LocalsAssignment { RETURN(a) })* {
       RETURN(PREPEND(first, rest))
     }
 
-LetAssignment
+LocalsAssignment
   = id:IdentifierName __ "=" __ expr:Expr {
       RETURN(MAP("name":id, "expr":expr))
     }
@@ -747,7 +748,7 @@ Primary
   / "(" __ expr:Expr __ ")" { RETURN(expr) }
 
 OverExpr
-  = "over" _ exprs:Exprs locals:(_ "with" _ l:LetAssignments { RETURN(l) })? __ "|" __ scope:Sequential {
+  = "over" _ exprs:Exprs locals:Locals? __ "|" __ scope:Sequential {
       RETURN(MAP("kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope))
     }
 


### PR DESCRIPTION
Unnecessary backtracking can really slow things down.  For example, this
change makes "zc '[1,1.5,{s:[1,{x:1}]}]'" run about 200 times faster.