### PR TITLE
cli/outputflags: always default to ZNG for -split

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -100,7 +100,8 @@ func (f *Flags) Init() error {
 	if f.outputFile == "-" {
 		f.outputFile = ""
 	}
-	if f.outputFile == "" && f.Format == "zng" && terminal.IsTerminalFile(os.Stdout) && !f.forceBinary {
+	if f.outputFile == "" && f.split == "" && f.Format == "zng" && !f.forceBinary &&
+		terminal.IsTerminalFile(os.Stdout) {
 		f.Format = "zson"
 		f.ZSON.Pretty = 0
 	}


### PR DESCRIPTION
Flags.Init sets Flags.Format to "zson" when -split is specified, -o is
not specified, and standard output is attached to a terminal.  This is
surprising because -split writes to files and ZNG is the default for
files under all other circumstances.  Make ZNG the default here too.

Unfortunately, I don't see a straightforward way to test this.