### PR TITLE
Fixes to ZST format doc

### DIFF
--- a/docs/formats/zst.md
+++ b/docs/formats/zst.md
@@ -257,7 +257,7 @@ when there are null values (as described below).
 
 If there are no null values, then the `presence` field contains an empty `<segmap>`.
 If all of the values are null, then the `column` field is null (and the `presence`
-both contain empty `<segmap>s`).  For empty `<segmap>s`, there is no
+contains an empty `<segmap>`).  For an empty `<segmap>`, there is no
 corresponding data stored in the data section.  Since a `<segmap>` is a Zed
 array, an empty `<segmap>` is simply the empty array value `[]`.
 

--- a/docs/formats/zst.md
+++ b/docs/formats/zst.md
@@ -134,8 +134,8 @@ from column streams, i.e., to map columns back to composite values.
 >
 > Also, the reassembly section is in general vastly smaller than the data section
 > so the goal here isn't to express information in cute and obscure compact forms
-> but rather to represent data in easy-to-digest, programmer-friendly forms that
-> leverage ZNG.
+> but rather to represent data in an easy-to-digest, programmer-friendly form that
+> leverages ZNG.
 
 The reassembly section is a ZNG stream.  Unlike Parquet,
 which uses an externally described schema

--- a/docs/formats/zst.md
+++ b/docs/formats/zst.md
@@ -282,7 +282,7 @@ A `<map_column>` has the form:
 {key:<any_column>,value:<any_column>}
 ```
 where
-* `key` encodes the column of map keys, and
+* `key` encodes the column of map keys and
 * `value` encodes the column of map values.
 
 #### Union Column


### PR DESCRIPTION
From a proofreading pass.

I'm including comments in a couple places where I want to make extra sure that my clarifications to the wording didn't affect the correctness of the message.