### PR TITLE
zfmt: print dag.Filter as "where"

### DIFF
--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -12,24 +12,24 @@ outputs:
     data: |
       from (
         (pushdown
-          filter x=="hello" or x==1.)
+          where x=="hello" or x==1.)
         pool G2eDzBUfU6IEmUSGCa5kHyXMhoO
       )
       ===
       from (
         (pushdown
-          filter x>1 and y<=1.)
+          where x>1 and y<=1.)
         pool G2eDzBUfU6IEmUSGCa5kHyXMhoO
       )
       ===
       from (
         (pushdown
-          filter x=="hello" or x!=1.)
+          where x=="hello" or x!=1.)
         pool G2eDzBUfU6IEmUSGCa5kHyXMhoO
       )
       ===
       from (
         (pushdown
-          filter x=="hello" or  !y==2 or y==3)
+          where x=="hello" or  !y==2 or y==3)
         pool G2eDzBUfU6IEmUSGCa5kHyXMhoO
       )

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -283,7 +283,7 @@ func (c *canonDAG) op(p dag.Op) {
 		c.write("pass")
 	case *dag.Filter:
 		c.next()
-		c.open("filter ")
+		c.open("where ")
 		if isDAGTrue(p.Expr) {
 			c.write("*")
 		} else {

--- a/zfmt/ztests/parallel.yaml
+++ b/zfmt/ztests/parallel.yaml
@@ -7,7 +7,7 @@ outputs:
       from (
         file bar
       )
-      | filter search("foo")
+      | where search("foo")
       | fork (
         =>
           summarize

--- a/zfmt/ztests/type-value.yaml
+++ b/zfmt/ztests/type-value.yaml
@@ -9,4 +9,4 @@ outputs:
       from (
         (internal reader)
       )
-      | filter is(<(uint16,ip)>) and search(80)
+      | where is(<(uint16,ip)>) and search(80)


### PR DESCRIPTION
Print a dag.Filter as a "where" in zfmt since "filter" is not an
operation in the language.