### PR TITLE
change zed.Value parameters to pointers in zst

### DIFF
--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -26,7 +26,7 @@ type Assembler struct {
 var _ zio.Reader = (*Assembler)(nil)
 
 type Assembly struct {
-	root  zed.Value
+	root  *zed.Value
 	types []zed.Type
 	maps  []*zed.Value
 }
@@ -39,7 +39,7 @@ func NewAssembler(a *Assembly, seeker *storage.Seeker) (*Assembler, error) {
 	var readers []column.Reader
 	for k := range a.types {
 		val := a.maps[k]
-		reader, err := column.NewReader(a.types[k], *val, seeker)
+		reader, err := column.NewReader(a.types[k], val, seeker)
 		if err != nil {
 			return nil, err
 		}

--- a/zst/column/array.go
+++ b/zst/column/array.go
@@ -64,7 +64,7 @@ type ArrayReader struct {
 	lengths *IntReader
 }
 
-func NewArrayReader(inner zed.Type, in zed.Value, r io.ReaderAt) (*ArrayReader, error) {
+func NewArrayReader(inner zed.Type, in *zed.Value, r io.ReaderAt) (*ArrayReader, error) {
 	typ, ok := in.Type.(*zed.TypeRecord)
 	if !ok {
 		return nil, errors.New("ZST object array_column not a record")
@@ -74,7 +74,7 @@ func NewArrayReader(inner zed.Type, in zed.Value, r io.ReaderAt) (*ArrayReader, 
 	if val.IsNull() {
 		return nil, errors.New("ZST array column has no values")
 	}
-	elems, err := NewReader(inner, *val, r)
+	elems, err := NewReader(inner, val, r)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func NewArrayReader(inner zed.Type, in zed.Value, r io.ReaderAt) (*ArrayReader, 
 	if val.IsNull() {
 		return nil, errors.New("ZST array column has no lengths")
 	}
-	lengths, err := NewIntReader(*val, r)
+	lengths, err := NewIntReader(val, r)
 	if err != nil {
 		return nil, err
 	}

--- a/zst/column/column.go
+++ b/zst/column/column.go
@@ -77,7 +77,7 @@ type Reader interface {
 	Read(*zcode.Builder) error
 }
 
-func NewReader(typ zed.Type, in zed.Value, r io.ReaderAt) (Reader, error) {
+func NewReader(typ zed.Type, in *zed.Value, r io.ReaderAt) (Reader, error) {
 	switch typ := typ.(type) {
 	case *zed.TypeNamed:
 		return NewReader(typ.Type, in, r)

--- a/zst/column/field.go
+++ b/zst/column/field.go
@@ -86,12 +86,12 @@ type FieldReader struct {
 	presence *PresenceReader
 }
 
-func NewFieldReader(typ zed.Type, in zed.Value, r io.ReaderAt) (*FieldReader, error) {
+func NewFieldReader(typ zed.Type, in *zed.Value, r io.ReaderAt) (*FieldReader, error) {
 	col := in.Deref("column").MissingAsNull()
 	var val Reader
 	if !col.IsNull() {
 		var err error
-		val, err = NewReader(typ, *col, r)
+		val, err = NewReader(typ, col, r)
 		if err != nil {
 			return nil, err
 		}
@@ -100,7 +100,7 @@ func NewFieldReader(typ zed.Type, in zed.Value, r io.ReaderAt) (*FieldReader, er
 	if presence.IsNull() {
 		return nil, errors.New("ZST field has no presence")
 	}
-	d, err := NewPrimitiveReader(*presence, r)
+	d, err := NewPrimitiveReader(presence, r)
 	if err != nil {
 		return nil, err
 	}

--- a/zst/column/int.go
+++ b/zst/column/int.go
@@ -22,7 +22,7 @@ type IntReader struct {
 	PrimitiveReader
 }
 
-func NewIntReader(val zed.Value, r io.ReaderAt) (*IntReader, error) {
+func NewIntReader(val *zed.Value, r io.ReaderAt) (*IntReader, error) {
 	reader, err := NewPrimitiveReader(val, r)
 	if err != nil {
 		return nil, err

--- a/zst/column/primitive.go
+++ b/zst/column/primitive.go
@@ -58,7 +58,7 @@ type PrimitiveReader struct {
 	reader io.ReaderAt
 }
 
-func NewPrimitiveReader(in zed.Value, reader io.ReaderAt) (*PrimitiveReader, error) {
+func NewPrimitiveReader(in *zed.Value, reader io.ReaderAt) (*PrimitiveReader, error) {
 	segmap, err := NewSegmap(in)
 	if err != nil {
 		return nil, err

--- a/zst/column/record.go
+++ b/zst/column/record.go
@@ -69,7 +69,7 @@ type RecordReader []FieldReader
 
 var _ Reader = (RecordReader)(nil)
 
-func NewRecordReader(utyp zed.Type, in zed.Value, reader io.ReaderAt) (RecordReader, error) {
+func NewRecordReader(utyp zed.Type, in *zed.Value, reader io.ReaderAt) (RecordReader, error) {
 	typ, ok := zed.TypeUnder(utyp).(*zed.TypeRecord)
 	if !ok {
 		return nil, errors.New("corrupt ZST object: record_column is not a record")
@@ -85,7 +85,7 @@ func NewRecordReader(utyp zed.Type, in zed.Value, reader io.ReaderAt) (RecordRea
 			return nil, errors.New("mismatch between record type and record_column") //XXX
 		}
 		fieldType := typ.Columns[k].Type
-		f, err := NewFieldReader(fieldType, zed.Value{rtype.Columns[k].Type, it.Next()}, reader)
+		f, err := NewFieldReader(fieldType, zed.NewValue(rtype.Columns[k].Type, it.Next()), reader)
 		if err != nil {
 			return nil, err
 		}

--- a/zst/column/segment.go
+++ b/zst/column/segment.go
@@ -33,7 +33,7 @@ func checkSegType(col zed.Column, which string, typ zed.Type) bool {
 	return col.Name == which && col.Type == typ
 }
 
-func NewSegmap(in zed.Value) ([]Segment, error) {
+func NewSegmap(in *zed.Value) ([]Segment, error) {
 	typ, ok := in.Type.(*zed.TypeArray)
 	if !ok {
 		return nil, errors.New("ZST object segmap not an array")

--- a/zst/column/union.go
+++ b/zst/column/union.go
@@ -87,7 +87,7 @@ type UnionReader struct {
 	presence *PresenceReader
 }
 
-func NewUnionReader(utyp zed.Type, in zed.Value, r io.ReaderAt) (*UnionReader, error) {
+func NewUnionReader(utyp zed.Type, in *zed.Value, r io.ReaderAt) (*UnionReader, error) {
 	typ, ok := utyp.(*zed.TypeUnion)
 	if !ok {
 		return nil, errors.New("cannot unmarshal non-union into union")
@@ -103,7 +103,7 @@ func NewUnionReader(utyp zed.Type, in zed.Value, r io.ReaderAt) (*UnionReader, e
 		if val.IsNull() {
 			return nil, errors.New("ZST union missing column")
 		}
-		d, err := NewReader(typ.Types[k], *val, r)
+		d, err := NewReader(typ.Types[k], val, r)
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +113,7 @@ func NewUnionReader(utyp zed.Type, in zed.Value, r io.ReaderAt) (*UnionReader, e
 	if selector.IsNull() {
 		return nil, errors.New("ZST union missing selector")
 	}
-	sr, err := NewIntReader(*selector, r)
+	sr, err := NewIntReader(selector, r)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func NewUnionReader(utyp zed.Type, in zed.Value, r io.ReaderAt) (*UnionReader, e
 	if presence.IsNull() {
 		return nil, errors.New("ZST union missing presence")
 	}
-	d, err := NewPrimitiveReader(*presence, r)
+	d, err := NewPrimitiveReader(presence, r)
 	if err != nil {
 		return nil, err
 	}

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -67,7 +67,7 @@ func NewCutAssembler(zctx *zed.Context, fields []string, object *Object) (*CutAs
 			// on this right now.
 			return nil, fmt.Errorf("ZST cut requires all top-level records to be records: encountered type %s", zson.FormatType(typ))
 		}
-		reader, err := column.NewRecordReader(recType, *a.maps[k], object.seeker)
+		reader, err := column.NewRecordReader(recType, a.maps[k], object.seeker)
 		if err != nil {
 			return nil, err
 		}

--- a/zst/object.go
+++ b/zst/object.go
@@ -131,7 +131,7 @@ func (o *Object) readAssembly() (*Assembly, error) {
 		}
 		assembly.types = append(assembly.types, val.Type)
 	}
-	assembly.root = *val.Copy()
+	assembly.root = val.Copy()
 	expectedType, err := zson.ParseType(o.zctx, column.SegmapTypeString)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
At five words, a zed.Value isn't tiny, so avoid unnecessary copies.