### PR TITLE
rename scheduler as planner and move to runtime/exec

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -20,6 +20,7 @@ import (
 	"github.com/brimdata/zed/lake/branches"
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/lakeparse"
+	"github.com/brimdata/zed/runtime/exec"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
@@ -201,9 +202,9 @@ func (c *Connection) Version(ctx context.Context) (string, error) {
 	return res.Version, nil
 }
 
-func (c *Connection) PoolStats(ctx context.Context, id ksuid.KSUID) (lake.PoolStats, error) {
+func (c *Connection) PoolStats(ctx context.Context, id ksuid.KSUID) (exec.PoolStats, error) {
 	req := c.NewRequest(ctx, http.MethodGet, path.Join("/pool", id.String(), "stats"), nil)
-	var stats lake.PoolStats
+	var stats exec.PoolStats
 	err := c.doAndUnmarshal(req, &stats)
 	if errIsStatus(err, http.StatusNotFound) {
 		err = ErrPoolNotFound

--- a/compiler/data/source.go
+++ b/compiler/data/source.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -11,8 +10,6 @@ import (
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/storage"
-	"github.com/brimdata/zed/runtime/expr/extent"
-	"github.com/brimdata/zed/runtime/op"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/segmentio/ksuid"
@@ -34,6 +31,10 @@ func (s *Source) IsLake() bool {
 	return s.lake != nil
 }
 
+func (s *Source) Lake() *lake.Root {
+	return s.lake
+}
+
 func (s *Source) PoolID(ctx context.Context, id string) (ksuid.KSUID, error) {
 	if s.lake != nil {
 		return s.lake.PoolID(ctx, id)
@@ -53,13 +54,6 @@ func (s *Source) Layout(ctx context.Context, src dag.Source) order.Layout {
 		return s.lake.Layout(ctx, src)
 	}
 	return order.Nil
-}
-
-func (s *Source) NewScheduler(ctx context.Context, zctx *zed.Context, src dag.Source, span extent.Span, f zbuf.Filter) (op.Scheduler, error) {
-	if s.lake != nil {
-		return s.lake.NewScheduler(ctx, zctx, src, span, f)
-	}
-	return nil, errors.New("pool scan not available when running on local file system")
 }
 
 func (s *Source) Open(ctx context.Context, zctx *zed.Context, path, format string, pushdown zbuf.Filter) (zbuf.Puller, error) {

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -61,7 +61,7 @@ func NewWriter(ctx context.Context, zctx *zed.Context, pool *Pool) (*Writer, err
 		zctx:       zctx,
 		errgroup:   g,
 		buffer:     ch,
-		comparator: importComparator(zctx, pool),
+		comparator: ImportComparator(zctx, pool),
 	}, nil
 }
 
@@ -187,7 +187,7 @@ func (s *ImportStats) Copy() ImportStats {
 	}
 }
 
-func importComparator(zctx *zed.Context, pool *Pool) *expr.Comparator {
+func ImportComparator(zctx *zed.Context, pool *Pool) *expr.Comparator {
 	layout := pool.Layout
 	layout.Keys = field.List{poolKey(layout)}
 	return zbuf.NewComparator(zctx, layout)

--- a/runtime/exec/meta.go
+++ b/runtime/exec/meta.go
@@ -1,0 +1,231 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/lake"
+	"github.com/brimdata/zed/lake/commits"
+	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/pkg/nano"
+	"github.com/brimdata/zed/runtime/expr/extent"
+	"github.com/brimdata/zed/runtime/op/from"
+	"github.com/brimdata/zed/zbuf"
+	"github.com/brimdata/zed/zson"
+	"github.com/segmentio/ksuid"
+)
+
+//XXX for backward compat keep this for now, and return branchstats for pool/main
+type PoolStats struct {
+	Size int64 `zed:"size"`
+	// XXX (nibs) - This shouldn't be a span because keys don't have to be time.
+	Span *nano.Span `zed:"span"`
+}
+
+func GetPoolStats(ctx context.Context, p *lake.Pool, snap commits.View) (info PoolStats, err error) {
+	ch := make(chan data.Object)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		err = ScanSpan(ctx, snap, nil, p.Layout.Order, ch)
+		close(ch)
+	}()
+	// XXX this doesn't scale... it should be stored in the snapshot and is
+	// not easy to compute in the face of deletes...
+	var poolSpan *extent.Generic
+	for object := range ch {
+		info.Size += object.Size
+		if poolSpan == nil {
+			poolSpan = extent.NewGenericFromOrder(object.First, object.Last, p.Layout.Order)
+		} else {
+			poolSpan.Extend(&object.First)
+			poolSpan.Extend(&object.Last)
+		}
+	}
+	//XXX need to change API to take return key range
+	if poolSpan != nil {
+		min := poolSpan.First()
+		if min.Type == zed.TypeTime {
+			firstTs := zed.DecodeTime(min.Bytes)
+			lastTs := zed.DecodeTime(poolSpan.Last().Bytes)
+			if lastTs < firstTs {
+				firstTs, lastTs = lastTs, firstTs
+			}
+			span := nano.NewSpanTs(firstTs, lastTs+1)
+			info.Span = &span
+		}
+	}
+	return info, err
+}
+
+type BranchStats struct {
+	Size int64 `zed:"size"`
+	// XXX (nibs) - This shouldn't be a span because keys don't have to be time.
+	Span *nano.Span `zed:"span"`
+}
+
+func GetBranchStats(ctx context.Context, b *lake.Branch, snap commits.View) (info BranchStats, err error) {
+	ch := make(chan data.Object)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		err = ScanSpan(ctx, snap, nil, b.Pool().Layout.Order, ch)
+		close(ch)
+	}()
+	// XXX this doesn't scale... it should be stored in the snapshot and is
+	// not easy to compute in the face of deletes...
+	var poolSpan *extent.Generic
+	for object := range ch {
+		info.Size += object.Size
+		if poolSpan == nil {
+			poolSpan = extent.NewGenericFromOrder(object.First, object.Last, b.Pool().Layout.Order)
+		} else {
+			poolSpan.Extend(&object.First)
+			poolSpan.Extend(&object.Last)
+		}
+	}
+	//XXX need to change API to take return key range
+	if poolSpan != nil {
+		min := poolSpan.First()
+		if min.Type == zed.TypeTime {
+			firstTs := zed.DecodeTime(min.Bytes)
+			lastTs := zed.DecodeTime(poolSpan.Last().Bytes)
+			if lastTs < firstTs {
+				firstTs, lastTs = lastTs, firstTs
+			}
+			span := nano.NewSpanTs(firstTs, lastTs+1)
+			info.Span = &span
+		}
+	}
+	return info, err
+}
+
+func NewLakeMetaPlanner(ctx context.Context, zctx *zed.Context, r *lake.Root, meta string, filter zbuf.Filter) (from.Planner, error) {
+	f, err := filter.AsEvaluator()
+	if err != nil {
+		return nil, err
+	}
+	var vals []zed.Value
+	switch meta {
+	case "pools":
+		vals, err = r.BatchifyPools(ctx, zctx, f)
+	case "branches":
+		vals, err = r.BatchifyBranches(ctx, zctx, f)
+	case "index_rules":
+		vals, err = r.BatchifyIndexRules(ctx, zctx, f)
+	default:
+		return nil, fmt.Errorf("unknown lake metadata type: %q", meta)
+	}
+	if err != nil {
+		return nil, err
+	}
+	s, err := zbuf.NewScanner(ctx, zbuf.NewArray(vals), filter)
+	if err != nil {
+		return nil, err
+	}
+	return newScannerScheduler(s), nil
+}
+
+func NewPoolMetaPlanner(ctx context.Context, zctx *zed.Context, r *lake.Root, poolID ksuid.KSUID, meta string, filter zbuf.Filter) (from.Planner, error) {
+	f, err := filter.AsEvaluator()
+	if err != nil {
+		return nil, err
+	}
+	p, err := r.OpenPool(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+	var vals []zed.Value
+	switch meta {
+	case "branches":
+		m := zson.NewZNGMarshalerWithContext(zctx)
+		m.Decorate(zson.StylePackage)
+		vals, err = p.BatchifyBranches(ctx, zctx, nil, m, f)
+	default:
+		return nil, fmt.Errorf("unknown pool metadata type: %q", meta)
+	}
+	s, err := zbuf.NewScanner(ctx, zbuf.NewArray(vals), filter)
+	if err != nil {
+		return nil, err
+	}
+	return newScannerScheduler(s), nil
+}
+
+func NewCommitMetaPlanner(ctx context.Context, zctx *zed.Context, r *lake.Root, poolID, commit ksuid.KSUID, meta string, span extent.Span, filter zbuf.Filter) (from.Planner, error) {
+	p, err := r.OpenPool(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+	switch meta {
+	case "objects":
+		snap, err := p.Snapshot(ctx, commit)
+		if err != nil {
+			return nil, err
+		}
+		reader, err := objectReader(ctx, zctx, snap, span, p.Layout.Order)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
+	case "indexes":
+		snap, err := p.Snapshot(ctx, commit)
+		if err != nil {
+			return nil, err
+		}
+		reader, err := indexObjectReader(ctx, zctx, snap, span, p.Layout.Order)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
+	case "partitions":
+		snap, err := p.Snapshot(ctx, commit)
+		if err != nil {
+			return nil, err
+		}
+		reader, err := partitionReader(ctx, zctx, snap, span, p.Layout.Order)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
+	case "log":
+		tips, err := p.BatchifyBranchTips(ctx, zctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		tipsScanner, err := zbuf.NewScanner(ctx, zbuf.NewArray(tips), filter)
+		if err != nil {
+			return nil, err
+		}
+		log := p.OpenCommitLog(ctx, zctx, commit)
+		logScanner, err := zbuf.NewScanner(ctx, log, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(tipsScanner, logScanner), nil
+	case "rawlog":
+		reader, err := p.OpenCommitLogAsZNG(ctx, zctx, commit)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
+	default:
+		return nil, fmt.Errorf("unknown commit metadata type: %q", meta)
+	}
+}

--- a/runtime/meta/partition.go
+++ b/runtime/meta/partition.go
@@ -1,0 +1,33 @@
+package meta
+
+import (
+	"fmt"
+
+	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/runtime/expr"
+	"github.com/brimdata/zed/runtime/expr/extent"
+	"github.com/brimdata/zed/zson"
+)
+
+// A Partition is a logical view of the records within a time span, stored
+// in one or more data objects.  This provides a way to return the list of
+// objects that should be scanned along with a span to limit the scan
+// to only the span involved.
+type Partition struct {
+	extent.Span
+	Compare expr.CompareFn
+	Objects []*data.ObjectScan
+}
+
+func (p Partition) IsZero() bool {
+	return p.Objects == nil
+}
+
+func (p Partition) FormatRangeOf(index int) string {
+	o := p.Objects[index]
+	return fmt.Sprintf("[%s-%s,%s-%s]", zson.String(*p.First()), zson.String(*p.Last()), zson.String(o.First), zson.String(o.Last))
+}
+
+func (p Partition) FormatRange() string {
+	return fmt.Sprintf("[%s-%s]", zson.String(*p.First()), zson.String(*p.Last()))
+}

--- a/runtime/op/op.go
+++ b/runtime/op/op.go
@@ -10,11 +10,6 @@ import (
 
 const BatchLen = 100
 
-type Scheduler interface {
-	PullScanTask() (zbuf.Puller, error)
-	Progress() zbuf.Progress
-}
-
 // Result is a convenient way to bundle the result of Proc.Pull() to
 // send over channels.
 type Result struct {

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -13,6 +13,7 @@ import (
 	lakeapi "github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/lake/branches"
 	"github.com/brimdata/zed/lake/pools"
+	"github.com/brimdata/zed/runtime/exec"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zio/zsonio"
@@ -26,7 +27,7 @@ type testClient struct {
 	*client.Connection
 }
 
-func (c *testClient) TestPoolStats(id ksuid.KSUID) lake.PoolStats {
+func (c *testClient) TestPoolStats(id ksuid.KSUID) exec.PoolStats {
 	r, err := c.Connection.PoolStats(context.Background(), id)
 	require.NoError(c, err)
 	return r

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/runtime"
+	"github.com/brimdata/zed/runtime/exec"
 	"github.com/brimdata/zed/runtime/op"
 	"github.com/brimdata/zed/service/auth"
 	"github.com/brimdata/zed/service/srverr"
@@ -154,7 +155,7 @@ func handlePoolStats(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(err)
 		return
 	}
-	info, err := pool.Stats(r.Context(), snap)
+	info, err := exec.GetPoolStats(r.Context(), pool, snap)
 	if err != nil {
 		w.Error(err)
 		return

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/brimdata/zed/api"
 	"github.com/brimdata/zed/api/client"
-	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/runtime/exec"
 	"github.com/brimdata/zed/service"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/segmentio/ksuid"
@@ -74,7 +74,7 @@ func TestPoolStats(t *testing.T) {
 	conn.TestLoad(poolID, "main", strings.NewReader(src))
 
 	span := nano.Span{Ts: 1e9, Dur: 1e9 + 1}
-	expected := lake.PoolStats{
+	expected := exec.PoolStats{
 		Span: &span,
 		Size: 84,
 	}
@@ -85,7 +85,7 @@ func TestPoolStatsNoData(t *testing.T) {
 	_, conn := newCore(t)
 	poolID := conn.TestPoolPost(api.PoolPostRequest{Name: "test", Layout: defaultLayout})
 	info := conn.TestPoolStats(poolID)
-	expected := lake.PoolStats{
+	expected := exec.PoolStats{
 		Size: 0,
 	}
 	require.Equal(t, expected, info)

--- a/service/ztests/curl-stats.yaml
+++ b/service/ztests/curl-stats.yaml
@@ -13,4 +13,4 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {size:32074,span:{ts:2020-04-21T22:40:30.06852324Z,dur:9789993714061(=nano.Duration)}(=nano.Span)}(=lake.PoolStats)
+      {size:32074,span:{ts:2020-04-21T22:40:30.06852324Z,dur:9789993714061(=nano.Duration)}(=nano.Span)}(=exec.PoolStats)

--- a/zio/lakeio/unmarshal.go
+++ b/zio/lakeio/unmarshal.go
@@ -7,6 +7,7 @@ import (
 	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/lake/pools"
 	"github.com/brimdata/zed/pkg/field"
+	"github.com/brimdata/zed/runtime/meta"
 	"github.com/brimdata/zed/zson"
 )
 
@@ -27,7 +28,7 @@ func init() {
 		index.FieldRule{},
 		index.TypeRule{},
 		index.AggRule{},
-		lake.Partition{},
+		meta.Partition{},
 		pools.Config{},
 		lake.BranchMeta{},
 		lake.BranchTip{},

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/pkg/terminal/color"
 	"github.com/brimdata/zed/pkg/units"
+	"github.com/brimdata/zed/runtime/meta"
 	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
 )
@@ -93,7 +94,7 @@ func (w *Writer) formatValue(t table, b *bytes.Buffer, v interface{}, width int,
 		formatDataObject(b, &v, "", 0)
 	case *data.Object:
 		formatDataObject(b, v, "", 0)
-	case lake.Partition:
+	case meta.Partition:
 		formatPartition(b, v)
 	case *commits.Commit:
 		branches := w.branches[v.ID]
@@ -173,7 +174,7 @@ func formatDataObject(b *bytes.Buffer, object *data.Object, prefix string, inden
 	b.WriteByte('\n')
 }
 
-func formatPartition(b *bytes.Buffer, p lake.Partition) {
+func formatPartition(b *bytes.Buffer, p meta.Partition) {
 	b.WriteString("from ")
 	b.WriteString(zson.String(*p.First()))
 	b.WriteString(" to ")


### PR DESCRIPTION
This commit repackages the scheduling concept as a "planner"
and moves the relevant code out of the lake implementation and
into an "execution engine" residing in the new package runtime/exec.

runtime/op.Scheduler is now runtime/op/from.Planner.

These changes get us ready to do more sophisticated planning
and pushdowns in preparation for the vector engine and cache.

No logic has been changed here.  Code has simply been moved
around and renamed a bit.