### PR TITLE
refactor index writer opts

### DIFF
--- a/cmd/zed/dev/indexfile/create/command.go
+++ b/cmd/zed/dev/indexfile/create/command.go
@@ -42,17 +42,22 @@ func init() {
 
 type Command struct {
 	*indexfile.Command
-	frameThresh int
-	order       string
-	outputFile  string
-	keys        string
-	inputFlags  inputflags.Flags
+	opts       index.WriterOpts
+	order      string
+	outputFile string
+	keys       string
+	inputFlags inputflags.Flags
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*indexfile.Command)}
-	f.IntVar(&c.frameThresh, "f", 32*1024, "minimum frame size used in Zed index file")
-	f.StringVar(&c.order, "order", "asc", "specify data in ascending (asc) or descending (desc) order")
+	f.IntVar(&c.opts.FrameThresh, "f", 32*1024, "minimum frame size used in Zed index file")
+	f.Func("order", "order of index (asc or desc) (default asc)", func(s string) (err error) {
+		if s != "" {
+			c.opts.Order, err = order.Parse(s)
+		}
+		return err
+	})
 	f.StringVar(&c.outputFile, "o", "index.zng", "name of index output file")
 	f.StringVar(&c.keys, "k", "", "comma-separated list of field names for keys")
 	c.inputFlags.SetFlags(f, true)
@@ -82,15 +87,8 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	o, err := order.Parse(c.order)
-	if err != nil {
-		return err
-	}
 	defer file.Close()
-	writer, err := index.NewWriter(zctx, local, c.outputFile, field.DottedList(c.keys),
-		index.FrameThresh(c.frameThresh),
-		index.Order(o),
-	)
+	writer, err := index.NewWriter(zctx, local, c.outputFile, field.DottedList(c.keys), c.opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/dev/indexfile/create/command.go
+++ b/cmd/zed/dev/indexfile/create/command.go
@@ -52,10 +52,9 @@ type Command struct {
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*indexfile.Command)}
 	f.IntVar(&c.opts.FrameThresh, "f", 32*1024, "minimum frame size used in Zed index file")
-	f.Func("order", "order of index (asc or desc) (default asc)", func(s string) (err error) {
-		if s != "" {
-			c.opts.Order, err = order.Parse(s)
-		}
+	f.Func("order", `order of index (asc or desc) (default "asc")`, func(s string) error {
+		var err error
+		c.opts.Order, err = order.Parse(s)
 		return err
 	})
 	f.StringVar(&c.outputFile, "o", "index.zng", "name of index output file")

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -30,7 +30,7 @@ func TestSearch(t *testing.T) {
 {key:"key5",value:"value5"}
 {key:"key6",value:"value6"}
 `
-	finder := buildAndOpen(t, storage.NewLocalEngine(), reader(data), field.DottedList("key"))
+	finder := buildAndOpen(t, storage.NewLocalEngine(), reader(data), field.DottedList("key"), index.WriterOpts{})
 	kv, err := finder.ParseKeys(`"key2"`)
 	require.NoError(t, err)
 	rec, err := finder.Lookup(kv...)
@@ -46,7 +46,7 @@ func TestMicroIndex(t *testing.T) {
 	require.NoError(t, err)
 	zctx := zed.NewContext()
 	engine := storage.NewLocalEngine()
-	writer, err := index.NewWriter(zctx, engine, path, field.DottedList("key"))
+	writer, err := index.NewWriter(zctx, engine, path, field.DottedList("key"), index.WriterOpts{})
 	require.NoError(t, err)
 	err = zio.Copy(writer, stream)
 	require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestNearest(t *testing.T) {
 
 	}
 	engine := storage.NewLocalEngine()
-	desc := buildAndOpen(t, engine, reader(records), field.DottedList("ts"), index.Order(order.Desc))
+	desc := buildAndOpen(t, engine, reader(records), field.DottedList("ts"), index.WriterOpts{Order: order.Desc})
 	t.Run("Descending", func(t *testing.T) {
 		for _, c := range cases {
 			runtest(t, desc, ">", c.value, c.gt)
@@ -120,7 +120,7 @@ func TestNearest(t *testing.T) {
 	q, err := runtime.NewQueryOnReader(context.Background(), zed.NewContext(), compiler.MustParseOp("sort ts"), reader(records), nil)
 	defer q.Pull(true)
 	require.NoError(t, err)
-	asc := buildAndOpen(t, engine, q.AsReader(), field.DottedList("ts"), index.Order(order.Asc))
+	asc := buildAndOpen(t, engine, q.AsReader(), field.DottedList("ts"), index.WriterOpts{Order: order.Asc})
 	t.Run("Ascending", func(t *testing.T) {
 		for _, c := range cases {
 			runtest(t, asc, ">", c.value, c.gt)
@@ -132,8 +132,8 @@ func TestNearest(t *testing.T) {
 	})
 }
 
-func buildAndOpen(t *testing.T, engine storage.Engine, r zio.Reader, keys field.List, opts ...index.Option) *index.Finder {
-	return openFinder(t, build(t, engine, r, keys, opts...))
+func buildAndOpen(t *testing.T, engine storage.Engine, r zio.Reader, keys field.List, opts index.WriterOpts) *index.Finder {
+	return openFinder(t, build(t, engine, r, keys, opts))
 }
 
 func openFinder(t *testing.T, path string) *index.Finder {
@@ -146,9 +146,9 @@ func openFinder(t *testing.T, path string) *index.Finder {
 	return finder
 }
 
-func build(t *testing.T, engine storage.Engine, r zio.Reader, keys field.List, opts ...index.Option) string {
+func build(t *testing.T, engine storage.Engine, r zio.Reader, keys field.List, opts index.WriterOpts) string {
 	path := filepath.Join(t.TempDir(), "test.zng")
-	writer, err := index.NewWriter(zed.NewContext(), engine, path, keys, opts...)
+	writer, err := index.NewWriter(zed.NewContext(), engine, path, keys, opts)
 	require.NoError(t, err)
 	require.NoError(t, zio.Copy(writer, r))
 	require.NoError(t, writer.Close())

--- a/lake/index/writer.go
+++ b/lake/index/writer.go
@@ -118,7 +118,7 @@ func newIndexer(ctx context.Context, engine storage.Engine, path *storage.URI, o
 		return nil, err
 	}
 	keys := rule.RuleKeys()
-	writer, err := index.NewWriterWithContext(ctx, zctx, engine, object.Path(path).String(), keys)
+	writer, err := index.NewWriterWithContext(ctx, zctx, engine, object.Path(path).String(), keys, index.WriterOpts{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refactor index writer opts to use the simple struct pattern instead of
callbacks.