### PR TITLE
add vector form of data objects to lake/data

### DIFF
--- a/docs/lake/format.md
+++ b/docs/lake/format.md
@@ -112,7 +112,7 @@ allowing a scan to do a byte-range retrieval of the ZNG object when
 processing only a subset of data.
 
 > Note the ZST format allows individual vector segments to be read in isolation
-> and the in-memory ZST representation is support for random access so there is
+> and the in-memory ZST representation supports random access so there is
 > no need to have a seek index for the vector object.
 
 #### Commit History

--- a/docs/lake/format.md
+++ b/docs/lake/format.md
@@ -73,6 +73,7 @@ such an assumption).
 
 A data object is created by a single writer using a globally unique name
 with an embedded KSUID.  
+
 New objects are written in their entirety.  No updates, appends, or modifications
 may be made once an object exists.  Given these semantics, any such object may be
 trivially cached as neither its name nor content ever change.
@@ -82,23 +83,23 @@ resulting object is immutable, there is no possible write concurrency to manage
 with respect to a given object.
 
 A data object is composed of
-* the primary data object stored as one or two objects (for row and/or column layout),
+* the primary data object stored as one or two objects (for sequence and/or vector layout),
 * an optional seek index, and
 * zero or more search indexes.
 
-Data objects may be either in sequential form (i.e., ZNG) or column form (i.e., ZST),
+Data objects may be either in sequence form (i.e., ZNG) or vector form (i.e., ZST),
 or both forms may be present as a query optimizer may choose to use whatever
 representation is more efficient.
-When both row and column data objects are present, they must contain the same
+When both sequence and vector data objects are present, they must contain the same
 underlying Zed data.
 
 Immutable objects are named as follows:
 
 |object type|name|
 |-----------|----|
-|column data|`<pool-id>/data/<id>.zst`|
-|row data|`<pool-id>/data/<id>.zng`|
-|row seek index|`<pool-id>/data/<id>-seek.zng`|
+|vector data|`<pool-id>/data/<id>.zst`|
+|sequence data|`<pool-id>/data/<id>.zng`|
+|sequence seek index|`<pool-id>/data/<id>-seek.zng`|
 |search index|`<pool-id>/index/<id>-<index-id>.zng`|
 
 `<id>` is the KSUID of the data object.
@@ -110,9 +111,9 @@ The seek index maps pool key values to seek offsets in the ZNG file thereby
 allowing a scan to do a byte-range retrieval of the ZNG object when
 processing only a subset of data.
 
-> Note the ZST format will have seekable checkpoints based on the sort key that
-> are encoded into its metadata section so there is no need to have a separate
-> seek index for the columnar object.
+> Note the ZST format allows individual vector segments to be read in isolation
+> and the in-memory ZST representation is support for random access so there is
+> no need to have a seek index for the vector object.
 
 #### Commit History
 

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -189,8 +189,7 @@ func (b *Branch) dbpCopies(ctx context.Context, c runtime.Compiler, snap *commit
 		// leverage the seek index to skip over irrelavant segments but we don't
 		// have a way to translate the delete filter into an extent.Span, so
 		// just read the whole file.
-		objectPath := o.RowObjectPath(b.pool.DataPath)
-		reader, err := b.pool.engine.Get(ctx, objectPath)
+		reader, err := b.pool.engine.Get(ctx, o.SequenceURI(b.pool.DataPath))
 		if err != nil {
 			return nil, err
 		}
@@ -502,7 +501,7 @@ func indexMessage(rules []index.Rule) string {
 }
 
 func (b *Branch) indexObject(ctx context.Context, c runtime.Compiler, rules []index.Rule, id ksuid.KSUID) ([]*index.Object, error) {
-	r, err := b.engine.Get(ctx, data.RowObjectPath(b.pool.DataPath, id))
+	r, err := b.engine.Get(ctx, data.SequenceURI(b.pool.DataPath, id))
 	if err != nil {
 		return nil, err
 	}

--- a/lake/data/object.go
+++ b/lake/data/object.go
@@ -135,28 +135,24 @@ func (o Object) ObjectPrefix(path *storage.URI) *storage.URI {
 	return path.AppendPath(o.ID.String())
 }
 
-func (o Object) RowObjectName() string {
-	return RowObjectName(o.ID)
+func (o Object) SequenceURI(path *storage.URI) *storage.URI {
+	return SequenceURI(path, o.ID)
 }
 
-func RowObjectName(id ksuid.KSUID) string {
-	return fmt.Sprintf("%s.zng", id)
+func SequenceURI(path *storage.URI, id ksuid.KSUID) *storage.URI {
+	return path.AppendPath(fmt.Sprintf("%s.zng", id))
 }
 
-func (o Object) RowObjectPath(path *storage.URI) *storage.URI {
-	return RowObjectPath(path, o.ID)
+func (o Object) SeekIndexURI(path *storage.URI) *storage.URI {
+	return path.AppendPath(fmt.Sprintf("%s-seek.zng", o.ID))
 }
 
-func RowObjectPath(path *storage.URI, id ksuid.KSUID) *storage.URI {
-	return path.AppendPath(RowObjectName(id))
+func (o Object) VectorURI(path *storage.URI) *storage.URI {
+	return VectorURI(path, o.ID)
 }
 
-func (o Object) SeekObjectName() string {
-	return fmt.Sprintf("%s-seek.zng", o.ID)
-}
-
-func (o Object) SeekObjectPath(path *storage.URI) *storage.URI {
-	return path.AppendPath(o.SeekObjectName())
+func VectorURI(path *storage.URI, id ksuid.KSUID) *storage.URI {
+	return path.AppendPath(fmt.Sprintf("%s.zst", id))
 }
 
 func (o Object) Range() string {

--- a/lake/data/reader.go
+++ b/lake/data/reader.go
@@ -37,7 +37,7 @@ type Reader struct {
 // and if the provided span skips part of the object, the seek index will be used to
 // limit the reading window of the returned reader.
 func (o *ObjectScan) NewReader(ctx context.Context, engine storage.Engine, path *storage.URI, scanRange extent.Span, cmp expr.CompareFn) (*Reader, error) {
-	objectPath := o.RowObjectPath(path)
+	objectPath := o.SequenceURI(path)
 	reader, err := engine.Get(ctx, objectPath)
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func (o *ObjectScan) NewReader(ctx context.Context, engine storage.Engine, path 
 	}
 	rg := seekindex.Range{0, math.MaxInt64}
 	if !bytes.Equal(o.First.Bytes, span.First().Bytes) || !bytes.Equal(o.Last.Bytes, span.Last().Bytes) {
-		indexReader, err := engine.Get(ctx, o.SeekObjectPath(path))
+		indexReader, err := engine.Get(ctx, o.SeekIndexURI(path))
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				return sr, nil

--- a/lake/data/vector.go
+++ b/lake/data/vector.go
@@ -30,6 +30,9 @@ func CreateVector(ctx context.Context, engine storage.Engine, path *storage.URI,
 		SkewThresh:   zstio.DefaultSkewThresh,
 	})
 	if err != nil {
+		get.Close()
+		put.Close()
+		DeleteVector(ctx, engine, path, id)
 		return err
 	}
 	// Note here that writer.Close closes the Put but reader.Close does not
@@ -44,6 +47,9 @@ func CreateVector(ctx context.Context, engine storage.Engine, path *storage.URI,
 	}
 	if closeErr := get.Close(); err == nil {
 		err = closeErr
+	}
+	if err != nil {
+		DeleteVector(ctx, engine, path, id)
 	}
 	return err
 }

--- a/lake/data/vector.go
+++ b/lake/data/vector.go
@@ -1,0 +1,56 @@
+package data
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/pkg/bufwriter"
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/zngio"
+	"github.com/brimdata/zed/zio/zstio"
+	"github.com/segmentio/ksuid"
+)
+
+// CreateVector writes the vectorized form of an existing Object in the ZST format.
+func CreateVector(ctx context.Context, engine storage.Engine, path *storage.URI, id ksuid.KSUID) error {
+	get, err := engine.Get(ctx, SequenceURI(path, id))
+	if err != nil {
+		return err
+	}
+	put, err := engine.Put(ctx, VectorURI(path, id))
+	if err != nil {
+		get.Close()
+		return err
+	}
+	writer, err := zstio.NewWriter(bufwriter.New(put), zstio.WriterOpts{
+		ColumnThresh: zstio.DefaultColumnThresh,
+		SkewThresh:   zstio.DefaultSkewThresh,
+	})
+	if err != nil {
+		return err
+	}
+	// Note here that writer.Close closes the Put but reader.Close does not
+	// close the Get.
+	reader := zngio.NewReader(get, zed.NewContext())
+	err = zio.Copy(writer, reader)
+	if closeErr := writer.Close(); err == nil {
+		err = closeErr
+	}
+	if closeErr := reader.Close(); err == nil {
+		err = closeErr
+	}
+	if closeErr := get.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+func DeleteVector(ctx context.Context, engine storage.Engine, path *storage.URI, id ksuid.KSUID) error {
+	if err := engine.Delete(ctx, VectorURI(path, id)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -37,7 +37,7 @@ type Writer struct {
 // Close as zed.Values from the various record bodies are referenced across
 // calls to Write.
 func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *storage.URI, order order.Which, poolKey field.Path, seekIndexStride int) (*Writer, error) {
-	out, err := engine.Put(ctx, o.RowObjectPath(path))
+	out, err := engine.Put(ctx, o.SequenceURI(path))
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *sto
 		seekIndexStride = DefaultSeekStride
 	}
 	w.seekIndexStride = seekIndexStride
-	seekOut, err := engine.Put(ctx, o.SeekObjectPath(path))
+	seekOut, err := engine.Put(ctx, o.SeekIndexURI(path))
 	if err != nil {
 		return nil, err
 	}

--- a/lake/data/writer_test.go
+++ b/lake/data/writer_test.go
@@ -1,4 +1,54 @@
-package data
+package data_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/pkg/field"
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zio/zstio"
+	"github.com/brimdata/zed/zson"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataReaderWriterVector(t *testing.T) {
+	engine := storage.NewLocalEngine()
+	tmp := storage.MustParseURI(t.TempDir())
+	object := data.NewObject()
+	ctx := context.Background()
+	w, err := object.NewWriter(ctx, engine, tmp, order.Asc, field.New("a"), 1000)
+	require.NoError(t, err)
+	zctx := zed.NewContext()
+	require.NoError(t, w.Write(zson.MustParseValue(zctx, "{a:1,b:4}")))
+	require.NoError(t, w.Write(zson.MustParseValue(zctx, "{a:2,b:5}")))
+	require.NoError(t, w.Write(zson.MustParseValue(zctx, "{a:3,b:6}")))
+	require.NoError(t, w.Close(ctx))
+	require.NoError(t, data.CreateVector(ctx, engine, tmp, object.ID))
+	// Read back the ZST file and make sure it's the same.
+	get, err := engine.Get(ctx, object.VectorURI(tmp))
+	require.NoError(t, err)
+	reader, err := zstio.NewReader(get, zed.NewContext())
+	require.NoError(t, err)
+	v, err := reader.Read()
+	require.NoError(t, err)
+	assert.Equal(t, zson.String(v), "{a:1,b:4}")
+	v, err = reader.Read()
+	require.NoError(t, err)
+	assert.Equal(t, zson.String(v), "{a:2,b:5}")
+	v, err = reader.Read()
+	require.NoError(t, err)
+	assert.Equal(t, zson.String(v), "{a:3,b:6}")
+	require.NoError(t, reader.Close())
+	require.NoError(t, get.Close())
+	require.NoError(t, data.DeleteVector(ctx, engine, tmp, object.ID))
+	exists, err := engine.Exists(ctx, data.VectorURI(tmp, object.ID))
+	require.NoError(t, err)
+	assert.Equal(t, exists, false)
+}
 
 /* NOT YET
 func TestWriterIndex(t *testing.T) {

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -193,7 +193,7 @@ func (p *Pool) BatchifyBranchTips(ctx context.Context, zctx *zed.Context, f expr
 
 //XXX this is inefficient but is only meant for interactive queries...?
 func (p *Pool) ObjectExists(ctx context.Context, id ksuid.KSUID) (bool, error) {
-	return p.engine.Exists(ctx, data.RowObjectPath(p.DataPath, id))
+	return p.engine.Exists(ctx, data.SequenceURI(p.DataPath, id))
 }
 
 func (p *Pool) Main(ctx context.Context) (BranchMeta, error) {

--- a/runtime/exec/planner.go
+++ b/runtime/exec/planner.go
@@ -175,7 +175,7 @@ func indexFilterPass(ctx context.Context, pool *lake.Pool, snap commits.View, fi
 }
 
 func seekIndexByCount(ctx context.Context, pool *lake.Pool, o *data.ObjectScan, span extent.Span) error {
-	r, err := pool.Storage().Get(ctx, o.SeekObjectPath(pool.DataPath))
+	r, err := pool.Storage().Get(ctx, o.SeekIndexURI(pool.DataPath))
 	if err != nil {
 		return err
 


### PR DESCRIPTION
This commit creates the vector concept for cloud data objects and
adds a simple test to make sure the creation and deletion of such
objects works.

We also updated some of the docs and code to replace the "row/column"
terminology with "sequence/vector" terminology to better describe
Zed's model of heterogeneous sequences of deeply typed values compared
to the relational model of tables, schemas, columns, and rows.
There is more work to do here in the report so we created issue ##3949
to track it.
