### PR TITLE
support marshaling of net.IP to Zed type ip

### DIFF
--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -329,6 +329,12 @@ func (m *MarshalZNGContext) encodeAny(v reflect.Value) (zed.Type, error) {
 		m.Builder.Append(zv.Bytes)
 		return typ, nil
 	}
+	if ip, ok := v.Interface().(net.IP); ok {
+		if a, err := netip.ParseAddr(ip.String()); err == nil {
+			m.Builder.Append(zed.EncodeIP(a))
+			return zed.TypeIP, nil
+		}
+	}
 	switch v.Kind() {
 	case reflect.Array:
 		if v.Type().Elem().Kind() == reflect.Uint8 {

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -2,6 +2,7 @@ package zson_test
 
 import (
 	"bytes"
+	"net"
 	"strings"
 	"testing"
 
@@ -306,4 +307,10 @@ func TestIgnoreField(t *testing.T) {
 	var v s
 	require.NoError(t, zson.Unmarshal(b, &v))
 	assert.Equal(t, s{Value: "test"}, v)
+}
+
+func TestMarshalNetIP(t *testing.T) {
+	b, err := zson.Marshal(net.ParseIP("10.0.0.1"))
+	require.NoError(t, err)
+	assert.Equal(t, `10.0.0.1`, b)
 }


### PR DESCRIPTION
This commit adds back support for marshaling IP addresses
from the Go net package.  When we moved to the netip package,
we lost this support.