### PR TITLE
zio/zngio: increase MaxSize from 10 MB to 1 GB

### DIFF
--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	ReadSize  = 512 * 1024
-	MaxSize   = 10 * 1024 * 1024
+	MaxSize   = 1024 * 1024 * 1024
 	TypeLimit = 10000
 )
 


### PR DESCRIPTION
The MaxSize constant limits the size of ZNG frames (and, consequently,
values) read by zngio, providing a defense against bad inputs that might
otherwise trigger an arbitrarily-large memory allocation.  Experience
has shown that the current value of 10 MB is too small, so increase it
to 1 GB.

For #3881.