### PR TITLE
Remove horizontal rules from docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,6 @@ sidebar_label: Introduction
 
 # The Zed Project
 
----
-
 Zed offers a new approach to data that makes it easier to manipulate and manage
 your data.
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -5,8 +5,6 @@ sidebar_label: Commands
 
 # Command Tooling
 
----
-
 The Zed system is managed and queried with the [`zed` command](zed.md),
 which is organized into numerous subcommands like the familiar command patterns
 of `docker` or `kubectrl`.
@@ -20,6 +18,6 @@ Zed data model, and interoperates with a number of other formats beyond JSON.
 If you don't need a Zed lake, you can install just the
 slimmer `zq` command which omits lake support and dev tools.
 
-`zq` is always installed alongside `zed`.  You might find yourself mixing and
+`zq` is always installed alongside `zed`. You might find yourself mixing and
 matching `zed` lake queries with `zq` local queries and stitching them
 all together with Unix pipelines.

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -18,6 +18,6 @@ Zed data model, and interoperates with a number of other formats beyond JSON.
 If you don't need a Zed lake, you can install just the
 slimmer `zq` command which omits lake support and dev tools.
 
-`zq` is always installed alongside `zed`. You might find yourself mixing and
+`zq` is always installed alongside `zed`.  You might find yourself mixing and
 matching `zed` lake queries with `zq` local queries and stitching them
 all together with Unix pipelines.

--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 0
 sidebar_label: zq
+description: A command-line tool that uses the Zed Language for pipeline-style search and analytics.
 ---
 
 # zq

--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -1,7 +1,5 @@
 # Zed Formats
 
----
-
 > **TL;DR** The Zed data model defines a new and easy way to manage, store,
 > and process data utilizing an emerging concept called
 [super-structured data](#2-zed-a-super-structured-pattern).

--- a/docs/formats/compression.md
+++ b/docs/formats/compression.md
@@ -5,8 +5,6 @@ sidebar_label: Compression
 
 # ZNG Compression Types
 
----
-
 This document specifies values for the `<format>` byte of a
 [ZNG compressed value message block](zng.md#2-the-zng-format)
 and the corresponding algorithms for the `<compressed paylod>` byte sequence.

--- a/docs/formats/zed.md
+++ b/docs/formats/zed.md
@@ -5,8 +5,6 @@ sidebar_label: Data Model
 
 # Zed Data Model
 
----
-
 Zed data is defined as an ordered sequence of one or more typed data values.
 Each value's type is either a "primitive type", a "complex type", the "type type",
 a "named type", or the "null type".

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -5,8 +5,6 @@ sidebar_label: ZJSON
 
 # ZJSON Specification
 
----
-
 ## 1. Introduction
 
 The [Zed data model](zed.md)

--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -5,8 +5,6 @@ sidebar_label: ZNG
 
 # ZNG Specification
 
----
-
 ## 1. Introduction
 
 ZNG (pronounced "zing") is an efficient, sequence-oriented serialization format for any data

--- a/docs/formats/zson.md
+++ b/docs/formats/zson.md
@@ -5,8 +5,6 @@ sidebar_label: ZSON
 
 # ZSON Specification
 
----
-
 ## 1. Introduction
 
 ZSON is the human-readable, text-based serialization format of

--- a/docs/formats/zst.md
+++ b/docs/formats/zst.md
@@ -5,8 +5,6 @@ sidebar_label: ZST
 
 # ZST Specification
 
----
-
 ZST, pronounced "zest", is a file format for columnar data based on
 [the Zed data model](zed.md).
 ZST is the "stacked" version of Zed, where the fields from a stream of

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,8 +5,6 @@ sidebar_label: Installation
 
 # Installation
 
----
-
 Several options for installing `zq` and/or `zed` are available:
 * [HomeBrew](#homebrew) for Mac or Linux,
 * [Binary Download](#binary-download), or

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -5,8 +5,6 @@ sidebar_label: API
 
 # Zed lake API
 
----
-
 ## _Status_
 
 > This is a brief sketch of the functionality exposed in the

--- a/docs/lake/format.md
+++ b/docs/lake/format.md
@@ -5,8 +5,6 @@ sidebar_label: Format
 
 # Zed Lake Format
 
----
-
 ## _Status_
 
 >This document is a rough draft and work in progress.  We plan to

--- a/docs/language/README.md
+++ b/docs/language/README.md
@@ -1,7 +1,5 @@
 # The Zed Language
 
----
-
 The language documents:
 * provide an [overview](overview.md) of the Zed language,
 * layout some [conventions](conventions.md) for the documenation, and

--- a/docs/language/conventions.md
+++ b/docs/language/conventions.md
@@ -5,8 +5,6 @@ sidebar_label: Conventions
 
 # Type Conventions
 
----
-
 Arguments to function and input values to operators are all dynamically typed,
 yet certain functions expect certain data types or classes of data types.
 To this end, the function and operator prototypes include a number

--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 1
 sidebar_label: Overview
-description: The Zed language is a query language for search, analytics, and transformation inspired by the pipeline pattern of the traditional Unix shell.
 ---
 
 # Zed Language Overview
@@ -14,18 +13,15 @@ and transformation inspired by the
 of the traditional Unix shell.
 Like a Unix pipeline, a query is expressed as a data source followed
 by a number of commands:
-
 ```
 command | command | command | ...
 ```
-
 However, in Zed, the entities that transform data are called
 "operators" instead of "commands" and unlike Unix pipelines,
 the streams of data in a Zed query
 are typed data sequences that adhere to the
 [Zed data model](../formats/zed.md#the-zed-data-model-specification).
 Moreover, Zed sequences can be forked and joined:
-
 ```
 operator
 | operator
@@ -35,7 +31,6 @@ operator
 )
 | join | ...
 ```
-
 Here, Zed programs can include multiple data sources and splitting operations
 where multiple paths run in parallel and paths can be combined (in an
 undefined order), merged (in a defined order) by one or more sort keys,
@@ -43,7 +38,7 @@ or joined using relational-style join logic.
 
 Generally speaking, a [flow graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph)
 defines a directed acyclic graph (DAG) composed
-of data sources and operator nodes. The Zed syntax leverages "fat arrows",
+of data sources and operator nodes.  The Zed syntax leverages "fat arrows",
 i.e., `=>`, to indicate the start of a parallel legs of the data flow.
 
 That said, the Zed language is
@@ -54,24 +49,20 @@ the flow implied by the pipeline yet reaching the same result &mdash;
 much as a modern SQL engine optimizes a declarative SQL query.
 
 Zed is also intended to provide a seamless transition from a simple search experience
-(e.g., typed into a search bar or as the query argument of the `zq` command-line
+(e.g., typed into a search bar or as the query argument of the  `zq` command-line
 tool) to more a complex analytics experience composed of complex joins and aggregations
 where the Zed language source text would typically be authored in a editor and
 managed under source-code control.
 
 Like an email or Web search, a simple keyword search is just the word itself,
 e.g.,
-
 ```
 example.com
 ```
-
 is a search for the string "example.com" and
-
 ```
 example.com urgent
 ```
-
 is a search for values with the both strings "example.com" and "urgent" present.
 
 Unlike typical log search systems, the Zed language operators are uniform:
@@ -82,22 +73,18 @@ etc. using the same syntax at any point in the pipeline as
 For example,
 the predicate `message_length > 100` can simply be tacked onto the keyword search
 from above, e.g.,
-
 ```
 example.com urgent message_length > 100
 ```
-
 finds all values containing the string "example.com" and "urgent" somewhere in them
 provided further that the field `message_length` is a numeric value greater than 100.
 A related query that performs an aggregation could be more formally
 written as follows:
-
 ```
 search "example.com" AND "urgent"
 | where message_length > 100
 | summarize kinds:=union(type) by net:=network_of(srcip)
 ```
-
 which computes an aggregation table of different message types (e.g.,
 from a hypothetical field called `type`) into a new, aggregated field
 called `kinds` and grouped by the network of all the source IP address
@@ -106,7 +93,7 @@ in the input
 
 The short-hand query from above might be typed into a search box while the
 latter query might be composed in a query editor or in Zed source files
-maintained in GitHub. Both forms are valid Zed queries.
+maintained in GitHub.  Both forms are valid Zed queries.
 
 ## 2. The Dataflow Model
 
@@ -121,7 +108,7 @@ In addition to the data sources specified as files on the `zq` command line,
 a source may also be specified with the [from operator](operators/from.md#operator).
 
 When running on the command-line, `from` may refer to a file, to an HTTP
-endpoint, or to an S3 URI. When running in a data lake, `from` typically
+endpoint, or to an S3 URI.  When running in a data lake, `from` typically
 refers to a collection of data called a "data pool" and is referenced using
 the pool's name much as SQL references database tables by their name.
 
@@ -129,19 +116,15 @@ For more detail, see the reference page of the [from operator](operators/from.md
 but as an example, you might use the `get` form of `from` to fetch data from an
 HTTP endpoint and process it with Zed, in this case, to extract the description
 and license of a GitHub repository:
-
 ```
 zq -f text "get https://api.github.com/repos/brimdata/zed | yield description,license.name"
 ```
-
 When a Zed query is run on the command-line with `zq`, the `from` source is
 typically omitted and implied instead by the command-line file arguments.
 The input may be stdin via `-` as in
-
 ```
 echo '"hello, world"' | zq  -
 ```
-
 The examples throughout the language documentation use this "echo pattern"
 to standard input of `zq -` to illustrate language semantics.
 Note that in these examples, the input values are expressed as Zed values serialized
@@ -165,7 +148,7 @@ For large queries that process all of their input, time may pass before
 seeing any output.
 
 On the other hand, most operators produce incremental output by operating
-on values as they are produced. For example, a long running query that
+on values as they are produced.  For example, a long running query that
 produces incremental output will stream results as they are produced, i.e.,
 running `zq` to standard output will display results incrementally.
 
@@ -178,21 +161,19 @@ providing a convenient means to derive arbitrary output values as a function
 of each input value, much like the map concept in the MapReduce framework.
 
 The [fork operator](operators/fork.md#operator) copies its input to parallel
-legs of a query. The output of these parallel paths can be combined
+legs of a query.  The output of these parallel paths can be combined
 in a number of ways:
-
-- merged in sorted order using the [merge operator](operators/merge.md#operator),
-- joined using the [join operator](operators/join.md#operator), or
-- combined in an undefined order using the implied [combine operator](operators/combine.md#operator).
+* merged in sorted order using the [merge operator](operators/merge.md#operator),
+* joined using the [join operator](operators/join.md#operator), or
+* combined in an undefined order using the implied [combine operator](operators/combine.md#operator).
 
 A path can also be split to multiple query legs using the
 [switch operator](operators/switch.md#operator), in which data is routed to only one
 corresponding leg (or dropped) based on the switch clauses.
 
 Switch operators typically
-involve multiline Zed programs, which are easiest to edit in a file. For example,
+involve multiline Zed programs, which are easiest to edit in a file.  For example,
 suppose this text is in a file called `switch.zed`:
-
 ```mdtest-input switch.zed
 switch this (
   case 1 => yield {val:this,message:"one"}
@@ -200,33 +181,28 @@ switch this (
   default => yield {val:this,message:"many"}
 ) | merge val
 ```
-
 Then, running `zq` with `-I switch.zed` like so:
-
 ```mdtest-command
 echo '1 2 3 4' | zq -z -I switch.zed -
 ```
-
 produces
-
 ```mdtest-output
 {val:1,message:"one"}
 {val:2,message:"two"}
 {val:3,message:"many"}
 {val:4,message:"many"}
 ```
-
 Note that the output order of the switch legs is undefined (indeed they run
-in parallel on multiple threads). To establish a consistent sequence order,
+in parallel on multiple threads).  To establish a consistent sequence order,
 a [merge operator](operators/merge.md)
 may be applied at the output of the switch specifying a sort key upon which
-to order the upstream data. Often such order does not matter (e.g., when the output
+to order the upstream data.  Often such order does not matter (e.g., when the output
 of the switch hits an aggregator), in which case it is typically more performant
 to omit the merge (though the Zed system will often delete such unnecessary
 operations automatically as part optimizing queries when they are compiled).
 
 If no `merge` or `join` is indicated downstream of a `fork` or `switch`,
-then the implied `combine` operator is presumed. In this case, values are
+then the implied `combine` operator is presumed.  In this case, values are
 forwarded from the switch to the downstream operator in an undefined order.
 
 ### 2.3 The Special Value `this`
@@ -242,30 +218,23 @@ there are no explicit tables and a Zed operator instead refers
 to its input values using the special identifier `this`.
 
 For example, sorting the following input
-
 ```mdtest-command
 echo '"foo" "bar" "BAZ"' | zq -z sort -
 ```
-
 produces this case-sensitive output:
-
 ```mdtest-output
 "BAZ"
 "bar"
 "foo"
 ```
-
 But we can make the sort case-insensitive by applying a function to the
 inputs values with the expression `lower(this)`, which converts
 each value to lower-case for use in in the sort without actually modifying
 the input value, e.g.,
-
 ```
 echo '"foo" "bar" "BAZ"' | zq -z 'sort lower(this)' -
 ```
-
 produces
-
 ```
 "bar"
 "BAZ"
@@ -276,35 +245,29 @@ produces
 
 A common use case for Zed is to process sequences of record-oriented data
 (e.g., arising from formats like JSON or Avro) in the form of events
-or structured logs. In this case, the input values to the operators
+or structured logs.  In this case, the input values to the operators
 are Zed "records" and the fields of a record are referenced with the dot operator.
 
 For example, if the input above were a sequence of records instead of strings
 and perhaps contained a second field, e.g.,
-
 ```
 {s:"foo",x:1}
 {s:"bar",x:2}
 {s:"BAZ",x:3}
 ```
-
 Then we could refer to the field `s` using `this.s` and sort the records
 as above with `sort this.s`, which would give
-
 ```
 {s:"BAZ",x:3}
 {s:"bar",x:2}
 {s:"foo",x:1}
 ```
-
 This pattern is so common that field references to `this` may be shortened
 by simply referring to the field by name wherever a Zed expression is expected,
 e.g.,
-
 ```
 sort s
 ```
-
 is shorthand for `sort this.s`
 
 ### 2.5 Field Assignments
@@ -316,18 +279,14 @@ Also, when aggregating data using group-by keys, the group-by assignments
 create new named record fields.
 
 In all of these cases, the Zed language uses the token `:=` to denote
-field assignment. For example,
-
+field assignment.  For example,
 ```
 put x:=y+1
 ```
-
 or
-
 ```
 summarize salary:=sum(income) by address:=lower(address)
 ```
-
 This style of "assignment" to a record value is distinguished from the `=`
 token which binds a locally scoped name to a value that can be referenced
 in later expressions.
@@ -346,52 +305,38 @@ To facilitate both a programming-like model as well as an ad hoc search
 experience, Zed has a canonical, long form that can be abbreviated
 using syntax that supports an agile, interactive query workflow.
 To this end, Zed allows certain operator names to be optionally omitted when
-they can be inferred from context. For example, the expression following
+they can be inferred from context.  For example, the expression following
 the `summarize` operator
-
 ```
 summarize count() by id
 ```
-
 is unambiguously an aggregation and can be shortened to
-
 ```
 count() by id
 ```
-
 Likewise, a very common lean-forward use pattern is "searching" so by default,
 expressions are interpreted as keyword searches, e.g.,
-
 ```
 search foo bar or x > 100
 ```
-
 is abbreviated
-
 ```
 foo bar or x > 100
 ```
-
 Furthermore, if an operator-free expression is not valid syntax for
 a search expression but is a valid [Zed expression](#expressions),
 then the abbreviation is treated as having an implied `yield` operator, e.g.,
-
 ```
 {s:lower(s)}
 ```
-
 is shorthand for
-
 ```
 yield {s:lower(s)}
 ```
-
 When operator names are omitted, `search` has precedence over `yield`, so
-
 ```
 foo
 ```
-
 is interpreted as a search for the string "foo" rather than a yield of
 the implied record field named `foo`.
 
@@ -400,34 +345,28 @@ where the input is presumed to be a sequence of records.
 The [put operator](operators/put.md#operator) provides this mechanism and the `put`
 keyword is implied by the mutator syntax `:=`, which is used in Zed when an
 input record field is modified, as compared to `=` which is used in constant
-and variable assignments. For example, the operation
-
+and variable assignments.  For example, the operation
 ```
 put y:=2*x+1
 ```
-
 can be expressed simply as
-
 ```
 y:=2*x+1
 ```
-
 When composing long-form queries that are shared via Brim or managed in GitHub,
 it is best practice to include all operator names in the Zed source text.
 
 In summary, if no operator name is given, the implied operator is determined
 from the operator-less source text, in the order given, as follows:
-
-- If the text can be interpreted as a search expression, then the operator is `search`.
-- If the text can be interpreted as a boolean expression, then the operator is `where`.
-- If the text can be interpreted as one or more field assignments, then the operator is `put`.
-- If the text can be interpreted as an aggregation, then the operator is `summarize`.
-- If the text can be interpreted as an expression, then the operator is `yield`.
-- Otherwise, the text causes a compile-time error.
+* If the text can be interpreted as a search expression, then the operator is `search`.
+* If the text can be interpreted as a boolean expression, then the operator is `where`.
+* If the text can be interpreted as one or more field assignments, then the operator is `put`.
+* If the text can be interpreted as an aggregation, then the operator is `summarize`.
+* If the text can be interpreted as an expression, then the operator is `yield`.
+* Otherwise, the text causes a compile-time error.
 
 When in doubt, you can always check what the compiler is doing under the hood
 by running `zq` with the `-C` flag to print the parsed query in "canonical form", e.g.,
-
 ```mdtest-command
 zq -C foo
 zq -C 'is(<foo>)'
@@ -435,9 +374,7 @@ zq -C 'count()'
 zq -C '{a:x+1,b:y-1}'
 zq -C 'a:=x+1,b:=y-1'
 ```
-
 produces
-
 ```mdtest-output
 search foo
 where is(<foo>)
@@ -450,21 +387,16 @@ put a:=x+1,b:=y-1
 ## 3. Const Statements
 
 Constants may be defined and assigned to a symbolic name with the syntax
-
 ```
 const <id> = <expr>
 ```
-
 where `<id>` is an identifier and `<expr>` is a constant [expression](#6-expressions)
 that must evaluate to a constant and at compile time and not reference any
 runtime state like `this`, e.g.,
-
 ```mdtest-command
 echo '{r:5}{r:10}' | zq -z "const PI=3.14159 2*PI*r" -
 ```
-
 produces
-
 ```mdtest-output
 31.4159
 62.8318
@@ -484,20 +416,15 @@ Const statements may appear intermixed with type statements.
 ## 4. Type Statements
 
 Named types may be created with the syntax
-
 ```
 type <id> = <type>
 ```
-
 where `<id>` is an identifier and `<type>` or a [Zed type](#first-class-types).
 This create a new type with the given name in the Zed type system, e.g.,
-
 ```mdtest-command
 echo 80 | zq -z 'type port=uint16 cast(this, <port>)' -
 ```
-
 produces
-
 ```mdtest-output
 80(port=uint16)
 ```
@@ -521,14 +448,14 @@ as defined in the [Zed data model](../formats/zed.md).
 The syntax of individual literal values generally follows
 the [ZSON syntax](../formats/zson.md) with the exception that
 [type decorators](../formats/zson.md#22-type-decorators)
-are not included in the language. Instead, a
+are not included in the language.  Instead, a
 [type cast](#casts) may be used in any expression for explicit
 type conversion.
 
 In particular, the syntax of primitive types follows the
 [primitive-value definitions](../formats/zson.md#23-primitive-values) in ZSON
 as well as the various [complex value definitions](../formats/zson.md#24-complex-values)
-like records, arrays, sets, and so forth. However, complex values are not limited to
+like records, arrays, sets, and so forth.  However, complex values are not limited to
 constant values like ZSON and can be composed from literal expressions as
 [defined below](#expressions).
 
@@ -539,21 +466,20 @@ any Zed type may be used as a value.
 
 The primitive types are listed in the
 [data model specification](../formats/zed.md#1-primitive-types)
-and have the same syntax in the Zed language. Complex types also follow
-the ZSON syntax. Note that the type of a type value is simply `type`.
+and have the same syntax in the Zed language.  Complex types also follow
+the ZSON syntax.  Note that the type of a type value is simply `type`.
 
 As in ZSON, _when types are used as values_, e.g., in a Zed expression,
-they must be referenced within angle brackets. That is, the integer type
+they must be referenced within angle brackets.  That is, the integer type
 `int64` is expressed as a type value using the syntax `<int64>`.
 
-Complex types in the Zed language follow the ZSON syntax as well. Here are
+Complex types in the Zed language follow the ZSON syntax as well.  Here are
 a few examples:
-
-- a simple record type - `{x:int64,y:int64}`
-- an array of integers - `[int64]`
-- a set of strings - `|[string]|`
-- a map of strings keys to integer values - `{[string,int64]}`
-- a union of string and integer - `(string,int64)`
+* a simple record type - `{x:int64,y:int64}`
+* an array of integers - `[int64]`
+* a set of strings - `|[string]|`
+* a map of strings keys to integer values - `{[string,int64]}`
+* a union of string and integer  - `(string,int64)`
 
 Complex types may be composed, as in `[({s:string},{x:int64})]` which is
 an array of type union of two types of records.
@@ -566,39 +492,30 @@ serve as group-by keys or be used in "data shaping" logic.
 A common query for data introspection is to perform some search query
 slicing and dicing some exploratory data then counting the shapes of
 each type of data as follows:
-
 ```
 search ... | count() by typeof(this)
 ```
-
 For example,
-
 ```mdtest-command
 echo '1 2 "foo" 10.0.0.1 <string>' | zq -z 'count() by typeof(this) | sort this' -
 ```
-
 produces
-
 ```mdtest-output
 {typeof:<int64>,count:2(uint64)}
 {typeof:<string>,count:1(uint64)}
 {typeof:<ip>,count:1(uint64)}
 {typeof:<type>,count:1(uint64)}
 ```
-
 When running such a query over complex, semi-structured data, the results can
 be quite illuminating and can inform the design of "data shaping" Zed queries
 to transform raw, messy data into clean data for downstream tooling.
 
 Note the somewhat subtle difference between a record value with a field `t` of
 type `type` whose value is type `string`
-
 ```
 {t:<string>}
 ```
-
 and a record type used as a value
-
 ```
 <{t:string}>
 ```
@@ -609,24 +526,19 @@ As in any modern programming language, types can be named and the type names
 persist into the data model and thus into the serialized input and output.
 
 Named types may be defined in three ways:
-
-- with a [type statement as described above](#4-type-statements),
-- with a definition inside of another type, or
-- by the input data itself.
+* with a [type statement as described above](#4-type-statements),
+* with a definition inside of another type, or
+* by the input data itself.
 
 Type names that are embedded in another type have the form
-
 ```
 name=type
 ```
-
 and create a binding between the indicated string `name` and the specified `type`.
 For example,
-
 ```
 type socket {addr:ip,port:port=uint16}
 ```
-
 defines a named type `socket` that is a record with field `addr` of type `ip`
 and field `port` of type "port", where type "port" is a named type for type `uint16` .
 
@@ -635,107 +547,83 @@ comprehensively self describing.
 When named types are defined in the input data, there is no need to declare their
 type in a query.
 In this case, a Zed expression may refer to the type by name that simply
-appears to the runtime as a side effect of operating upon the data. If the type
+appears to the runtime as a side effect of operating upon the data.  If the type
 name referred to this way does not exist, then the type value reference
-results in `error("missing")`. For example,
-
+results in `error("missing")`.  For example,
 ```mdtest-command
 echo '1(=foo) 2(=bar) 3(=foo)' | zq -z 'typeof(this)==<foo>' -
 ```
-
 results in
-
 ```mdtest-output
 1(=foo)
 3(=foo)
 ```
-
 and
-
 ```mdtest-command
 echo '1(=foo)' | zq -z 'yield <foo>' -
 ```
-
 results in
-
 ```mdtest-output
 <foo=int64>
 ```
-
 but
-
 ```mdtest-command
 zq -z 'yield <foo>'
 ```
-
 gives
-
 ```mdtest-output
 error("missing")
 ```
-
 Each instance of a named type definition overrides any earlier definition.
 In this way, types are local in scope.
 
 Each value that references a named type retains its local definition of the
 named type retaining the proper type binding while accommodating changes in a
-particular named type. For example,
-
+particular named type.  For example,
 ```mdtest-command
 echo '1(=foo) 2(=bar) "hello"(=foo) 3(=foo)' | zq -z 'count() by typeof(this) | sort this' -
 ```
-
 results in
-
 ```mdtest-output
 {typeof:<bar=int64>,count:1(uint64)}
 {typeof:<foo=int64>,count:2(uint64)}
 {typeof:<foo=string>,count:1(uint64)}
 ```
-
 Here, the two versions of type "foo" are retained in the group-by results.
 
 In general, it is bad practice to define multiple versions a single named type
 though the Zed system and Zed data model accommodate such dynamic bindings.
 Managing and enforcing the relationship between type names and their type definitions
 on a global basis (e.g., across many different data pools in a Zed lake) is outside
-the scope of the Zed data model and language. That said, Zed provides flexible
+the scope of the Zed data model and language.  That said, Zed provides flexible
 building blocks so systems can define their own schema versioning and schema
 management policies on top of these Zed primitives.
 
 Zed's super-structured data model is a superset of relational tables and
 the Zed language's type system can easily make this connection.
 As an example, consider this type definition for "employee":
-
 ```
 type employee {id:int64,first:string,last:string,job:string,salary:float64}
 ```
-
 In SQL, you might find the top five salaries by last name with
-
 ```
 SELECT last,salary
 FROM employee
 ORDER BY salary
 LIMIT 5
 ```
-
 In Zed, you would say
-
 ```
 from anywhere | typeof(this)==<employee> | cut last,salary | sort salary | head 5
 ```
-
 and since type comparisons are so useful and common, the function [is](functions/is.md)
 can be used to perform the type match:
-
 ```
 from anywhere | is(<employee>) | cut last,salary | sort salary | head 5
 ```
-
 The power of Zed is that you can interpret data on the fly as belonging to
 a certain schemas, in this case "employee", and those records can be intermixed
-with other relevant data. There is no need to create a table called "employee"
+with other relevant data.  There is no need to create a table called "employee"
 and put the data into the table before that data can be queried as an "employee".
 And if the schema or type name for "employee" changes, queries still continue
 to work.
@@ -746,55 +634,43 @@ As with types, errors in Zed are first-class: any value can be transformed
 into an error by wrapping it in the Zed [error type](../formats/zed.md#27-error).
 
 In general, expressions and functions that result in errors simply return
-a value of type error as a result. This encourages a powerful flow-style
+a value of type error as a result.  This encourages a powerful flow-style
 of error handling where errors simply propagate from one operation to the
 next and land in the output alongside non-error values to provide a very helpful
-context and rich information for tracking down the source of errors. There is
+context and rich information for tracking down the source of errors.  There is
 no need to check for error conditions everywhere or look through auxiliary
 logs to find out what happened.
 
 For example,
 input values can be transformed to errors as follows:
-
 ```mdtest-command
 echo '0 "foo" 10.0.0.1' | zq -z 'error(this)' -
 ```
-
 produces
-
 ```mdtest-output
 error(0)
 error("foo")
 error(10.0.0.1)
 ```
-
 More practically, errors from the runtime show up as error values.
 For example,
-
 ```mdtest-command
 echo 0 | zq -z '1/this' -
 ```
-
 produces
-
 ```mdtest-output
 error("divide by zero")
 ```
-
 And since errors are first-class and just values, they have a type.
 In particular, they are a complex type where the error value's type is the
-complex type error containing the type of the value. For example,
-
+complex type error containing the type of the value.  For example,
 ```mdtest-command
 echo 0 | zq -z 'typeof(1/this)' -
 ```
-
 produces
-
 ```mdtest-output
 <error(string)>
 ```
-
 First-class errors are particularly useful for creating structured errors.
 When a Zed query encounters a problematic condition,
 instead of silently dropping the problematic error
@@ -803,32 +679,24 @@ ETL pipelines do, the Zed logic can
 preferably wrap the offending value as an error and propagate it to its output.
 
 For example, suppose a bad value shows up:
-
 ```
 {kind:"bad", stuff:{foo:1,bar:2}}
 ```
-
 A Zed shaper could catch the bad value (e.g., as a default case in a
 switch topology) and propagate it as an error using the Zed expression:
-
 ```
 yield error({message:"unrecognized input",input:this})
 ```
-
 then such errors could be detected and searched for downstream with the
 [is_error function](functions/is_error.md).
 For example,
-
 ```
 is_error(this)
 ```
-
 on the wrapped error from above produces
-
 ```
 error({message:"unrecognized input",input:{kind:"bad", stuff:{foo:1,bar:2}}})
 ```
-
 There is no need to create special tables in a complex warehouse-style ETL
 to land such errors as they can simply land next to the output values themselves.
 
@@ -854,63 +722,52 @@ that include a field called `x` but not valid for those that do not.
 What is the value of `x` when the field `x` does not exist?
 
 A similar question faced SQL when it was adapted in various different forms
-to operate on semi-structured data like JSON or XML. SQL already had the `NULL` value
+to operate on semi-structured data like JSON or XML.  SQL already had the `NULL` value
 so perhaps a reference to a missing value could simply be `NULL`.
 
 But JSON also has `null`, so a reference to `x` in the JSON value
-
 ```
 {"x":null}
 ```
-
 and a reference to `x` in the JSON value
-
 ```
 {}
 ```
-
-would have the same value of `NULL`. Furthermore, an expression like `x==NULL`
+would have the same value of `NULL`.  Furthermore, an expression like `x==NULL`
 could not differentiate between these two cases.
 
 To solve this problem, the `MISSING` value was proposed to represent the value that
-results from accessing a field that is not present. Thus, `x==NULL` and
+results from accessing a field that is not present.  Thus, `x==NULL` and
 `x==MISSING` could disambiguate the two cases above.
 
 Zed, instead, recognizes that the SQL value is `MISSING` is a paradox:
-I'm here but I'm not.
+I'm here but I'm not.  
 
-In reality, a MISSING value is not a value. It's an error condition
+In reality, a MISSING value is not a value.  It's an error condition
 that resulted from trying to reference something that didn't exist.
 
-So why should we pretend that this is a bona fide value? SQL adopted this
+So why should we pretend that this is a bona fide value?  SQL adopted this
 approach because it lacks first-class errors.
 
 But Zed has first-class errors so
 a reference to something that does not exist is an error of type
-`error<string>` whose value is `error("missing")`. For example,
-
+`error<string>` whose value is `error("missing")`.  For example,
 ```mdtest-command
 echo "{x:1} {y:2}" | zq -z 'yield x' -
 ```
-
 produces
-
 ```mdtest-output
 1
 error("missing")
 ```
-
 Sometimes you want missing errors to show up and sometimes you don't.
 The [quiet function](functions/quiet.md) transforms missing errors into
-"quiet errors". A quiet error is the value `error("quiet")` and is ignored
-by most operators, in particular yield. For example,
-
+"quiet errors".  A quiet error is the value `error("quiet")` and is ignored
+by most operators, in particular yield.  For example,
 ```mdtest-command
 echo "{x:1} {y:2}" | zq -z "yield quiet(x)" -
 ```
-
 produces
-
 ```mdtest-output
 1
 ```
@@ -929,16 +786,13 @@ various expressions as part of their operation.
 
 Arithmetic operations (`*`, `/`, `%`, `+`, `-`) follow customary syntax
 and semantics and are left-associative with multiplication and division having
-precedence over addition and subtraction. `%` is the modulo operator.
+precedence over addition and subtraction.  `%` is the modulo operator.
 
 For example,
-
 ```mdtest-command
 zq -z 'yield 2*3+1, 11%5, 1/0, "foo"+"bar"'
 ```
-
 produces
-
 ```mdtest-output
 7
 1
@@ -954,20 +808,17 @@ A comparison expression is any valid Zed expression compared to any other
 valid Zed expression using a comparison operator.
 
 When the operands are coercible to like types, the result is the truth value
-of the comparison. Otherwise, the result is `false`.
+of the comparison.  Otherwise, the result is `false`.
 
 If either operand to a comparison
 is `error("missing")`, then the result is `error("missing")`.
 
 For example,
-
 ```mdtest-command
 zq -z 'yield 1 > 2, 1 < 2, "b" > "a", 1 > "a", 1 > x'
 
 ```
-
 produces
-
 ```mdtest-output
 false
 true
@@ -979,24 +830,19 @@ error("missing")
 ### 6.3 Containment
 
 The `in` operator has the form
-
 ```
 <item-expr> in <container-expr>
 ```
-
 and is true if the `<item-expr>` expression results in a value that
 appears somewhere in the `<container-expr>` as an exact match of the item.
 The right-hand side value can be any Zed value and complex values are
 recursively traversed to determine if the item is present anywhere within them.
 
 For example,
-
 ```mdtest-command
 echo '{a:[1,2]}{b:{c:3}}{d:{e:1}}' | zq -z '1 in this' -
 ```
-
 produces
-
 ```mdtest-output
 {a:[1,2]}
 {d:{e:1}}
@@ -1006,7 +852,7 @@ produces
 
 The keywords `and`, `or`, and `not` perform logic on operands of type `bool`.
 The binary operators `and` and `or` operate on Boolean values and result in
-an error value if either operand is not a Boolean. Likewise, `not` operates
+an error value if either operand is not a Boolean.  Likewise, `not` operates
 on its unary operand and results in an error if its operand is not type `bool`.
 Unlike many other languages, non-Boolean values are not automatically converted to
 Boolean type using "truthiness" heuristics.
@@ -1015,11 +861,9 @@ Boolean type using "truthiness" heuristics.
 
 Records fields are dereferenced with the dot operator `.` as is customary
 in other languages and have the form
-
 ```
 <value> . <id>
 ```
-
 where `<id>` is an identifier representing the field name referenced.
 If a field name is not representable as an identifier, then [indexing](#indexing)
 may be used with a quoted string to represent any valid field name.
@@ -1033,11 +877,9 @@ or if the record does not have the given field, then the result is
 ### 6.6 Indexing
 
 The index operation can be applied to various data types and has the form:
-
 ```
 <value> [ <index> ]
 ```
-
 If the `<value>` expression is a record, then the `<index>` operand
 must be coercible to a string and the result of the record's field
 of that name.
@@ -1052,7 +894,7 @@ value in the set of that index ordered by total order of Zed values.
 
 If the `<value>` expression is a map, then the `<index>` operand
 is presumed to be a key and the corresponding value for that key is
-the result of the operation. If no such key exists in the map, then
+the result of the operation.  If no such key exists in the map, then
 `error("missing")` results.
 
 If the `<value>` expression is a string, then the `<index>` operand
@@ -1066,15 +908,13 @@ representing the byte value at that offset in the bytes sequence.
 ### 6.7 Slices
 
 The slice operation can be applied to various data types and has the form:
-
 ```
 <value> [ <from> : <to> ]
 ```
-
 The `<from>` and `<to>` terms must be expressions that are coercible
 to integer and represent a range of index values to form a subset of elements
-from the `<value>` term provided. The range begins at the `<from>` position
-and ends one before the `<to>` position. A negative
+from the `<value>` term provided.  The range begins at the `<from>` position
+and ends one before the `<to>` position.  A negative
 value of `<from>` or `<to>` represents a position relative to the
 end of the value being sliced.
 
@@ -1093,29 +933,24 @@ consisting of bytes comprising the given range.
 ### 6.8 Conditional
 
 A conditional expression has the form
-
 ```
 <boolean> ? <expr> : <expr>`
 ```
-
 The `<boolean>` expression is evaluated and must have a result of type `bool`.
 If not, an error results.
 
 If the result is true, then the first `<expr>` expression is evaluated and becomes
-the result. Otherwise, the second `<expr>` expression is evaluated.
+the result.  Otherwise, the second `<expr>` expression is evaluated.
 
 Note that if the expression has side effects,
 as with [aggregation calls](#aggregation-calls), only the selected expression
 will be evaluated.
 
 For example,
-
 ```mdtest-command
 echo '{s:"foo",v:1}{s:"bar",v:2}' | zq -z 'yield (s=="foo") ? v : -v' -
 ```
-
 produces
-
 ```mdtest-output
 1
 -2
@@ -1125,19 +960,16 @@ produces
 
 Functions perform stateless transformations of their input value to their
 return value and utilize call-by value semantics with positional and unnamed
-arguments. Some functions take a variable number of arguments.
+arguments.  Some functions take a variable number of arguments.
 
 > The only available functions are built-in but user-defined functions and
 > library package management will be added to the Zed language soon.
 
 For example,
-
 ```mdtest-command
 zq -z 'yield pow(2,3), lower("ABC")+upper("def"), typeof(1)'
 ```
-
 produces
-
 ```mdtest-output
 8.
 "abcDEF"
@@ -1156,27 +988,20 @@ optimizer from parallelizing a query.
 
 That said, aggregate function calls can be quite useful in a number of contexts.
 For example, a unique ID can be assigned to the input quite easily:
-
 ```mdtest-command
 echo '"foo" "bar" "baz"' | zq -z 'yield {id:count(),value:this}' -
 ```
-
 produces
-
 ```mdtest-output
 {id:1(uint64),value:"foo"}
 {id:2(uint64),value:"bar"}
 {id:3(uint64),value:"baz"}
 ```
-
 In contrast, calling aggregate functions within `summarize`
-
 ```mdtest-command
 echo '"foo" "bar" "baz"' | zq -z 'summarize count(),union(this)' -
 ```
-
 produces just one output value
-
 ```mdtest-output
 {count:3(uint64),union:|["bar","baz","foo"]|}
 ```
@@ -1188,19 +1013,17 @@ as long as it is compatible with the semantics of the expression.
 
 String literals are enclosed in either single quotes or double quotes and
 must conform to UTF-8 encoding and follow the JavaScript escaping
-conventions and unicode escape syntax. Also, if the sequence `${` appears
+conventions and unicode escape syntax.  Also, if the sequence `${` appears
 in a string the `$` character must be escaped, i.e., `\$`.
 
 #### 6.11.1 String Interpolation
 
 Strings may include interpolation expressions, which has the form
-
 ```
 ${ <expr> }
 ```
-
 In this case, the characters starting with `$` and ending at `}` are substituted
-with the result of evaluating the expression `<expr>`. If this result is not
+with the result of evaluating the expression `<expr>`.  If this result is not
 a string, it is implicitly cast to a string.
 
 If any template expression results in an error, then the value of the template
@@ -1216,23 +1039,19 @@ with interpolated expressions.
 #### 6.11.2 Record Expressions
 
 Record literals have the form
-
 ```
 { <spec>, <spec>, ... }
 ```
-
 where a `<spec>` has one of three forms:
-
 ```
 <field> : <expr>
 <ref>
 ...<expr>
 ```
-
 The first form is a customary colon-separated field and value similar to JavaScript,
 where `<field>` may be an identifier or quoted string.
 The second form is an implied field reference `<ref>`, which is shorthand
-for `<ref>:<ref>`. The third form is the `...` spread operator which expects
+for `<ref>:<ref>`.  The third form is the `...` spread operator which expects
 a record value as the result of `<expr>` and inserts all of the fields from
 the resulting record.
 If a spread expression results in a non-record type (e.g., errors), then that
@@ -1243,13 +1062,10 @@ field names collide the rightmost instance of the name determines that
 field's value.
 
 For example,
-
 ```mdtest-command
 echo '{x:1,y:2,r:{a:1,b:2}}' | zq -z 'yield {a:0},{x}, {...r}, {a:0,...r,b:3}' -
 ```
-
 produces
-
 ```mdtest-output
 {a:0}
 {x:1}
@@ -1260,22 +1076,17 @@ produces
 #### 6.11.3 Array Expressions
 
 Array literals have the form
-
 ```
 [ <expr>, <expr>, ... ]
 ```
-
 When the expressions result in values of non-uniform type, then the implied
 type of the array is an array of type union of the types that appear.
 
 For example,
-
 ```mdtest-command
 zq -z 'yield [1,2,3],["hello","world"]'
 ```
-
 produces
-
 ```mdtest-output
 [1,2,3]
 ["hello","world"]
@@ -1284,11 +1095,9 @@ produces
 #### 6.11.4 Set Expressions
 
 Set literals have the form
-
 ```
 |[ <expr>, <expr>, ... ]|
 ```
-
 When the expressions result in values of non-uniform type, then the implied
 type of the set is a set of type union of the types that appear.
 
@@ -1296,13 +1105,10 @@ Set values are always organized in their "natural order" independent of the orde
 they appear in the set literal.
 
 For example,
-
 ```mdtest-command
 zq -z 'yield |[3,1,2]|,|["hello","world","hello"]|'
 ```
-
 produces
-
 ```mdtest-output
 |[1,2,3]|
 |["hello","world"]|
@@ -1311,11 +1117,9 @@ produces
 #### 6.11.5 Map Expressions
 
 Map literals have the form
-
 ```
 |{ <expr>:<expr>, <expr>:<expr>, ... }|
 ```
-
 where the first expression of each colon-separated entry is the key value
 and the second expression is the value.
 When the key and/or value expressions results in values of non-uniform type,
@@ -1323,61 +1127,47 @@ then the implied type of the map has a key type and/or value type that is
 a union of the types that appear in each respective category.
 
 For example,
-
 ```mdtest-command
 zq -z 'yield |{"foo":1,"bar"+"baz":2+3}|'
 ```
-
 produces
-
 ```mdtest-output
 |{"foo":1,"barbaz":5}|
 ```
 
 #### 6.11.6 Union Values
 
-A union value can be created with a cast. For example, a union of types `int64`
+A union value can be created with a cast.  For example, a union of types `int64`
 and `string` is expressed as `(int64,string)` and any value that has a type
 that appears in the union type may be cast to that union type.
 Since 1 is an `int64` and "foo" is a `string`, they both can be
 values of type `(int64,string)`, e.g.,
-
 ```mdtest-command
 echo '1 "foo"' | zq -z 'yield cast(this,<(int64,string)>)' -
 ```
-
 produces
-
 ```mdtest-output
 1((int64,string))
 "foo"((int64,string))
 ```
-
 The value underlying a union-tagged value is accessed with the
 [under function](functions/under.md):
-
 ```mdtest-command
 echo '1((int64,string))' | zq -z 'yield under(this)' -
 ```
-
 produces
-
 ```mdtest-output
 1
 ```
-
 Union values are powerful because they provide a mechanism to precisely
 describe the type of any nested, semi-structured value composed of elements
-of different types. For example, the type of the value `[1,"foo"]` in Javascript
-is simply a generic Javascript "object". But in Zed, the type of this
+of different types.  For example, the type of the value `[1,"foo"]` in Javascript
+is simply a generic Javascript "object".  But in Zed, the type of this
 value is an array of union of string and integer, e.g.,
-
 ```mdtest-command
 echo '[1,"foo"]' | zq -z 'typeof(this)' -
 ```
-
 produces
-
 ```mdtest-output
 <[(int64,string)]>
 ```
@@ -1386,11 +1176,9 @@ produces
 
 Constants may be declared and bound to an identifier with a `const` statement,
 which has the form
-
 ```
 const <id> = <expr>
 ```
-
 This statement evaluates the expressions `<expr>` before any input is processed
 to determine the constant value assigned to the identifier `<id>`.
 This expression may not refer to `this` or any implied fields of `this`.
@@ -1401,9 +1189,7 @@ of a query or the beginning of a [parenthesized scope](#scopes).
 ```mdtest-command
 echo '{diameter:1}{diameter:5}' | zq -z 'const PI = 3.14159 circumference:=2*PI*diameter' -
 ```
-
 produces
-
 ```mdtest-output
 {diameter:1,circumference:6.28318}
 {diameter:5,circumference:31.4159}
@@ -1413,11 +1199,9 @@ produces
 
 Named types may be declared and bound to an identifier with a `type` statement,
 which has the form
-
 ```
 type <name> = <type>
 ```
-
 This statement evaluates the type `<type>` before any input is processed
 to compute a type value assigned to the identifier `<id>`.
 
@@ -1435,9 +1219,7 @@ of a query or the beginning of a [parenthesized scope](#scopes).
 ```mdtest-command
 echo '{s:1}{s:10.0.0.1}' | zq -z 'type foo = {s:string} cast(this, foo)' -
 ```
-
 produces
-
 ```mdtest-output
 {s:"1"}(=foo)
 {s:"10.0.0.1"}(=foo)
@@ -1448,11 +1230,9 @@ produces
 Type conversion is performed with casts and the built-in function `cast()`.
 
 Casts for primitive types have a function-style syntax of the form
-
 ```
 <type> ( <expr> )
 ```
-
 where `<type>` is a Zed type and `<expr>` is any Zed expression.
 In the case of primitive types, the type-value angle brackets
 may be omitted, e.g., `<string>(1)` is equivalent to `string(1)`.
@@ -1460,13 +1240,10 @@ If the result of `<expr>` cannot be converted
 to the indicated type, then the cast's result is an error value.
 
 For example,
-
 ```mdtest-command
 echo '1 200 "123" "200"' | zq -z 'yield int8(this)' -
 ```
-
 produces
-
 ```mdtest-output
 1(int8)
 error("cannot cast 200 to type int8")
@@ -1474,16 +1251,14 @@ error("cannot cast 200 to type int8")
 error("cannot cast \"200\" to type int8")
 ```
 
-Casting attempts to be fairly liberal in conversions. For example, values
+Casting attempts to be fairly liberal in conversions.  For example, values
 of type `time` can be created from a diverse set of data/time input strings
 based on the [Go Date Parser library](https://github.com/araddon/dateparse).
 
 ```mdtest-command
 echo '"May 8, 2009 5:57:51 PM" "oct 7, 1970"' | zq -z 'yield time(this)' -
 ```
-
 produces
-
 ```mdtest-output
 2009-05-08T17:57:51Z
 1970-10-07T00:00:00Z
@@ -1491,48 +1266,36 @@ produces
 
 Casts of complex or named types may be performed using type values
 either in functional form or with `cast`:
-
 ```
 <type-value> ( <expr> )
 cast(<expr>, <type-value>)
 ```
-
 For example
-
 ```mdtest-command
 echo '80 8080' | zq -z 'type port = uint16 yield <port>(this)' -
 ```
-
 produces
-
 ```mdtest-output
 80(port=uint16)
 8080(port=uint16)
 ```
 
-Casts may be used with complex types as well. As long as the target type can
+Casts may be used with complex types as well.  As long as the target type can
 accommodate the value, the case will be recursively applied to the components
-of a nested value. For example,
+of a nested value.  For example,
 For example
-
 ```mdtest-command
 echo '["10.0.0.1","10.0.0.2"]' | zq -z 'cast(this,<[ip]>)' -
 ```
-
 produces
-
 ```mdtest-output
 [10.0.0.1,10.0.0.2]
 ```
-
 and
-
 ```mdtest-command
 echo '{ts:"1/1/2022",r:{x:"1",y:"2"}} {ts:"1/2/2022",r:{x:3,y:4}}' | zq -z 'cast(this,<{ts:time,r:{x:float64,y:float64}}>)' -
 ```
-
 produces
-
 ```mdtest-output
 {ts:2022-01-01T00:00:00Z,r:{x:1.,y:2.}}
 {ts:2022-01-02T00:00:00Z,r:{x:3.,y:4.}}
@@ -1541,9 +1304,9 @@ produces
 ## 7. Search Expressions
 
 Search expressions provide a hybrid syntax between keyword search
-and boolean expressions. In this way, a search is a shorthand for
+and boolean expressions.  In this way, a search is a shorthand for
 a "lean forward" style activity where one is interactively exploring
-data with ad hoc searches. All shorthand searches have a corresponding
+data with ad hoc searches.  All shorthand searches have a corresponding
 long form built from the expression syntax above in combination with the
 [search term syntax](#721-search-terms) described below.
 
@@ -1566,27 +1329,20 @@ and is documented in the
 [RE2 Wiki](https://github.com/google/re2/wiki/Syntax).
 
 Regular expressions may be used freely in search expressions, e.g.,
-
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z '/(foo|bar)/' -
 ```
-
 produces
-
 ```mdtest-output
 "foo"
 {s:"bar"}
 {foo:1}
 ```
-
 Regular expressions may also appear in the `grep` function:
-
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z 'yield grep(/ba.*/, s)' -
 ```
-
 produces
-
 ```mdtest-output
 false
 true
@@ -1603,49 +1359,36 @@ Zed globs are a simple, special case utilize only the `*` wildcard.
 Valid glob characters include `a` through `z`, `A` through `Z`,
 any valid string escape sequence
 (along with escapes for `*`, `=`, `+`, `-`), and the unescaped characters:
-
 ```
 _ . : / % # @ ~
 ```
-
 A glob must begin with one of these characters or `*` then may be
 followed by any of these characters, `*`, or digits `0` through `9`.
 
 > Note that these rules do not allow for a leading digit.
 
 For example, a prefix match is easily accomplished via `prefix*`, e.g.,
-
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z 'b*' -
 ```
-
 produces
-
 ```mdtest-output
 {s:"bar"}
 {s:"baz"}
 ```
-
 Likewise, a suffix match may be performed as follows:
-
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z '*z' -
 ```
-
 produces
-
 ```mdtest-output
 {s:"baz"}
 ```
-
 and
-
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {a:1}' | zq -z '*a*' -
 ```
-
 produces
-
 ```mdtest-output
 {s:"bar"}
 {s:"baz"}
@@ -1654,17 +1397,13 @@ produces
 
 Note that a glob may look like multiplication but context disambiguates
 these condition, e.g.,
-
 ```
 a*b
 ```
-
 is a glob match for any matching string value in the input, but
-
 ```
 a*b==c
 ```
-
 is a Boolean comparison between the product `a*b` and `c`.
 
 ### 7.2 Search Logic
@@ -1676,58 +1415,49 @@ using Boolean logic.
 > Note that when processing ZNG data, the Zed runtime performs a multi-threaded
 > Boyer-Moore scan over decompressed data buffers before parsing any data.
 > This allows large buffers of data to be efficiently discarded and skipped when
-> searching for rarely occurring values. For a [Zed lake](../lake/format.md), search indexes
+> searching for rarely occurring values.  For a [Zed lake](../lake/format.md), search indexes
 > may also be configured to further accelerate searches.
 > In a forthcoming release, Zed will also offer an approach for locating
 > delimited words within string fields, which will allow accelerated
-> search using a full-text search index. Currently, search indexes may be built
+> search using a full-text search index.  Currently, search indexes may be built
 > for exact value match as text segmentation is in the works.a
 
 #### 7.2.1 Search Terms
 
 A "search term" is one of the following;
-
-- a regular expression as described above,
-- a glob as described above,
-- a keyword,
-- any literal of a primitive type, or
-- expression predicates.
+* a regular expression as described above,
+* a glob as described above,
+* a keyword,
+* any literal of a primitive type, or
+* expression predicates.
 
 ##### 7.2.1.1 Regular Expression Search Term
 
 A regular expression `/re/` is equivalent to
-
 ```
 grep(/reg/, this)
 ```
-
 but shorter and easier to type in a search expression.
 
 For example,
-
 ```
 /(foo|bar.*baz.*\.com)/
 ```
-
 Searches for any string that begins with `foo` or `bar` has the string
 `baz` in it and ends with `.com`.
 
 ##### 7.2.1.2 Glob Search Term
 
 A glob search term `<glob>` is equivalent to
-
 ```
 grep(/reg/, this)
 ```
-
 but shorter and easier to type in a search expression.
 
 For example,
-
 ```
 foo*baz*.com
 ```
-
 Searches for any string that begins with `foo` has the string
 `baz` in it and ends with `.com`.
 
@@ -1743,40 +1473,31 @@ Keyword search has the look and feel of Web search or email search.
 Valid keyword characters include `a` through `z`, `A` through `Z`,
 any valid string escape sequence
 (along with escapes for `*`, `=`, `+`, `-`), and the unescaped characters:
-
 ```
 _ . : / % # @ ~
 ```
-
 A keyword must begin with one of these characters then may be
 followed by any of these characters or digits `0` through `9`.
 
 A keyword search is equivalent to
-
 ```
 grep(<keyword>, this)
 ```
-
 where `<keyword>` is the quoted string-literal of the unquoted string.
 For example,
-
 ```
 search foo
 ```
-
 is equivalent to
-
 ```
 where grep("foo", this)
 ```
 
 Note that the "search" keyword may be omitted.
 For example, the simplest Zed program is perhaps a single keyword search, e.g.,
-
 ```
 foo
 ```
-
 As above, this program searches the implied input for input values that
 contain the string "foo".
 
@@ -1784,19 +1505,14 @@ contain the string "foo".
 
 A string literal as a search term is simply a search for that string and is
 equivalent to
-
 ```
 grep(<string>, this)
 ```
-
 For example,
-
 ```
 search "foo"
 ```
-
 is equivalent to
-
 ```
 where grep("foo", this)
 ```
@@ -1811,45 +1527,36 @@ where grep("foo", this)
 
 Search terms representing non-string Zed values search for both an exact
 match for the given value as well as a string search for the term exactly
-as it appears as typed. Such values include:
-
-- integers,
-- floating point numbers,
-- time values,
-- durations,
-- IPs,
-- networks,
-- bytes values, and
-- type values.
+as it appears as typed.  Such values include:
+* integers,
+* floating point numbers,
+* time values,
+* durations,
+* IPs,
+* networks,
+* bytes values, and
+* type values.
 
 A search for a Zed value `<value>` represented as the string `<string>` is
 equivalent to
-
 ```
 <value> in this or grep(<string>, this)
 ```
-
 For example,
-
 ```
 search 123 and 10.0.0.1
 ```
-
 which can be abbreviated
-
 ```
 123 10.0.0.1
 ```
-
 is equivalent to
-
 ```
 where (123 in this or grep("123", this)) and (10.0.0.1 in this or grep("10.0.0.1", this))
 ```
 
 Complex values are not supported as search terms but may be queried with
 the "in" operator, e.g.,
-
 ```
 {s:"foo"} in this
 ```
@@ -1861,25 +1568,21 @@ Any Boolean-valued [function](functions/README.md) like `is()`, `has()`,
 may be used as a search term and mixed into a search expression.
 
 For example,
-
 ```
 is(<foo>) has(bar) baz x==y+z
 ```
-
 is a valid search expression but
-
 ```
 /foo.*/ x+1
 ```
-
 is not.
 
 #### 7.3 Boolean Logic
 
 Search terms may be combined into boolean expressions using logical operators
-`and`, `or` and `not`. `and` may be elided; i.e., concatenation of search terms
-is a logical `and`. `not` has highest precedence and `and` has precedence over
-`or`. Parentheses may be used to override natural precedence.
+`and`, `or` and `not`.  `and` may be elided; i.e., concatenation of search terms
+is a logical `and`.  `not` has highest precedence and `and` has precedence over
+`or`.  Parentheses may be used to override natural precedence.
 
 Note that the concatenation form of `and` is not valid in standard expressions and
 is available only in search expressions.
@@ -1887,25 +1590,18 @@ Concatenation is convenient in interactive sessions but it is best practice to
 explicitly include the `and` operator when editing Zed source files.
 
 For example,
-
 ```
 not foo bar or baz
 ```
-
 means
-
 ```
 ((not grep("foo")) and grep("bar)) or grep("baz")
 ```
-
 while
-
 ```
 foo (bar or baz)
 ```
-
 means
-
 ```
 grep("foo") and (grep("bar)) or grep("baz"))
 ```
@@ -1921,58 +1617,44 @@ Lateral subqueries are created using the scoped form of the
 [over operator](operators/over.md#operator) and may be nested to arbitrary depth.
 
 For example,
-
 ```mdtest-command
 echo '{s:"foo",a:[1,2]} {s:"bar",a:[3]}' | zq -z 'over a with name=s => (yield {name,elem:this})' -
 ```
-
 produces
-
 ```mdtest-output
 {name:"foo",elem:1}
 {name:"foo",elem:2}
 {name:"bar",elem:3}
 ```
-
 Here the lateral scope, described below, creates a subquery
-
 ```
 yield {name,elem:this}
 ```
-
 for each sub-sequence of values derived from each outer input value.
 In the example above, there are two input values:
-
 ```
 {s:"foo",a:[1,2]}
 {s:"bar",a:[3]}
 ```
-
 which imply two subqueries derived from the `over` operator traversing `a`.
 The first subquery thus operates on the input values `1, 2` with the variable
 `name` set to "foo" assigning `1` and then `2` to `this`, thereby emitting
-
 ```
 {name:"foo",elem:1}
 {name:"foo",elem:2}
 ```
-
 and the second subquery operators on the input value `3` with the variable
 `name` set to "bar", emitting
-
 ```
 {name:"bar",elem:3}
 ```
 
 You can also import a parent-scope field reference into the inner scope by
 simply referring to its name without assignment, e.g.,
-
 ```mdtest-command
 echo '{s:"foo",a:[1,2]} {s:"bar",a:[3]}' | zq -z 'over a with s => (yield {s,elem:this})' -
 ```
-
 produces
-
 ```mdtest-output
 {s:"foo",elem:1}
 {s:"foo",elem:2}
@@ -1984,23 +1666,17 @@ produces
 A lateral scope has the form `=> ( <query> )` and currently appears
 only the context of an [over operator](operators/over.md#operator),
 as illustrated above, and has the form:
-
 ```
 over ... with <elem> [, <elem> ...] => ( <query> )
 ```
-
 where `<elem>` has either an assignment form
-
 ```
 <var>=<expr>
 ```
-
 or a field reference form
-
 ```
 <field>
 ```
-
 For each input value to the outer scope, the assignment form creates a binding
 between each `<expr>` evaluated in the outer scope and each `<var>`, which
 represents a new symbol in the inner scope of the `<query>`.
@@ -2009,23 +1685,20 @@ in the parent scope and makes that field's value available in the lateral scope
 with the same name.
 
 The `<query>`, which may be any Zed query, is evaluated once per outer value
-on the sequence generated by the `over` expression. In the lateral scope,
+on the sequence generated by the `over` expression.  In the lateral scope,
 the value `this` refers to the inner sequence generated from the `over` expressions.
 This query runs to completion for each inner sequence and emits
 each subquery result as each inner sequence traversal completes.
 
 This structure is powerful because _any_ Zed query can be appear in the body of
-the lateral scope. In contrast to the `yield` example, a sort could be
+the lateral scope.  In contrast to the `yield` example, a sort could be
 applied to each sub-sequence in the subquery, where sort
 reads all of values of the subsequence, sorts them, emits them, then
-repeats the process for the next subsequence. For example,
-
+repeats the process for the next subsequence.  For example,
 ```mdtest-command
 echo '[3,2,1] [4,1,7] [1,2,3]' | zq -z 'over this => (sort this | collect(this))' -
 ```
-
 produces
-
 ```mdtest-output
 {collect:[1,2,3]}
 {collect:[1,4,7]}
@@ -2036,11 +1709,9 @@ produces
 
 Lateral subqueries can also appear in expression context using the
 parenthesized form:
-
 ```
 ( over <expr> [, <expr>...] [with <var>=<expr> [, ... <var>[=<expr>]] | <lateral> )
 ```
-
 > Note that the parentheses disambiguate a lateral expression from a lateral
 > dataflow operator.
 
@@ -2050,32 +1721,25 @@ As with the `over` operator, values from the outer scope can be brought into
 the lateral scope using the `with` clause.
 
 The lateral expression is evaluated by evalating each `<expr>` and feeding
-the results as inputs to the `<lateral>` dataflow operators. Each time the
+the results as inputs to the `<lateral>` dataflow operators.  Each time the
 lateral expression is evaluated, the lateral operators are run to completion,
 e.g.,
-
 ```mdtest-command
 echo '[3,2,1] [4,1,7] [1,2,3]' | zq -z 'yield (over this | sum(this))' -
 ```
-
 produces
-
 ```mdtest-output
 {sum:6}
 {sum:12}
 {sum:6}
 ```
-
 This structure generalizes to any more complicated expression context,
 e.g., we can embed multiple lateral expressions inside of a record literal
 and use the spread operator to tighten up the output:
-
 ```mdtest-command
 echo '[3,2,1] [4,1,7] [1,2,3]' | zq -z '{...(over this | sort this | sorted:=collect(this)),...(over this | sum(this))}' -
 ```
-
 produces
-
 ```mdtest-output
 {sorted:[1,2,3],sum:6}
 {sorted:[1,4,7],sum:12}
@@ -2100,11 +1764,11 @@ to "fit" a given shape, and reordering fields.
 While shaping remains an active area of development, the core functions in Zed
 that currently perform shaping are:
 
-- [cast](functions/cast.md) - coerce a value to a different type
-- [crop](functions/crop.md) - remove fields from a value that are missing in a specified type
-- [fill](functions/fill.md) - add null values for missing fields
-- [order](functions/order.md) - reorder record fields
-- [shape](functions/shape.md) - apply cast, fill, and order
+* [cast](functions/cast.md) - coerce a value to a different type
+* [crop](functions/crop.md) - remove fields from a value that are missing in a specified type
+* [fill](functions/fill.md) - add null values for missing fields
+* [order](functions/order.md) - reorder record fields
+* [shape](functions/shape.md) - apply cast, fill, and order
 
 They all have the same signature, taking two parameters: the value to be
 transformed and a type value for the target type.
@@ -2121,7 +1785,6 @@ transformed and a type value for the target type.
 In the examples below, we will use the following named type `connection`
 that is stored in a file `connection.zed`
 and is included in the example Zed queries with `-I` option of `zq`:
-
 ```mdtest-input connection.zed
 type socket = { addr:ip, port:port=uint16 }
 type connection = {
@@ -2131,9 +1794,7 @@ type connection = {
     vlan: uint16
 }
 ```
-
 We also use this sample JSON input in a file called `sample.json`:
-
 ```mdtest-input sample.json
 {
   "kind": "dns",
@@ -2153,16 +1814,13 @@ We also use this sample JSON input in a file called `sample.json`:
 
 The cast function applies a cast operation to each leaf value that matches the
 field path in the specified type, e.g.,
-
 ```mdtest-command
 zq -Z -I connection.zed "cast(this, <connection>)" sample.json
 ```
-
 casts the address fields to type `ip`, the port fields to type `port`
 (which is a typedef for `uint16`) and the address port pairs to
 type `socket` without modifying the `uid` field or changing the
 order of the `server` and `client` fields:
-
 ```mdtest-output
 {
     kind: "dns",
@@ -2181,13 +1839,10 @@ order of the `server` and `client` fields:
 ### 9.2 Crop
 
 Cropping is a useful when you want records to "fit" a schema tightly, e.g.,
-
 ```mdtest-command
 zq -Z -I connection.zed "crop(this, <connection>)" sample.json
 ```
-
 removes the `uid` field since it is not in the _connection_ type:
-
 ```mdtest-output
 {
     kind: "dns",
@@ -2205,14 +1860,11 @@ removes the `uid` field since it is not in the _connection_ type:
 ### 9.3 Fill
 
 Use fill when you want to fill out missing fields with nulls, e.g.,
-
 ```mdtest-command
 zq -Z -I connection.zed "fill(this, <connection>)" sample.json
 ```
-
 adds a null-valued `vlan` field since the input value is missing it and
 the _connection_ type has it:
-
 ```mdtest-output
 {
     kind: "dns",
@@ -2233,14 +1885,11 @@ the _connection_ type has it:
 
 The order function changes the order of fields in its input to match the
 specified order, as field order is significant in Zed records, e.g.,
-
 ```mdtest-command
 zq -Z -I connection.zed "order(this, <connection>)" sample.json
 ```
-
 reorders the `client` and `server` fields to match the input but does nothing
 about the `uid` field as it is not in the _connection_ type:
-
 ```mdtest-output
 {
     kind: "dns",
@@ -2260,14 +1909,11 @@ about the `uid` field as it is not in the _connection_ type:
 
 The shape function brings everything together by applying `cast`,
 `fill`, and `order` all in one step, e.g.,
-
 ```mdtest-command
 zq -Z -I connection.zed "shape(this, <connection>)" sample.json
 ```
-
 reorders the `client` and `server` fields to match the input but does nothing
 about the `uid` field as it is not in the _connection_ type:
-
 ```mdtest-output
 {
     kind: "dns",
@@ -2283,16 +1929,12 @@ about the `uid` field as it is not in the _connection_ type:
     uid: "C2zK5f13SbCtKcyiW5"
 }
 ```
-
 To get a tight shape of the target type,
 apply `crop` to the output of `shape`, e.g.,
-
 ```mdtest-command
 zq -Z -I connection.zed "shape(this, <connection>) | crop(this, <connection>)" sample.json
 ```
-
 drops the `uid` field after shaping:
-
 ```mdtest-output
 {
     kind: "dns",
@@ -2307,7 +1949,6 @@ drops the `uid` field after shaping:
     vlan: null (uint16)
 }
 ```
-
 ## 10. Type Fusion
 
 Type fusion is another important building block of data shaping.
@@ -2315,7 +1956,7 @@ Here, types are operated upon by fusing them together, where the
 result is single fused type.
 Some systems call a related process "schema inference" where a set
 of values, typically JSON, is analyzed to determine a relational schema
-that all the data will fit into. However, this is just a special case of
+that all the data will fit into.  However, this is just a special case of
 type fusion as fusion is fine-grained and based on Zed's type system rather
 than having the narrower goal of computing a schema for representations
 like relational tables, Parquet, Avro, etc.
@@ -2326,16 +1967,13 @@ The first technique is to simply combine types with a type union.
 For example, an `int64` and a `string` can be merged into a common
 type of union `(int64,string)`, e.g., the value sequence `1 "foo"`
 can be fused into the single-type sequence:
-
 ```
 1((int64,string))
 "foo"((int64,string))
 ```
-
 The second technique is to merge fields of records, analogous to a spread
-expression. Here, the value sequence `{a:1}{b:"foo"}` may be
+expression.  Here, the value sequence `{a:1}{b:"foo"}` may be
 fused into the single-type sequence:
-
 ```
 {a:1,b:null(string)}
 {a:null(int64),b:"foo"}
@@ -2344,7 +1982,6 @@ fused into the single-type sequence:
 Of course, these two techniques can be powerfully combined,
 e.g., where the value sequence `{a:1}{a:"foo",b:2}` may be
 fused into the single-type sequence:
-
 ```
 {a:1((int64,string)),b:null(int64)}
 {a:"foo"((int64,string)),b:2}
@@ -2352,35 +1989,27 @@ fused into the single-type sequence:
 
 To perform fusion, Zed currently includes two key mechanisms
 (though this is an active area of development):
-
-- the [fuse operator](operators/fuse.md#operator), and
-- the [fuse aggregate function](aggregates/fuse.md).
+* the [fuse operator](operators/fuse.md#operator), and
+* the [fuse aggregate function](aggregates/fuse.md).
 
 ### 10.1 Fuse Operator
 
 The _fuse operator_ reads all of its input, computes a fused type using
 the techniques above, and outputs the result, e.g.,
-
 ```mdtest-command
 echo '{x:1} {y:"foo"}{x:2,y:"bar"}' | zq -z fuse -
 ```
-
 produces
-
 ```mdtest-output
 {x:1,y:null(string)}
 {x:null(int64),y:"foo"}
 {x:2,y:"bar"}
 ```
-
 whereas
-
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"}{x:2,y:"bar"}' | zq -z fuse -
 ```
-
 requires a type union for field `x` and produces:
-
 ```mdtest-output
 {x:1((int64,string)),y:null(string)}
 {x:"foo"((int64,string)),y:"foo"}
@@ -2395,36 +2024,27 @@ or unknown input data and how those various shapes relate to one another.
 
 For example, in example sequence above, we can use the _fuse function_ to determine
 the fused type rather than transforming the values, e.g.,
-
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"}{x:2,y:"bar"}' | zq -z 'fuse(this)' -
 ```
-
 results in
-
 ```mdtest-output
 {fuse:<{x:(int64,string),y:string}>}
 ```
-
 Since the _fuse_ here is an aggregate function, it can also be used with
-group-by keys. Supposing we wanted to fuse different type records into
-different types, we can use a group-by. In this simple example, we will
+group-by keys.  Supposing we wanted to fuse different type records into
+different types, we can use a group-by.  In this simple example, we will
 fuse records based on their number of fields using the `len()` function:
-
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"}{x:2,y:"bar"}' | zq -z 'fuse(this) by len(this) | sort len' -
 ```
-
 which produces
-
 ```mdtest-output
 {len:1,fuse:<{x:int64}>}
 {len:2,fuse:<{x:(int64,string),y:string}>}
 ```
-
 Now, we can turn around and write a "shaper" for data that has the patterns
 we "discovered" above, e.g., if this Zed source is in `shape.zed`
-
 ```mdtest-input shape.zed
 switch len(this) (
     case 1 => pass
@@ -2432,15 +2052,11 @@ switch len(this) (
     default => yield error({kind:"unrecognized shape",value:this})
 )
 ```
-
 when we run
-
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"}{x:2,y:"bar"}{a:1,b:2,c:3}' | zq -z -I shape.zed '| sort -r this' -
 ```
-
 we get
-
 ```mdtest-output
 {x:1}
 {x:"foo"((int64,string)),y:"foo"}

--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -1,11 +1,10 @@
 ---
 sidebar_position: 1
 sidebar_label: Overview
+description: The Zed language is a query language for search, analytics, and transformation inspired by the pipeline pattern of the traditional Unix shell.
 ---
 
 # Zed Language Overview
-
----
 
 ## 1. Introduction
 
@@ -15,15 +14,18 @@ and transformation inspired by the
 of the traditional Unix shell.
 Like a Unix pipeline, a query is expressed as a data source followed
 by a number of commands:
+
 ```
 command | command | command | ...
 ```
+
 However, in Zed, the entities that transform data are called
 "operators" instead of "commands" and unlike Unix pipelines,
 the streams of data in a Zed query
 are typed data sequences that adhere to the
 [Zed data model](../formats/zed.md#the-zed-data-model-specification).
 Moreover, Zed sequences can be forked and joined:
+
 ```
 operator
 | operator
@@ -33,6 +35,7 @@ operator
 )
 | join | ...
 ```
+
 Here, Zed programs can include multiple data sources and splitting operations
 where multiple paths run in parallel and paths can be combined (in an
 undefined order), merged (in a defined order) by one or more sort keys,
@@ -40,7 +43,7 @@ or joined using relational-style join logic.
 
 Generally speaking, a [flow graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph)
 defines a directed acyclic graph (DAG) composed
-of data sources and operator nodes.  The Zed syntax leverages "fat arrows",
+of data sources and operator nodes. The Zed syntax leverages "fat arrows",
 i.e., `=>`, to indicate the start of a parallel legs of the data flow.
 
 That said, the Zed language is
@@ -51,20 +54,24 @@ the flow implied by the pipeline yet reaching the same result &mdash;
 much as a modern SQL engine optimizes a declarative SQL query.
 
 Zed is also intended to provide a seamless transition from a simple search experience
-(e.g., typed into a search bar or as the query argument of the  `zq` command-line
+(e.g., typed into a search bar or as the query argument of the `zq` command-line
 tool) to more a complex analytics experience composed of complex joins and aggregations
 where the Zed language source text would typically be authored in a editor and
 managed under source-code control.
 
 Like an email or Web search, a simple keyword search is just the word itself,
 e.g.,
+
 ```
 example.com
 ```
+
 is a search for the string "example.com" and
+
 ```
 example.com urgent
 ```
+
 is a search for values with the both strings "example.com" and "urgent" present.
 
 Unlike typical log search systems, the Zed language operators are uniform:
@@ -75,18 +82,22 @@ etc. using the same syntax at any point in the pipeline as
 For example,
 the predicate `message_length > 100` can simply be tacked onto the keyword search
 from above, e.g.,
+
 ```
 example.com urgent message_length > 100
 ```
+
 finds all values containing the string "example.com" and "urgent" somewhere in them
 provided further that the field `message_length` is a numeric value greater than 100.
 A related query that performs an aggregation could be more formally
 written as follows:
+
 ```
 search "example.com" AND "urgent"
 | where message_length > 100
 | summarize kinds:=union(type) by net:=network_of(srcip)
 ```
+
 which computes an aggregation table of different message types (e.g.,
 from a hypothetical field called `type`) into a new, aggregated field
 called `kinds` and grouped by the network of all the source IP address
@@ -95,7 +106,7 @@ in the input
 
 The short-hand query from above might be typed into a search box while the
 latter query might be composed in a query editor or in Zed source files
-maintained in GitHub.  Both forms are valid Zed queries.
+maintained in GitHub. Both forms are valid Zed queries.
 
 ## 2. The Dataflow Model
 
@@ -110,7 +121,7 @@ In addition to the data sources specified as files on the `zq` command line,
 a source may also be specified with the [from operator](operators/from.md#operator).
 
 When running on the command-line, `from` may refer to a file, to an HTTP
-endpoint, or to an S3 URI.  When running in a data lake, `from` typically
+endpoint, or to an S3 URI. When running in a data lake, `from` typically
 refers to a collection of data called a "data pool" and is referenced using
 the pool's name much as SQL references database tables by their name.
 
@@ -118,15 +129,19 @@ For more detail, see the reference page of the [from operator](operators/from.md
 but as an example, you might use the `get` form of `from` to fetch data from an
 HTTP endpoint and process it with Zed, in this case, to extract the description
 and license of a GitHub repository:
+
 ```
 zq -f text "get https://api.github.com/repos/brimdata/zed | yield description,license.name"
 ```
+
 When a Zed query is run on the command-line with `zq`, the `from` source is
 typically omitted and implied instead by the command-line file arguments.
 The input may be stdin via `-` as in
+
 ```
 echo '"hello, world"' | zq  -
 ```
+
 The examples throughout the language documentation use this "echo pattern"
 to standard input of `zq -` to illustrate language semantics.
 Note that in these examples, the input values are expressed as Zed values serialized
@@ -150,7 +165,7 @@ For large queries that process all of their input, time may pass before
 seeing any output.
 
 On the other hand, most operators produce incremental output by operating
-on values as they are produced.  For example, a long running query that
+on values as they are produced. For example, a long running query that
 produces incremental output will stream results as they are produced, i.e.,
 running `zq` to standard output will display results incrementally.
 
@@ -163,19 +178,21 @@ providing a convenient means to derive arbitrary output values as a function
 of each input value, much like the map concept in the MapReduce framework.
 
 The [fork operator](operators/fork.md#operator) copies its input to parallel
-legs of a query.  The output of these parallel paths can be combined
+legs of a query. The output of these parallel paths can be combined
 in a number of ways:
-* merged in sorted order using the [merge operator](operators/merge.md#operator),
-* joined using the [join operator](operators/join.md#operator), or
-* combined in an undefined order using the implied [combine operator](operators/combine.md#operator).
+
+- merged in sorted order using the [merge operator](operators/merge.md#operator),
+- joined using the [join operator](operators/join.md#operator), or
+- combined in an undefined order using the implied [combine operator](operators/combine.md#operator).
 
 A path can also be split to multiple query legs using the
 [switch operator](operators/switch.md#operator), in which data is routed to only one
 corresponding leg (or dropped) based on the switch clauses.
 
 Switch operators typically
-involve multiline Zed programs, which are easiest to edit in a file.  For example,
+involve multiline Zed programs, which are easiest to edit in a file. For example,
 suppose this text is in a file called `switch.zed`:
+
 ```mdtest-input switch.zed
 switch this (
   case 1 => yield {val:this,message:"one"}
@@ -183,28 +200,33 @@ switch this (
   default => yield {val:this,message:"many"}
 ) | merge val
 ```
+
 Then, running `zq` with `-I switch.zed` like so:
+
 ```mdtest-command
 echo '1 2 3 4' | zq -z -I switch.zed -
 ```
+
 produces
+
 ```mdtest-output
 {val:1,message:"one"}
 {val:2,message:"two"}
 {val:3,message:"many"}
 {val:4,message:"many"}
 ```
+
 Note that the output order of the switch legs is undefined (indeed they run
-in parallel on multiple threads).  To establish a consistent sequence order,
+in parallel on multiple threads). To establish a consistent sequence order,
 a [merge operator](operators/merge.md)
 may be applied at the output of the switch specifying a sort key upon which
-to order the upstream data.  Often such order does not matter (e.g., when the output
+to order the upstream data. Often such order does not matter (e.g., when the output
 of the switch hits an aggregator), in which case it is typically more performant
 to omit the merge (though the Zed system will often delete such unnecessary
 operations automatically as part optimizing queries when they are compiled).
 
 If no `merge` or `join` is indicated downstream of a `fork` or `switch`,
-then the implied `combine` operator is presumed.  In this case, values are
+then the implied `combine` operator is presumed. In this case, values are
 forwarded from the switch to the downstream operator in an undefined order.
 
 ### 2.3 The Special Value `this`
@@ -220,23 +242,30 @@ there are no explicit tables and a Zed operator instead refers
 to its input values using the special identifier `this`.
 
 For example, sorting the following input
+
 ```mdtest-command
 echo '"foo" "bar" "BAZ"' | zq -z sort -
 ```
+
 produces this case-sensitive output:
+
 ```mdtest-output
 "BAZ"
 "bar"
 "foo"
 ```
+
 But we can make the sort case-insensitive by applying a function to the
 inputs values with the expression `lower(this)`, which converts
 each value to lower-case for use in in the sort without actually modifying
 the input value, e.g.,
+
 ```
 echo '"foo" "bar" "BAZ"' | zq -z 'sort lower(this)' -
 ```
+
 produces
+
 ```
 "bar"
 "BAZ"
@@ -247,29 +276,35 @@ produces
 
 A common use case for Zed is to process sequences of record-oriented data
 (e.g., arising from formats like JSON or Avro) in the form of events
-or structured logs.  In this case, the input values to the operators
+or structured logs. In this case, the input values to the operators
 are Zed "records" and the fields of a record are referenced with the dot operator.
 
 For example, if the input above were a sequence of records instead of strings
 and perhaps contained a second field, e.g.,
+
 ```
 {s:"foo",x:1}
 {s:"bar",x:2}
 {s:"BAZ",x:3}
 ```
+
 Then we could refer to the field `s` using `this.s` and sort the records
 as above with `sort this.s`, which would give
+
 ```
 {s:"BAZ",x:3}
 {s:"bar",x:2}
 {s:"foo",x:1}
 ```
+
 This pattern is so common that field references to `this` may be shortened
 by simply referring to the field by name wherever a Zed expression is expected,
 e.g.,
+
 ```
 sort s
 ```
+
 is shorthand for `sort this.s`
 
 ### 2.5 Field Assignments
@@ -281,14 +316,18 @@ Also, when aggregating data using group-by keys, the group-by assignments
 create new named record fields.
 
 In all of these cases, the Zed language uses the token `:=` to denote
-field assignment.  For example,
+field assignment. For example,
+
 ```
 put x:=y+1
 ```
+
 or
+
 ```
 summarize salary:=sum(income) by address:=lower(address)
 ```
+
 This style of "assignment" to a record value is distinguished from the `=`
 token which binds a locally scoped name to a value that can be referenced
 in later expressions.
@@ -307,38 +346,52 @@ To facilitate both a programming-like model as well as an ad hoc search
 experience, Zed has a canonical, long form that can be abbreviated
 using syntax that supports an agile, interactive query workflow.
 To this end, Zed allows certain operator names to be optionally omitted when
-they can be inferred from context.  For example, the expression following
+they can be inferred from context. For example, the expression following
 the `summarize` operator
+
 ```
 summarize count() by id
 ```
+
 is unambiguously an aggregation and can be shortened to
+
 ```
 count() by id
 ```
+
 Likewise, a very common lean-forward use pattern is "searching" so by default,
 expressions are interpreted as keyword searches, e.g.,
+
 ```
 search foo bar or x > 100
 ```
+
 is abbreviated
+
 ```
 foo bar or x > 100
 ```
+
 Furthermore, if an operator-free expression is not valid syntax for
 a search expression but is a valid [Zed expression](#expressions),
 then the abbreviation is treated as having an implied `yield` operator, e.g.,
+
 ```
 {s:lower(s)}
 ```
+
 is shorthand for
+
 ```
 yield {s:lower(s)}
 ```
+
 When operator names are omitted, `search` has precedence over `yield`, so
+
 ```
 foo
 ```
+
 is interpreted as a search for the string "foo" rather than a yield of
 the implied record field named `foo`.
 
@@ -347,28 +400,34 @@ where the input is presumed to be a sequence of records.
 The [put operator](operators/put.md#operator) provides this mechanism and the `put`
 keyword is implied by the mutator syntax `:=`, which is used in Zed when an
 input record field is modified, as compared to `=` which is used in constant
-and variable assignments.  For example, the operation
+and variable assignments. For example, the operation
+
 ```
 put y:=2*x+1
 ```
+
 can be expressed simply as
+
 ```
 y:=2*x+1
 ```
+
 When composing long-form queries that are shared via Brim or managed in GitHub,
 it is best practice to include all operator names in the Zed source text.
 
 In summary, if no operator name is given, the implied operator is determined
 from the operator-less source text, in the order given, as follows:
-* If the text can be interpreted as a search expression, then the operator is `search`.
-* If the text can be interpreted as a boolean expression, then the operator is `where`.
-* If the text can be interpreted as one or more field assignments, then the operator is `put`.
-* If the text can be interpreted as an aggregation, then the operator is `summarize`.
-* If the text can be interpreted as an expression, then the operator is `yield`.
-* Otherwise, the text causes a compile-time error.
+
+- If the text can be interpreted as a search expression, then the operator is `search`.
+- If the text can be interpreted as a boolean expression, then the operator is `where`.
+- If the text can be interpreted as one or more field assignments, then the operator is `put`.
+- If the text can be interpreted as an aggregation, then the operator is `summarize`.
+- If the text can be interpreted as an expression, then the operator is `yield`.
+- Otherwise, the text causes a compile-time error.
 
 When in doubt, you can always check what the compiler is doing under the hood
 by running `zq` with the `-C` flag to print the parsed query in "canonical form", e.g.,
+
 ```mdtest-command
 zq -C foo
 zq -C 'is(<foo>)'
@@ -376,7 +435,9 @@ zq -C 'count()'
 zq -C '{a:x+1,b:y-1}'
 zq -C 'a:=x+1,b:=y-1'
 ```
+
 produces
+
 ```mdtest-output
 search foo
 where is(<foo>)
@@ -389,16 +450,21 @@ put a:=x+1,b:=y-1
 ## 3. Const Statements
 
 Constants may be defined and assigned to a symbolic name with the syntax
+
 ```
 const <id> = <expr>
 ```
+
 where `<id>` is an identifier and `<expr>` is a constant [expression](#6-expressions)
 that must evaluate to a constant and at compile time and not reference any
 runtime state like `this`, e.g.,
+
 ```mdtest-command
 echo '{r:5}{r:10}' | zq -z "const PI=3.14159 2*PI*r" -
 ```
+
 produces
+
 ```mdtest-output
 31.4159
 62.8318
@@ -418,15 +484,20 @@ Const statements may appear intermixed with type statements.
 ## 4. Type Statements
 
 Named types may be created with the syntax
+
 ```
 type <id> = <type>
 ```
+
 where `<id>` is an identifier and `<type>` or a [Zed type](#first-class-types).
 This create a new type with the given name in the Zed type system, e.g.,
+
 ```mdtest-command
 echo 80 | zq -z 'type port=uint16 cast(this, <port>)' -
 ```
+
 produces
+
 ```mdtest-output
 80(port=uint16)
 ```
@@ -450,14 +521,14 @@ as defined in the [Zed data model](../formats/zed.md).
 The syntax of individual literal values generally follows
 the [ZSON syntax](../formats/zson.md) with the exception that
 [type decorators](../formats/zson.md#22-type-decorators)
-are not included in the language.  Instead, a
+are not included in the language. Instead, a
 [type cast](#casts) may be used in any expression for explicit
 type conversion.
 
 In particular, the syntax of primitive types follows the
 [primitive-value definitions](../formats/zson.md#23-primitive-values) in ZSON
 as well as the various [complex value definitions](../formats/zson.md#24-complex-values)
-like records, arrays, sets, and so forth.  However, complex values are not limited to
+like records, arrays, sets, and so forth. However, complex values are not limited to
 constant values like ZSON and can be composed from literal expressions as
 [defined below](#expressions).
 
@@ -468,20 +539,21 @@ any Zed type may be used as a value.
 
 The primitive types are listed in the
 [data model specification](../formats/zed.md#1-primitive-types)
-and have the same syntax in the Zed language.  Complex types also follow
-the ZSON syntax.  Note that the type of a type value is simply `type`.
+and have the same syntax in the Zed language. Complex types also follow
+the ZSON syntax. Note that the type of a type value is simply `type`.
 
 As in ZSON, _when types are used as values_, e.g., in a Zed expression,
-they must be referenced within angle brackets.  That is, the integer type
+they must be referenced within angle brackets. That is, the integer type
 `int64` is expressed as a type value using the syntax `<int64>`.
 
-Complex types in the Zed language follow the ZSON syntax as well.  Here are
+Complex types in the Zed language follow the ZSON syntax as well. Here are
 a few examples:
-* a simple record type - `{x:int64,y:int64}`
-* an array of integers - `[int64]`
-* a set of strings - `|[string]|`
-* a map of strings keys to integer values - `{[string,int64]}`
-* a union of string and integer  - `(string,int64)`
+
+- a simple record type - `{x:int64,y:int64}`
+- an array of integers - `[int64]`
+- a set of strings - `|[string]|`
+- a map of strings keys to integer values - `{[string,int64]}`
+- a union of string and integer - `(string,int64)`
 
 Complex types may be composed, as in `[({s:string},{x:int64})]` which is
 an array of type union of two types of records.
@@ -494,30 +566,39 @@ serve as group-by keys or be used in "data shaping" logic.
 A common query for data introspection is to perform some search query
 slicing and dicing some exploratory data then counting the shapes of
 each type of data as follows:
+
 ```
 search ... | count() by typeof(this)
 ```
+
 For example,
+
 ```mdtest-command
 echo '1 2 "foo" 10.0.0.1 <string>' | zq -z 'count() by typeof(this) | sort this' -
 ```
+
 produces
+
 ```mdtest-output
 {typeof:<int64>,count:2(uint64)}
 {typeof:<string>,count:1(uint64)}
 {typeof:<ip>,count:1(uint64)}
 {typeof:<type>,count:1(uint64)}
 ```
+
 When running such a query over complex, semi-structured data, the results can
 be quite illuminating and can inform the design of "data shaping" Zed queries
 to transform raw, messy data into clean data for downstream tooling.
 
 Note the somewhat subtle difference between a record value with a field `t` of
 type `type` whose value is type `string`
+
 ```
 {t:<string>}
 ```
+
 and a record type used as a value
+
 ```
 <{t:string}>
 ```
@@ -528,19 +609,24 @@ As in any modern programming language, types can be named and the type names
 persist into the data model and thus into the serialized input and output.
 
 Named types may be defined in three ways:
-* with a [type statement as described above](#4-type-statements),
-* with a definition inside of another type, or
-* by the input data itself.
+
+- with a [type statement as described above](#4-type-statements),
+- with a definition inside of another type, or
+- by the input data itself.
 
 Type names that are embedded in another type have the form
+
 ```
 name=type
 ```
+
 and create a binding between the indicated string `name` and the specified `type`.
 For example,
+
 ```
 type socket {addr:ip,port:port=uint16}
 ```
+
 defines a named type `socket` that is a record with field `addr` of type `ip`
 and field `port` of type "port", where type "port" is a named type for type `uint16` .
 
@@ -549,83 +635,107 @@ comprehensively self describing.
 When named types are defined in the input data, there is no need to declare their
 type in a query.
 In this case, a Zed expression may refer to the type by name that simply
-appears to the runtime as a side effect of operating upon the data.  If the type
+appears to the runtime as a side effect of operating upon the data. If the type
 name referred to this way does not exist, then the type value reference
-results in `error("missing")`.  For example,
+results in `error("missing")`. For example,
+
 ```mdtest-command
 echo '1(=foo) 2(=bar) 3(=foo)' | zq -z 'typeof(this)==<foo>' -
 ```
+
 results in
+
 ```mdtest-output
 1(=foo)
 3(=foo)
 ```
+
 and
+
 ```mdtest-command
 echo '1(=foo)' | zq -z 'yield <foo>' -
 ```
+
 results in
+
 ```mdtest-output
 <foo=int64>
 ```
+
 but
+
 ```mdtest-command
 zq -z 'yield <foo>'
 ```
+
 gives
+
 ```mdtest-output
 error("missing")
 ```
+
 Each instance of a named type definition overrides any earlier definition.
 In this way, types are local in scope.
 
 Each value that references a named type retains its local definition of the
 named type retaining the proper type binding while accommodating changes in a
-particular named type.  For example,
+particular named type. For example,
+
 ```mdtest-command
 echo '1(=foo) 2(=bar) "hello"(=foo) 3(=foo)' | zq -z 'count() by typeof(this) | sort this' -
 ```
+
 results in
+
 ```mdtest-output
 {typeof:<bar=int64>,count:1(uint64)}
 {typeof:<foo=int64>,count:2(uint64)}
 {typeof:<foo=string>,count:1(uint64)}
 ```
+
 Here, the two versions of type "foo" are retained in the group-by results.
 
 In general, it is bad practice to define multiple versions a single named type
 though the Zed system and Zed data model accommodate such dynamic bindings.
 Managing and enforcing the relationship between type names and their type definitions
 on a global basis (e.g., across many different data pools in a Zed lake) is outside
-the scope of the Zed data model and language.  That said, Zed provides flexible
+the scope of the Zed data model and language. That said, Zed provides flexible
 building blocks so systems can define their own schema versioning and schema
 management policies on top of these Zed primitives.
 
 Zed's super-structured data model is a superset of relational tables and
 the Zed language's type system can easily make this connection.
 As an example, consider this type definition for "employee":
+
 ```
 type employee {id:int64,first:string,last:string,job:string,salary:float64}
 ```
+
 In SQL, you might find the top five salaries by last name with
+
 ```
 SELECT last,salary
 FROM employee
 ORDER BY salary
 LIMIT 5
 ```
+
 In Zed, you would say
+
 ```
 from anywhere | typeof(this)==<employee> | cut last,salary | sort salary | head 5
 ```
+
 and since type comparisons are so useful and common, the function [is](functions/is.md)
 can be used to perform the type match:
+
 ```
 from anywhere | is(<employee>) | cut last,salary | sort salary | head 5
 ```
+
 The power of Zed is that you can interpret data on the fly as belonging to
 a certain schemas, in this case "employee", and those records can be intermixed
-with other relevant data.  There is no need to create a table called "employee"
+with other relevant data. There is no need to create a table called "employee"
 and put the data into the table before that data can be queried as an "employee".
 And if the schema or type name for "employee" changes, queries still continue
 to work.
@@ -636,43 +746,55 @@ As with types, errors in Zed are first-class: any value can be transformed
 into an error by wrapping it in the Zed [error type](../formats/zed.md#27-error).
 
 In general, expressions and functions that result in errors simply return
-a value of type error as a result.  This encourages a powerful flow-style
+a value of type error as a result. This encourages a powerful flow-style
 of error handling where errors simply propagate from one operation to the
 next and land in the output alongside non-error values to provide a very helpful
-context and rich information for tracking down the source of errors.  There is
+context and rich information for tracking down the source of errors. There is
 no need to check for error conditions everywhere or look through auxiliary
 logs to find out what happened.
 
 For example,
 input values can be transformed to errors as follows:
+
 ```mdtest-command
 echo '0 "foo" 10.0.0.1' | zq -z 'error(this)' -
 ```
+
 produces
+
 ```mdtest-output
 error(0)
 error("foo")
 error(10.0.0.1)
 ```
+
 More practically, errors from the runtime show up as error values.
 For example,
+
 ```mdtest-command
 echo 0 | zq -z '1/this' -
 ```
+
 produces
+
 ```mdtest-output
 error("divide by zero")
 ```
+
 And since errors are first-class and just values, they have a type.
 In particular, they are a complex type where the error value's type is the
-complex type error containing the type of the value.  For example,
+complex type error containing the type of the value. For example,
+
 ```mdtest-command
 echo 0 | zq -z 'typeof(1/this)' -
 ```
+
 produces
+
 ```mdtest-output
 <error(string)>
 ```
+
 First-class errors are particularly useful for creating structured errors.
 When a Zed query encounters a problematic condition,
 instead of silently dropping the problematic error
@@ -681,24 +803,32 @@ ETL pipelines do, the Zed logic can
 preferably wrap the offending value as an error and propagate it to its output.
 
 For example, suppose a bad value shows up:
+
 ```
 {kind:"bad", stuff:{foo:1,bar:2}}
 ```
+
 A Zed shaper could catch the bad value (e.g., as a default case in a
 switch topology) and propagate it as an error using the Zed expression:
+
 ```
 yield error({message:"unrecognized input",input:this})
 ```
+
 then such errors could be detected and searched for downstream with the
 [is_error function](functions/is_error.md).
 For example,
+
 ```
 is_error(this)
 ```
+
 on the wrapped error from above produces
+
 ```
 error({message:"unrecognized input",input:{kind:"bad", stuff:{foo:1,bar:2}}})
 ```
+
 There is no need to create special tables in a complex warehouse-style ETL
 to land such errors as they can simply land next to the output values themselves.
 
@@ -724,52 +854,63 @@ that include a field called `x` but not valid for those that do not.
 What is the value of `x` when the field `x` does not exist?
 
 A similar question faced SQL when it was adapted in various different forms
-to operate on semi-structured data like JSON or XML.  SQL already had the `NULL` value
+to operate on semi-structured data like JSON or XML. SQL already had the `NULL` value
 so perhaps a reference to a missing value could simply be `NULL`.
 
 But JSON also has `null`, so a reference to `x` in the JSON value
+
 ```
 {"x":null}
 ```
+
 and a reference to `x` in the JSON value
+
 ```
 {}
 ```
-would have the same value of `NULL`.  Furthermore, an expression like `x==NULL`
+
+would have the same value of `NULL`. Furthermore, an expression like `x==NULL`
 could not differentiate between these two cases.
 
 To solve this problem, the `MISSING` value was proposed to represent the value that
-results from accessing a field that is not present.  Thus, `x==NULL` and
+results from accessing a field that is not present. Thus, `x==NULL` and
 `x==MISSING` could disambiguate the two cases above.
 
 Zed, instead, recognizes that the SQL value is `MISSING` is a paradox:
-I'm here but I'm not.  
+I'm here but I'm not.
 
-In reality, a MISSING value is not a value.  It's an error condition
+In reality, a MISSING value is not a value. It's an error condition
 that resulted from trying to reference something that didn't exist.
 
-So why should we pretend that this is a bona fide value?  SQL adopted this
+So why should we pretend that this is a bona fide value? SQL adopted this
 approach because it lacks first-class errors.
 
 But Zed has first-class errors so
 a reference to something that does not exist is an error of type
-`error<string>` whose value is `error("missing")`.  For example,
+`error<string>` whose value is `error("missing")`. For example,
+
 ```mdtest-command
 echo "{x:1} {y:2}" | zq -z 'yield x' -
 ```
+
 produces
+
 ```mdtest-output
 1
 error("missing")
 ```
+
 Sometimes you want missing errors to show up and sometimes you don't.
 The [quiet function](functions/quiet.md) transforms missing errors into
-"quiet errors".  A quiet error is the value `error("quiet")` and is ignored
-by most operators, in particular yield.  For example,
+"quiet errors". A quiet error is the value `error("quiet")` and is ignored
+by most operators, in particular yield. For example,
+
 ```mdtest-command
 echo "{x:1} {y:2}" | zq -z "yield quiet(x)" -
 ```
+
 produces
+
 ```mdtest-output
 1
 ```
@@ -788,13 +929,16 @@ various expressions as part of their operation.
 
 Arithmetic operations (`*`, `/`, `%`, `+`, `-`) follow customary syntax
 and semantics and are left-associative with multiplication and division having
-precedence over addition and subtraction.  `%` is the modulo operator.
+precedence over addition and subtraction. `%` is the modulo operator.
 
 For example,
+
 ```mdtest-command
 zq -z 'yield 2*3+1, 11%5, 1/0, "foo"+"bar"'
 ```
+
 produces
+
 ```mdtest-output
 7
 1
@@ -810,17 +954,20 @@ A comparison expression is any valid Zed expression compared to any other
 valid Zed expression using a comparison operator.
 
 When the operands are coercible to like types, the result is the truth value
-of the comparison.  Otherwise, the result is `false`.
+of the comparison. Otherwise, the result is `false`.
 
 If either operand to a comparison
 is `error("missing")`, then the result is `error("missing")`.
 
 For example,
+
 ```mdtest-command
 zq -z 'yield 1 > 2, 1 < 2, "b" > "a", 1 > "a", 1 > x'
 
 ```
+
 produces
+
 ```mdtest-output
 false
 true
@@ -832,19 +979,24 @@ error("missing")
 ### 6.3 Containment
 
 The `in` operator has the form
+
 ```
 <item-expr> in <container-expr>
 ```
+
 and is true if the `<item-expr>` expression results in a value that
 appears somewhere in the `<container-expr>` as an exact match of the item.
 The right-hand side value can be any Zed value and complex values are
 recursively traversed to determine if the item is present anywhere within them.
 
 For example,
+
 ```mdtest-command
 echo '{a:[1,2]}{b:{c:3}}{d:{e:1}}' | zq -z '1 in this' -
 ```
+
 produces
+
 ```mdtest-output
 {a:[1,2]}
 {d:{e:1}}
@@ -854,7 +1006,7 @@ produces
 
 The keywords `and`, `or`, and `not` perform logic on operands of type `bool`.
 The binary operators `and` and `or` operate on Boolean values and result in
-an error value if either operand is not a Boolean.  Likewise, `not` operates
+an error value if either operand is not a Boolean. Likewise, `not` operates
 on its unary operand and results in an error if its operand is not type `bool`.
 Unlike many other languages, non-Boolean values are not automatically converted to
 Boolean type using "truthiness" heuristics.
@@ -863,9 +1015,11 @@ Boolean type using "truthiness" heuristics.
 
 Records fields are dereferenced with the dot operator `.` as is customary
 in other languages and have the form
+
 ```
 <value> . <id>
 ```
+
 where `<id>` is an identifier representing the field name referenced.
 If a field name is not representable as an identifier, then [indexing](#indexing)
 may be used with a quoted string to represent any valid field name.
@@ -879,9 +1033,11 @@ or if the record does not have the given field, then the result is
 ### 6.6 Indexing
 
 The index operation can be applied to various data types and has the form:
+
 ```
 <value> [ <index> ]
 ```
+
 If the `<value>` expression is a record, then the `<index>` operand
 must be coercible to a string and the result of the record's field
 of that name.
@@ -896,7 +1052,7 @@ value in the set of that index ordered by total order of Zed values.
 
 If the `<value>` expression is a map, then the `<index>` operand
 is presumed to be a key and the corresponding value for that key is
-the result of the operation.  If no such key exists in the map, then
+the result of the operation. If no such key exists in the map, then
 `error("missing")` results.
 
 If the `<value>` expression is a string, then the `<index>` operand
@@ -910,13 +1066,15 @@ representing the byte value at that offset in the bytes sequence.
 ### 6.7 Slices
 
 The slice operation can be applied to various data types and has the form:
+
 ```
 <value> [ <from> : <to> ]
 ```
+
 The `<from>` and `<to>` terms must be expressions that are coercible
 to integer and represent a range of index values to form a subset of elements
-from the `<value>` term provided.  The range begins at the `<from>` position
-and ends one before the `<to>` position.  A negative
+from the `<value>` term provided. The range begins at the `<from>` position
+and ends one before the `<to>` position. A negative
 value of `<from>` or `<to>` represents a position relative to the
 end of the value being sliced.
 
@@ -935,24 +1093,29 @@ consisting of bytes comprising the given range.
 ### 6.8 Conditional
 
 A conditional expression has the form
+
 ```
 <boolean> ? <expr> : <expr>`
 ```
+
 The `<boolean>` expression is evaluated and must have a result of type `bool`.
 If not, an error results.
 
 If the result is true, then the first `<expr>` expression is evaluated and becomes
-the result.  Otherwise, the second `<expr>` expression is evaluated.
+the result. Otherwise, the second `<expr>` expression is evaluated.
 
 Note that if the expression has side effects,
 as with [aggregation calls](#aggregation-calls), only the selected expression
 will be evaluated.
 
 For example,
+
 ```mdtest-command
 echo '{s:"foo",v:1}{s:"bar",v:2}' | zq -z 'yield (s=="foo") ? v : -v' -
 ```
+
 produces
+
 ```mdtest-output
 1
 -2
@@ -962,16 +1125,19 @@ produces
 
 Functions perform stateless transformations of their input value to their
 return value and utilize call-by value semantics with positional and unnamed
-arguments.  Some functions take a variable number of arguments.
+arguments. Some functions take a variable number of arguments.
 
 > The only available functions are built-in but user-defined functions and
 > library package management will be added to the Zed language soon.
 
 For example,
+
 ```mdtest-command
 zq -z 'yield pow(2,3), lower("ABC")+upper("def"), typeof(1)'
 ```
+
 produces
+
 ```mdtest-output
 8.
 "abcDEF"
@@ -990,20 +1156,27 @@ optimizer from parallelizing a query.
 
 That said, aggregate function calls can be quite useful in a number of contexts.
 For example, a unique ID can be assigned to the input quite easily:
+
 ```mdtest-command
 echo '"foo" "bar" "baz"' | zq -z 'yield {id:count(),value:this}' -
 ```
+
 produces
+
 ```mdtest-output
 {id:1(uint64),value:"foo"}
 {id:2(uint64),value:"bar"}
 {id:3(uint64),value:"baz"}
 ```
+
 In contrast, calling aggregate functions within `summarize`
+
 ```mdtest-command
 echo '"foo" "bar" "baz"' | zq -z 'summarize count(),union(this)' -
 ```
+
 produces just one output value
+
 ```mdtest-output
 {count:3(uint64),union:|["bar","baz","foo"]|}
 ```
@@ -1015,17 +1188,19 @@ as long as it is compatible with the semantics of the expression.
 
 String literals are enclosed in either single quotes or double quotes and
 must conform to UTF-8 encoding and follow the JavaScript escaping
-conventions and unicode escape syntax.  Also, if the sequence `${` appears
+conventions and unicode escape syntax. Also, if the sequence `${` appears
 in a string the `$` character must be escaped, i.e., `\$`.
 
 #### 6.11.1 String Interpolation
 
 Strings may include interpolation expressions, which has the form
+
 ```
 ${ <expr> }
 ```
+
 In this case, the characters starting with `$` and ending at `}` are substituted
-with the result of evaluating the expression `<expr>`.  If this result is not
+with the result of evaluating the expression `<expr>`. If this result is not
 a string, it is implicitly cast to a string.
 
 If any template expression results in an error, then the value of the template
@@ -1041,19 +1216,23 @@ with interpolated expressions.
 #### 6.11.2 Record Expressions
 
 Record literals have the form
+
 ```
 { <spec>, <spec>, ... }
 ```
+
 where a `<spec>` has one of three forms:
+
 ```
 <field> : <expr>
 <ref>
 ...<expr>
 ```
+
 The first form is a customary colon-separated field and value similar to JavaScript,
 where `<field>` may be an identifier or quoted string.
 The second form is an implied field reference `<ref>`, which is shorthand
-for `<ref>:<ref>`.  The third form is the `...` spread operator which expects
+for `<ref>:<ref>`. The third form is the `...` spread operator which expects
 a record value as the result of `<expr>` and inserts all of the fields from
 the resulting record.
 If a spread expression results in a non-record type (e.g., errors), then that
@@ -1064,10 +1243,13 @@ field names collide the rightmost instance of the name determines that
 field's value.
 
 For example,
+
 ```mdtest-command
 echo '{x:1,y:2,r:{a:1,b:2}}' | zq -z 'yield {a:0},{x}, {...r}, {a:0,...r,b:3}' -
 ```
+
 produces
+
 ```mdtest-output
 {a:0}
 {x:1}
@@ -1078,17 +1260,22 @@ produces
 #### 6.11.3 Array Expressions
 
 Array literals have the form
+
 ```
 [ <expr>, <expr>, ... ]
 ```
+
 When the expressions result in values of non-uniform type, then the implied
 type of the array is an array of type union of the types that appear.
 
 For example,
+
 ```mdtest-command
 zq -z 'yield [1,2,3],["hello","world"]'
 ```
+
 produces
+
 ```mdtest-output
 [1,2,3]
 ["hello","world"]
@@ -1097,9 +1284,11 @@ produces
 #### 6.11.4 Set Expressions
 
 Set literals have the form
+
 ```
 |[ <expr>, <expr>, ... ]|
 ```
+
 When the expressions result in values of non-uniform type, then the implied
 type of the set is a set of type union of the types that appear.
 
@@ -1107,10 +1296,13 @@ Set values are always organized in their "natural order" independent of the orde
 they appear in the set literal.
 
 For example,
+
 ```mdtest-command
 zq -z 'yield |[3,1,2]|,|["hello","world","hello"]|'
 ```
+
 produces
+
 ```mdtest-output
 |[1,2,3]|
 |["hello","world"]|
@@ -1119,9 +1311,11 @@ produces
 #### 6.11.5 Map Expressions
 
 Map literals have the form
+
 ```
 |{ <expr>:<expr>, <expr>:<expr>, ... }|
 ```
+
 where the first expression of each colon-separated entry is the key value
 and the second expression is the value.
 When the key and/or value expressions results in values of non-uniform type,
@@ -1129,47 +1323,61 @@ then the implied type of the map has a key type and/or value type that is
 a union of the types that appear in each respective category.
 
 For example,
+
 ```mdtest-command
 zq -z 'yield |{"foo":1,"bar"+"baz":2+3}|'
 ```
+
 produces
+
 ```mdtest-output
 |{"foo":1,"barbaz":5}|
 ```
 
 #### 6.11.6 Union Values
 
-A union value can be created with a cast.  For example, a union of types `int64`
+A union value can be created with a cast. For example, a union of types `int64`
 and `string` is expressed as `(int64,string)` and any value that has a type
 that appears in the union type may be cast to that union type.
 Since 1 is an `int64` and "foo" is a `string`, they both can be
 values of type `(int64,string)`, e.g.,
+
 ```mdtest-command
 echo '1 "foo"' | zq -z 'yield cast(this,<(int64,string)>)' -
 ```
+
 produces
+
 ```mdtest-output
 1((int64,string))
 "foo"((int64,string))
 ```
+
 The value underlying a union-tagged value is accessed with the
 [under function](functions/under.md):
+
 ```mdtest-command
 echo '1((int64,string))' | zq -z 'yield under(this)' -
 ```
+
 produces
+
 ```mdtest-output
 1
 ```
+
 Union values are powerful because they provide a mechanism to precisely
 describe the type of any nested, semi-structured value composed of elements
-of different types.  For example, the type of the value `[1,"foo"]` in Javascript
-is simply a generic Javascript "object".  But in Zed, the type of this
+of different types. For example, the type of the value `[1,"foo"]` in Javascript
+is simply a generic Javascript "object". But in Zed, the type of this
 value is an array of union of string and integer, e.g.,
+
 ```mdtest-command
 echo '[1,"foo"]' | zq -z 'typeof(this)' -
 ```
+
 produces
+
 ```mdtest-output
 <[(int64,string)]>
 ```
@@ -1178,9 +1386,11 @@ produces
 
 Constants may be declared and bound to an identifier with a `const` statement,
 which has the form
+
 ```
 const <id> = <expr>
 ```
+
 This statement evaluates the expressions `<expr>` before any input is processed
 to determine the constant value assigned to the identifier `<id>`.
 This expression may not refer to `this` or any implied fields of `this`.
@@ -1191,7 +1401,9 @@ of a query or the beginning of a [parenthesized scope](#scopes).
 ```mdtest-command
 echo '{diameter:1}{diameter:5}' | zq -z 'const PI = 3.14159 circumference:=2*PI*diameter' -
 ```
+
 produces
+
 ```mdtest-output
 {diameter:1,circumference:6.28318}
 {diameter:5,circumference:31.4159}
@@ -1201,9 +1413,11 @@ produces
 
 Named types may be declared and bound to an identifier with a `type` statement,
 which has the form
+
 ```
 type <name> = <type>
 ```
+
 This statement evaluates the type `<type>` before any input is processed
 to compute a type value assigned to the identifier `<id>`.
 
@@ -1221,7 +1435,9 @@ of a query or the beginning of a [parenthesized scope](#scopes).
 ```mdtest-command
 echo '{s:1}{s:10.0.0.1}' | zq -z 'type foo = {s:string} cast(this, foo)' -
 ```
+
 produces
+
 ```mdtest-output
 {s:"1"}(=foo)
 {s:"10.0.0.1"}(=foo)
@@ -1232,9 +1448,11 @@ produces
 Type conversion is performed with casts and the built-in function `cast()`.
 
 Casts for primitive types have a function-style syntax of the form
+
 ```
 <type> ( <expr> )
 ```
+
 where `<type>` is a Zed type and `<expr>` is any Zed expression.
 In the case of primitive types, the type-value angle brackets
 may be omitted, e.g., `<string>(1)` is equivalent to `string(1)`.
@@ -1242,10 +1460,13 @@ If the result of `<expr>` cannot be converted
 to the indicated type, then the cast's result is an error value.
 
 For example,
+
 ```mdtest-command
 echo '1 200 "123" "200"' | zq -z 'yield int8(this)' -
 ```
+
 produces
+
 ```mdtest-output
 1(int8)
 error("cannot cast 200 to type int8")
@@ -1253,14 +1474,16 @@ error("cannot cast 200 to type int8")
 error("cannot cast \"200\" to type int8")
 ```
 
-Casting attempts to be fairly liberal in conversions.  For example, values
+Casting attempts to be fairly liberal in conversions. For example, values
 of type `time` can be created from a diverse set of data/time input strings
 based on the [Go Date Parser library](https://github.com/araddon/dateparse).
 
 ```mdtest-command
 echo '"May 8, 2009 5:57:51 PM" "oct 7, 1970"' | zq -z 'yield time(this)' -
 ```
+
 produces
+
 ```mdtest-output
 2009-05-08T17:57:51Z
 1970-10-07T00:00:00Z
@@ -1268,36 +1491,48 @@ produces
 
 Casts of complex or named types may be performed using type values
 either in functional form or with `cast`:
+
 ```
 <type-value> ( <expr> )
 cast(<expr>, <type-value>)
 ```
+
 For example
+
 ```mdtest-command
 echo '80 8080' | zq -z 'type port = uint16 yield <port>(this)' -
 ```
+
 produces
+
 ```mdtest-output
 80(port=uint16)
 8080(port=uint16)
 ```
 
-Casts may be used with complex types as well.  As long as the target type can
+Casts may be used with complex types as well. As long as the target type can
 accommodate the value, the case will be recursively applied to the components
-of a nested value.  For example,
+of a nested value. For example,
 For example
+
 ```mdtest-command
 echo '["10.0.0.1","10.0.0.2"]' | zq -z 'cast(this,<[ip]>)' -
 ```
+
 produces
+
 ```mdtest-output
 [10.0.0.1,10.0.0.2]
 ```
+
 and
+
 ```mdtest-command
 echo '{ts:"1/1/2022",r:{x:"1",y:"2"}} {ts:"1/2/2022",r:{x:3,y:4}}' | zq -z 'cast(this,<{ts:time,r:{x:float64,y:float64}}>)' -
 ```
+
 produces
+
 ```mdtest-output
 {ts:2022-01-01T00:00:00Z,r:{x:1.,y:2.}}
 {ts:2022-01-02T00:00:00Z,r:{x:3.,y:4.}}
@@ -1306,9 +1541,9 @@ produces
 ## 7. Search Expressions
 
 Search expressions provide a hybrid syntax between keyword search
-and boolean expressions.  In this way, a search is a shorthand for
+and boolean expressions. In this way, a search is a shorthand for
 a "lean forward" style activity where one is interactively exploring
-data with ad hoc searches.  All shorthand searches have a corresponding
+data with ad hoc searches. All shorthand searches have a corresponding
 long form built from the expression syntax above in combination with the
 [search term syntax](#721-search-terms) described below.
 
@@ -1331,20 +1566,27 @@ and is documented in the
 [RE2 Wiki](https://github.com/google/re2/wiki/Syntax).
 
 Regular expressions may be used freely in search expressions, e.g.,
+
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z '/(foo|bar)/' -
 ```
+
 produces
+
 ```mdtest-output
 "foo"
 {s:"bar"}
 {foo:1}
 ```
+
 Regular expressions may also appear in the `grep` function:
+
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z 'yield grep(/ba.*/, s)' -
 ```
+
 produces
+
 ```mdtest-output
 false
 true
@@ -1361,36 +1603,49 @@ Zed globs are a simple, special case utilize only the `*` wildcard.
 Valid glob characters include `a` through `z`, `A` through `Z`,
 any valid string escape sequence
 (along with escapes for `*`, `=`, `+`, `-`), and the unescaped characters:
+
 ```
 _ . : / % # @ ~
 ```
+
 A glob must begin with one of these characters or `*` then may be
 followed by any of these characters, `*`, or digits `0` through `9`.
 
 > Note that these rules do not allow for a leading digit.
 
 For example, a prefix match is easily accomplished via `prefix*`, e.g.,
+
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z 'b*' -
 ```
+
 produces
+
 ```mdtest-output
 {s:"bar"}
 {s:"baz"}
 ```
+
 Likewise, a suffix match may be performed as follows:
+
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z '*z' -
 ```
+
 produces
+
 ```mdtest-output
 {s:"baz"}
 ```
+
 and
+
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {a:1}' | zq -z '*a*' -
 ```
+
 produces
+
 ```mdtest-output
 {s:"bar"}
 {s:"baz"}
@@ -1399,13 +1654,17 @@ produces
 
 Note that a glob may look like multiplication but context disambiguates
 these condition, e.g.,
+
 ```
 a*b
 ```
+
 is a glob match for any matching string value in the input, but
+
 ```
 a*b==c
 ```
+
 is a Boolean comparison between the product `a*b` and `c`.
 
 ### 7.2 Search Logic
@@ -1417,49 +1676,58 @@ using Boolean logic.
 > Note that when processing ZNG data, the Zed runtime performs a multi-threaded
 > Boyer-Moore scan over decompressed data buffers before parsing any data.
 > This allows large buffers of data to be efficiently discarded and skipped when
-> searching for rarely occurring values.  For a [Zed lake](../lake/format.md), search indexes
+> searching for rarely occurring values. For a [Zed lake](../lake/format.md), search indexes
 > may also be configured to further accelerate searches.
 > In a forthcoming release, Zed will also offer an approach for locating
 > delimited words within string fields, which will allow accelerated
-> search using a full-text search index.  Currently, search indexes may be built
+> search using a full-text search index. Currently, search indexes may be built
 > for exact value match as text segmentation is in the works.a
 
 #### 7.2.1 Search Terms
 
 A "search term" is one of the following;
-* a regular expression as described above,
-* a glob as described above,
-* a keyword,
-* any literal of a primitive type, or
-* expression predicates.
+
+- a regular expression as described above,
+- a glob as described above,
+- a keyword,
+- any literal of a primitive type, or
+- expression predicates.
 
 ##### 7.2.1.1 Regular Expression Search Term
 
 A regular expression `/re/` is equivalent to
+
 ```
 grep(/reg/, this)
 ```
+
 but shorter and easier to type in a search expression.
 
 For example,
+
 ```
 /(foo|bar.*baz.*\.com)/
 ```
+
 Searches for any string that begins with `foo` or `bar` has the string
 `baz` in it and ends with `.com`.
 
 ##### 7.2.1.2 Glob Search Term
 
 A glob search term `<glob>` is equivalent to
+
 ```
 grep(/reg/, this)
 ```
+
 but shorter and easier to type in a search expression.
 
 For example,
+
 ```
 foo*baz*.com
 ```
+
 Searches for any string that begins with `foo` has the string
 `baz` in it and ends with `.com`.
 
@@ -1475,31 +1743,40 @@ Keyword search has the look and feel of Web search or email search.
 Valid keyword characters include `a` through `z`, `A` through `Z`,
 any valid string escape sequence
 (along with escapes for `*`, `=`, `+`, `-`), and the unescaped characters:
+
 ```
 _ . : / % # @ ~
 ```
+
 A keyword must begin with one of these characters then may be
 followed by any of these characters or digits `0` through `9`.
 
 A keyword search is equivalent to
+
 ```
 grep(<keyword>, this)
 ```
+
 where `<keyword>` is the quoted string-literal of the unquoted string.
 For example,
+
 ```
 search foo
 ```
+
 is equivalent to
+
 ```
 where grep("foo", this)
 ```
 
 Note that the "search" keyword may be omitted.
 For example, the simplest Zed program is perhaps a single keyword search, e.g.,
+
 ```
 foo
 ```
+
 As above, this program searches the implied input for input values that
 contain the string "foo".
 
@@ -1507,14 +1784,19 @@ contain the string "foo".
 
 A string literal as a search term is simply a search for that string and is
 equivalent to
+
 ```
 grep(<string>, this)
 ```
+
 For example,
+
 ```
 search "foo"
 ```
+
 is equivalent to
+
 ```
 where grep("foo", this)
 ```
@@ -1529,36 +1811,45 @@ where grep("foo", this)
 
 Search terms representing non-string Zed values search for both an exact
 match for the given value as well as a string search for the term exactly
-as it appears as typed.  Such values include:
-* integers,
-* floating point numbers,
-* time values,
-* durations,
-* IPs,
-* networks,
-* bytes values, and
-* type values.
+as it appears as typed. Such values include:
+
+- integers,
+- floating point numbers,
+- time values,
+- durations,
+- IPs,
+- networks,
+- bytes values, and
+- type values.
 
 A search for a Zed value `<value>` represented as the string `<string>` is
 equivalent to
+
 ```
 <value> in this or grep(<string>, this)
 ```
+
 For example,
+
 ```
 search 123 and 10.0.0.1
 ```
+
 which can be abbreviated
+
 ```
 123 10.0.0.1
 ```
+
 is equivalent to
+
 ```
 where (123 in this or grep("123", this)) and (10.0.0.1 in this or grep("10.0.0.1", this))
 ```
 
 Complex values are not supported as search terms but may be queried with
 the "in" operator, e.g.,
+
 ```
 {s:"foo"} in this
 ```
@@ -1570,21 +1861,25 @@ Any Boolean-valued [function](functions/README.md) like `is()`, `has()`,
 may be used as a search term and mixed into a search expression.
 
 For example,
+
 ```
 is(<foo>) has(bar) baz x==y+z
 ```
+
 is a valid search expression but
+
 ```
 /foo.*/ x+1
 ```
+
 is not.
 
 #### 7.3 Boolean Logic
 
 Search terms may be combined into boolean expressions using logical operators
-`and`, `or` and `not`.  `and` may be elided; i.e., concatenation of search terms
-is a logical `and`.  `not` has highest precedence and `and` has precedence over
-`or`.  Parentheses may be used to override natural precedence.
+`and`, `or` and `not`. `and` may be elided; i.e., concatenation of search terms
+is a logical `and`. `not` has highest precedence and `and` has precedence over
+`or`. Parentheses may be used to override natural precedence.
 
 Note that the concatenation form of `and` is not valid in standard expressions and
 is available only in search expressions.
@@ -1592,18 +1887,25 @@ Concatenation is convenient in interactive sessions but it is best practice to
 explicitly include the `and` operator when editing Zed source files.
 
 For example,
+
 ```
 not foo bar or baz
 ```
+
 means
+
 ```
 ((not grep("foo")) and grep("bar)) or grep("baz")
 ```
+
 while
+
 ```
 foo (bar or baz)
 ```
+
 means
+
 ```
 grep("foo") and (grep("bar)) or grep("baz"))
 ```
@@ -1619,44 +1921,58 @@ Lateral subqueries are created using the scoped form of the
 [over operator](operators/over.md#operator) and may be nested to arbitrary depth.
 
 For example,
+
 ```mdtest-command
 echo '{s:"foo",a:[1,2]} {s:"bar",a:[3]}' | zq -z 'over a with name=s => (yield {name,elem:this})' -
 ```
+
 produces
+
 ```mdtest-output
 {name:"foo",elem:1}
 {name:"foo",elem:2}
 {name:"bar",elem:3}
 ```
+
 Here the lateral scope, described below, creates a subquery
+
 ```
 yield {name,elem:this}
 ```
+
 for each sub-sequence of values derived from each outer input value.
 In the example above, there are two input values:
+
 ```
 {s:"foo",a:[1,2]}
 {s:"bar",a:[3]}
 ```
+
 which imply two subqueries derived from the `over` operator traversing `a`.
 The first subquery thus operates on the input values `1, 2` with the variable
 `name` set to "foo" assigning `1` and then `2` to `this`, thereby emitting
+
 ```
 {name:"foo",elem:1}
 {name:"foo",elem:2}
 ```
+
 and the second subquery operators on the input value `3` with the variable
 `name` set to "bar", emitting
+
 ```
 {name:"bar",elem:3}
 ```
 
 You can also import a parent-scope field reference into the inner scope by
 simply referring to its name without assignment, e.g.,
+
 ```mdtest-command
 echo '{s:"foo",a:[1,2]} {s:"bar",a:[3]}' | zq -z 'over a with s => (yield {s,elem:this})' -
 ```
+
 produces
+
 ```mdtest-output
 {s:"foo",elem:1}
 {s:"foo",elem:2}
@@ -1668,17 +1984,23 @@ produces
 A lateral scope has the form `=> ( <query> )` and currently appears
 only the context of an [over operator](operators/over.md#operator),
 as illustrated above, and has the form:
+
 ```
 over ... with <elem> [, <elem> ...] => ( <query> )
 ```
+
 where `<elem>` has either an assignment form
+
 ```
 <var>=<expr>
 ```
+
 or a field reference form
+
 ```
 <field>
 ```
+
 For each input value to the outer scope, the assignment form creates a binding
 between each `<expr>` evaluated in the outer scope and each `<var>`, which
 represents a new symbol in the inner scope of the `<query>`.
@@ -1687,20 +2009,23 @@ in the parent scope and makes that field's value available in the lateral scope
 with the same name.
 
 The `<query>`, which may be any Zed query, is evaluated once per outer value
-on the sequence generated by the `over` expression.  In the lateral scope,
+on the sequence generated by the `over` expression. In the lateral scope,
 the value `this` refers to the inner sequence generated from the `over` expressions.
 This query runs to completion for each inner sequence and emits
 each subquery result as each inner sequence traversal completes.
 
 This structure is powerful because _any_ Zed query can be appear in the body of
-the lateral scope.  In contrast to the `yield` example, a sort could be
+the lateral scope. In contrast to the `yield` example, a sort could be
 applied to each sub-sequence in the subquery, where sort
 reads all of values of the subsequence, sorts them, emits them, then
-repeats the process for the next subsequence.  For example,
+repeats the process for the next subsequence. For example,
+
 ```mdtest-command
 echo '[3,2,1] [4,1,7] [1,2,3]' | zq -z 'over this => (sort this | collect(this))' -
 ```
+
 produces
+
 ```mdtest-output
 {collect:[1,2,3]}
 {collect:[1,4,7]}
@@ -1711,9 +2036,11 @@ produces
 
 Lateral subqueries can also appear in expression context using the
 parenthesized form:
+
 ```
 ( over <expr> [, <expr>...] [with <var>=<expr> [, ... <var>[=<expr>]] | <lateral> )
 ```
+
 > Note that the parentheses disambiguate a lateral expression from a lateral
 > dataflow operator.
 
@@ -1723,25 +2050,32 @@ As with the `over` operator, values from the outer scope can be brought into
 the lateral scope using the `with` clause.
 
 The lateral expression is evaluated by evalating each `<expr>` and feeding
-the results as inputs to the `<lateral>` dataflow operators.  Each time the
+the results as inputs to the `<lateral>` dataflow operators. Each time the
 lateral expression is evaluated, the lateral operators are run to completion,
 e.g.,
+
 ```mdtest-command
 echo '[3,2,1] [4,1,7] [1,2,3]' | zq -z 'yield (over this | sum(this))' -
 ```
+
 produces
+
 ```mdtest-output
 {sum:6}
 {sum:12}
 {sum:6}
 ```
+
 This structure generalizes to any more complicated expression context,
 e.g., we can embed multiple lateral expressions inside of a record literal
 and use the spread operator to tighten up the output:
+
 ```mdtest-command
 echo '[3,2,1] [4,1,7] [1,2,3]' | zq -z '{...(over this | sort this | sorted:=collect(this)),...(over this | sum(this))}' -
 ```
+
 produces
+
 ```mdtest-output
 {sorted:[1,2,3],sum:6}
 {sorted:[1,4,7],sum:12}
@@ -1766,11 +2100,11 @@ to "fit" a given shape, and reordering fields.
 While shaping remains an active area of development, the core functions in Zed
 that currently perform shaping are:
 
-* [cast](functions/cast.md) - coerce a value to a different type
-* [crop](functions/crop.md) - remove fields from a value that are missing in a specified type
-* [fill](functions/fill.md) - add null values for missing fields
-* [order](functions/order.md) - reorder record fields
-* [shape](functions/shape.md) - apply cast, fill, and order
+- [cast](functions/cast.md) - coerce a value to a different type
+- [crop](functions/crop.md) - remove fields from a value that are missing in a specified type
+- [fill](functions/fill.md) - add null values for missing fields
+- [order](functions/order.md) - reorder record fields
+- [shape](functions/shape.md) - apply cast, fill, and order
 
 They all have the same signature, taking two parameters: the value to be
 transformed and a type value for the target type.
@@ -1787,6 +2121,7 @@ transformed and a type value for the target type.
 In the examples below, we will use the following named type `connection`
 that is stored in a file `connection.zed`
 and is included in the example Zed queries with `-I` option of `zq`:
+
 ```mdtest-input connection.zed
 type socket = { addr:ip, port:port=uint16 }
 type connection = {
@@ -1796,7 +2131,9 @@ type connection = {
     vlan: uint16
 }
 ```
+
 We also use this sample JSON input in a file called `sample.json`:
+
 ```mdtest-input sample.json
 {
   "kind": "dns",
@@ -1816,13 +2153,16 @@ We also use this sample JSON input in a file called `sample.json`:
 
 The cast function applies a cast operation to each leaf value that matches the
 field path in the specified type, e.g.,
+
 ```mdtest-command
 zq -Z -I connection.zed "cast(this, <connection>)" sample.json
 ```
+
 casts the address fields to type `ip`, the port fields to type `port`
 (which is a typedef for `uint16`) and the address port pairs to
 type `socket` without modifying the `uid` field or changing the
 order of the `server` and `client` fields:
+
 ```mdtest-output
 {
     kind: "dns",
@@ -1841,10 +2181,13 @@ order of the `server` and `client` fields:
 ### 9.2 Crop
 
 Cropping is a useful when you want records to "fit" a schema tightly, e.g.,
+
 ```mdtest-command
 zq -Z -I connection.zed "crop(this, <connection>)" sample.json
 ```
+
 removes the `uid` field since it is not in the _connection_ type:
+
 ```mdtest-output
 {
     kind: "dns",
@@ -1862,11 +2205,14 @@ removes the `uid` field since it is not in the _connection_ type:
 ### 9.3 Fill
 
 Use fill when you want to fill out missing fields with nulls, e.g.,
+
 ```mdtest-command
 zq -Z -I connection.zed "fill(this, <connection>)" sample.json
 ```
+
 adds a null-valued `vlan` field since the input value is missing it and
 the _connection_ type has it:
+
 ```mdtest-output
 {
     kind: "dns",
@@ -1887,11 +2233,14 @@ the _connection_ type has it:
 
 The order function changes the order of fields in its input to match the
 specified order, as field order is significant in Zed records, e.g.,
+
 ```mdtest-command
 zq -Z -I connection.zed "order(this, <connection>)" sample.json
 ```
+
 reorders the `client` and `server` fields to match the input but does nothing
 about the `uid` field as it is not in the _connection_ type:
+
 ```mdtest-output
 {
     kind: "dns",
@@ -1911,11 +2260,14 @@ about the `uid` field as it is not in the _connection_ type:
 
 The shape function brings everything together by applying `cast`,
 `fill`, and `order` all in one step, e.g.,
+
 ```mdtest-command
 zq -Z -I connection.zed "shape(this, <connection>)" sample.json
 ```
+
 reorders the `client` and `server` fields to match the input but does nothing
 about the `uid` field as it is not in the _connection_ type:
+
 ```mdtest-output
 {
     kind: "dns",
@@ -1931,12 +2283,16 @@ about the `uid` field as it is not in the _connection_ type:
     uid: "C2zK5f13SbCtKcyiW5"
 }
 ```
+
 To get a tight shape of the target type,
 apply `crop` to the output of `shape`, e.g.,
+
 ```mdtest-command
 zq -Z -I connection.zed "shape(this, <connection>) | crop(this, <connection>)" sample.json
 ```
+
 drops the `uid` field after shaping:
+
 ```mdtest-output
 {
     kind: "dns",
@@ -1951,6 +2307,7 @@ drops the `uid` field after shaping:
     vlan: null (uint16)
 }
 ```
+
 ## 10. Type Fusion
 
 Type fusion is another important building block of data shaping.
@@ -1958,7 +2315,7 @@ Here, types are operated upon by fusing them together, where the
 result is single fused type.
 Some systems call a related process "schema inference" where a set
 of values, typically JSON, is analyzed to determine a relational schema
-that all the data will fit into.  However, this is just a special case of
+that all the data will fit into. However, this is just a special case of
 type fusion as fusion is fine-grained and based on Zed's type system rather
 than having the narrower goal of computing a schema for representations
 like relational tables, Parquet, Avro, etc.
@@ -1969,13 +2326,16 @@ The first technique is to simply combine types with a type union.
 For example, an `int64` and a `string` can be merged into a common
 type of union `(int64,string)`, e.g., the value sequence `1 "foo"`
 can be fused into the single-type sequence:
+
 ```
 1((int64,string))
 "foo"((int64,string))
 ```
+
 The second technique is to merge fields of records, analogous to a spread
-expression.  Here, the value sequence `{a:1}{b:"foo"}` may be
+expression. Here, the value sequence `{a:1}{b:"foo"}` may be
 fused into the single-type sequence:
+
 ```
 {a:1,b:null(string)}
 {a:null(int64),b:"foo"}
@@ -1984,6 +2344,7 @@ fused into the single-type sequence:
 Of course, these two techniques can be powerfully combined,
 e.g., where the value sequence `{a:1}{a:"foo",b:2}` may be
 fused into the single-type sequence:
+
 ```
 {a:1((int64,string)),b:null(int64)}
 {a:"foo"((int64,string)),b:2}
@@ -1991,27 +2352,35 @@ fused into the single-type sequence:
 
 To perform fusion, Zed currently includes two key mechanisms
 (though this is an active area of development):
-* the [fuse operator](operators/fuse.md#operator), and
-* the [fuse aggregate function](aggregates/fuse.md).
+
+- the [fuse operator](operators/fuse.md#operator), and
+- the [fuse aggregate function](aggregates/fuse.md).
 
 ### 10.1 Fuse Operator
 
 The _fuse operator_ reads all of its input, computes a fused type using
 the techniques above, and outputs the result, e.g.,
+
 ```mdtest-command
 echo '{x:1} {y:"foo"}{x:2,y:"bar"}' | zq -z fuse -
 ```
+
 produces
+
 ```mdtest-output
 {x:1,y:null(string)}
 {x:null(int64),y:"foo"}
 {x:2,y:"bar"}
 ```
+
 whereas
+
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"}{x:2,y:"bar"}' | zq -z fuse -
 ```
+
 requires a type union for field `x` and produces:
+
 ```mdtest-output
 {x:1((int64,string)),y:null(string)}
 {x:"foo"((int64,string)),y:"foo"}
@@ -2026,27 +2395,36 @@ or unknown input data and how those various shapes relate to one another.
 
 For example, in example sequence above, we can use the _fuse function_ to determine
 the fused type rather than transforming the values, e.g.,
+
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"}{x:2,y:"bar"}' | zq -z 'fuse(this)' -
 ```
+
 results in
+
 ```mdtest-output
 {fuse:<{x:(int64,string),y:string}>}
 ```
+
 Since the _fuse_ here is an aggregate function, it can also be used with
-group-by keys.  Supposing we wanted to fuse different type records into
-different types, we can use a group-by.  In this simple example, we will
+group-by keys. Supposing we wanted to fuse different type records into
+different types, we can use a group-by. In this simple example, we will
 fuse records based on their number of fields using the `len()` function:
+
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"}{x:2,y:"bar"}' | zq -z 'fuse(this) by len(this) | sort len' -
 ```
+
 which produces
+
 ```mdtest-output
 {len:1,fuse:<{x:int64}>}
 {len:2,fuse:<{x:(int64,string),y:string}>}
 ```
+
 Now, we can turn around and write a "shaper" for data that has the patterns
 we "discovered" above, e.g., if this Zed source is in `shape.zed`
+
 ```mdtest-input shape.zed
 switch len(this) (
     case 1 => pass
@@ -2054,11 +2432,15 @@ switch len(this) (
     default => yield error({kind:"unrecognized shape",value:this})
 )
 ```
+
 when we run
+
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"}{x:2,y:"bar"}{a:1,b:2,c:3}' | zq -z -I shape.zed '| sort -r this' -
 ```
+
 we get
+
 ```mdtest-output
 {x:1}
 {x:"foo"((int64,string)),y:"foo"}

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -5,8 +5,6 @@ sidebar_label: Commands
 
 # Tutorials
 
----
-
 The tutorials contain a number of overviews of different aspects
 of the Zed system walking through examples with various sets
 of data.

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -5,8 +5,6 @@ sidebar_label: Join
 
 # Join Overview
 
----
-
 This is a brief primer on Zed's experimental [join operator](../language/operators/join.md).
 
 Currently, join is limited in the following ways:

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -5,8 +5,6 @@ sidebar_label: Schools Data
 
 # Zed and Schools Data
 
----
-
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
 [real-world data](../../testdata/edu) relating to California schools

--- a/docs/tutorials/zed.md
+++ b/docs/tutorials/zed.md
@@ -5,8 +5,6 @@ sidebar_label: zed
 
 # zed Tutorial
 
----
-
 `zq` is great, but what if we have a lot of data on which we want to perform search and
 analytics? This is where the `zed` command comes in. `zed` builds on the type
 system and language found in `zq` and adds a high performance data lake on top.

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -5,8 +5,6 @@ sidebar_label: zq
 
 # zq Tutorial
 
----
-
 This tour provides new users of `zq` an overview of `zq` and
 the [Zed language](../language/README.md)
 by walking through a number of examples on the command-line.


### PR DESCRIPTION
Many pages in the docs site have a horizontal rule under the heading. This breaks the automatic description tag used by the social networks. I don't think they are necessary as a visual style and removing them makes our twitter descriptions work automatically.

This is how it used to look:

<img width="627" alt="image" src="https://user-images.githubusercontent.com/3460638/165138405-b575bf96-2456-4223-b8a3-74b2997795fd.png">

We want those "---" under the title to actually be a preview of the content.

If we want to control the exact description of a page, add a 'description' key in the front-matter.

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/3460638/165138569-7ed6b15f-bf39-49f9-899e-8309cfc28463.png">

