### PR TITLE
zio/zngio: remove reader interface

### DIFF
--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -131,14 +131,6 @@ func (r *Reader) ReadPayload() (*zed.Value, *Control, error) {
 	return val, nil, err
 }
 
-type reader interface {
-	io.ByteReader
-	// read returns an error if fewer than n bytes are available.
-	read(n int) ([]byte, error)
-}
-
-var _ reader = (*buffer)(nil)
-
 func readUvarintAsInt(r io.ByteReader) (int, error) {
 	u64, err := binary.ReadUvarint(r)
 	return int(u64), err

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -295,12 +295,12 @@ func (w *worker) scanBatch(buf *buffer, local localctx) (zbuf.Batch, error) {
 	return batch, nil
 }
 
-func (w *worker) decodeVal(r reader, valRef *zed.Value) error {
-	id, err := readUvarintAsInt(r)
+func (w *worker) decodeVal(buf *buffer, valRef *zed.Value) error {
+	id, err := readUvarintAsInt(buf)
 	if err != nil {
 		return err
 	}
-	n, err := zcode.ReadTag(r)
+	n, err := zcode.ReadTag(buf)
 	if err != nil {
 		return zed.ErrBadFormat
 	}
@@ -308,7 +308,7 @@ func (w *worker) decodeVal(r reader, valRef *zed.Value) error {
 	if n == 0 {
 		b = []byte{}
 	} else if n > 0 {
-		b, err = r.read(n)
+		b, err = buf.read(n)
 		if err != nil && err != io.EOF {
 			if err == peeker.ErrBufferOverflow {
 				return fmt.Errorf("large value of %d bytes exceeds maximum read buffer", n)


### PR DESCRIPTION
The reader interface is no longer necessary, and using it for the first
worker.decodeVal parameter slows that function because the compiler has
to insert a call to runtime.convI2I before readUvarintAsInt and another
before zcode.ReadTag.  Remove it.