### PR TITLE
lakeparse: fix error handling and string in ParseID

### DIFF
--- a/lakeparse/id.go
+++ b/lakeparse/id.go
@@ -14,7 +14,7 @@ func ParseID(s string) (ksuid.KSUID, error) {
 	var err error
 	if len(s) == 42 && s[0:2] == "0x" {
 		var b []byte
-		b, err := hex.DecodeString(s[2:])
+		b, err = hex.DecodeString(s[2:])
 		if err == nil {
 			id, err = ksuid.FromBytes(b)
 		}
@@ -22,7 +22,7 @@ func ParseID(s string) (ksuid.KSUID, error) {
 		id, err = ksuid.Parse(s)
 	}
 	if err != nil {
-		return ksuid.Nil, fmt.Errorf("invalid commit ID: %s", s)
+		return ksuid.Nil, fmt.Errorf("invalid ID: %s", s)
 	}
 	return id, nil
 }

--- a/lakeparse/id_test.go
+++ b/lakeparse/id_test.go
@@ -1,0 +1,29 @@
+package lakeparse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseID(t *testing.T) {
+	id, err := ParseID("0x0123456789012345678901234567890123456789")
+	assert.NoError(t, err)
+	assert.Equal(t, "0A42ooXOWFkGit78ZjPVLpDkRgn", id.String())
+
+	// _ isn't a valid hexadecimal digit.
+	_, err = ParseID("0x012345678901234567890123456789012345678_")
+	assert.EqualError(t, err, "invalid ID: 0x012345678901234567890123456789012345678_")
+
+	id, err = ParseID("0A42ooXOWFkGit78ZjPVLpDkRgn")
+	assert.NoError(t, err)
+	assert.Equal(t, "0A42ooXOWFkGit78ZjPVLpDkRgn", id.String())
+
+	// Too long.
+	_, err = ParseID("0A42ooXOWFkGit78ZjPVLpDkRgnn")
+	assert.EqualError(t, err, "invalid ID: 0A42ooXOWFkGit78ZjPVLpDkRgnn")
+
+	// Too short.
+	_, err = ParseID("0A42ooXOWFkGit78ZjPVLpDkRg")
+	assert.EqualError(t, err, "invalid ID: 0A42ooXOWFkGit78ZjPVLpDkRg")
+}


### PR DESCRIPTION
ParseID succeeds for any 42-byte string that begins with "0x" (due to
variable shadowing).  And when ParseID does return an error, the error
string refers to a commit ID even though the ID may not refer to a
commit.  Fix both issues.