### PR TITLE
zio/zngio: honor -readmax flag in frame length checks

### DIFF
--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -35,8 +35,9 @@ func newScanner(ctx context.Context, zctx *zed.Context, r io.Reader, filter zbuf
 		ctx:    ctx,
 		cancel: cancel,
 		parser: parser{
-			peeker: peeker.NewReader(r, opts.Size, opts.Max),
-			types:  NewDecoder(zctx),
+			peeker:  peeker.NewReader(r, opts.Size, opts.Max),
+			types:   NewDecoder(zctx),
+			maxSize: opts.Max,
 		},
 		validate:   opts.Validate,
 		workerCh:   make(chan *worker),

--- a/zio/zngio/sync.go
+++ b/zio/zngio/sync.go
@@ -26,8 +26,9 @@ func newScannerSync(ctx context.Context, zctx *zed.Context, r io.Reader, filter 
 		ctx:    ctx,
 		cancel: cancel,
 		parser: parser{
-			peeker: peeker.NewReader(r, opts.Size, opts.Max),
-			types:  NewDecoder(zctx),
+			peeker:  peeker.NewReader(r, opts.Size, opts.Max),
+			types:   NewDecoder(zctx),
+			maxSize: opts.Max,
 		},
 	}
 	var bf *expr.BufferFilter

--- a/zio/zngio/ztests/big-value.yaml
+++ b/zio/zngio/ztests/big-value.yaml
@@ -16,4 +16,4 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      bigrow.zng: large value of 278535 bytes exceeds maximum read buffer
+      bigrow.zng: zngio: frame length (278535) exceeds maximum allowed (10000)


### PR DESCRIPTION
The -readmax flag to zed and zq sets zio/zngio.ReaderOpts.Max, which is
meant to be used in ZNG frame length checks but is not, making it
impossible to raise the maximum frame length above the default.  Fix
this by using ReaderOpts.Max in those checks.

For #3881.