### PR TITLE
Fix unflatten bug

### DIFF
--- a/runtime/expr/function/unflatten.go
+++ b/runtime/expr/function/unflatten.go
@@ -8,9 +8,10 @@ import (
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#unflatten
 type Unflatten struct {
+	zctx *zed.Context
+
 	builder     zcode.Builder
-	recordCache *recordCache
-	zctx        *zed.Context
+	recordCache recordCache
 
 	// These exist only to reduce memory allocations.
 	path   field.Path
@@ -20,8 +21,7 @@ type Unflatten struct {
 
 func NewUnflatten(zctx *zed.Context) *Unflatten {
 	return &Unflatten{
-		recordCache: &recordCache{},
-		zctx:        zctx,
+		zctx: zctx,
 	}
 }
 
@@ -40,7 +40,7 @@ func (u *Unflatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		if typ == nil {
 			continue
 		}
-		root.addPath(u.recordCache, path)
+		root.addPath(&u.recordCache, path)
 		u.types = append(u.types, typ)
 		u.values = append(u.values, vb)
 	}
@@ -95,7 +95,7 @@ type recordCache struct {
 }
 
 func (c *recordCache) new() *record {
-	if c.index == cap(c.records) {
+	if c.index == len(c.records) {
 		c.records = append(c.records, new(record))
 	}
 	r := c.records[c.index]

--- a/runtime/expr/function/unflatten.go
+++ b/runtime/expr/function/unflatten.go
@@ -119,7 +119,7 @@ func (r *record) addPath(c *recordCache, p []string) {
 		return
 	}
 	if len(r.columns) == 0 || r.columns[len(r.columns)-1].Name != p[0] {
-		r.appendColumn(p[0])
+		r.columns = append(r.columns, zed.NewColumn(p[0], nil))
 		var rec *record
 		if len(p) > 1 {
 			rec = c.new()
@@ -127,15 +127,6 @@ func (r *record) addPath(c *recordCache, p []string) {
 		r.records = append(r.records, rec)
 	}
 	r.records[len(r.records)-1].addPath(c, p[1:])
-}
-
-func (r *record) appendColumn(name string) {
-	if len(r.columns) == cap(r.columns) {
-		r.columns = append(r.columns, zed.Column{})
-	} else {
-		r.columns = r.columns[:len(r.columns)+1]
-	}
-	r.columns[len(r.columns)-1].Name = name
 }
 
 func (r *record) build(zctx *zed.Context, b *zcode.Builder, next func() (zed.Type, zcode.Bytes)) zed.Type {

--- a/runtime/expr/function/ztests/unflatten.yaml
+++ b/runtime/expr/function/ztests/unflatten.yaml
@@ -2,5 +2,6 @@ zed: "yield unflatten(flatten(this))"
 
 input: &input |
   {a:{a:1,b:2,x:{z:"foo"}},b:2,c:3}
+  {b:{b1:4,b2:5,b3:{c:[6,7,8]},b4:["one","two","three"]}}
 
 output: *input


### PR DESCRIPTION
Fix bug where unflatten was producing incorrect results for certain
nested records. The previous approach where the record structure and
bytes value was constructed in a single pass, made the code difficult to
reason about. This pr reformats unflatten so it is done in two
passes: The first pass constructs the shape of the nested record and the
second pass builds the type the value for the record.

Closes #3904