### PR TITLE
zio/emitter: number Split files sequentially

### DIFF
--- a/cmd/zq/ztests/split-o.yaml
+++ b/cmd/zq/ztests/split-o.yaml
@@ -1,0 +1,20 @@
+script: |
+  zq -z -split dir -o prefix -
+
+inputs:
+  - name: stdin
+    data: |
+      1
+      {a:1}
+      {a:2}
+      2
+
+outputs:
+  - name: dir/prefix-0.zson
+    data: |
+      1
+      2
+  - name: dir/prefix-1.zson
+    data: |
+      {a:1}
+      {a:2}

--- a/cmd/zq/ztests/split.yaml
+++ b/cmd/zq/ztests/split.yaml
@@ -1,0 +1,20 @@
+script: |
+  zq -z -split dir -
+
+inputs:
+  - name: stdin
+    data: |
+      1
+      {a:1}
+      {a:2}
+      2
+
+outputs:
+  - name: dir/0.zson
+    data: |
+      1
+      2
+  - name: dir/1.zson
+    data: |
+      {a:1}
+      {a:2}

--- a/zio/emitter/split.go
+++ b/zio/emitter/split.go
@@ -66,12 +66,12 @@ func (s *Split) lookupOutput(val *zed.Value) (zio.WriteCloser, error) {
 	return w, nil
 }
 
-// path returns the storage URI given the prefix combined with a type ID
-// to make a unique path for each Zed type. If the _path field is present,
-// we use that for the unique ID but add the type ID if there any _path
-// string appears with different Zed types.
+// path returns the storage URI given the prefix combined with a unique ID
+// to make a unique path for each Zed type.  If the _path field is present,
+// we use that for the unique ID, but if the _path string appears with
+// different Zed types, then we prepend it to the unique ID.
 func (s *Split) path(r *zed.Value) *storage.URI {
-	uniq := strconv.Itoa(r.Type.ID())
+	uniq := strconv.Itoa(len(s.writers))
 	if _path := r.Deref("_path").AsString(); _path != "" {
 		if _, ok := s.seen[_path]; ok {
 			uniq = _path + "-" + uniq


### PR DESCRIPTION
Split, which implements the -split output flag to zed and zq, uses type
ID numbers to generate unique file names.  Exposing type IDs like this
is peculiar.  Use sequential non-negative integers instead.