### PR TITLE
service: fix GET /events Content-Type header

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -577,7 +577,7 @@ func handleEvents(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(srverr.ErrInvalid(err))
 	}
 	w.Header().Set("Content-Type", "text/event-stream")
-	writer := &eventStreamWriter{body: w, format: format}
+	writer := &eventStreamWriter{body: w.ResponseWriter, format: format}
 	subscription := make(chan event)
 	c.subscriptionsMu.Lock()
 	c.subscriptions[subscription] = struct{}{}


### PR DESCRIPTION
With #3870, the value of the Content-Type response header for GET
/events changed from text/event-stream to the negotiated content type.
This route is intended to provided server-sent events, for which
text/event-stream is the correct type, so revert to that (by using an
http.ResponseWriter instead of a service.ResponseWriter for
eventStreamWriter.body).

Unfortunately, I don't see a straightforward way to test this right now, so
I created #3963 to track adding test coverage.

Fixes #3924.