### PR TITLE
Index Writer: fix bug with LZ4 size

### DIFF
--- a/index/writer.go
+++ b/index/writer.go
@@ -276,11 +276,13 @@ func newIndexWriter(base *Writer, w io.WriteCloser, name string, ectx expr.Conte
 	}
 	writer := bufwriter.New(w)
 	return &indexWriter{
-		base:     base,
-		buffer:   writer,
-		ectx:     ectx,
-		name:     name,
-		zng:      zngio.NewWriter(writer, zngio.WriterOpts{}),
+		base:   base,
+		buffer: writer,
+		ectx:   ectx,
+		name:   name,
+		zng: zngio.NewWriter(writer, zngio.WriterOpts{
+			LZ4BlockSize: zngio.DefaultLZ4BlockSize,
+		}),
 		frameEnd: int64(base.frameThresh),
 	}, nil
 }


### PR DESCRIPTION
Fix bug in the IndexWriter where the zngio.Writer LZ4 options was not
getting set, resulting in the index getting created with a bunch of
single value value frames.