### PR TITLE
Fix panic on dropping deeply nested records

### DIFF
--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -91,7 +91,7 @@ func complementFields(drops field.List, prefix field.Path, typ *zed.TypeRecord) 
 				continue
 			}
 		}
-		fields = append(fields, append([]string{}, fld...))
+		fields = append(fields, append(field.Path{}, fld...))
 		types = append(types, c.Type)
 	}
 	return fields, types, match

--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -78,31 +78,23 @@ func complementFields(drops field.List, prefix field.Path, typ *zed.TypeRecord) 
 	var types []zed.Type
 	var match bool
 	for _, c := range typ.Columns {
-		if contains(drops, append(prefix, c.Name)) {
+		fld := append(prefix, c.Name)
+		if drops.Has(fld) {
 			match = true
 			continue
 		}
 		if typ, ok := zed.TypeUnder(c.Type).(*zed.TypeRecord); ok {
-			if fs, ts, m := complementFields(drops, append(prefix, c.Name), typ); m {
+			if fs, ts, m := complementFields(drops, fld, typ); m {
 				fields = append(fields, fs...)
 				types = append(types, ts...)
 				match = true
 				continue
 			}
 		}
-		fields = append(fields, append(prefix, c.Name))
+		fields = append(fields, append([]string{}, fld...))
 		types = append(types, c.Type)
 	}
 	return fields, types, match
-}
-
-func contains(ss field.List, el field.Path) bool {
-	for _, s := range ss {
-		if s.Equal(el) {
-			return true
-		}
-	}
-	return false
 }
 
 func (_ *Dropper) String() string { return "drop" }

--- a/runtime/expr/ztests/drop-nested.yaml
+++ b/runtime/expr/ztests/drop-nested.yaml
@@ -2,6 +2,8 @@ script: |
   zq -z "drop rec.bar" nested1.zson
   echo ===
   zq -z "drop rec1" nested2.zson
+  echo ===
+  zq -z "drop level0.level1.level2.level3" nested3.zson
 
 inputs:
   - name: nested1.zson
@@ -13,6 +15,19 @@ inputs:
     data: |
       {foo:"outer1",rec1:{sub1:{foo:"foo1.1",bar:"bar1.1"},sub2:{foo:"foo2.1",bar:"bar2.1"}},rec2:{foo:"foo3.1"}}
       {foo:"outer2",rec1:{sub1:{foo:"foo1.2",bar:"bar1.2"},sub2:{foo:"foo2.2",bar:"bar2.2"}}(=rec1_named),rec2:{foo:"foo3.2"}(=rec2_named)}(=named)
+  - name: nested3.zson
+    data: |
+      {
+        level0: {
+          level1: {
+            level2: {
+              level3: "hi",
+              foo: 1,
+              bar: 2
+            }
+          }
+        }
+      }
 
 outputs:
   - name: stdout
@@ -23,3 +38,5 @@ outputs:
       ===
       {foo:"outer1",rec2:{foo:"foo3.1"}}
       {foo:"outer2",rec2:{foo:"foo3.2"}(=rec2_named)}
+      ===
+      {level0:{level1:{level2:{foo:1,bar:2}}}}


### PR DESCRIPTION
Fix a bug in drop where dropping records nested with a depth of three or
more would cause a duplicate column panic. The issue is caused when a
third item is appended to a slice and go expands the capacity from 2 to 4. With
available capacity in the prefix when a fourth item is appended go does
not allocate a new array and insteads returns the same slice with the
last value changed. The code meanwhile expected append to always return a new
array which resulted in the same slice getting added multiple times
causing the panic.

Closes #3882