### PR TITLE
Disable markdown check for github link

### DIFF
--- a/docs/tutorials/zed.md
+++ b/docs/tutorials/zed.md
@@ -47,7 +47,7 @@ data since this will allow Zed to efficiently query data within a range of the
 pool key without having to touch the entire data set.
 
 For this primer we'll work with pull requests on this public repository via the
-[Github API](https://docs.github.com/en/rest/reference/pulls#list-pull-requests).
+[Github API](https://docs.github.com/en/rest/reference/pulls#list-pull-requests). <!-- markdown-link-check-disable-line -->
 Let's create a pool to store this data and use the field `created_at` as the
 pool key, sorted in descending order:
 


### PR DESCRIPTION
The markdown check for a link to documentation on the github rest API
has recently been consistently returning 403 and therefore causing the
test to fail even though the link is working for an unauthenticated
browser client. Disable the check on the specific link for now.
The issue is being tracked here: https://github.com/github/feedback/discussions/14773