### PR TITLE
Add compare function

### DIFF
--- a/docs/language/functions/README.md
+++ b/docs/language/functions/README.md
@@ -11,6 +11,7 @@ take Zed values as arguments and produce a value as a result.
 * [cast](cast.md) - coerce a value to a different type
 * [ceil](ceil.md) - ceiling of a number
 * [cidr_match](cidr_match.md) - test if IP is in a network
+* [compare](compare.md) - returns an int comparing two values
 * [crop](crop.md) - remove fields from a value that are missing in a specified type
 * [error](error.md) - wrap a value as an error
 * [every](every.md) - bucket `ts` using a duration

--- a/docs/language/functions/README.md
+++ b/docs/language/functions/README.md
@@ -11,7 +11,7 @@ take Zed values as arguments and produce a value as a result.
 * [cast](cast.md) - coerce a value to a different type
 * [ceil](ceil.md) - ceiling of a number
 * [cidr_match](cidr_match.md) - test if IP is in a network
-* [compare](compare.md) - returns an int comparing two values
+* [compare](compare.md) - return an int comparing two values
 * [crop](crop.md) - remove fields from a value that are missing in a specified type
 * [error](error.md) - wrap a value as an error
 * [every](every.md) - bucket `ts` using a duration

--- a/docs/language/functions/compare.md
+++ b/docs/language/functions/compare.md
@@ -12,7 +12,7 @@ compare(a: any, b: any) -> int64
 
 The _compare_ function returns an integer comparing two values. The result will
 be 0 if a is equal to b, +1 if a is greater than b, and -1 if a is less than b.
-_compare_ differs from <, >, <=, >=, == comparators in that it will
+_compare_ differs from `<`, `>`, `<=`, `>=`, `==`, and `!=` in that it will
 work for any type (e.g., `compare(1, "1")`). `null` values are the max value.
 
 ### Examples

--- a/docs/language/functions/compare.md
+++ b/docs/language/functions/compare.md
@@ -1,0 +1,26 @@
+### Function
+
+&emsp; **compare** &mdash; returns an integer comparing two values
+
+### Synopsis
+
+```
+compare(a: any, b: any) -> int64
+```
+
+### Description
+
+The _compare_ function returns an integer comparing two values. The result will
+be 0 if a is equal to b, +1 if a is greater than b, and -1 if a is less than b.
+_compare_ differs from <, >, <=, >=, == comparators in that it will
+work for any type (e.g., `compare(1, "1")`). `null` values are the max value.
+
+### Examples
+
+```mdtest-command
+echo '{a: 2, b: "1"}' | zq -z 'yield compare(a, b)' -
+```
+=>
+```mdtest-output
+-1
+```

--- a/docs/language/functions/compare.md
+++ b/docs/language/functions/compare.md
@@ -1,6 +1,6 @@
 ### Function
 
-&emsp; **compare** &mdash; returns an integer comparing two values
+&emsp; **compare** &mdash; return an integer comparing two values
 
 ### Synopsis
 

--- a/docs/language/functions/compare.md
+++ b/docs/language/functions/compare.md
@@ -13,7 +13,7 @@ compare(a: any, b: any) -> int64
 The _compare_ function returns an integer comparing two values. The result will
 be 0 if a is equal to b, +1 if a is greater than b, and -1 if a is less than b.
 _compare_ differs from `<`, `>`, `<=`, `>=`, `==`, and `!=` in that it will
-work for any type (e.g., `compare(1, "1")`). `null` values are the max value.
+work for any type (e.g., `compare(1, "1")`). `null` values compare greater than non-`null` values.
 
 ### Examples
 

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -236,8 +236,8 @@ const THRESH = %s
 from %s@%s:objects
 | {
 	id: id,
-	lower: meta.first < meta.last ? meta.first : meta.last,
-	upper: meta.first < meta.last ? meta.last : meta.first
+	lower: compare(meta.first, meta.last) < 0 ? meta.first : meta.last,
+	upper: compare(meta.first, meta.last) < 0 ? meta.last : meta.first
   }
 | switch (
   case %s %s THRESH => deletes:=collect(id)

--- a/runtime/expr/function/compare.go
+++ b/runtime/expr/function/compare.go
@@ -1,0 +1,21 @@
+package function
+
+import (
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/runtime/expr"
+)
+
+// https://github.com/brimdata/zed/blob/main/docs/language/functions.md#compare
+type Compare struct {
+	cmp expr.CompareFn
+}
+
+func NewCompare() *Compare {
+	return &Compare{
+		cmp: expr.NewValueCompareFn(true),
+	}
+}
+
+func (e *Compare) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+	return newInt64(ctx, int64(e.cmp(&args[0], &args[1])))
+}

--- a/runtime/expr/function/function.go
+++ b/runtime/expr/function/function.go
@@ -124,6 +124,10 @@ func New(zctx *zed.Context, name string, narg int) (expr.Function, field.Path, e
 		f = &Base64{zctx: zctx}
 	case "hex":
 		f = &Hex{zctx: zctx}
+	case "compare":
+		argmin = 2
+		argmax = 2
+		f = NewCompare()
 	case "cidr_match":
 		argmin = 2
 		argmax = 2

--- a/runtime/expr/function/ztests/compare.yaml
+++ b/runtime/expr/function/ztests/compare.yaml
@@ -1,0 +1,13 @@
+zed: yield compare(a, b)
+
+input: |
+  {a: 2, b: 1}
+  {a: 2, b: "1"}
+  {a: null, b: 2}
+  {a: 0, b: 0.}
+
+output: |
+  1
+  -1
+  1
+  0


### PR DESCRIPTION
Add compare function and use it in delete-by-predicate. This fixes an
issue with delete-by-predicate where values are not deleted if they
can't be coerced with the comparison value.