### PR TITLE
add support for Parquet API responses

### DIFF
--- a/api/mime.go
+++ b/api/mime.go
@@ -8,13 +8,14 @@ import (
 )
 
 const (
-	MediaTypeAny    = "*/*"
-	MediaTypeCSV    = "text/csv"
-	MediaTypeJSON   = "application/json"
-	MediaTypeNDJSON = "application/x-ndjson"
-	MediaTypeZJSON  = "application/x-zjson"
-	MediaTypeZNG    = "application/x-zng"
-	MediaTypeZSON   = "application/x-zson"
+	MediaTypeAny     = "*/*"
+	MediaTypeCSV     = "text/csv"
+	MediaTypeJSON    = "application/json"
+	MediaTypeNDJSON  = "application/x-ndjson"
+	MediaTypeParquet = "application/x-parquet"
+	MediaTypeZJSON   = "application/x-zjson"
+	MediaTypeZNG     = "application/x-zng"
+	MediaTypeZSON    = "application/x-zson"
 )
 
 type ErrUnsupportedMimeType struct {
@@ -44,6 +45,8 @@ func MediaTypeToFormat(s string, dflt string) (string, error) {
 		return "json", nil
 	case MediaTypeNDJSON:
 		return "ndjson", nil
+	case MediaTypeParquet:
+		return "parquet", nil
 	case MediaTypeZJSON:
 		return "zjson", nil
 	case MediaTypeZNG:
@@ -62,6 +65,8 @@ func FormatToMediaType(format string) string {
 		return MediaTypeJSON
 	case "ndjson":
 		return MediaTypeNDJSON
+	case "parquet":
+		return MediaTypeParquet
 	case "zjson":
 		return MediaTypeZJSON
 	case "zng":

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -483,6 +483,7 @@ The supported MIME types are as follows:
 | CSV | text/csv |
 | JSON | application/json |
 | NDJSON | application/x-ndjson |
+| Parquet | application/x-parquet |
 | ZJSON | application/x-zjson |
 | ZSON | application/x-zson |
 | ZNG | application/x-zng |

--- a/service/ztests/curl-query.yaml
+++ b/service/ztests/curl-query.yaml
@@ -7,6 +7,9 @@ script: |
     curl -H "Accept: $accept" -d '{"query":"from test"}' $ZED_LAKE/query\?ctrl=true |
       sed -E '/QueryStats/s/[0-9]{3,}/xxx/g' # for ZJSON
   done
+  echo === application/x-parquet ===
+  curl -H 'Accept: application/x-parquet' -d '{"query":"from test"}' -o out.parquet $ZED_LAKE/query
+  zq -z -i parquet out.parquet
 
 inputs:
   - name: service.sh
@@ -37,5 +40,8 @@ outputs:
       {a:"hello",b:{c:"world",d:"goodbye"}}
       {a:"one",b:{c:"two",d:"three"}}
       === ===
+      {a:"hello",b:{c:"world",d:"goodbye"}}
+      {a:"one",b:{c:"two",d:"three"}}
+      === application/x-parquet ===
       {a:"hello",b:{c:"world",d:"goodbye"}}
       {a:"one",b:{c:"two",d:"three"}}


### PR DESCRIPTION
Send a Parquet response for an API request whose negotiated content type
is application/x-parquet.  (There's no established MIME type for
Parquet.)