### PR TITLE
Python doc links

### DIFF
--- a/docs/libraries/python.md
+++ b/docs/libraries/python.md
@@ -5,7 +5,7 @@ with a Zed lake.
 The Zed Python package supports loading data into a Zed lake as well as
 querying and retrieving results in the [ZJSON format](../formats/zjson.md).
 The Python client interacts with the Zed lake via the REST API served by
-[`zed serve`](../../cmd/zed/serve).
+[`zed serve`](../../commands/zed.md#213-serve).
 
 This approach works adequately when high data throughput is not required.
 We will soon introduce native [ZNG](../formats/zng.md) support for
@@ -31,7 +31,7 @@ To run this example, first start a Zed lake service from your shell:
 zed init -lake scratch
 zed serve -lake scratch
 ```
-> Or you can launch the Brim app and it will run a Zed lake service
+> Or you can launch the [Brim app](https://github.com/brimdata/brim) and it will run a Zed lake service
 > on the default port at `http://localhost:9867`.
 
 Then, in another shell, use Python to create a pool, load some data,

--- a/docs/libraries/python.md
+++ b/docs/libraries/python.md
@@ -5,7 +5,7 @@ with a Zed lake.
 The Zed Python package supports loading data into a Zed lake as well as
 querying and retrieving results in the [ZJSON format](../formats/zjson.md).
 The Python client interacts with the Zed lake via the REST API served by
-[`zed serve`](../../commands/zed.md#213-serve).
+[`zed serve`](../commands/zed.md#213-serve).
 
 This approach works adequately when high data throughput is not required.
 We will soon introduce native [ZNG](../formats/zng.md) support for


### PR DESCRIPTION
After the recent merge of #3856 I spotted a broken link still left in the doc. While I was at it, I added a link to the Brim app for good measure, in the event that someone's exclusive entry point to the projects is via the Zed repo and they're not yet fully aware of how the Brim app relates.