### PR TITLE
Revert "fix typo in docs/language/operators/join.md (#3842)"

### DIFF
--- a/docs/language/operators/join.md
+++ b/docs/language/operators/join.md
@@ -6,7 +6,7 @@
 
 ```
 ( => left path => right path )
-| [anti|inner|left|right] join on <left-key>=<right-key> [<field>=<right-expr>, ...]
+| [anti|inner|left|right] join on <left-key>=<right-key> [<field>:=<right-expr>, ...]
 ```
 ### Description
 


### PR DESCRIPTION
This reverts #3842 .

The mdtest-protected examples in the [join tutorial](https://zed.brimdata.io/docs/tutorials/join/) all confirm that `:=` is indeed the correct syntax for field assignment with `join`, so there wasn't a typo here.

cc: @henridf