### PR TITLE
add error checks to journal replay and simplify snapshots

### DIFF
--- a/lake/branch.go
+++ b/lake/branch.go
@@ -373,14 +373,17 @@ func (b *Branch) buildMergeObject(ctx context.Context, parent *branches.Config, 
 	if err != nil {
 		return nil, err
 	}
-	if overlap := childPatch.OverlappingDeletes(parentPatch); overlap != nil {
-		//XXX add IDs of (some of the) overlaps
-		return nil, errors.New("write conflict on merge")
-	}
 	if message == "" {
 		message = fmt.Sprintf("merged %s into %s", b.Name, parent.Name)
 	}
-	return childPatch.NewCommitObject(parent.Commit, retries, author, message, zed.Value{zed.TypeNull, nil}), nil
+	// Now compute the diff between the parent patch and the child path so that
+	// the diff patch will reflect into the parent the changes in the child.
+	// Diff() will also check for delete conflicts.
+	diff, err := commits.Diff(parentPatch, childPatch)
+	if err != nil {
+		return nil, fmt.Errorf("error trying to merge %s into %s: %w", b.Name, parent.Name, err)
+	}
+	return diff.NewCommitObject(parent.Commit, retries, author, message, zed.Value{zed.TypeNull, nil}), nil
 }
 
 func commonAncestor(a, b []ksuid.KSUID) ksuid.KSUID {

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -374,14 +374,14 @@ func (b *Branch) buildMergeObject(ctx context.Context, parent *branches.Config, 
 		return nil, err
 	}
 	if message == "" {
-		message = fmt.Sprintf("merged %s into %s", b.Name, parent.Name)
+		message = fmt.Sprintf("merged %q into %q", b.Name, parent.Name)
 	}
-	// Now compute the diff between the parent patch and the child path so that
-	// the diff patch will reflect into the parent the changes in the child.
+	// Now compute the diff between the parent patch and the child patch so that
+	// the diff patch will reflect the changes from the child into the parent.
 	// Diff() will also check for delete conflicts.
 	diff, err := commits.Diff(parentPatch, childPatch)
 	if err != nil {
-		return nil, fmt.Errorf("error trying to merge %s into %s: %w", b.Name, parent.Name, err)
+		return nil, fmt.Errorf("error merging %q into %q: %w", b.Name, parent.Name, err)
 	}
 	return diff.NewCommitObject(parent.Commit, retries, author, message, zed.Value{zed.TypeNull, nil}), nil
 }

--- a/lake/commits/patch.go
+++ b/lake/commits/patch.go
@@ -169,7 +169,7 @@ func (p *Patch) Revert(tip *Snapshot, commit, parent ksuid.KSUID, retries int, a
 			return nil, err
 		}
 		if dataObject == nil {
-			return nil, fmt.Errorf("corrupt snapshot: id %s is in patch's deleted objects but not in patch's base snapshot", id)
+			return nil, fmt.Errorf("corrupt snapshot: ID %s is in patch's deleted objects but not in patch's base snapshot", id)
 		}
 		if !Exists(tip, dataObject.ID) {
 			object.appendAdd(dataObject)
@@ -264,7 +264,7 @@ func Diff(parent, child *Patch) (*Patch, error) {
 		}
 	}
 	if !dirty {
-		return nil, errors.New("nothing to merge")
+		return nil, errors.New("difference is empty")
 	}
 	return p, nil
 }

--- a/lake/commits/snapshot.go
+++ b/lake/commits/snapshot.go
@@ -62,8 +62,7 @@ func (s *Snapshot) AddDataObject(object *data.Object) error {
 }
 
 func (s *Snapshot) DeleteObject(id ksuid.KSUID) error {
-	_, ok := s.objects[id]
-	if !ok {
+	if _, ok := s.objects[id]; !ok {
 		return fmt.Errorf("%s: delete of a non-existent data object: %w", id, ErrWriteConflict)
 	}
 	delete(s.objects, id)
@@ -243,25 +242,18 @@ func PlayAction(w Writeable, action Action) error {
 	if _, ok := action.(Action); !ok {
 		return badObject(action)
 	}
+	var err error
 	switch action := action.(type) {
 	case *Add:
-		if err := w.AddDataObject(&action.Object); err != nil {
-			return err
-		}
+		err = w.AddDataObject(&action.Object)
 	case *Delete:
-		if err := w.DeleteObject(action.ID); err != nil {
-			return err
-		}
+		err = w.DeleteObject(action.ID)
 	case *AddIndex:
-		if err := w.AddIndexObject(&action.Object); err != nil {
-			return err
-		}
+		err = w.AddIndexObject(&action.Object)
 	case *DeleteIndex:
-		if err := w.DeleteIndexObject(action.RuleID, action.ID); err != nil {
-			return err
-		}
+		err = w.DeleteIndexObject(action.RuleID, action.ID)
 	}
-	return nil
+	return err
 }
 
 // Play "plays" a recorded transaction into a writeable snapshot.

--- a/lake/commits/snapshot.go
+++ b/lake/commits/snapshot.go
@@ -39,7 +39,7 @@ type Writeable interface {
 // XXX redefine snapshot as type map instead of struct
 type Snapshot struct {
 	objects map[ksuid.KSUID]*data.Object
-	indexes index.Map // map[ksuid.KSUID]*index.Object
+	indexes index.Map
 }
 
 var _ View = (*Snapshot)(nil)

--- a/lake/commits/snapshot.go
+++ b/lake/commits/snapshot.go
@@ -23,6 +23,7 @@ type View interface {
 	Select(extent.Span, order.Which) DataObjects
 	SelectAll() DataObjects
 	SelectIndexes(extent.Span, order.Which) []*index.Object
+	SelectAllIndexes() []*index.Object
 }
 
 type Writeable interface {
@@ -37,10 +38,8 @@ type Writeable interface {
 // the commit object tree.
 // XXX redefine snapshot as type map instead of struct
 type Snapshot struct {
-	objects        map[ksuid.KSUID]*data.Object
-	deletedObjects map[ksuid.KSUID]*data.Object
-	indexes        index.Map
-	deletedIndexes index.Map
+	objects map[ksuid.KSUID]*data.Object
+	indexes index.Map // map[ksuid.KSUID]*index.Object
 }
 
 var _ View = (*Snapshot)(nil)
@@ -48,10 +47,8 @@ var _ Writeable = (*Snapshot)(nil)
 
 func NewSnapshot() *Snapshot {
 	return &Snapshot{
-		objects:        make(map[ksuid.KSUID]*data.Object),
-		deletedObjects: make(map[ksuid.KSUID]*data.Object),
-		indexes:        make(index.Map),
-		deletedIndexes: make(index.Map),
+		objects: make(map[ksuid.KSUID]*data.Object),
+		indexes: make(index.Map),
 	}
 }
 
@@ -61,17 +58,15 @@ func (s *Snapshot) AddDataObject(object *data.Object) error {
 		return fmt.Errorf("%s: add of a duplicate data object: %w", id, ErrWriteConflict)
 	}
 	s.objects[id] = object
-	delete(s.deletedObjects, id)
 	return nil
 }
 
 func (s *Snapshot) DeleteObject(id ksuid.KSUID) error {
-	object, ok := s.objects[id]
+	_, ok := s.objects[id]
 	if !ok {
 		return fmt.Errorf("%s: delete of a non-existent data object: %w", id, ErrWriteConflict)
 	}
 	delete(s.objects, id)
-	s.deletedObjects[id] = object
 	return nil
 }
 
@@ -81,7 +76,6 @@ func (s *Snapshot) AddIndexObject(object *index.Object) error {
 		return fmt.Errorf("%s: add of a duplicate index object: %w", id, ErrWriteConflict)
 	}
 	s.indexes.Insert(object)
-	s.deletedIndexes.Delete(object.Rule.RuleID(), id)
 	return nil
 }
 
@@ -91,7 +85,6 @@ func (s *Snapshot) DeleteIndexObject(ruleID ksuid.KSUID, id ksuid.KSUID) error {
 		return fmt.Errorf("%s: delete of a non-existent index object: %w", index.ObjectName(ruleID, id), ErrWriteConflict)
 	}
 	s.indexes.Delete(ruleID, id)
-	s.deletedIndexes.Insert(object)
 	return nil
 }
 
@@ -132,14 +125,6 @@ func (s *Snapshot) LookupIndexObjectRules(id ksuid.KSUID) ([]index.Rule, error) 
 	return r.Rules(), nil
 }
 
-func (s *Snapshot) LookupDeleted(id ksuid.KSUID) (*data.Object, error) {
-	o, ok := s.deletedObjects[id]
-	if !ok {
-		return nil, fmt.Errorf("%s: %w", id, ErrNotFound)
-	}
-	return o, nil
-}
-
 func (s *Snapshot) Select(scan extent.Span, order order.Which) DataObjects {
 	var objects DataObjects
 	for _, o := range s.objects {
@@ -174,6 +159,10 @@ func (s *Snapshot) SelectIndexes(scan extent.Span, order order.Which) []*index.O
 	return indexes
 }
 
+func (s *Snapshot) SelectAllIndexes() []*index.Object {
+	return s.indexes.All()
+}
+
 func (s *Snapshot) Unindexed(rules []index.Rule) map[ksuid.KSUID][]index.Rule {
 	unindexed := make(map[ksuid.KSUID][]index.Rule)
 	for id := range s.objects {
@@ -193,11 +182,7 @@ func (s *Snapshot) Copy() *Snapshot {
 	for key, val := range s.objects {
 		out.objects[key] = val
 	}
-	for key, val := range s.deletedObjects {
-		out.deletedObjects[key] = val
-	}
 	out.indexes = s.indexes.Copy()
-	out.deletedIndexes = s.deletedIndexes.Copy()
 	return out
 }
 
@@ -213,27 +198,9 @@ func (s *Snapshot) serialize() ([]byte, error) {
 			return nil, err
 		}
 	}
-	for _, o := range s.deletedObjects {
-		if err := zs.Write(&Add{Object: *o}); err != nil {
-			return nil, err
-		}
-		if err := zs.Write(&Delete{ID: o.ID}); err != nil {
-			return nil, err
-		}
-	}
 	for _, objectRule := range s.indexes {
 		for _, o := range objectRule {
 			if err := zs.Write(&AddIndex{Object: *o}); err != nil {
-				return nil, err
-			}
-		}
-	}
-	for _, objectRule := range s.deletedIndexes {
-		for _, o := range objectRule {
-			if err := zs.Write(&AddIndex{Object: *o}); err != nil {
-				return nil, err
-			}
-			if err := zs.Write(&DeleteIndex{ID: o.ID, RuleID: o.Rule.RuleID()}); err != nil {
 				return nil, err
 			}
 		}
@@ -278,13 +245,21 @@ func PlayAction(w Writeable, action Action) error {
 	}
 	switch action := action.(type) {
 	case *Add:
-		w.AddDataObject(&action.Object)
+		if err := w.AddDataObject(&action.Object); err != nil {
+			return err
+		}
 	case *Delete:
-		w.DeleteObject(action.ID)
+		if err := w.DeleteObject(action.ID); err != nil {
+			return err
+		}
 	case *AddIndex:
-		w.AddIndexObject(&action.Object)
+		if err := w.AddIndexObject(&action.Object); err != nil {
+			return err
+		}
 	case *DeleteIndex:
-		w.DeleteIndexObject(action.RuleID, action.ID)
+		if err := w.DeleteIndexObject(action.RuleID, action.ID); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This commit adds error checks to the logic that plays a log
to build a snapshot.  This change exposed some bugs that
led to the realization that the snapshot abstraction was
tracking deleted stuff when such tracking belongs in Patches
not Snaphots.  We removed the deleted objects from Snapshot
and updated all the surrounding logic to use Patches instead.

While we were at it, we changed the branch merge logic to use
a new method on Patch to compute a diff between patches and also
detect deletion conflicts.  This allowed us to remove the
OverlappingDeletes check that is better done in the Diff computation.