### PR TITLE
add -splitsize flag to zed and zq

### DIFF
--- a/cmd/zq/ztests/splitsize.yaml
+++ b/cmd/zq/ztests/splitsize.yaml
@@ -1,0 +1,40 @@
+script: |
+  zq -z -split 2B -splitsize 2B in.zson
+  zq -z -split 4B -splitsize 4B in.zson
+  zq -z -split 6B -splitsize 6B in.zson
+  zq -z -split 6B-o -splitsize 6B -o prefix in.zson
+
+inputs:
+  - name: in.zson
+    data: |
+      0
+      1
+      2
+
+outputs:
+  - name: 2B/0.zson
+    data: |
+      0
+  - name: 2B/1.zson
+    data: |
+      1
+  - name: 2B/2.zson
+    data: |
+      2
+  - name: 4B/0.zson
+    data: |
+      0
+      1
+  - name: 4B/1.zson
+    data: |
+      2
+  - name: 6B/0.zson
+    data: |
+      0
+      1
+      2
+  - name: 6B-o/prefix-0.zson
+    data: |
+      0
+      1
+      2

--- a/zio/emitter/sizesplitter.go
+++ b/zio/emitter/sizesplitter.go
@@ -1,0 +1,106 @@
+package emitter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/pkg/bufwriter"
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/anyio"
+)
+
+type sizeSplitter struct {
+	ctx    context.Context
+	engine storage.Engine
+	dir    *storage.URI
+	prefix string
+	opts   anyio.WriterOpts
+	size   int64
+
+	cwc countingWriteCloser
+	ext string
+	seq int
+	zwc zio.WriteCloser
+}
+
+// NewSizeSplitter returns a zio.WriteCloser that writes to sequentially
+// numbered files created by engine in dir with optional prefix and with opts,
+// creating a new file after the current one reaches size bytes.  Files may
+// exceed size substantially due to buffering in the underlying writer as
+// determined by opts.Format.
+func NewSizeSplitter(ctx context.Context, engine storage.Engine, dir *storage.URI, prefix string,
+	opts anyio.WriterOpts, size int64) (zio.WriteCloser, error) {
+	ext := zio.Extension(opts.Format)
+	if ext == "" {
+		return nil, fmt.Errorf("unknown format: %s", opts.Format)
+	}
+	if prefix != "" {
+		prefix = prefix + "-"
+	}
+	return &sizeSplitter{
+		ctx:    ctx,
+		engine: engine,
+		dir:    dir,
+		prefix: prefix,
+		opts:   opts,
+		size:   size,
+		ext:    ext,
+	}, nil
+}
+
+func (s *sizeSplitter) Close() error {
+	if s.zwc == nil {
+		return nil
+	}
+	return s.zwc.Close()
+}
+
+func (s *sizeSplitter) Write(val *zed.Value) error {
+	if s.zwc == nil {
+		if err := s.nextFile(); err != nil {
+			return err
+		}
+	}
+	if err := s.zwc.Write(val); err != nil {
+		return err
+	}
+	if s.cwc.n >= s.size {
+		if err := s.zwc.Close(); err != nil {
+			return err
+		}
+		s.zwc = nil
+	}
+	return nil
+}
+
+func (s *sizeSplitter) nextFile() error {
+	path := s.dir.AppendPath(s.prefix + strconv.Itoa(s.seq) + s.ext)
+	s.seq++
+	wc, err := s.engine.Put(s.ctx, path)
+	if err != nil {
+		return err
+	}
+	s.cwc = countingWriteCloser{bufwriter.New(wc), 0}
+	s.zwc, err = anyio.NewWriter(&s.cwc, s.opts)
+	if err != nil {
+		wc.Close()
+		s.engine.Delete(s.ctx, path)
+		return err
+	}
+	return nil
+}
+
+type countingWriteCloser struct {
+	io.WriteCloser
+	n int64
+}
+
+func (c *countingWriteCloser) Write(b []byte) (int, error) {
+	n, err := c.WriteCloser.Write(b)
+	c.n += int64(n)
+	return n, err
+}


### PR DESCRIPTION
The -splitsize flag to zed and zq changes the behavior of -split,
splitting output into files of at least the given size rather than by
data type.  Files may exceed the target size substantially due to
buffering in the underlying writer as determined by -f et al.

Closes #3955.