### PR TITLE
runtime/expr/agg: increase MaxValueSize from 20 MB to 1 GB

### DIFF
--- a/runtime/expr/agg/agg.go
+++ b/runtime/expr/agg/agg.go
@@ -15,7 +15,7 @@ type Pattern func() Function
 // MaxValueSize is a limit on an individual aggregation value since sets
 // and arrays could otherwise grow without limit leading to a single record
 // value that cannot fit in memory.
-const MaxValueSize = 20 * 1024 * 1024
+const MaxValueSize = 1024 * 1024 * 1024
 
 type Function interface {
 	Consume(*zed.Value)


### PR DESCRIPTION
Experience has shown that the current value is too small.

For #3895.

We'll add a flag to adjust this in a separate PR.