### PR TITLE
tail: Propagate batch context

### DIFF
--- a/runtime/op/tail/ztests/over-with.yaml
+++ b/runtime/op/tail/ztests/over-with.yaml
@@ -1,0 +1,7 @@
+zed: |
+  over this with foo="bar" => (tail 1 | yield {num: this, foo})
+
+input: '[1,2,3,4,5]'
+
+output: |
+  {num:5,foo:"bar"}


### PR DESCRIPTION
Tail was stripping the batch context causing panics on when used inside
of an over with. Fix this by keep around a reference batch.