### PR TITLE
consistent *zed.Context parameter position

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -136,7 +136,7 @@ func (c *Connection) doAndUnmarshal(req *Request, v interface{}, templates ...in
 		return err
 	}
 	defer res.Body.Close()
-	zr := zngio.NewReader(res.Body, zed.NewContext())
+	zr := zngio.NewReader(zed.NewContext(), res.Body)
 	defer zr.Close()
 	rec, err := zr.Read()
 	if err != nil || rec == nil {

--- a/api/queryio/client.go
+++ b/api/queryio/client.go
@@ -21,7 +21,7 @@ type Query struct {
 // from rc and decodes it.  Closing the Query also closes rc.
 func NewQuery(rc io.ReadCloser) *Query {
 	return &Query{
-		reader: zngio.NewReader(rc, zed.NewContext()),
+		reader: zngio.NewReader(zed.NewContext(), rc),
 		closer: rc,
 	}
 }

--- a/api/queryio/zjson_test.go
+++ b/api/queryio/zjson_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func mkRecord(t *testing.T, s string) *zed.Value {
-	r := zsonio.NewReader(strings.NewReader(s), zed.NewContext())
+	r := zsonio.NewReader(zed.NewContext(), strings.NewReader(s))
 	rec, err := r.Read()
 	require.NoError(t, err)
 	return rec

--- a/cmd/zed/dev/dig/section/command.go
+++ b/cmd/zed/dev/dig/section/command.go
@@ -102,5 +102,5 @@ func newSectionReader(r io.ReaderAt, which int, sections []int64) (*zngio.Reader
 		off += sections[k]
 	}
 	reader := io.NewSectionReader(r, off, sections[which])
-	return zngio.NewReader(reader, zed.NewContext()), nil
+	return zngio.NewReader(zed.NewContext(), reader), nil
 }

--- a/cmd/zed/dev/dig/slice/command.go
+++ b/cmd/zed/dev/dig/slice/command.go
@@ -76,7 +76,7 @@ func (c *Command) Run(args []string) error {
 	if from > to {
 		return errors.New("slice start cannot be after the end")
 	}
-	reader := zngio.NewReader(io.NewSectionReader(r, int64(from), int64(to-from)), zed.NewContext())
+	reader := zngio.NewReader(zed.NewContext(), io.NewSectionReader(r, int64(from), int64(to-from)))
 	writer, err := c.outputFlags.Open(ctx, engine)
 	if err != nil {
 		return err

--- a/cmd/zed/dev/dig/trailer/command.go
+++ b/cmd/zed/dev/dig/trailer/command.go
@@ -72,7 +72,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	zr := zngio.NewReader(bytes.NewReader(b), zed.NewContext())
+	zr := zngio.NewReader(zed.NewContext(), bytes.NewReader(b))
 	defer zr.Close()
 	writer, err := c.outputFlags.Open(ctx, engine)
 	if err != nil {

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -150,7 +150,7 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		if err != nil {
 			return nil, fmt.Errorf("compiling top: %w", err)
 		}
-		return top.New(parent, b.pctx.Zctx, v.Limit, fields, v.Flush), nil
+		return top.New(b.pctx.Zctx, parent, v.Limit, fields, v.Flush), nil
 	case *dag.Put:
 		clauses, err := b.compileAssignments(v.Args)
 		if err != nil {

--- a/complex_test.go
+++ b/complex_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRecordAccessNamed(t *testing.T) {
 	const input = `{foo:"hello" (=zfile),bar:true (=zbool)} (=0)`
-	reader := zsonio.NewReader(strings.NewReader(input), zed.NewContext())
+	reader := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 	rec, err := reader.Read()
 	require.NoError(t, err)
 	s := rec.Deref("foo").AsString()
@@ -31,7 +31,7 @@ func TestNonRecordDeref(t *testing.T) {
 null
 [1,2,3]
 |[1,2,3]|`
-	reader := zsonio.NewReader(strings.NewReader(input), zed.NewContext())
+	reader := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 	for {
 		val, err := reader.Read()
 		if val == nil {

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -157,7 +157,7 @@ func build(t *testing.T, engine storage.Engine, r zio.Reader, keys field.List, o
 }
 
 func reader(logs string) zio.Reader {
-	return zsonio.NewReader(strings.NewReader(logs), zed.NewContext())
+	return zsonio.NewReader(zed.NewContext(), strings.NewReader(logs))
 }
 
 func newReader(size int) (zio.Reader, error) {

--- a/index/reader.go
+++ b/index/reader.go
@@ -101,7 +101,7 @@ func (r *Reader) newSectionReader(level int, sectionOff int64) (*zngio.Reader, e
 	off += sectionOff
 	len -= sectionOff
 	sectionReader := io.NewSectionReader(r.reader, off, len)
-	return zngio.NewReaderWithOpts(sectionReader, r.zctx, zngio.ReaderOpts{Size: FrameBufSize}), nil
+	return zngio.NewReaderWithOpts(r.zctx, sectionReader, zngio.ReaderOpts{Size: FrameBufSize}), nil
 }
 
 func (r *Reader) NewSectionReader(section int) (*zngio.Reader, error) {

--- a/index/writer.go
+++ b/index/writer.go
@@ -162,7 +162,7 @@ func (w *Writer) Close() error {
 		// In this case, bypass the base layer, write an empty trailer
 		// directly to the output, and close.
 		zw := zngio.NewWriter(w.iow, w.opts.ZNGWriterOpts)
-		err := writeTrailer(zw, w.zctx, w.childField, w.opts.FrameThresh, nil, w.keyer.Keys(), w.opts.Order)
+		err := writeTrailer(w.zctx, zw, w.childField, w.opts.FrameThresh, nil, w.keyer.Keys(), w.opts.Order)
 		if err2 := w.iow.Close(); err == nil {
 			err = err2
 		}
@@ -232,10 +232,10 @@ func (w *Writer) finalize() error {
 			return err
 		}
 	}
-	return writeTrailer(base.zng, w.zctx, w.childField, w.opts.FrameThresh, sizes, w.keyer.Keys(), w.opts.Order)
+	return writeTrailer(w.zctx, base.zng, w.childField, w.opts.FrameThresh, sizes, w.keyer.Keys(), w.opts.Order)
 }
 
-func writeTrailer(w *zngio.Writer, zctx *zed.Context, childField string, frameThresh int, sections []int64, keys field.List, o order.Which) error {
+func writeTrailer(zctx *zed.Context, w *zngio.Writer, childField string, frameThresh int, sections []int64, keys field.List, o order.Which) error {
 	meta := &FileMeta{
 		ChildOffsetField: childField,
 		FrameThresh:      frameThresh,

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -194,7 +194,7 @@ func (b *Branch) dbpCopies(ctx context.Context, c runtime.Compiler, snap *commit
 			return nil, err
 		}
 		defer reader.Close()
-		readers[i] = zngio.NewReader(reader, zctx)
+		readers[i] = zngio.NewReader(zctx, reader)
 		defer readers[i].(*zngio.Reader).Close()
 	}
 	// Keeps values that don't fit the filter by adding "not".
@@ -505,7 +505,7 @@ func (b *Branch) indexObject(ctx context.Context, c runtime.Compiler, rules []in
 	if err != nil {
 		return nil, err
 	}
-	reader := zngio.NewReader(r, zed.NewContext())
+	reader := zngio.NewReader(zed.NewContext(), r)
 	defer reader.Close()
 	w, err := index.NewCombiner(ctx, c, b.engine, b.pool.IndexPath, rules, id)
 	if err != nil {

--- a/lake/commits/store.go
+++ b/lake/commits/store.go
@@ -269,7 +269,7 @@ func (s *Store) OpenAsZNG(ctx context.Context, zctx *zed.Context, commit, stop k
 	if err != nil {
 		return nil, err
 	}
-	return zngio.NewReader(r, zctx), nil
+	return zngio.NewReader(zctx, r), nil
 }
 
 func (s *Store) OpenCommitLog(ctx context.Context, zctx *zed.Context, commit, stop ksuid.KSUID) zio.Reader {

--- a/lake/data/reader.go
+++ b/lake/data/reader.go
@@ -62,7 +62,7 @@ func (o *ObjectScan) NewReader(ctx context.Context, engine storage.Engine, path 
 			return nil, err
 		}
 		defer indexReader.Close()
-		zr := zngio.NewReader(indexReader, zed.NewContext())
+		zr := zngio.NewReader(zed.NewContext(), indexReader)
 		defer zr.Close()
 		rg, err = seekindex.Lookup(zr, scanRange.First(), scanRange.Last(), cmp)
 		if err != nil {

--- a/lake/data/vector.go
+++ b/lake/data/vector.go
@@ -37,7 +37,7 @@ func CreateVector(ctx context.Context, engine storage.Engine, path *storage.URI,
 	}
 	// Note here that writer.Close closes the Put but reader.Close does not
 	// close the Get.
-	reader := zngio.NewReader(get, zed.NewContext())
+	reader := zngio.NewReader(zed.NewContext(), get)
 	err = zio.Copy(writer, reader)
 	if closeErr := writer.Close(); err == nil {
 		err = closeErr

--- a/lake/data/writer_test.go
+++ b/lake/data/writer_test.go
@@ -31,7 +31,7 @@ func TestDataReaderWriterVector(t *testing.T) {
 	// Read back the ZST file and make sure it's the same.
 	get, err := engine.Get(ctx, object.VectorURI(tmp))
 	require.NoError(t, err)
-	reader, err := zstio.NewReader(get, zed.NewContext())
+	reader, err := zstio.NewReader(zed.NewContext(), get)
 	require.NoError(t, err)
 	v, err := reader.Read()
 	require.NoError(t, err)

--- a/lake/index/index_test.go
+++ b/lake/index/index_test.go
@@ -20,7 +20,7 @@ func boomerang(t *testing.T, r1 index.Rule) (r2 index.Rule) {
 	t.Helper()
 	b, err := index.Serialize(r1)
 	require.NoError(t, err)
-	reader := zngio.NewReader(bytes.NewReader(b), zed.NewContext())
+	reader := zngio.NewReader(zed.NewContext(), bytes.NewReader(b))
 	defer reader.Close()
 	rec, err := reader.Read()
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func babbleReader(t *testing.T) zio.Reader {
 	r, err := os.Open("../../testdata/babble-sorted.zson")
 	require.NoError(t, err)
 	t.Cleanup(func() { r.Close() })
-	return zsonio.NewReader(r, zed.NewContext())
+	return zsonio.NewReader(zed.NewContext(), r)
 }
 
 /* Not yet

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -177,7 +177,7 @@ func (q *Queue) OpenAsZNG(ctx context.Context, zctx *zed.Context, head, tail ID)
 	if err != nil {
 		return nil, err
 	}
-	return zngio.NewReader(r, zctx), nil
+	return zngio.NewReader(zctx, r), nil
 }
 
 func writeID(ctx context.Context, engine storage.Engine, u *storage.URI, id ID) error {

--- a/lake/seekindex/seekindex_test.go
+++ b/lake/seekindex/seekindex_test.go
@@ -75,7 +75,7 @@ type testSeekIndex struct {
 }
 
 func (t *testSeekIndex) Lookup(s nano.Span, expected Range, o order.Which) {
-	r := zngio.NewReader(bytes.NewReader(t.buffer.Bytes()), zed.NewContext())
+	r := zngio.NewReader(zed.NewContext(), bytes.NewReader(t.buffer.Bytes()))
 	defer r.Close()
 	cmp := extent.CompareFunc(o)
 	var first, last *zed.Value

--- a/runtime/exec/planner.go
+++ b/runtime/exec/planner.go
@@ -181,7 +181,7 @@ func seekIndexByCount(ctx context.Context, pool *lake.Pool, o *data.ObjectScan, 
 
 	}
 	defer r.Close()
-	zr := zngio.NewReader(r, zed.NewContext())
+	zr := zngio.NewReader(zed.NewContext(), r)
 	defer zr.Close()
 	rg, err := seekindex.LookupByCount(zr, span.First(), span.Last())
 	if err != nil {

--- a/runtime/exec/sorted.go
+++ b/runtime/exec/sorted.go
@@ -33,7 +33,7 @@ func newSortedScanner(p *Planner, part meta.Partition) (zbuf.Puller, error) {
 			pullersDone()
 			return nil, err
 		}
-		scanner, err := zngio.NewReader(rc, p.zctx).NewScanner(p.ctx, f)
+		scanner, err := zngio.NewReader(p.zctx, rc).NewScanner(p.ctx, f)
 		if err != nil {
 			pullersDone()
 			rc.Close()

--- a/runtime/expr/function/fields.go
+++ b/runtime/expr/function/fields.go
@@ -37,7 +37,7 @@ func buildPath(typ *zed.TypeRecord, b *zcode.Builder, prefix []string) []string 
 
 func (f *Fields) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	zvSubject := args[0]
-	typ := isRecordType(zvSubject, f.zctx)
+	typ := f.recordType(zvSubject)
 	if typ == nil {
 		return f.zctx.Missing()
 	}
@@ -47,12 +47,12 @@ func (f *Fields) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	return ctx.NewValue(f.typ, b.Bytes())
 }
 
-func isRecordType(zv zed.Value, zctx *zed.Context) *zed.TypeRecord {
+func (f *Fields) recordType(zv zed.Value) *zed.TypeRecord {
 	if typ, ok := zed.TypeUnder(zv.Type).(*zed.TypeRecord); ok {
 		return typ
 	}
 	if zv.Type == zed.TypeType {
-		typ, err := zctx.LookupByValue(zv.Bytes)
+		typ, err := f.zctx.LookupByValue(zv.Bytes)
 		if err != nil {
 			return nil
 		}

--- a/runtime/op/groupby/groupby_test.go
+++ b/runtime/op/groupby/groupby_test.go
@@ -294,7 +294,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 		assert.NoError(t, err)
 
 		zctx := zed.NewContext()
-		zr := zsonio.NewReader(strings.NewReader(strings.Join(data, "\n")), zctx)
+		zr := zsonio.NewReader(zctx, strings.NewReader(strings.Join(data, "\n")))
 		cr := &countReader{r: zr}
 		var outbuf bytes.Buffer
 		zw := zsonio.NewWriter(&nopCloser{&outbuf}, zsonio.WriterOpts{})

--- a/runtime/op/merge/merge_test.go
+++ b/runtime/op/merge/merge_test.go
@@ -99,7 +99,7 @@ func TestParallelOrder(t *testing.T) {
 			pctx := &op.Context{Context: context.Background(), Zctx: zctx}
 			var parents []zbuf.Puller
 			for _, input := range c.inputs {
-				r := zsonio.NewReader(strings.NewReader(input), zctx)
+				r := zsonio.NewReader(zctx, strings.NewReader(input))
 				parents = append(parents, zbuf.NewPuller(r, 10))
 			}
 			layout := order.NewLayout(c.order, field.DottedList(c.field))

--- a/runtime/op/spill/file.go
+++ b/runtime/op/spill/file.go
@@ -40,7 +40,7 @@ func NewTempFile() (*File, error) {
 	return NewFile(f), nil
 }
 
-func NewFileWithPath(path string, zctx *zed.Context) (*File, error) {
+func NewFileWithPath(path string) (*File, error) {
 	f, err := fs.Create(path)
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (f *File) Rewind(zctx *zed.Context) error {
 	if f.Reader != nil {
 		f.Reader.Close()
 	}
-	f.Reader = zngio.NewReader(bufio.NewReader(f.file), zctx)
+	f.Reader = zngio.NewReader(zctx, bufio.NewReader(f.file))
 	return nil
 }
 

--- a/runtime/op/spill/merge.go
+++ b/runtime/op/spill/merge.go
@@ -69,7 +69,7 @@ func (r *MergeSort) Spill(ctx context.Context, vals []zed.Value) error {
 		return err
 	}
 	filename := filepath.Join(r.tempDir, strconv.Itoa(r.nspill))
-	runFile, err := newPeeker(ctx, filename, r.nspill, zbuf.NewArray(vals), r.zctx)
+	runFile, err := newPeeker(ctx, r.zctx, filename, r.nspill, zbuf.NewArray(vals))
 	if err != nil {
 		return err
 	}

--- a/runtime/op/spill/peeker.go
+++ b/runtime/op/spill/peeker.go
@@ -14,8 +14,8 @@ type peeker struct {
 	ordinal    int
 }
 
-func newPeeker(ctx context.Context, filename string, ordinal int, arr *zbuf.Array, zctx *zed.Context) (*peeker, error) {
-	f, err := NewFileWithPath(filename, zctx)
+func newPeeker(ctx context.Context, zctx *zed.Context, filename string, ordinal int, arr *zbuf.Array) (*peeker, error) {
+	f, err := NewFileWithPath(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/op/top/top.go
+++ b/runtime/op/top/top.go
@@ -26,7 +26,7 @@ type Proc struct {
 	flushEvery bool
 }
 
-func New(parent zbuf.Puller, zctx *zed.Context, limit int, fields []expr.Evaluator, flushEvery bool) *Proc {
+func New(zctx *zed.Context, parent zbuf.Puller, limit int, fields []expr.Evaluator, flushEvery bool) *Proc {
 	if limit == 0 {
 		limit = defaultTopLimit
 	}

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -52,7 +52,7 @@ func (c *testClient) TestPoolList() []pools.Config {
 	require.NoError(c, err)
 	defer r.Body.Close()
 	var confs []pools.Config
-	zr := zngio.NewReader(r.Body, zed.NewContext())
+	zr := zngio.NewReader(zed.NewContext(), r.Body)
 	defer zr.Close()
 	for {
 		rec, err := zr.Read()
@@ -83,7 +83,7 @@ func (c *testClient) TestQuery(query string) string {
 	r, err := c.Connection.Query(context.Background(), nil, query)
 	require.NoError(c, err)
 	defer r.Body.Close()
-	zr := zngio.NewReader(r.Body, zed.NewContext())
+	zr := zngio.NewReader(zed.NewContext(), r.Body)
 	defer zr.Close()
 	var buf bytes.Buffer
 	zw := zsonio.NewWriter(zio.NopCloser(&buf), zsonio.WriterOpts{})

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -347,7 +347,7 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 	var opts anyio.ReaderOpts
 	opts.ZNG.Validate = true
 	zctx := zed.NewContext()
-	zrc, err := anyio.NewReaderWithOpts(anyio.GzipReader(r.Body), zctx, opts)
+	zrc, err := anyio.NewReaderWithOpts(zctx, anyio.GzipReader(r.Body), opts)
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return

--- a/service/request.go
+++ b/service/request.go
@@ -163,7 +163,7 @@ func (r *Request) Unmarshal(w *ResponseWriter, body interface{}, templates ...in
 			return false
 		}
 	}
-	zrc, err := anyio.NewReaderWithOpts(r.Body, zed.NewContext(), anyio.ReaderOpts{Format: format})
+	zrc, err := anyio.NewReaderWithOpts(zed.NewContext(), r.Body, anyio.ReaderOpts{Format: format})
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return false

--- a/zed_test.go
+++ b/zed_test.go
@@ -125,7 +125,7 @@ func expectFailure(b ztest.Bundle) bool {
 }
 
 func isValidForZSON(input string) bool {
-	zrc, err := anyio.NewReader(strings.NewReader(input), zed.NewContext())
+	zrc, err := anyio.NewReader(zed.NewContext(), strings.NewReader(input))
 	if err != nil {
 		return false
 	}
@@ -180,7 +180,7 @@ diff baseline.parquet boomerang.parquet
 }
 
 func isValidForParquet(input string) bool {
-	zrc, err := anyio.NewReader(strings.NewReader(input), zed.NewContext())
+	zrc, err := anyio.NewReader(zed.NewContext(), strings.NewReader(input))
 	if err != nil {
 		return false
 	}

--- a/zio/anyio/file.go
+++ b/zio/anyio/file.go
@@ -49,9 +49,9 @@ func NewFile(zctx *zed.Context, rc io.ReadCloser, path string, opts ReaderOpts) 
 	}
 	var zr zio.Reader
 	if opts.Format == "" || opts.Format == "auto" {
-		zr, err = NewReaderWithOpts(r, zctx, opts)
+		zr, err = NewReaderWithOpts(zctx, r, opts)
 	} else {
-		zr, err = lookupReader(r, zctx, opts)
+		zr, err = lookupReader(zctx, r, opts)
 	}
 	if err != nil {
 		return nil, err

--- a/zio/anyio/lookup.go
+++ b/zio/anyio/lookup.go
@@ -17,30 +17,30 @@ import (
 	"github.com/brimdata/zed/zio/zstio"
 )
 
-func lookupReader(r io.Reader, zctx *zed.Context, opts ReaderOpts) (zio.ReadCloser, error) {
+func lookupReader(zctx *zed.Context, r io.Reader, opts ReaderOpts) (zio.ReadCloser, error) {
 	switch opts.Format {
 	case "csv":
-		return zio.NopReadCloser(csvio.NewReader(r, zctx)), nil
+		return zio.NopReadCloser(csvio.NewReader(zctx, r)), nil
 	case "zeek":
-		return zio.NopReadCloser(zeekio.NewReader(r, zctx)), nil
+		return zio.NopReadCloser(zeekio.NewReader(zctx, r)), nil
 	case "json":
-		return zio.NopReadCloser(jsonio.NewReader(r, zctx)), nil
+		return zio.NopReadCloser(jsonio.NewReader(zctx, r)), nil
 	case "zjson":
-		return zio.NopReadCloser(zjsonio.NewReader(r, zctx)), nil
+		return zio.NopReadCloser(zjsonio.NewReader(zctx, r)), nil
 	case "zng":
-		return zngio.NewReaderWithOpts(r, zctx, opts.ZNG), nil
+		return zngio.NewReaderWithOpts(zctx, r, opts.ZNG), nil
 	case "zng21":
-		return zio.NopReadCloser(zng21io.NewReaderWithOpts(r, zctx, opts.ZNG)), nil
+		return zio.NopReadCloser(zng21io.NewReaderWithOpts(zctx, r, opts.ZNG)), nil
 	case "zson":
-		return zio.NopReadCloser(zsonio.NewReader(r, zctx)), nil
+		return zio.NopReadCloser(zsonio.NewReader(zctx, r)), nil
 	case "zst":
-		zr, err := zstio.NewReader(r, zctx)
+		zr, err := zstio.NewReader(zctx, r)
 		if err != nil {
 			return nil, err
 		}
 		return zio.NopReadCloser(zr), nil
 	case "parquet":
-		zr, err := parquetio.NewReader(r, zctx)
+		zr, err := parquetio.NewReader(zctx, r)
 		if err != nil {
 			return nil, err
 		}

--- a/zio/counter_test.go
+++ b/zio/counter_test.go
@@ -32,7 +32,7 @@ func TestCounter(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		for i := 0; i < 22; i++ {
-			stream := zsonio.NewReader(strings.NewReader(input), zed.NewContext())
+			stream := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 			counter := NewCounter(stream, &count)
 			require.NoError(t, Copy(&sink, counter))
 		}
@@ -40,7 +40,7 @@ func TestCounter(t *testing.T) {
 	}()
 	go func() {
 		for i := 0; i < 17; i++ {
-			stream := zsonio.NewReader(strings.NewReader(input), zed.NewContext())
+			stream := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 			counter := NewCounter(stream, &count)
 			require.NoError(t, Copy(&sink, counter))
 		}

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -28,7 +28,7 @@ type Reader struct {
 //	StringsOnly bool
 //}
 
-func NewReader(r io.Reader, zctx *zed.Context) *Reader {
+func NewReader(zctx *zed.Context, r io.Reader) *Reader {
 	preprocess := newPreprocess(r)
 	reader := csv.NewReader(preprocess)
 	reader.ReuseRecord = true

--- a/zio/csvio/reader_test.go
+++ b/zio/csvio/reader_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewReaderUsesContextParameter(t *testing.T) {
 	zctx := zed.NewContext()
-	rec, err := NewReader(strings.NewReader("f\n1\n"), zctx).Read()
+	rec, err := NewReader(zctx, strings.NewReader("f\n1\n")).Read()
 	require.NoError(t, err)
 	typ, err := zctx.LookupType(rec.Type.ID())
 	require.NoError(t, err)

--- a/zio/emitter/split_test.go
+++ b/zio/emitter/split_test.go
@@ -33,7 +33,7 @@ func TestDirS3Source(t *testing.T) {
 	engine.EXPECT().Put(context.Background(), uri.AppendPath("http.zson")).
 		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
 
-	r := zsonio.NewReader(strings.NewReader(input), zed.NewContext())
+	r := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 	require.NoError(t, err)
 	w, err := NewSplit(context.Background(), engine, uri, "", anyio.WriterOpts{Format: "zson"})
 	require.NoError(t, err)

--- a/zio/jsonio/reader.go
+++ b/zio/jsonio/reader.go
@@ -17,7 +17,7 @@ type Reader struct {
 	buf     []byte
 }
 
-func NewReader(r io.Reader, zctx *zed.Context) *Reader {
+func NewReader(zctx *zed.Context, r io.Reader) *Reader {
 	return &Reader{
 		builder: builder{zctx: zctx},
 		// 64 KB gave the best performance when this was written.

--- a/zio/mapper.go
+++ b/zio/mapper.go
@@ -9,7 +9,7 @@ type Mapper struct {
 	mapper *zed.Mapper
 }
 
-func NewMapper(reader Reader, zctx *zed.Context) *Mapper {
+func NewMapper(zctx *zed.Context, reader Reader) *Mapper {
 	return &Mapper{
 		Reader: reader,
 		mapper: zed.NewMapper(zctx),

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -15,7 +15,7 @@ type Reader struct {
 	builder builder
 }
 
-func NewReader(r io.Reader, zctx *zed.Context) (*Reader, error) {
+func NewReader(zctx *zed.Context, r io.Reader) (*Reader, error) {
 	rs, ok := r.(io.ReadSeeker)
 	if !ok {
 		return nil, errors.New("reader cannot seek")

--- a/zio/peeker_test.go
+++ b/zio/peeker_test.go
@@ -18,7 +18,7 @@ func TestPeeker(t *testing.T) {
 {key:"key5",value:"value5"}
 {key:"key6",value:"value6"}
 `
-	stream := zsonio.NewReader(strings.NewReader(input), zed.NewContext())
+	stream := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 	peeker := NewPeeker(stream)
 	rec1, err := peeker.Peek()
 	if err != nil {

--- a/zio/zeekio/reader.go
+++ b/zio/zeekio/reader.go
@@ -19,7 +19,7 @@ type Reader struct {
 	parser  *Parser
 }
 
-func NewReader(reader io.Reader, zctx *zed.Context) *Reader {
+func NewReader(zctx *zed.Context, reader io.Reader) *Reader {
 	buffer := make([]byte, ReadSize)
 	return &Reader{
 		scanner: skim.NewScanner(reader, buffer, MaxLineSize),

--- a/zio/zeekio/reader_test.go
+++ b/zio/zeekio/reader_test.go
@@ -23,7 +23,7 @@ func TestReaderCRLF(t *testing.T) {
 10.000000	1
 `
 	input = strings.ReplaceAll(input, "\n", "\r\n")
-	r := NewReader(strings.NewReader(input), zed.NewContext())
+	r := NewReader(zed.NewContext(), strings.NewReader(input))
 	rec, err := r.Read()
 	require.NoError(t, err)
 	ts := rec.Deref("ts").AsTime()

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -24,7 +24,7 @@ type Reader struct {
 	builder *zcode.Builder
 }
 
-func NewReader(reader io.Reader, zctx *zed.Context) *Reader {
+func NewReader(zctx *zed.Context, reader io.Reader) *Reader {
 	buffer := make([]byte, ReadSize)
 	return &Reader{
 		scanner: skim.NewScanner(reader, buffer, MaxLineSize),

--- a/zio/zng21io/reader.go
+++ b/zio/zng21io/reader.go
@@ -39,11 +39,11 @@ type AppMessage struct {
 	Bytes    []byte
 }
 
-func NewReader(reader io.Reader, sctx *zed.Context) *Reader {
-	return NewReaderWithOpts(reader, sctx, zngio.ReaderOpts{})
+func NewReader(sctx *zed.Context, reader io.Reader) *Reader {
+	return NewReaderWithOpts(sctx, reader, zngio.ReaderOpts{})
 }
 
-func NewReaderWithOpts(reader io.Reader, sctx *zed.Context, opts zngio.ReaderOpts) *Reader {
+func NewReaderWithOpts(sctx *zed.Context, reader io.Reader, opts zngio.ReaderOpts) *Reader {
 	if opts.Size == 0 {
 		opts.Size = ReadSize
 	}

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -40,11 +40,11 @@ type Control struct {
 	Bytes  []byte
 }
 
-func NewReader(reader io.Reader, sctx *zed.Context) *Reader {
-	return NewReaderWithOpts(reader, sctx, ReaderOpts{})
+func NewReader(sctx *zed.Context, reader io.Reader) *Reader {
+	return NewReaderWithOpts(sctx, reader, ReaderOpts{})
 }
 
-func NewReaderWithOpts(reader io.Reader, zctx *zed.Context, opts ReaderOpts) *Reader {
+func NewReaderWithOpts(zctx *zed.Context, reader io.Reader, opts ReaderOpts) *Reader {
 	if opts.Size == 0 {
 		opts.Size = ReadSize
 	}

--- a/zio/zngio/scanner_test.go
+++ b/zio/zngio/scanner_test.go
@@ -45,7 +45,7 @@ func TestScannerContext(t *testing.T) {
 			readers = append(readers, bytes.NewReader(bufs[j]))
 		}
 	}
-	r := NewReaderWithOpts(io.MultiReader(readers...), zed.NewContext(), ReaderOpts{
+	r := NewReaderWithOpts(zed.NewContext(), io.MultiReader(readers...), ReaderOpts{
 		Validate: true,
 	})
 	// Create a scanner and scan, validating each record.

--- a/zio/zngio/trailer.go
+++ b/zio/zngio/trailer.go
@@ -126,7 +126,7 @@ func findCandidate(b []byte, off int) int {
 	}
 }
 func readTrailer(b []byte) *zed.Value {
-	val, _ := NewReader(bytes.NewReader(b), zed.NewContext()).Read()
+	val, _ := NewReader(zed.NewContext(), bytes.NewReader(b)).Read()
 	return val
 }
 

--- a/zio/zngio/writer_test.go
+++ b/zio/zngio/writer_test.go
@@ -75,7 +75,7 @@ ff
 	expected, err := hex.DecodeString(expectedHex)
 	require.NoError(t, err)
 
-	zr := zsonio.NewReader(strings.NewReader(input), zed.NewContext())
+	zr := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 	var buf bytes.Buffer
 	zw := NewWriter(zio.NopCloser(&buf), WriterOpts{})
 	require.NoError(t, zio.Copy(zw, zr))

--- a/zio/zsonio/reader.go
+++ b/zio/zsonio/reader.go
@@ -16,7 +16,7 @@ type Reader struct {
 	builder  *zcode.Builder
 }
 
-func NewReader(r io.Reader, zctx *zed.Context) *Reader {
+func NewReader(zctx *zed.Context, r io.Reader) *Reader {
 	return &Reader{
 		reader:   r,
 		zctx:     zctx,

--- a/zio/zsonio/reader_test.go
+++ b/zio/zsonio/reader_test.go
@@ -24,7 +24,7 @@ func TestReadOneLineNoEOF(t *testing.T) {
 		// The test needs two records because with a single record the parser
 		// will stall waiting to see if the record has a decorator.
 		reader <- []byte(expected + "\n" + expected)
-		r := zsonio.NewReader(reader, zed.NewContext())
+		r := zsonio.NewReader(zed.NewContext(), reader)
 		rec, err := r.Read()
 		done <- result{zv: rec, err: err}
 	}()

--- a/zio/zstio/reader.go
+++ b/zio/zstio/reader.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimdata/zed/zst"
 )
 
-func NewReader(r io.Reader, zctx *zed.Context) (*zst.Reader, error) {
+func NewReader(zctx *zed.Context, r io.Reader) (*zst.Reader, error) {
 	reader, ok := r.(storage.Reader)
 	if !ok {
 		return nil, errors.New("zst must be used with a seekable input")

--- a/zngbytes/deserializer.go
+++ b/zngbytes/deserializer.go
@@ -21,7 +21,7 @@ func NewDeserializerWithContext(zctx *zed.Context, reader io.Reader, templates [
 	u := zson.NewZNGUnmarshaler()
 	u.Bind(templates...)
 	return &Deserializer{
-		reader:      zngio.NewReader(reader, zctx),
+		reader:      zngio.NewReader(zctx, reader),
 		unmarshaler: u,
 	}
 }

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -213,8 +213,7 @@ func TestBug2575(t *testing.T) {
 	writer.Write(recExpected)
 	writer.Close()
 
-	r := bytes.NewReader(buffer.Bytes())
-	reader := zngio.NewReader(r, zed.NewContext())
+	reader := zngio.NewReader(zed.NewContext(), &buffer)
 	defer reader.Close()
 	recActual, err := reader.Read()
 	exp, err := zson.FormatValue(recExpected)

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -32,7 +32,7 @@ func boomerang(t *testing.T, in interface{}, out interface{}) {
 	err = zw.Write(rec)
 	require.NoError(t, err)
 	zctx := zed.NewContext()
-	zr := zngio.NewReader(&buf, zctx)
+	zr := zngio.NewReader(zctx, &buf)
 	defer zr.Close()
 	rec, err = zr.Read()
 	require.NoError(t, err)
@@ -182,8 +182,7 @@ func TestUnmarshalRecord(t *testing.T) {
 	const expected = `{top:{T2f1:{T3f1:1(int32),T3f2:1.(float32)},T2f2:"t2f2-string1"}}`
 	require.Equal(t, expected, toZSON(t, rec))
 
-	zctx := zed.NewContext()
-	rec, err = zsonio.NewReader(strings.NewReader(expected), zctx).Read()
+	rec, err = zsonio.NewReader(zed.NewContext(), strings.NewReader(expected)).Read()
 	require.NoError(t, err)
 
 	var v2 T1

--- a/zst/object.go
+++ b/zst/object.go
@@ -168,7 +168,7 @@ func (o *Object) newSectionReader(level int, sectionOff int64) *zngio.Reader {
 	off += sectionOff
 	len -= sectionOff
 	reader := io.NewSectionReader(o.seeker, off, len)
-	return zngio.NewReader(reader, o.zctx)
+	return zngio.NewReader(o.zctx, reader)
 }
 
 func (o *Object) NewReassemblyReader() *zngio.Reader {

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -516,7 +516,7 @@ func runzq(path, zedProgram, input string, outputFlags []string, inputFlags []st
 		return "", "", err
 	}
 	zctx := zed.NewContext()
-	zrc, err := anyio.NewReaderWithOpts(anyio.GzipReader(strings.NewReader(input)), zctx, inflags.Options())
+	zrc, err := anyio.NewReaderWithOpts(zctx, anyio.GzipReader(strings.NewReader(input)), inflags.Options())
 	if err != nil {
 		return "", err.Error(), err
 	}


### PR DESCRIPTION
For consistency, change some function and method signatures so that a
*zed.Context parameter follows a context.Context parameter but precedes
all other parameters.