### PR TITLE
unflatten: fix panic on invalid key types

### DIFF
--- a/docs/language/functions/unflatten.md
+++ b/docs/language/functions/unflatten.md
@@ -6,7 +6,7 @@ record.
 ### Synopsis
 
 ```
-unflatten(val: [{key:[string],value:any}) -> record
+unflatten(val: [{key:string|[string],value:any}) -> record
 ```
 ### Description
 The _unflatten_ function converts the key/value records in array `val` into
@@ -16,7 +16,7 @@ will produce a record identical to `r`.
 ### Examples
 Simple:
 ```mdtest-command
-echo '[{key:["a"],value:1},{key:["b"],value:2}]' | zq -z 'yield unflatten(this)' -
+echo '[{key:"a",value:1},{key:["b"],value:2}]' | zq -z 'yield unflatten(this)' -
 ```
 =>
 ```mdtest-output

--- a/runtime/expr/function/ztests/unflatten.yaml
+++ b/runtime/expr/function/ztests/unflatten.yaml
@@ -5,9 +5,15 @@ input: |
   [{key:["b","b1"],value:4},{key:["b","b2"],value:5},{key:["b","b3","c"],value:[6,7,8]},{key:["b","b4"],value:["one","two","three"]}]
   [{key:"s",value:1}]
   [{key:1,value:1}]
+  [{key:["a","b"],value:1},{key:["a","c"],value:2},{key:"a",value:3}]
+  [{key:"a",value:1},{key:"a",value:2}]
+  [{key:["a","b"],value:1},{key:["a","b","c"],value:2}]
 
 output: |
   {a:{a:1,b:2,x:{z:"foo"}},b:2,c:3}
   {b:{b1:4,b2:5,b3:{c:[6,7,8]},b4:["one","two","three"]}}
   {s:1}
   error({message:"invalid key type int64: expected either string or [string]",on:{key:1,value:1}})
+  {a:3}
+  {a:2}
+  {a:{b:{c:2}}}

--- a/runtime/expr/function/ztests/unflatten.yaml
+++ b/runtime/expr/function/ztests/unflatten.yaml
@@ -1,7 +1,13 @@
-zed: "yield unflatten(flatten(this))"
+zed: "yield unflatten(this)"
 
-input: &input |
+input: |
+  [{key:["a","a"],value:1},{key:["a","b"],value:2},{key:["a","x","z"],value:"foo"},{key:["b"],value:2},{key:["c"],value:3}]
+  [{key:["b","b1"],value:4},{key:["b","b2"],value:5},{key:["b","b3","c"],value:[6,7,8]},{key:["b","b4"],value:["one","two","three"]}]
+  [{key:"s",value:1}]
+  [{key:1,value:1}]
+
+output: |
   {a:{a:1,b:2,x:{z:"foo"}},b:2,c:3}
   {b:{b1:4,b2:5,b3:{c:[6,7,8]},b4:["one","two","three"]}}
-
-output: *input
+  {s:1}
+  error({message:"invalid key type int64: expected either string or [string]",on:{key:1,value:1}})

--- a/runtime/expr/function/ztests/unflatten.yaml
+++ b/runtime/expr/function/ztests/unflatten.yaml
@@ -4,16 +4,18 @@ input: |
   [{key:["a","a"],value:1},{key:["a","b"],value:2},{key:["a","x","z"],value:"foo"},{key:["b"],value:2},{key:["c"],value:3}]
   [{key:["b","b1"],value:4},{key:["b","b2"],value:5},{key:["b","b3","c"],value:[6,7,8]},{key:["b","b4"],value:["one","two","three"]}]
   [{key:"s",value:1}]
-  [{key:1,value:1}]
   [{key:["a","b"],value:1},{key:["a","c"],value:2},{key:"a",value:3}]
   [{key:"a",value:1},{key:"a",value:2}]
   [{key:["a","b"],value:1},{key:["a","b","c"],value:2}]
+  [{key:1,value:1}]
+  [{key:"a",value:1},{key:"b",value:2},{key:"a",value:2}]
 
 output: |
   {a:{a:1,b:2,x:{z:"foo"}},b:2,c:3}
   {b:{b1:4,b2:5,b3:{c:[6,7,8]},b4:["one","two","three"]}}
   {s:1}
-  error({message:"invalid key type int64: expected either string or [string]",on:{key:1,value:1}})
   {a:3}
   {a:2}
   {a:{b:{c:2}}}
+  error({message:"invalid key type int64: expected either string or [string]",on:{key:1,value:1}})
+  error({message:"duplicate field: \"a\"",on:[{key:"a",value:1},{key:"b",value:2},{key:"a",value:2}]})


### PR DESCRIPTION
Fix issue where unflatten would panic when encountering an unsupported
key type. Also add support so that key can be a string and return an
error value if an invalid key type is encountered.

Closes #3925