### PR TITLE
honor from operator's format option

### DIFF
--- a/cli/adaptor.go
+++ b/cli/adaptor.go
@@ -45,11 +45,11 @@ func (*FileAdaptor) NewScheduler(context.Context, *zed.Context, dag.Source, exte
 	return nil, errors.New("pool scan not available when running on local file system")
 }
 
-func (f *FileAdaptor) Open(ctx context.Context, zctx *zed.Context, path string, pushdown zbuf.Filter) (zbuf.Puller, error) {
+func (f *FileAdaptor) Open(ctx context.Context, zctx *zed.Context, path, format string, pushdown zbuf.Filter) (zbuf.Puller, error) {
 	if path == "-" {
 		path = "stdio:stdin"
 	}
-	file, err := anyio.Open(ctx, zctx, f.engine, path, anyio.ReaderOpts{})
+	file, err := anyio.Open(ctx, zctx, f.engine, path, anyio.ReaderOpts{Format: format})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -577,13 +577,13 @@ func (b *Builder) compileTrunk(trunk *dag.Trunk, parent zbuf.Puller) ([]zbuf.Pul
 		}
 		source = from.NewScheduler(b.pctx, sched)
 	case *dag.HTTP:
-		puller, err := b.adaptor.Open(b.pctx.Context, b.pctx.Zctx, src.URL, pushdown)
+		puller, err := b.adaptor.Open(b.pctx.Context, b.pctx.Zctx, src.URL, src.Format, pushdown)
 		if err != nil {
 			return nil, err
 		}
 		source = from.NewPuller(b.pctx, puller)
 	case *dag.File:
-		scanner, err := b.adaptor.Open(b.pctx.Context, b.pctx.Zctx, src.Path, pushdown)
+		scanner, err := b.adaptor.Open(b.pctx.Context, b.pctx.Zctx, src.Path, src.Format, pushdown)
 		if err != nil {
 			return nil, err
 		}

--- a/compiler/reader.go
+++ b/compiler/reader.go
@@ -53,6 +53,6 @@ func (*internalAdaptor) NewScheduler(context.Context, *zed.Context, dag.Source, 
 	return nil, errors.New("invalid pool or file scan specified for internally streamed Zed query")
 }
 
-func (*internalAdaptor) Open(context.Context, *zed.Context, string, zbuf.Filter) (zbuf.Puller, error) {
+func (*internalAdaptor) Open(context.Context, *zed.Context, string, string, zbuf.Filter) (zbuf.Puller, error) {
 	return nil, errors.New("invalid file or URL access for internally streamed Zed query")
 }

--- a/compiler/ztests/from-file-format.yaml
+++ b/compiler/ztests/from-file-format.yaml
@@ -1,0 +1,13 @@
+script: |
+  zq -z 'file in.csv format csv'
+
+inputs:
+  - name: in.csv
+    data: |
+      "a"
+      1
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1.}

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -8,7 +8,7 @@ and appear as the components of a dataflow pipeline.
 * [combine](combine.md) - combine parallel paths into a single output
 * [cut](cut.md) - extract subsets of record fields into new records
 * [drop](drop.md) - drop fields from record values
-* [from](from.md) - source data from pools, URIs, or connectors
+* [from](from.md) - source data from pools, files, or URIs
 * [fork](fork.md) - copy values to parallel paths
 * [fuse](fuse.md) - coerce all input values into a merged type
 * [head](head.md) - copy leading values of input sequence

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -1,41 +1,32 @@
 ### Operator
 
-&emsp; **from** &mdash; source data from pools, URIs, or connectors
+&emsp; **from** &mdash; source data from pools, files, or URIs
 
 ### Synopsis
 
 ```
 from <pool>[@<tag>] [range <start>] [to <end>] [ => <leg> ]
-get <uri>
-file <path>
+file <path> [format <format>]
+get <uri> [format <format>]
 from (
    pool <pool>[@<tag>] [range <start>] [to <end>] [ => <leg> ]
-   get <uri> [ => <leg> ]
-   file <path> [ => <leg> ]
+   file <path> [format <format>] [ => <leg> ]
+   get <uri> [format <format>] [ => <leg> ]
    ...
 )
 ```
 ### Description
 
-The `from` operator identifies data from a source `<src>` and logically
-transmits the data to its output.  A `<src>` is:
-* a URI representing and HTTP endpoint, S3 endoint, or file; or,
-* the name of a data pool in a Zed lake.
+The `from` operator identifies one or more data sources and transmits
+their data to its output.  A data source can be
+* the name of a data pool in a Zed lake;
+* a path to a file; or
+* an HTTP, HTTPS, or S3 URI.
+Paths and URIs may be followed by an optional format specifier.
 
-In the first form, a single source is connected to a single output.
-In the second form, multiple sources are accessed in parallel and may be
+In the first three forms, a single source is connected to a single output.
+In the fourth form, multiple sources are accessed in parallel and may be
 [joined](join.md), [combined](combine.md), or [merged](merge.md).
-
-In the examples above, the data source is implied.  For example, the
-`zed query` command takes a list of files and the concatenated files
-are the implied input.
-Likewise, in the [Brim app](https://github.com/brimdata/brim),
-the UI allows for the selection of a data source and key range.
-
-Data sources can also be explicitly specified using the `from` keyword.
-Depending on the operating context, `from` may take a file system path,
-an HTTP URL, an S3 URL, or in the
-context of a Zed lake, the name of a data pool.
 
 A data path can be split with the `fork` operator as in
 ```
@@ -52,6 +43,7 @@ from (
   pool PoolTwo => op1 | op2 | ...
 ) | join on key=key | ...
 ```
+
 Similarly, data can be routed to different paths with replication
 using `switch`:
 ```

--- a/lake/mock/mock.go
+++ b/lake/mock/mock.go
@@ -107,6 +107,6 @@ func (*Lake) NewScheduler(context.Context, *zed.Context, dag.Source, extent.Span
 	return nil, fmt.Errorf("mock.Lake.NewScheduler() should not be called")
 }
 
-func (*Lake) Open(_ context.Context, _ *zed.Context, _ string, _ zbuf.Filter) (zbuf.Puller, error) {
+func (*Lake) Open(_ context.Context, _ *zed.Context, _, _ string, _ zbuf.Filter) (zbuf.Puller, error) {
 	return nil, fmt.Errorf("mock.Lake.Open() should not be called")
 }

--- a/lake/root.go
+++ b/lake/root.go
@@ -614,6 +614,6 @@ func (r *Root) newPoolScheduler(ctx context.Context, zctx *zed.Context, poolID, 
 	return pool.newScheduler(ctx, zctx, commit, span, filter, idx)
 }
 
-func (r *Root) Open(context.Context, *zed.Context, string, zbuf.Filter) (zbuf.Puller, error) {
+func (r *Root) Open(context.Context, *zed.Context, string, string, zbuf.Filter) (zbuf.Puller, error) {
 	return nil, errors.New("cannot use 'file' or 'http' source in a lake query")
 }

--- a/runtime/op/op.go
+++ b/runtime/op/op.go
@@ -19,7 +19,7 @@ type DataAdaptor interface {
 	CommitObject(context.Context, ksuid.KSUID, string) (ksuid.KSUID, error)
 	Layout(context.Context, dag.Source) order.Layout
 	NewScheduler(context.Context, *zed.Context, dag.Source, extent.Span, zbuf.Filter, *dag.Filter) (Scheduler, error)
-	Open(context.Context, *zed.Context, string, zbuf.Filter) (zbuf.Puller, error)
+	Open(context.Context, *zed.Context, string, string, zbuf.Filter) (zbuf.Puller, error)
 }
 
 type Scheduler interface {

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -608,11 +608,17 @@ func IsSearch(e ast.Expr) bool {
 func (c *canon) http(p *ast.HTTP) {
 	//XXX TBD other stuff
 	c.write("get %s", p.URL)
+	if p.Format != "" {
+		c.write(" format %s", p.Format)
+	}
 }
 
 func (c *canon) file(p *ast.File) {
 	//XXX TBD other stuff
 	c.write("file %s", p.Path)
+	if p.Format != "" {
+		c.write(" format %s", p.Format)
+	}
 }
 
 func (c *canon) source(src ast.Source) {

--- a/zfmt/ztests/from.yaml
+++ b/zfmt/ztests/from.yaml
@@ -1,13 +1,21 @@
 script: |
   zc -C 'file path'
   echo ===
+  zc -C 'file path format f'
+  echo ===
   zc -C 'get http://host/path'
+  echo ===
+  zc -C 'get http://host/path format f'
   echo ===
   zc -C 'from foo'
   echo ===
   zc -C 'from ( file path get http://host/path pool name )'
   echo ===
+  zc -C 'from ( file path format f get http://host/path format g pool name )'
+  echo ===
   zc -C 'from ( file path => head get http://host/path => head pool name => head )'
+  echo ===
+  zc -C 'from ( file path format f => head get http://host/path format g => head pool name => head )'
 
 outputs:
   - name: stdout
@@ -17,7 +25,15 @@ outputs:
       )
       ===
       from (
+        file path format f
+      )
+      ===
+      from (
         get http://host/path
+      )
+      ===
+      from (
+        get http://host/path format f
       )
       ===
       from (
@@ -31,9 +47,24 @@ outputs:
       )
       ===
       from (
+        file path format f
+        get http://host/path format g
+        pool name
+      )
+      ===
+      from (
         file path =>
           head 1
         get http://host/path =>
+          head 1
+        pool name =>
+          head 1
+      )
+      ===
+      from (
+        file path format f =>
+          head 1
+        get http://host/path format g =>
           head 1
         pool name =>
           head 1


### PR DESCRIPTION
The from operator allows a format option after a path or URI, but the
option's value is ignored.  Wire things up to honor it.

Closes #3844.