### PR TITLE
zfmt: add parentheses to binary expressions

### DIFF
--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -107,7 +107,13 @@ func (c *canon) expr(e ast.Expr, paren bool) {
 		c.write(e.Op)
 		c.expr(e.Operand, true)
 	case *ast.BinaryExpr:
+		if paren {
+			c.write("(")
+		}
 		c.binary(e)
+		if paren {
+			c.write(")")
+		}
 	case *ast.Conditional:
 		c.write("(")
 		c.expr(e.Cond, true)

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -77,7 +77,13 @@ func (c *canonDAG) expr(e dag.Expr, paren bool) {
 		c.write(e.Op)
 		c.expr(e.Operand, true)
 	case *dag.BinaryExpr:
+		if paren {
+			c.write("(")
+		}
 		c.binary(e)
+		if paren {
+			c.write(")")
+		}
 	case *dag.Conditional:
 		c.write("(")
 		c.expr(e.Cond, true)

--- a/zfmt/ztests/parens.yaml
+++ b/zfmt/ztests/parens.yaml
@@ -1,0 +1,14 @@
+script: |
+  zc -C '!(ts < 4)'
+  echo ===
+  zc -s -C '!(ts < 4)'
+
+outputs:
+  - name: stdout
+    data: |
+      where  !(ts<4)
+      ===
+      from (
+        (internal reader)
+      )
+      | where  !(ts<4)


### PR DESCRIPTION
Add parentheses on binary expressions when requested by the parent
caller. This change fixes an issue where zfmt would lose needed order
of operations in certain circumstances.