### PR TITLE
index: rename NewWriterWithContext to NewWriter

### DIFF
--- a/cmd/zed/dev/indexfile/create/command.go
+++ b/cmd/zed/dev/indexfile/create/command.go
@@ -91,7 +91,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer file.Close()
-	writer, err := index.NewWriter(zctx, local, c.outputFile, field.DottedList(c.keys), c.opts)
+	writer, err := index.NewWriter(ctx, zctx, local, c.outputFile, field.DottedList(c.keys), c.opts)
 	if err != nil {
 		return err
 	}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -44,9 +44,10 @@ func TestMicroIndex(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test2.zng")
 	stream, err := newReader(N)
 	require.NoError(t, err)
+	ctx := context.Background()
 	zctx := zed.NewContext()
 	engine := storage.NewLocalEngine()
-	writer, err := index.NewWriter(zctx, engine, path, field.DottedList("key"), index.WriterOpts{})
+	writer, err := index.NewWriter(ctx, zctx, engine, path, field.DottedList("key"), index.WriterOpts{})
 	require.NoError(t, err)
 	err = zio.Copy(writer, stream)
 	require.NoError(t, err)
@@ -149,7 +150,7 @@ func openFinder(t *testing.T, path string) *index.Finder {
 
 func build(t *testing.T, engine storage.Engine, r zio.Reader, keys field.List, opts index.WriterOpts) string {
 	path := filepath.Join(t.TempDir(), "test.zng")
-	writer, err := index.NewWriter(zed.NewContext(), engine, path, keys, opts)
+	writer, err := index.NewWriter(context.Background(), zed.NewContext(), engine, path, keys, opts)
 	require.NoError(t, err)
 	require.NoError(t, zio.Copy(writer, r))
 	require.NoError(t, writer.Close())

--- a/index/writer.go
+++ b/index/writer.go
@@ -82,11 +82,8 @@ type WriterOpts struct {
 // provide keys in increasing lexicographic order.  Duplicate keys are not
 // allowed but will not be detected.  Close() or Abort() must be called when
 // done writing.
-func NewWriter(zctx *zed.Context, engine storage.Engine, path string, keys field.List, opts WriterOpts) (*Writer, error) {
-	return NewWriterWithContext(context.Background(), zctx, engine, path, keys, opts)
-}
-
-func NewWriterWithContext(ctx context.Context, zctx *zed.Context, engine storage.Engine, path string, keys field.List, opts WriterOpts) (*Writer, error) {
+func NewWriter(ctx context.Context, zctx *zed.Context, engine storage.Engine, path string, keys field.List,
+	opts WriterOpts) (*Writer, error) {
 	if len(keys) == 0 {
 		return nil, errors.New("must specify at least one key")
 	}

--- a/lake/index/writer.go
+++ b/lake/index/writer.go
@@ -117,7 +117,7 @@ func newIndexer(ctx context.Context, c runtime.Compiler, engine storage.Engine, 
 		return nil, err
 	}
 	keys := rule.RuleKeys()
-	writer, err := index.NewWriterWithContext(ctx, zctx, engine, object.Path(path).String(), keys, index.WriterOpts{})
+	writer, err := index.NewWriter(ctx, zctx, engine, object.Path(path).String(), keys, index.WriterOpts{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The current NewWriter is a convenience wrapper for NewWriterWithContext,
but I think the risk of using it even though a context is available (as
in cmd/zed/dev/indexfile/create/command.go) outweighs the convenience.
Remove it and rename NewWriterWithContext to NewWriter.