### PR TITLE
service: Improve accept header handling

### DIFF
--- a/api/mime.go
+++ b/api/mime.go
@@ -69,6 +69,6 @@ func FormatToMediaType(format string) string {
 	case "zson":
 		return MediaTypeZSON
 	default:
-		return ""
+		panic(fmt.Sprintf("unknown format type: %s", format))
 	}
 }

--- a/api/mime.go
+++ b/api/mime.go
@@ -53,3 +53,22 @@ func MediaTypeToFormat(s string, dflt string) (string, error) {
 	}
 	return "", &ErrUnsupportedMimeType{typ}
 }
+
+func FormatToMediaType(format string) string {
+	switch format {
+	case "csv":
+		return MediaTypeCSV
+	case "json":
+		return MediaTypeJSON
+	case "ndjson":
+		return MediaTypeNDJSON
+	case "zjson":
+		return MediaTypeZJSON
+	case "zng":
+		return MediaTypeZNG
+	case "zson":
+		return MediaTypeZSON
+	default:
+		return ""
+	}
+}

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -460,7 +460,7 @@ For response content types, the service can produce a variety of formats. To
 receive responses in the desired format, include the MIME type of the format in
 the request's Accept HTTP header.
 
-If the Accept header is not specified, the service will return JSON as the
+If the Accept header is not specified, the service will return ZSON as the
 default response format for the endpoints described above.
 
 The supported MIME types are as follows:

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -397,7 +397,7 @@ POST /query
 | query | string | body | Zed query to execute. All data is returned if not specified. ||
 | head.pool | string | body | Pool to query against Not required if pool is specified in query. |
 | head.branch | string | body | Branch to query against. Defaults to "main". |
-| Accept | [MIME Type](#media-types) | header | The data format of the results. ZSON is selected if unspecified. |
+| Accept | [MIME Type](#media-types) | header | The data format of the results. JSON is selected if unspecified. |
 
 **Example Request**
 
@@ -462,8 +462,7 @@ receive responses in the desired format, include the MIME type of the format in
 the request's Accept HTTP header.
 
 If the Accept header is not specified, the service will return JSON as the
-default response format for the endpoints described above, with the exception
-of the [query](#query) endpoint that returns ZSON by default.
+default response format for the endpoints described above.
 
 The supported MIME types are as follows:
 

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -397,7 +397,6 @@ POST /query
 | query | string | body | Zed query to execute. All data is returned if not specified. ||
 | head.pool | string | body | Pool to query against Not required if pool is specified in query. |
 | head.branch | string | body | Branch to query against. Defaults to "main". |
-| Accept | [MIME Type](#media-types) | header | The data format of the results. JSON is selected if unspecified. |
 
 **Example Request**
 

--- a/service/core.go
+++ b/service/core.go
@@ -172,8 +172,9 @@ func (c *Core) addAPIServerRoutes() {
 
 func (c *Core) handler(f func(*Core, *ResponseWriter, *Request)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		res, req := newRequest(w, r, c.logger)
-		f(c, res, req)
+		if res, req, ok := newRequest(w, r, c.logger); ok {
+			f(c, res, req)
+		}
 	})
 }
 

--- a/service/core.go
+++ b/service/core.go
@@ -167,22 +167,38 @@ func (c *Core) addAPIServerRoutes() {
 	c.authhandle("/pool/{pool}/branch/{branch}/merge/{child}", handleBranchMerge).Methods("POST")
 	c.authhandle("/pool/{pool}/branch/{branch}/revert/{commit}", handleRevertPost).Methods("POST")
 	c.authhandle("/pool/{pool}/stats", handlePoolStats).Methods("GET")
-	c.authhandle("/query", handleQuery).Methods("OPTIONS", "POST")
+	c.authhandle("/query", handleQuery, defaultFormat("zson")).Methods("OPTIONS", "POST")
 }
 
-func (c *Core) handler(f func(*Core, *ResponseWriter, *Request)) http.Handler {
+type routeOpts struct {
+	defaultFormat string
+}
+
+type routeOpt func(*routeOpts)
+
+func defaultFormat(format string) routeOpt {
+	return func(o *routeOpts) {
+		o.defaultFormat = format
+	}
+}
+
+func (c *Core) handler(f func(*Core, *ResponseWriter, *Request), opts ...routeOpt) http.Handler {
+	opt := &routeOpts{defaultFormat: "json"}
+	for _, fn := range opts {
+		fn(opt)
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if res, req, ok := newRequest(w, r, c.logger); ok {
+		if res, req, ok := newRequest(w, r, c.logger, opt.defaultFormat); ok {
 			f(c, res, req)
 		}
 	})
 }
 
-func (c *Core) authhandle(path string, f func(*Core, *ResponseWriter, *Request)) *mux.Route {
+func (c *Core) authhandle(path string, f func(*Core, *ResponseWriter, *Request), opts ...routeOpt) *mux.Route {
 	if c.auth != nil {
 		f = c.auth.Middleware(f)
 	}
-	return c.routerAPI.Handle(path, c.handler(f))
+	return c.routerAPI.Handle(path, c.handler(f, opts...))
 }
 
 func branchHandle(f func(*Core, *ResponseWriter, *Request, *lake.Branch)) func(*Core, *ResponseWriter, *Request) {

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -43,18 +43,13 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(srverr.ErrInvalid(err))
 		return
 	}
-	format, err := api.MediaTypeToFormat(r.Header.Get("Accept"), DefaultZedFormat)
-	if err != nil {
-		w.Error(srverr.ErrInvalid(err))
-		return
-	}
 	flowgraph, err := runtime.NewQueryOnLake(r.Context(), zed.NewContext(), query, c.root, &req.Head, r.Logger)
 	if err != nil {
 		w.Error(err)
 		return
 	}
 	flusher, _ := w.ResponseWriter.(http.Flusher)
-	writer, err := queryio.NewWriter(zio.NopCloser(w), format, flusher)
+	writer, err := queryio.NewWriter(zio.NopCloser(w), w.Format, flusher)
 	if err != nil {
 		w.Error(err)
 		return

--- a/service/request.go
+++ b/service/request.go
@@ -49,7 +49,7 @@ func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger, defa
 	if len(ss) == 0 {
 		ss = []string{""}
 	}
-	for _, mime := range strings.Split(r.Header.Get("Accept"), ",") {
+	for _, mime := range ss {
 		format, err := api.MediaTypeToFormat(mime, defaultFormat)
 		if err != nil {
 			continue

--- a/service/request.go
+++ b/service/request.go
@@ -32,7 +32,7 @@ type Request struct {
 	Logger *zap.Logger
 }
 
-func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger, defaultFormat string) (*ResponseWriter, *Request, bool) {
+func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*ResponseWriter, *Request, bool) {
 	logger = logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
 	req := &Request{
 		Request: r,
@@ -50,7 +50,7 @@ func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger, defa
 		ss = []string{""}
 	}
 	for _, mime := range ss {
-		format, err := api.MediaTypeToFormat(mime, defaultFormat)
+		format, err := api.MediaTypeToFormat(mime, "json")
 		if err != nil {
 			continue
 		}

--- a/service/request.go
+++ b/service/request.go
@@ -50,7 +50,7 @@ func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*Re
 		ss = []string{""}
 	}
 	for _, mime := range ss {
-		format, err := api.MediaTypeToFormat(mime, "json")
+		format, err := api.MediaTypeToFormat(mime, DefaultZedFormat)
 		if err != nil {
 			continue
 		}

--- a/service/request.go
+++ b/service/request.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"github.com/brimdata/zed"
@@ -31,7 +32,7 @@ type Request struct {
 	Logger *zap.Logger
 }
 
-func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*ResponseWriter, *Request) {
+func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*ResponseWriter, *Request, bool) {
 	logger = logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
 	req := &Request{
 		Request: r,
@@ -44,12 +45,20 @@ func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*Re
 		Logger:         logger,
 		marshaler:      m,
 	}
-	accept := r.Header.Get("Accept")
-	if accept == "" || accept == "*/*" {
-		accept = "application/json"
+	ss := strings.Split(r.Header.Get("Accept"), ",")
+	if len(ss) == 0 {
+		ss = []string{""}
 	}
-	res.SetContentType(accept)
-	return res, req
+	for _, mime := range strings.Split(r.Header.Get("Accept"), ",") {
+		format, err := api.MediaTypeToFormat(mime, "json")
+		if err != nil {
+			continue
+		}
+		res.Format = format
+		return res, req, true
+	}
+	res.Error(srverr.ErrInvalid("could not find supported mime type in ACCEPT header"))
+	return nil, nil, false
 }
 
 func (r *Request) PoolID(w *ResponseWriter, root *lake.Root) (ksuid.KSUID, bool) {
@@ -179,6 +188,7 @@ func (r *Request) Unmarshal(w *ResponseWriter, body interface{}, templates ...in
 
 type ResponseWriter struct {
 	http.ResponseWriter
+	Format    string
 	Logger    *zap.Logger
 	zw        zio.WriteCloser
 	marshaler *zson.MarshalZNGContext
@@ -189,25 +199,11 @@ func (w *ResponseWriter) ContentType() string {
 	return w.Header().Get("Content-Type")
 }
 
-func (w *ResponseWriter) SetContentType(ct string) {
-	w.Header().Set("Content-Type", ct)
-}
-
 func (w *ResponseWriter) ZioWriter() zio.WriteCloser {
-	return w.ZioWriterWithOpts(anyio.WriterOpts{})
-}
-
-func (w *ResponseWriter) ZioWriterWithOpts(opts anyio.WriterOpts) zio.WriteCloser {
 	if w.zw == nil {
+		w.Header().Set("Content-Type", api.FormatToMediaType(w.Format))
 		var err error
-		if opts.Format == "" {
-			opts.Format, err = api.MediaTypeToFormat(w.ContentType(), DefaultZedFormat)
-			if err != nil {
-				w.Error(srverr.ErrInvalid(err))
-				return nil
-			}
-		}
-		w.zw, err = anyio.NewWriter(zio.NopCloser(w), opts)
+		w.zw, err = anyio.NewWriter(zio.NopCloser(w), anyio.WriterOpts{Format: w.Format})
 		if err != nil {
 			w.Error(err)
 			return nil
@@ -215,9 +211,10 @@ func (w *ResponseWriter) ZioWriterWithOpts(opts anyio.WriterOpts) zio.WriteClose
 	}
 	return w.zw
 }
-
 func (w *ResponseWriter) Write(b []byte) (int, error) {
-	atomic.StoreInt32(&w.written, 1)
+	if atomic.CompareAndSwapInt32(&w.written, 0, 1) {
+		w.Header().Set("Content-Type", api.FormatToMediaType(w.Format))
+	}
 	return w.ResponseWriter.Write(b)
 }
 
@@ -234,7 +231,7 @@ func (w *ResponseWriter) Error(err error) {
 	if atomic.CompareAndSwapInt32(&w.written, 0, 1) {
 		// Should errors be returned in different encodings, i.e. adhere to
 		// the encoding ?
-		w.SetContentType("application/json")
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		if err := json.NewEncoder(w).Encode(res); err != nil {
 			w.Logger.Warn("Error writing response", zap.Error(err))

--- a/service/request.go
+++ b/service/request.go
@@ -32,7 +32,7 @@ type Request struct {
 	Logger *zap.Logger
 }
 
-func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*ResponseWriter, *Request, bool) {
+func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger, defaultFormat string) (*ResponseWriter, *Request, bool) {
 	logger = logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
 	req := &Request{
 		Request: r,
@@ -50,7 +50,7 @@ func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*Re
 		ss = []string{""}
 	}
 	for _, mime := range strings.Split(r.Header.Get("Accept"), ",") {
-		format, err := api.MediaTypeToFormat(mime, "json")
+		format, err := api.MediaTypeToFormat(mime, defaultFormat)
 		if err != nil {
 			continue
 		}

--- a/service/request.go
+++ b/service/request.go
@@ -57,7 +57,7 @@ func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger, defa
 		res.Format = format
 		return res, req, true
 	}
-	res.Error(srverr.ErrInvalid("could not find supported mime type in ACCEPT header"))
+	res.Error(srverr.ErrInvalid("could not find supported MIME type in Accept header"))
 	return nil, nil, false
 }
 

--- a/service/ztests/accept-header.yaml
+++ b/service/ztests/accept-header.yaml
@@ -3,7 +3,7 @@ script: |
   zed create -q test
   echo '{ts:0}' | zed load -use test -q -
   for accept in "text/plain, application/json" "application/xml, text/css"; do
-    echo === $accept ===
+    echo // $accept
     curl -H "Accept: $accept" -d '{"query":"from test@main"}' $ZED_LAKE/query
   done
 
@@ -13,7 +13,7 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      === text/plain, application/json ===
+      // text/plain, application/json
       [{"ts":0}]
-      === application/xml, text/css ===
-      {"type":"Error","kind":"invalid operation","error":"could not find supported mime type in ACCEPT header"}
+      // application/xml, text/css
+      {"type":"Error","kind":"invalid operation","error":"could not find supported MIME type in Accept header"}

--- a/service/ztests/accept-header.yaml
+++ b/service/ztests/accept-header.yaml
@@ -1,0 +1,22 @@
+script: |
+  source service.sh
+  zed create -q test
+  echo '{ts:0}' | zed load -use test -q -
+  for accept in "text/plain, application/json" "application/xml, text/css"; do
+    echo === $accept ===
+    curl -X POST \
+      -H "Accept: $accept" \
+      -d '{"query":"from test@main"}' \
+      $ZED_LAKE/query
+  done
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      === text/plain, application/json ===
+      [{"ts":0}]
+      === application/xml, text/css ===
+      {"type":"Error","kind":"invalid operation","error":"could not find supported mime type in ACCEPT header"}

--- a/service/ztests/accept-header.yaml
+++ b/service/ztests/accept-header.yaml
@@ -4,10 +4,7 @@ script: |
   echo '{ts:0}' | zed load -use test -q -
   for accept in "text/plain, application/json" "application/xml, text/css"; do
     echo === $accept ===
-    curl -X POST \
-      -H "Accept: $accept" \
-      -d '{"query":"from test@main"}' \
-      $ZED_LAKE/query
+    curl -H "Accept: $accept" -d '{"query":"from test@main"}' $ZED_LAKE/query
   done
 
 inputs:

--- a/service/ztests/curl-add-gzip.yaml
+++ b/service/ztests/curl-add-gzip.yaml
@@ -1,7 +1,7 @@
 script: |
   source service.sh
   curl -X POST -d '{"name":"test"}' $ZED_LAKE/pool > pool.json
-  poolID=$(zq -f text "cut pool.id" pool.json)
+  poolID=$(zq -f text "yield ksuid(pool.id)" pool.json)
   curl -X POST --data-binary @- $ZED_LAKE/pool/$poolID/branch/main | zq -z "commit:=0" -
 
 inputs:
@@ -15,4 +15,4 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {commit:0,warnings:[]([null])}
+      {commit:0,warnings:[]([string])}

--- a/service/ztests/curl-query.yaml
+++ b/service/ztests/curl-query.yaml
@@ -37,4 +37,5 @@ outputs:
       {a:"hello",b:{c:"world",d:"goodbye"}}
       {a:"one",b:{c:"two",d:"three"}}
       === ===
-      [{"a":"hello","b":{"c":"world","d":"goodbye"}},{"a":"one","b":{"c":"two","d":"three"}}]
+      {a:"hello",b:{c:"world",d:"goodbye"}}
+      {a:"one",b:{c:"two",d:"three"}}

--- a/service/ztests/curl-query.yaml
+++ b/service/ztests/curl-query.yaml
@@ -37,5 +37,4 @@ outputs:
       {a:"hello",b:{c:"world",d:"goodbye"}}
       {a:"one",b:{c:"two",d:"three"}}
       === ===
-      {a:"hello",b:{c:"world",d:"goodbye"}}
-      {a:"one",b:{c:"two",d:"three"}}
+      [{"a":"hello","b":{"c":"world","d":"goodbye"}},{"a":"one","b":{"c":"two","d":"three"}}]

--- a/service/ztests/curl-stats.yaml
+++ b/service/ztests/curl-stats.yaml
@@ -1,7 +1,7 @@
 script: |
   source service.sh
   curl -X POST -d '{"name":"test"}' $ZED_LAKE/pool > pool.json
-  poolID=$(zq -f text 'cut pool.id' pool.json)
+  poolID=$(zq -f text 'yield ksuid(pool.id)' pool.json)
   curl -X POST -d @- $ZED_LAKE/pool/$poolID/branch/main > load.json
   curl $ZED_LAKE/pool/$poolID/stats
 
@@ -13,4 +13,4 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {"size":33695,"span":{"ts":"2020-04-21T22:40:30.06852324Z","dur":9789993714061}}
+      {size:33695,span:{ts:2020-04-21T22:40:30.06852324Z,dur:9789993714061(=nano.Duration)}(=nano.Span)}(=lake.PoolStats)


### PR DESCRIPTION
Import handling of accept headers so that HTTP Accept headers with multiple
types are handled without error. This pr also improves and centralizes
how the derived format type from the selected Accept mime type is used
in constructing the response.

Closes #3859