### PR TITLE
fix named primitive handling in zio/csvio.Writer

### DIFF
--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -92,7 +92,7 @@ func (w *Writer) Write(rec *zed.Value) error {
 func formatValue(typ zed.Type, bytes zcode.Bytes) string {
 	// Avoid ZSON decoration.
 	if typ.ID() < zed.IDTypeComplex {
-		return zson.FormatPrimitive(typ, bytes)
+		return zson.FormatPrimitive(zed.TypeUnder(typ), bytes)
 	}
 	return zson.String(zed.Value{typ, bytes})
 }

--- a/zio/csvio/ztests/named.yaml
+++ b/zio/csvio/ztests/named.yaml
@@ -1,7 +1,7 @@
 zed: '*'
 
 input: |
-  {a:{b:1}(=record_named)}
+  {a:{b:1(=my_int64)}(=my_inner_record)}(=my_outer_record)
 
 output-flags: -f csv
 


### PR DESCRIPTION
To format a Zed primitive, zio/csvio.formatValue calls
zson.FormatPrimitive, which returns an error string for named types.
Avoid this by sending the type through zed.TypeUnder before calling
FormatPrimitive.

Closes #3830.