### PR TITLE
api: fix DeleteRequest.Where "zed" field tag typo

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -61,7 +61,7 @@ type CompactRequest struct {
 
 type DeleteRequest struct {
 	ObjectIDs []string `zed:"object_ids"`
-	Where     string   `zed:"were"`
+	Where     string   `zed:"where"`
 }
 
 type CommitMessage struct {

--- a/service/ztests/curl-delete-by-predicate.yaml
+++ b/service/ztests/curl-delete-by-predicate.yaml
@@ -1,0 +1,24 @@
+script: |
+  source service.sh
+  zed create -q -orderby x:asc test
+  zed use -q test
+  echo '{x:1}{x:2}{x:3}' | zed load -q -
+  echo '{x:3}{x:4}{x:5}' | zed load -q -
+  echo '{x:6}{x:7}{x:8}' | zed load -q -
+  curl -s -d '{where:"x <= 4"}' $ZED_LAKE/pool/test/branch/main/delete |
+    sed -E 's/0x[0-9a-f]{40}/xxx/'
+  echo ===
+  zed query -z '*
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      {commit:xxx(=ksuid.KSUID),warnings:null([string])}(=api.CommitResponse)
+      ===
+      {x:5}
+      {x:6}
+      {x:7}
+      {x:8}

--- a/service/ztests/curl-delete-by-predicate.yaml
+++ b/service/ztests/curl-delete-by-predicate.yaml
@@ -8,7 +8,7 @@ script: |
   curl -s -d '{where:"x <= 4"}' $ZED_LAKE/pool/test/branch/main/delete |
     sed -E 's/0x[0-9a-f]{40}/xxx/'
   echo ===
-  zed query -z '*
+  zed query -z '*'
 
 inputs:
   - name: service.sh


### PR DESCRIPTION
The name in the "zed" field tag for DeleteRequest.Where is "were".
Change it to "where".