### PR TITLE
change zed.Value parameters to pointers in runtime/expr/coerce

### DIFF
--- a/runtime/expr/agg/avg.go
+++ b/runtime/expr/agg/avg.go
@@ -21,7 +21,7 @@ func (a *Avg) Consume(val *zed.Value) {
 	if val.IsNull() {
 		return
 	}
-	if d, ok := coerce.ToFloat(*val); ok {
+	if d, ok := coerce.ToFloat(val); ok {
 		a.sum += float64(d)
 		a.count++
 	}

--- a/runtime/expr/agg/math.go
+++ b/runtime/expr/agg/math.go
@@ -93,7 +93,7 @@ func (f *Float64) result() *zed.Value {
 }
 
 func (f *Float64) consume(val *zed.Value) {
-	if v, ok := coerce.ToFloat(*val); ok {
+	if v, ok := coerce.ToFloat(val); ok {
 		f.state = f.function(f.state, v)
 	}
 }
@@ -115,7 +115,7 @@ func (i *Int64) result() *zed.Value {
 }
 
 func (i *Int64) consume(val *zed.Value) {
-	if v, ok := coerce.ToInt(*val); ok {
+	if v, ok := coerce.ToInt(val); ok {
 		i.state = i.function(i.state, v)
 	}
 }
@@ -137,7 +137,7 @@ func (u *Uint64) result() *zed.Value {
 }
 
 func (u *Uint64) consume(val *zed.Value) {
-	if v, ok := coerce.ToUint(*val); ok {
+	if v, ok := coerce.ToUint(val); ok {
 		u.state = u.function(u.state, v)
 	}
 }
@@ -159,7 +159,7 @@ func (d *Duration) result() *zed.Value {
 }
 
 func (d *Duration) consume(val *zed.Value) {
-	if v, ok := coerce.ToDuration(*val); ok {
+	if v, ok := coerce.ToDuration(val); ok {
 		d.state = d.function(d.state, int64(v))
 	}
 }
@@ -181,7 +181,7 @@ func (t *Time) result() *zed.Value {
 }
 
 func (t *Time) consume(val *zed.Value) {
-	if v, ok := coerce.ToTime(*val); ok {
+	if v, ok := coerce.ToTime(val); ok {
 		t.state = nano.Ts(t.function(int64(t.state), int64(v)))
 	}
 }

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -63,7 +63,7 @@ type casterIntN struct {
 }
 
 func (c *casterIntN) Eval(ectx Context, val *zed.Value) *zed.Value {
-	v, ok := coerce.ToInt(*val)
+	v, ok := coerce.ToInt(val)
 	if !ok || (c.min != 0 && (v < c.min || v > c.max)) {
 		return ectx.CopyValue(*c.zctx.NewErrorf(
 			"cannot cast %s to type %s", zson.MustFormatValue(*val), zson.FormatType(c.typ)))
@@ -78,7 +78,7 @@ type casterUintN struct {
 }
 
 func (c *casterUintN) Eval(ectx Context, val *zed.Value) *zed.Value {
-	v, ok := coerce.ToUint(*val)
+	v, ok := coerce.ToUint(val)
 	if !ok || (c.max != 0 && v > c.max) {
 		return ectx.CopyValue(*c.zctx.NewErrorf(
 			"cannot cast %s to type %s", zson.MustFormatValue(*val), zson.FormatType(c.typ)))
@@ -91,7 +91,7 @@ type casterBool struct {
 }
 
 func (c *casterBool) Eval(ectx Context, val *zed.Value) *zed.Value {
-	b, ok := coerce.ToBool(*val)
+	b, ok := coerce.ToBool(val)
 	if !ok {
 		return ectx.CopyValue(*c.zctx.NewErrorf("cannot cast %s to bool", zson.MustFormatValue(*val)))
 	}
@@ -103,7 +103,7 @@ type casterFloat32 struct {
 }
 
 func (c *casterFloat32) Eval(ectx Context, val *zed.Value) *zed.Value {
-	f, ok := coerce.ToFloat(*val)
+	f, ok := coerce.ToFloat(val)
 	if !ok {
 		return ectx.CopyValue(*c.zctx.NewErrorf("cannot cast %s to type float32", zson.MustFormatValue(*val)))
 	}
@@ -115,7 +115,7 @@ type casterFloat64 struct {
 }
 
 func (c *casterFloat64) Eval(ectx Context, val *zed.Value) *zed.Value {
-	f, ok := coerce.ToFloat(*val)
+	f, ok := coerce.ToFloat(val)
 	if !ok {
 		return ectx.CopyValue(*c.zctx.NewErrorf("cannot cast %s to type float64", zson.MustFormatValue(*val)))
 	}
@@ -184,7 +184,7 @@ func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
 		d := nano.Duration(zed.DecodeFloat(val.Bytes))
 		return ectx.NewValue(zed.TypeDuration, zed.EncodeDuration(d))
 	}
-	v, ok := coerce.ToInt(*val)
+	v, ok := coerce.ToInt(val)
 	if !ok {
 		return ectx.CopyValue(*c.zctx.NewErrorf("cannot cast %s to type duration", zson.MustFormatValue(*val)))
 	}
@@ -218,7 +218,7 @@ func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
 		}
 	case zed.IsNumber(id):
 		//XXX we call coerce on integers here to avoid unsigned/signed decode
-		v, ok := coerce.ToInt(*val)
+		v, ok := coerce.ToInt(val)
 		if !ok {
 			panic(fmt.Sprintf("coerce %s to int failed", zson.MustFormatValue(*val)))
 		}

--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -162,7 +162,7 @@ func (c *Pair) coerceNumbers(aid, bid int) (int, bool) {
 	return id, ok
 }
 
-func ToFloat(zv zed.Value) (float64, bool) {
+func ToFloat(zv *zed.Value) (float64, bool) {
 	id := zv.Type.ID()
 	if zed.IsFloat(id) {
 		return zed.DecodeFloat(zv.Bytes), true
@@ -187,7 +187,7 @@ func ToFloat(zv zed.Value) (float64, bool) {
 	return 0, false
 }
 
-func ToUint(zv zed.Value) (uint64, bool) {
+func ToUint(zv *zed.Value) (uint64, bool) {
 	id := zv.Type.ID()
 	if zed.IsFloat(id) {
 		return uint64(zed.DecodeFloat(zv.Bytes)), true
@@ -216,7 +216,7 @@ func ToUint(zv zed.Value) (uint64, bool) {
 	return 0, false
 }
 
-func ToInt(zv zed.Value) (int64, bool) {
+func ToInt(zv *zed.Value) (int64, bool) {
 	id := zv.Type.ID()
 	if zed.IsFloat(id) {
 		return int64(zed.DecodeFloat(zv.Bytes)), true
@@ -242,7 +242,7 @@ func ToInt(zv zed.Value) (int64, bool) {
 	return 0, false
 }
 
-func ToBool(zv zed.Value) (bool, bool) {
+func ToBool(zv *zed.Value) (bool, bool) {
 	if zv.IsString() {
 		v, err := strconv.ParseBool(string(zv.Bytes))
 		return v, err == nil
@@ -251,7 +251,7 @@ func ToBool(zv zed.Value) (bool, bool) {
 	return v != 0, ok
 }
 
-func ToTime(zv zed.Value) (nano.Ts, bool) {
+func ToTime(zv *zed.Value) (nano.Ts, bool) {
 	id := zv.Type.ID()
 	if id == zed.IDTime {
 		return zed.DecodeTime(zv.Bytes), true
@@ -277,7 +277,7 @@ func ToTime(zv zed.Value) (nano.Ts, bool) {
 // and Double are converted as seconds. The resulting coerced value is
 // written to out, and true is returned. If the value cannot be
 // coerced, then false is returned.
-func ToDuration(in zed.Value) (nano.Duration, bool) {
+func ToDuration(in *zed.Value) (nano.Duration, bool) {
 	switch in.Type.ID() {
 	case zed.IDDuration:
 		return zed.DecodeDuration(in.Bytes), true

--- a/runtime/expr/function/math.go
+++ b/runtime/expr/function/math.go
@@ -88,7 +88,7 @@ type Log struct {
 }
 
 func (l *Log) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	x, ok := coerce.ToFloat(args[0])
+	x, ok := coerce.ToFloat(&args[0])
 	if !ok {
 		return newErrorf(l.zctx, ctx, "log: numeric argument required")
 	}
@@ -105,7 +105,7 @@ type reducer struct {
 }
 
 func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zv := args[0]
+	zv := &args[0]
 	typ := zv.Type
 	id := typ.ID()
 	if zed.IsFloat(id) {
@@ -122,14 +122,14 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newFloat64(ctx, result)
 	}
 	if !zed.IsNumber(id) {
-		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(zv))
+		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(*zv))
 	}
 	if zed.IsSigned(id) {
 		result := zed.DecodeInt(zv.Bytes)
 		for _, val := range args[1:] {
 			//XXX this is really bad because we silently coerce
 			// floats to ints if we hit a float first
-			v, ok := coerce.ToInt(val)
+			v, ok := coerce.ToInt(&val)
 			if !ok {
 				return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(val))
 			}
@@ -139,7 +139,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	}
 	result := zed.DecodeUint(zv.Bytes)
 	for _, val := range args[1:] {
-		v, ok := coerce.ToUint(val)
+		v, ok := coerce.ToUint(&val)
 		if !ok {
 			return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(val))
 		}
@@ -176,11 +176,11 @@ type Pow struct {
 }
 
 func (p *Pow) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	x, ok := coerce.ToFloat(args[0])
+	x, ok := coerce.ToFloat(&args[0])
 	if !ok {
 		return newErrorf(p.zctx, ctx, "pow: not a number: %s", zson.MustFormatValue(args[0]))
 	}
-	y, ok := coerce.ToFloat(args[1])
+	y, ok := coerce.ToFloat(&args[1])
 	if !ok {
 		return newErrorf(p.zctx, ctx, "pow: not a number: %s", zson.MustFormatValue(args[1]))
 	}
@@ -193,7 +193,7 @@ type Sqrt struct {
 }
 
 func (s *Sqrt) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	x, ok := coerce.ToFloat(args[0])
+	x, ok := coerce.ToFloat(&args[0])
 	if !ok {
 		return newErrorf(s.zctx, ctx, "sqrt: not a number: %s", zson.MustFormatValue(args[0]))
 	}

--- a/runtime/expr/function/time.go
+++ b/runtime/expr/function/time.go
@@ -20,8 +20,8 @@ type Bucket struct {
 }
 
 func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	tsArg := args[0]
-	binArg := args[1]
+	tsArg := &args[0]
+	binArg := &args[1]
 	if tsArg.IsNull() || binArg.IsNull() {
 		return zed.NullTime
 	}

--- a/runtime/expr/slice.go
+++ b/runtime/expr/slice.go
@@ -90,7 +90,7 @@ func sliceIndex(ectx Context, this *zed.Value, slot Evaluator, length int) (int,
 		return 0, ErrSliceIndexEmpty
 	}
 	zv := slot.Eval(ectx, this)
-	v, ok := coerce.ToInt(*zv)
+	v, ok := coerce.ToInt(zv)
 	if !ok {
 		return 0, ErrSliceIndex
 	}


### PR DESCRIPTION
At five words, a zed.Value isn't tiny, so avoid unnecessary copies.