### PR TITLE
use net/netip instead of inet.af/netaddr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	golang.org/x/text v0.3.4
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.0-20210106172901-c476de37821d
-	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
 )
 
 require (
@@ -57,11 +56,11 @@ require (
 	github.com/rivo/uniseg v0.1.0 // indirect
 	go.opentelemetry.io/otel v0.16.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 // indirect
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/mod v0.4.0 // indirect
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
+	golang.org/x/tools v0.1.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.25.1-0.20201020201750-d3470999428b // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,6 @@ github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsY
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/fraugster/parquet-go v0.10.1-0.20220222153523-e6b70a8a7212 h1:u7X3aZRlWSm18x0EysX9szRULhH7QYQv7UkxW1yHbik=
 github.com/fraugster/parquet-go v0.10.1-0.20220222153523-e6b70a8a7212/go.mod h1:dGzUxdNqXsAijatByVgbAWVPlFirnhknQbdazcUIjY0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -210,10 +209,6 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.16.0 h1:uFRZXykJGK9lLY4HtgSw44DnIcAM+kRBP7x5m+NpAOM=
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
-go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
-go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -330,5 +325,3 @@ gopkg.in/yaml.v3 v3.0.0-20210106172901-c476de37821d/go.mod h1:K4uyk7z7BCEPqu6E+C
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.1.0 h1:AWNL1W1i7f0wNZ8VwOKNJ0sliKvOF/adn0EHenfUh+c=
 honnef.co/go/tools v0.1.0/go.mod h1:XtegFAyX/PfluP4921rXU5IkjkqBCDnUq4W8VCIoKvM=
-inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6 h1:acCzuUSQ79tGsM/O50VRFySfMm19IoMKL+sZztZkCxw=
-inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6/go.mod h1:y3MGhcFMlh0KZPMuXXow8mpjxxAk3yoDNsp4cQz54i8=

--- a/pkg/byteconv/byteconv.go
+++ b/pkg/byteconv/byteconv.go
@@ -3,10 +3,9 @@
 package byteconv
 
 import (
+	"net/netip"
 	"strconv"
 	"unsafe"
-
-	"inet.af/netaddr"
 )
 
 // UnsafeString converts a byte slice to a string without copying the underlying
@@ -20,8 +19,8 @@ func ParseBool(b []byte) (bool, error) {
 	return strconv.ParseBool(UnsafeString(b))
 }
 
-func ParseIP(b []byte) (netaddr.IP, error) {
-	return netaddr.ParseIP(UnsafeString(b))
+func ParseIP(b []byte) (netip.Addr, error) {
+	return netip.ParseAddr(UnsafeString(b))
 }
 
 func ParseInt8(b []byte) (int8, error) {

--- a/primitive.go
+++ b/primitive.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/netip"
 
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zcode"
-	"inet.af/netaddr"
 )
 
 type TypeOfBool struct{}
@@ -307,11 +307,11 @@ func (t *TypeOfUint64) Kind() Kind {
 
 type TypeOfIP struct{}
 
-func NewIP(a netaddr.IP) *Value {
+func NewIP(a netip.Addr) *Value {
 	return &Value{TypeIP, EncodeIP(a)}
 }
 
-func AppendIP(zb zcode.Bytes, a netaddr.IP) zcode.Bytes {
+func AppendIP(zb zcode.Bytes, a netip.Addr) zcode.Bytes {
 	if a.Is4() {
 		ip := a.As4()
 		return append(zb, ip[:]...)
@@ -320,16 +320,16 @@ func AppendIP(zb zcode.Bytes, a netaddr.IP) zcode.Bytes {
 	return append(zb, ip[:]...)
 }
 
-func EncodeIP(a netaddr.IP) zcode.Bytes {
+func EncodeIP(a netip.Addr) zcode.Bytes {
 	return AppendIP(nil, a)
 }
 
-func DecodeIP(zv zcode.Bytes) netaddr.IP {
-	var ip netaddr.IP
-	if err := ip.UnmarshalBinary(zv); err != nil {
+func DecodeIP(zv zcode.Bytes) netip.Addr {
+	var a netip.Addr
+	if err := a.UnmarshalBinary(zv); err != nil {
 		panic(fmt.Errorf("failure trying to decode IP address: %w", err))
 	}
-	return ip
+	return a
 }
 
 func (t *TypeOfIP) ID() int {

--- a/runtime/expr/boolean.go
+++ b/runtime/expr/boolean.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"net/netip"
 	"regexp"
 	"regexp/syntax"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/byteconv"
 	"github.com/brimdata/zed/zcode"
-	"inet.af/netaddr"
 )
 
 //XXX TBD:
@@ -128,19 +128,19 @@ func CompareTime(op string, pattern int64) (Boolean, error) {
 
 //XXX should just do equality and we should compare in the encoded domain
 // and not make copies and have separate cases for len 4 and len 16
-var compareAddr = map[string]func(netaddr.IP, netaddr.IP) bool{
-	"==": func(a, b netaddr.IP) bool { return a.Compare(b) == 0 },
-	"!=": func(a, b netaddr.IP) bool { return a.Compare(b) != 0 },
-	">":  func(a, b netaddr.IP) bool { return a.Compare(b) > 0 },
-	">=": func(a, b netaddr.IP) bool { return a.Compare(b) >= 0 },
-	"<":  func(a, b netaddr.IP) bool { return a.Compare(b) < 0 },
-	"<=": func(a, b netaddr.IP) bool { return a.Compare(b) <= 0 },
+var compareAddr = map[string]func(netip.Addr, netip.Addr) bool{
+	"==": func(a, b netip.Addr) bool { return a.Compare(b) == 0 },
+	"!=": func(a, b netip.Addr) bool { return a.Compare(b) != 0 },
+	">":  func(a, b netip.Addr) bool { return a.Compare(b) > 0 },
+	">=": func(a, b netip.Addr) bool { return a.Compare(b) >= 0 },
+	"<":  func(a, b netip.Addr) bool { return a.Compare(b) < 0 },
+	"<=": func(a, b netip.Addr) bool { return a.Compare(b) <= 0 },
 }
 
 // Comparison returns a Predicate that compares typed byte slices that must
 // be TypeAddr with the value's address using a comparison based on op.
 // Only equality operands are allowed.
-func CompareIP(op string, pattern netaddr.IP) (Boolean, error) {
+func CompareIP(op string, pattern netip.Addr) (Boolean, error) {
 	compare, ok := compareAddr[op]
 	if !ok {
 		return nil, fmt.Errorf("unknown addr comparator: %s", op)

--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -3,6 +3,7 @@ package expr_test
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/brimdata/zed/zson"
 	"github.com/brimdata/zed/ztest"
 	"github.com/stretchr/testify/require"
-	"inet.af/netaddr"
 )
 
 func testSuccessful(t *testing.T, e string, input string, expectedVal zed.Value) {
@@ -71,7 +71,7 @@ func zstring(s string) zed.Value {
 }
 
 func zip(t *testing.T, s string) zed.Value {
-	return zed.Value{zed.TypeIP, zed.EncodeIP(netaddr.MustParseIP(s))}
+	return zed.Value{zed.TypeIP, zed.EncodeIP(netip.MustParseAddr(s))}
 }
 func znet(t *testing.T, s string) zed.Value {
 	_, net, err := net.ParseCIDR(s)

--- a/runtime/expr/function/ip.go
+++ b/runtime/expr/function/ip.go
@@ -24,7 +24,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	ip := zed.DecodeIP(args[0].Bytes)
 	var mask net.IPMask
 	if len(args) == 1 {
-		mask = ip.IPAddr().IP.DefaultMask()
+		mask = net.IP(ip.AsSlice()).DefaultMask()
 		if mask == nil {
 			return newErrorf(n.zctx, ctx, "network_of: not an IPv4 address")
 		}
@@ -54,7 +54,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 	}
 	// XXX GC
-	netIP := ip.IPAddr().IP.Mask(mask)
+	netIP := net.IP(ip.AsSlice()).Mask(mask)
 	v := &net.IPNet{netIP, mask}
 	return ctx.NewValue(zed.TypeNet, zed.EncodeNet(v))
 }
@@ -74,7 +74,7 @@ func (c *CIDRMatch) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	cidrMask := zed.DecodeNet(maskVal.Bytes)
 	if errMatch == args[1].Walk(func(typ zed.Type, body zcode.Bytes) error {
 		if typ.ID() == zed.IDIP {
-			addr := zed.DecodeIP(body).IPAddr().IP
+			addr := net.IP(zed.DecodeIP(body).AsSlice())
 			if cidrMask.IP.Equal(addr.Mask(cidrMask.Mask)) {
 				return errMatch
 			}

--- a/runtime/expr/functions_test.go
+++ b/runtime/expr/functions_test.go
@@ -2,16 +2,16 @@ package expr_test
 
 import (
 	"fmt"
+	"net/netip"
 	"testing"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/runtime/expr/function"
 	"github.com/brimdata/zed/zson"
-	"inet.af/netaddr"
 )
 
 func zaddr(addr string) zed.Value {
-	return zed.Value{zed.TypeIP, zed.EncodeIP(netaddr.MustParseIP(addr))}
+	return zed.Value{zed.TypeIP, zed.EncodeIP(netip.MustParseAddr(addr))}
 }
 
 func TestBadFunction(t *testing.T) {

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"time"
 	"unicode/utf8"
@@ -13,7 +14,6 @@ import (
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zcode"
 	"golang.org/x/text/unicode/norm"
-	"inet.af/netaddr"
 )
 
 func Build(b *zcode.Builder, val Value) (*zed.Value, error) {
@@ -134,7 +134,7 @@ func BuildPrimitive(b *zcode.Builder, val Primitive) error {
 		b.Append(norm.NFC.Bytes(body))
 		return nil
 	case *zed.TypeOfIP:
-		ip, err := netaddr.ParseIP(val.Text)
+		ip, err := netip.ParseAddr(val.Text)
 		if err != nil {
 			return err
 		}

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"math"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/brimdata/zed/zson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"inet.af/netaddr"
 )
 
 func toZSON(t *testing.T, rec *zed.Value) string {
@@ -141,11 +141,11 @@ func TestMarshalTime(t *testing.T) {
 }
 
 type TestIP struct {
-	Addr netaddr.IP
+	Addr netip.Addr
 }
 
 func TestIPType(t *testing.T) {
-	s := TestIP{Addr: netaddr.MustParseIP("192.168.1.1")}
+	s := TestIP{Addr: netip.MustParseAddr("192.168.1.1")}
 	zctx := zed.NewContext()
 	m := zson.NewZNGMarshalerWithContext(zctx)
 	rec, err := m.MarshalRecord(s)


### PR DESCRIPTION
Note that this really commits us to Go 1.18 since that version introduces net/netip.