### PR TITLE
zbuf: copy zed.Value.Bytes in Array.Write

### DIFF
--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -44,7 +44,7 @@ func (a *Array) Vars() []zed.Value {
 }
 
 func (a *Array) Write(r *zed.Value) error {
-	a.Append(r)
+	a.Append(r.Copy())
 	return nil
 }
 

--- a/zbuf/array_test.go
+++ b/zbuf/array_test.go
@@ -1,0 +1,16 @@
+package zbuf
+
+import (
+	"testing"
+
+	"github.com/brimdata/zed"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArrayWriteCopiesValueBytes(t *testing.T) {
+	var a Array
+	val := zed.NewString("old")
+	a.Write(val)
+	copy(val.Bytes, zed.EncodeString("new"))
+	require.Equal(t, zed.NewString("old"), &a.Values()[0])
+}


### PR DESCRIPTION
Array.Write incorrectly assumes ownership of its argument's
zed.Value.Bytes slice.  Fix that by calling zed.Value.Copy.

For brimdata/zync#91.