### PR TITLE
fix synopsis of fork operator

### DIFF
--- a/docs/language/operators/fork.md
+++ b/docs/language/operators/fork.md
@@ -5,11 +5,11 @@
 ### Synopsis
 
 ```
-fork {
+fork (
   => <leg>
   => <leg>
   ...
-}
+)
 ```
 ### Description
 


### PR DESCRIPTION
This commit fixes the synopsis of fork to use parentheses instead
of braces.