### PR TITLE
Work around docs.github.com link checker problem

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -4,5 +4,13 @@
       "pattern": "^http://localhost:9867"
     }
   ],
-  "retryOn429": true
+  "retryOn429": true,
+  "httpHeaders": [
+    {
+      "urls": ["https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ]
 }

--- a/docs/tutorials/zed.md
+++ b/docs/tutorials/zed.md
@@ -45,7 +45,7 @@ data since this will allow Zed to efficiently query data within a range of the
 pool key without having to touch the entire data set.
 
 For this primer we'll work with pull requests on this public repository via the
-[Github API](https://docs.github.com/en/rest/reference/pulls#list-pull-requests). <!-- markdown-link-check-disable-line -->
+[Github API](https://docs.github.com/en/rest/reference/pulls#list-pull-requests).
 Let's create a pool to store this data and use the field `created_at` as the
 pool key, sorted in descending order:
 


### PR DESCRIPTION
I've been keeping an eye on the thread for those who were also affected by docs.github.com starting to return HTTP 403 to link checkers. Nobody from GitHub has chimed in yet with any kind of "bwahahaha this is all part of our master plan!" nor "oops, our bad, we'll fix". However, someone did chime at [https://github.com/github/feedback/discussions/14773#discussioncomment-2679987](https://github.com/github/feedback/discussions/14773#discussioncomment-2679987) with a workaround that I tested out successfully in a personal repo. So here's a PR to put that to use so the link can be checked again.