### PR TITLE
use default ZNG writer options where possible

### DIFF
--- a/api/client/connection_test.go
+++ b/api/client/connection_test.go
@@ -30,6 +30,7 @@ func TestClientRedirectReplay(t *testing.T) {
 				Domain: ts.URL,
 			},
 		})
+		s.Close()
 		w.Write(s.Bytes())
 	})
 	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {

--- a/api/client/request.go
+++ b/api/client/request.go
@@ -102,7 +102,7 @@ func (r *Request) reader() (io.Reader, error) {
 		return nil, err
 	}
 	var buf bytes.Buffer
-	zw := zngio.NewWriterWithOpts(zio.NopCloser(&buf), zngio.WriterOpts{})
+	zw := zngio.NewWriter(zio.NopCloser(&buf))
 	if err := zw.Write(zv); err != nil {
 		return nil, err
 	}

--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -58,8 +58,7 @@ func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *sto
 	if err != nil {
 		return nil, err
 	}
-	// XXX Use compression and nonzero frame threshold if possible.
-	w.seekWriter = zngio.NewWriterWithOpts(bufwriter.New(seekOut), zngio.WriterOpts{})
+	w.seekWriter = zngio.NewWriter(bufwriter.New(seekOut))
 	w.seekIndex = seekindex.NewWriter(w.seekWriter)
 	return w, nil
 }

--- a/lake/index/writer.go
+++ b/lake/index/writer.go
@@ -6,12 +6,12 @@ import (
 	"sync"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/zbuf"
-
 	"github.com/brimdata/zed/index"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/runtime"
+	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
+	"github.com/brimdata/zed/zio/zngio"
 )
 
 func NewWriter(ctx context.Context, c runtime.Compiler, engine storage.Engine, path *storage.URI, object *Object) (*Writer, error) {
@@ -117,7 +117,9 @@ func newIndexer(ctx context.Context, c runtime.Compiler, engine storage.Engine, 
 		return nil, err
 	}
 	keys := rule.RuleKeys()
-	writer, err := index.NewWriterWithContext(ctx, zctx, engine, object.Path(path).String(), keys, index.WriterOpts{})
+	writer, err := index.NewWriterWithContext(ctx, zctx, engine, object.Path(path).String(), keys, index.WriterOpts{
+		ZNGWriterOpts: zngio.WriterOpts{Compress: true},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/lake/seekindex/seekindex_test.go
+++ b/lake/seekindex/seekindex_test.go
@@ -98,11 +98,13 @@ func newTestSeekIndex(t *testing.T, entries []entry) *testSeekIndex {
 
 func build(t *testing.T, entries entries) *bytes.Buffer {
 	var buffer bytes.Buffer
-	w := NewWriter(zngio.NewWriterWithOpts(zio.NopCloser(&buffer), zngio.WriterOpts{}))
+	zw := zngio.NewWriter(zio.NopCloser(&buffer))
+	w := NewWriter(zw)
 	for i, entry := range entries {
 		zv := zed.Value{zed.TypeTime, zed.EncodeTime(entry.ts)}
 		err := w.Write(zv, uint64(i), entry.offset)
 		require.NoError(t, err)
 	}
+	require.NoError(t, zw.Close())
 	return &buffer
 }

--- a/runtime/op/spill/file.go
+++ b/runtime/op/spill/file.go
@@ -27,8 +27,11 @@ type File struct {
 // records via the zio.Reader interface.
 func NewFile(f *os.File) *File {
 	return &File{
-		Writer: zngio.NewWriterWithOpts(bufwriter.New(zio.NopCloser(f)), zngio.WriterOpts{}),
-		file:   f,
+		Writer: zngio.NewWriterWithOpts(bufwriter.New(zio.NopCloser(f)), zngio.WriterOpts{
+			Compress:    false, // Compression reduces write throughput; see #3973.
+			FrameThresh: zngio.DefaultFrameThresh,
+		}),
+		file: f,
 	}
 }
 

--- a/service/request.go
+++ b/service/request.go
@@ -21,6 +21,7 @@ import (
 	"github.com/brimdata/zed/service/srverr"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
+	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zson"
 	"github.com/gorilla/mux"
 	"github.com/segmentio/ksuid"
@@ -203,7 +204,13 @@ func (w *ResponseWriter) ZioWriter() zio.WriteCloser {
 	if w.zw == nil {
 		w.Header().Set("Content-Type", api.FormatToMediaType(w.Format))
 		var err error
-		w.zw, err = anyio.NewWriter(zio.NopCloser(w), anyio.WriterOpts{Format: w.Format})
+		w.zw, err = anyio.NewWriter(zio.NopCloser(w), anyio.WriterOpts{
+			Format: w.Format,
+			ZNG: zngio.WriterOpts{
+				Compress:    true,
+				FrameThresh: zngio.DefaultFrameThresh,
+			},
+		})
 		if err != nil {
 			w.Error(err)
 			return nil

--- a/zio/zng_test.go
+++ b/zio/zng_test.go
@@ -30,13 +30,9 @@ func boomerang(t *testing.T, logs string, compress bool) {
 	in := []byte(strings.TrimSpace(logs) + "\n")
 	zsonSrc := zsonio.NewReader(zed.NewContext(), bytes.NewReader(in))
 	var rawzng Output
-	var zngFrameThresh int
-	if compress {
-		zngFrameThresh = zngio.DefaultFrameThresh
-	}
 	rawDst := zngio.NewWriterWithOpts(&rawzng, zngio.WriterOpts{
 		Compress:    compress,
-		FrameThresh: zngFrameThresh,
+		FrameThresh: zngio.DefaultFrameThresh,
 	})
 	require.NoError(t, zio.Copy(rawDst, zsonSrc))
 	require.NoError(t, rawDst.Close())

--- a/zio/zngio/scanner_test.go
+++ b/zio/zngio/scanner_test.go
@@ -30,7 +30,7 @@ func TestScannerContext(t *testing.T) {
 		rec, err := zson.NewZNGMarshaler().MarshalCustom(names, values)
 		require.NoError(t, err)
 		var buf bytes.Buffer
-		w := NewWriterWithOpts(zio.NopCloser(&buf), WriterOpts{})
+		w := NewWriter(zio.NopCloser(&buf))
 		for j := 0; j < 100; j++ {
 			require.NoError(t, w.Write(rec))
 		}

--- a/zngbytes/serializer.go
+++ b/zngbytes/serializer.go
@@ -20,7 +20,7 @@ func NewSerializer() *Serializer {
 	s := &Serializer{
 		marshaler: m,
 	}
-	s.writer = zngio.NewWriterWithOpts(zio.NopCloser(&s.buffer), zngio.WriterOpts{})
+	s.writer = zngio.NewWriter(zio.NopCloser(&s.buffer))
 	return s
 }
 
@@ -36,9 +36,12 @@ func (s *Serializer) Write(v interface{}) error {
 	return s.writer.Write(rec)
 }
 
+// Bytes returns a slice holding the serialized values.  Close must be called
+// before Bytes.
 func (s *Serializer) Bytes() []byte {
 	return s.buffer.Bytes()
 }
+
 func (s *Serializer) Close() error {
 	return s.writer.Close()
 }

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -208,7 +208,7 @@ func TestBug2575(t *testing.T) {
 	require.NoError(t, err)
 
 	var buffer bytes.Buffer
-	writer := zngio.NewWriterWithOpts(zio.NopCloser(&buffer), zngio.WriterOpts{})
+	writer := zngio.NewWriter(zio.NopCloser(&buffer))
 	recExpected := zed.NewValue(zv.Type, zv.Bytes)
 	writer.Write(recExpected)
 	writer.Close()

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -28,9 +28,10 @@ func boomerang(t *testing.T, in interface{}, out interface{}) {
 	rec, err := zson.NewZNGMarshaler().MarshalRecord(in)
 	require.NoError(t, err)
 	var buf bytes.Buffer
-	zw := zngio.NewWriterWithOpts(zio.NopCloser(&buf), zngio.WriterOpts{})
+	zw := zngio.NewWriter(zio.NopCloser(&buf))
 	err = zw.Write(rec)
 	require.NoError(t, err)
+	require.NoError(t, zw.Close())
 	zctx := zed.NewContext()
 	zr := zngio.NewReader(zctx, &buf)
 	defer zr.Close()

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -163,7 +163,7 @@ func (w *Writer) finalize() error {
 	}
 	// At this point all the column data has been written out
 	// to the underlying spiller, so we start writing zng at this point.
-	zw := zngio.NewWriterWithOpts(w.writer, zngio.WriterOpts{})
+	zw := zngio.NewWriter(w.writer)
 	dataSize := w.spiller.Position()
 	// First, we write out null values for each column corresponding to
 	// a type serialized into the ZST file in the order of its type number


### PR DESCRIPTION
Enable compression and use the default frame threshold for most ZNG
writers, with two notable exceptions:

* runtime/op/spill.NewFile, where enabling compression decreases write
  throughput by a factor of 10 (but using the default frame threshold
  improves read throughput by a factor of 70)

* index.WriterOpts values, because the index package uses
  zio/zngio.Writer.Position in a way that requires a single value per
  ZNG frame

(The runtime/op/spill.NewFile change should help to address the spilling slowness described in #2780.)