### PR TITLE
Clarify Accept header significance on /events endpoint

### DIFF
--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -432,8 +432,8 @@ curl -X POST \
 
 Subscribe to an events feed, which returns an event stream in the format of
 [server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html).
-The MIME type specified in the request's Accept HTTP header only affects the format
-of the objects returned in the `data` fields of the event stream.
+The MIME type specified in the request's Accept HTTP header determines the format
+of `data` field values in the event stream.
 
 ```
 GET /events

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -435,7 +435,6 @@ Subscribe to an events feed, which returns an event stream in the format of
 The MIME type specified in the request's Accept HTTP header only affects the format
 of the objects returned in the `data` fields of the event stream.
 
-
 ```
 GET /events
 ```

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -432,6 +432,9 @@ curl -X POST \
 
 Subscribe to an events feed, which returns an event stream in the format of
 [server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html).
+The MIME type specified in the request's Accept HTTP header only affects the format
+of the objects returned in the `data` fields of the event stream.
+
 
 ```
 GET /events


### PR DESCRIPTION
While verifying #3924, I double checked that the API docs are still accurate. They effectively are, but since the server-side events concept might not be familiar to some audiences, I figured a little extra clarity was justified.