### PR TITLE
zio/zngio: improve Writer constructor ergonomics

### DIFF
--- a/api/client/request.go
+++ b/api/client/request.go
@@ -102,7 +102,7 @@ func (r *Request) reader() (io.Reader, error) {
 		return nil, err
 	}
 	var buf bytes.Buffer
-	zw := zngio.NewWriter(zio.NopCloser(&buf), zngio.WriterOpts{})
+	zw := zngio.NewWriterWithOpts(zio.NopCloser(&buf), zngio.WriterOpts{})
 	if err := zw.Write(zv); err != nil {
 		return nil, err
 	}

--- a/api/queryio/zng.go
+++ b/api/queryio/zng.go
@@ -21,9 +21,7 @@ func NewZNGWriter(w io.Writer) *ZNGWriter {
 	m := zson.NewZNGMarshaler()
 	m.Decorate(zson.StyleSimple)
 	return &ZNGWriter{
-		Writer: zngio.NewWriter(zio.NopCloser(w), zngio.WriterOpts{
-			LZ4BlockSize: zngio.DefaultLZ4BlockSize,
-		}),
+		Writer:    zngio.NewWriter(zio.NopCloser(w)),
 		marshaler: m,
 	}
 }

--- a/index/writer.go
+++ b/index/writer.go
@@ -161,7 +161,7 @@ func (w *Writer) Close() error {
 		// encountered, then the base layer writer was never created.
 		// In this case, bypass the base layer, write an empty trailer
 		// directly to the output, and close.
-		zw := zngio.NewWriter(w.iow, w.opts.ZNGWriterOpts)
+		zw := zngio.NewWriterWithOpts(w.iow, w.opts.ZNGWriterOpts)
 		err := w.writeTrailer(zw, nil)
 		if err2 := w.iow.Close(); err == nil {
 			err = err2
@@ -263,7 +263,7 @@ func newIndexWriter(base *Writer, w io.WriteCloser, name string, ectx expr.Conte
 		buffer:   writer,
 		ectx:     ectx,
 		name:     name,
-		zng:      zngio.NewWriter(writer, opts),
+		zng:      zngio.NewWriterWithOpts(writer, opts),
 		frameEnd: int64(base.opts.FrameThresh),
 	}, nil
 }

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -94,8 +94,8 @@ func (r *remote) RenamePool(ctx context.Context, pool ksuid.KSUID, name string) 
 
 func (r *remote) Load(ctx context.Context, _ *zed.Context, poolID ksuid.KSUID, branchName string, reader zio.Reader, commit api.CommitMessage) (ksuid.KSUID, error) {
 	pr, pw := io.Pipe()
-	w := zngio.NewWriter(pw, zngio.WriterOpts{LZ4BlockSize: zngio.DefaultLZ4BlockSize})
 	go func() {
+		w := zngio.NewWriter(pw)
 		zio.CopyWithContext(ctx, w, reader)
 		w.Close()
 	}()

--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -42,13 +42,10 @@ func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *sto
 		return nil, err
 	}
 	counter := &writeCounter{bufwriter.New(out), 0}
-	writer := zngio.NewWriter(counter, zngio.WriterOpts{
-		LZ4BlockSize: zngio.DefaultLZ4BlockSize,
-	})
 	w := &Writer{
 		object:      o,
 		byteCounter: counter,
-		writer:      writer,
+		writer:      zngio.NewWriter(counter),
 		order:       order,
 		first:       true,
 		poolKey:     poolKey,
@@ -64,7 +61,7 @@ func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *sto
 	opts := zngio.WriterOpts{
 		//LZ4BlockSize: zngio.DefaultLZ4BlockSize,
 	}
-	w.seekWriter = zngio.NewWriter(bufwriter.New(seekOut), opts)
+	w.seekWriter = zngio.NewWriterWithOpts(bufwriter.New(seekOut), opts)
 	w.seekIndex = seekindex.NewWriter(w.seekWriter)
 	return w, nil
 }

--- a/lake/seekindex/seekindex_test.go
+++ b/lake/seekindex/seekindex_test.go
@@ -98,7 +98,7 @@ func newTestSeekIndex(t *testing.T, entries []entry) *testSeekIndex {
 
 func build(t *testing.T, entries entries) *bytes.Buffer {
 	var buffer bytes.Buffer
-	w := NewWriter(zngio.NewWriter(zio.NopCloser(&buffer), zngio.WriterOpts{}))
+	w := NewWriter(zngio.NewWriterWithOpts(zio.NopCloser(&buffer), zngio.WriterOpts{}))
 	for i, entry := range entries {
 		zv := zed.Value{zed.TypeTime, zed.EncodeTime(entry.ts)}
 		err := w.Write(zv, uint64(i), entry.offset)

--- a/runtime/op/spill/file.go
+++ b/runtime/op/spill/file.go
@@ -27,7 +27,7 @@ type File struct {
 // records via the zio.Reader interface.
 func NewFile(f *os.File) *File {
 	return &File{
-		Writer: zngio.NewWriter(bufwriter.New(zio.NopCloser(f)), zngio.WriterOpts{}),
+		Writer: zngio.NewWriterWithOpts(bufwriter.New(zio.NopCloser(f)), zngio.WriterOpts{}),
 		file:   f,
 	}
 }

--- a/zio/anyio/writer.go
+++ b/zio/anyio/writer.go
@@ -32,7 +32,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) (zio.WriteCloser, error) {
 	case "null":
 		return &nullWriter{}, nil
 	case "zng":
-		return zngio.NewWriter(w, opts.ZNG), nil
+		return zngio.NewWriterWithOpts(w, opts.ZNG), nil
 	case "zeek":
 		return zeekio.NewWriter(w), nil
 	case "json":

--- a/zio/zng_test.go
+++ b/zio/zng_test.go
@@ -34,7 +34,7 @@ func boomerang(t *testing.T, logs string, compress bool) {
 	if compress {
 		zngLZ4BlockSize = zngio.DefaultLZ4BlockSize
 	}
-	rawDst := zngio.NewWriter(&rawzng, zngio.WriterOpts{LZ4BlockSize: zngLZ4BlockSize})
+	rawDst := zngio.NewWriterWithOpts(&rawzng, zngio.WriterOpts{LZ4BlockSize: zngLZ4BlockSize})
 	require.NoError(t, zio.Copy(rawDst, zsonSrc))
 	require.NoError(t, rawDst.Close())
 

--- a/zio/zngio/scanner_test.go
+++ b/zio/zngio/scanner_test.go
@@ -30,7 +30,7 @@ func TestScannerContext(t *testing.T) {
 		rec, err := zson.NewZNGMarshaler().MarshalCustom(names, values)
 		require.NoError(t, err)
 		var buf bytes.Buffer
-		w := NewWriter(zio.NopCloser(&buf), WriterOpts{})
+		w := NewWriterWithOpts(zio.NopCloser(&buf), WriterOpts{})
 		for j := 0; j < 100; j++ {
 			require.NoError(t, w.Write(rec))
 		}

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -28,7 +28,16 @@ type WriterOpts struct {
 	LZ4BlockSize int
 }
 
-func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
+// NewWriter returns a writer to w with reasonable default options.
+// Specifically, it sets WriterOpts.LZ4BlockSize to DefaultLZ4BlockSize.
+func NewWriter(w io.WriteCloser) *Writer {
+	return NewWriterWithOpts(w, WriterOpts{
+		LZ4BlockSize: DefaultLZ4BlockSize,
+	})
+}
+
+// NewWriterWithOpts returns a writer to w with opts.
+func NewWriterWithOpts(w io.WriteCloser, opts WriterOpts) *Writer {
 	var comp *compressor
 	if opts.LZ4BlockSize > 0 {
 		comp = &compressor{}

--- a/zio/zngio/writer_test.go
+++ b/zio/zngio/writer_test.go
@@ -77,7 +77,7 @@ ff
 
 	zr := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 	var buf bytes.Buffer
-	zw := NewWriter(zio.NopCloser(&buf), WriterOpts{})
+	zw := NewWriterWithOpts(zio.NopCloser(&buf), WriterOpts{})
 	require.NoError(t, zio.Copy(zw, zr))
 	require.NoError(t, zw.Close())
 	assert.Equal(t, expected, buf.Bytes())

--- a/zngbytes/serializer.go
+++ b/zngbytes/serializer.go
@@ -20,7 +20,7 @@ func NewSerializer() *Serializer {
 	s := &Serializer{
 		marshaler: m,
 	}
-	s.writer = zngio.NewWriter(zio.NopCloser(&s.buffer), zngio.WriterOpts{})
+	s.writer = zngio.NewWriterWithOpts(zio.NopCloser(&s.buffer), zngio.WriterOpts{})
 	return s
 }
 

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -208,7 +208,7 @@ func TestBug2575(t *testing.T) {
 	require.NoError(t, err)
 
 	var buffer bytes.Buffer
-	writer := zngio.NewWriter(zio.NopCloser(&buffer), zngio.WriterOpts{})
+	writer := zngio.NewWriterWithOpts(zio.NopCloser(&buffer), zngio.WriterOpts{})
 	recExpected := zed.NewValue(zv.Type, zv.Bytes)
 	writer.Write(recExpected)
 	writer.Close()

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -28,7 +28,7 @@ func boomerang(t *testing.T, in interface{}, out interface{}) {
 	rec, err := zson.NewZNGMarshaler().MarshalRecord(in)
 	require.NoError(t, err)
 	var buf bytes.Buffer
-	zw := zngio.NewWriter(zio.NopCloser(&buf), zngio.WriterOpts{})
+	zw := zngio.NewWriterWithOpts(zio.NopCloser(&buf), zngio.WriterOpts{})
 	err = zw.Write(rec)
 	require.NoError(t, err)
 	zctx := zed.NewContext()

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -163,7 +163,7 @@ func (w *Writer) finalize() error {
 	}
 	// At this point all the column data has been written out
 	// to the underlying spiller, so we start writing zng at this point.
-	zw := zngio.NewWriter(w.writer, zngio.WriterOpts{})
+	zw := zngio.NewWriterWithOpts(w.writer, zngio.WriterOpts{})
 	dataSize := w.spiller.Position()
 	// First, we write out null values for each column corresponding to
 	// a type serialized into the ZST file in the order of its type number


### PR DESCRIPTION
Creating a zio/zngio.Writer with reasonable default options is
cumbersome.  Make it easier by renaming the current constructor,
NewWriter, to NewWriterWithOpts and adding a new version of NewWriter
that calls NewWriterWithOpts with reasonable default options.

(I plan to introduce separate options for compression and frame threshold in a subsequent PR.)