### PR TITLE
sort: Propagate batch context

### DIFF
--- a/runtime/op/sort/ztests/over-with.yaml
+++ b/runtime/op/sort/ztests/over-with.yaml
@@ -1,0 +1,10 @@
+zed: |
+  over this with foo="bar" => (sort this | yield {num: this, foo})
+
+input: "[4,2,6,1]"
+
+output: |
+  {num:1,foo:"bar"}
+  {num:2,foo:"bar"}
+  {num:4,foo:"bar"}
+  {num:6,foo:"bar"}


### PR DESCRIPTION
Fix issue where sort was not keeping around the batch context causing
downstream dependencies reliant on the context (for vars) to panic.