### PR TITLE
fix bugs in IP marshaling

### DIFF
--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -3,6 +3,7 @@ package zson_test
 import (
 	"bytes"
 	"net"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -311,9 +312,25 @@ func TestIgnoreField(t *testing.T) {
 }
 
 func TestMarshalNetIP(t *testing.T) {
-	b, err := zson.Marshal(net.ParseIP("10.0.0.1"))
+	before := net.ParseIP("10.0.0.1")
+	b, err := zson.Marshal(before)
 	require.NoError(t, err)
 	assert.Equal(t, `10.0.0.1`, b)
+	var after net.IP
+	err = zson.Unmarshal(string(b), &after)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+}
+
+func TestMarshalNetipAddr(t *testing.T) {
+	before := netip.MustParseAddr("10.0.0.1")
+	b, err := zson.Marshal(before)
+	require.NoError(t, err)
+	assert.Equal(t, `10.0.0.1`, b)
+	var after netip.Addr
+	err = zson.Unmarshal(string(b), &after)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
 }
 
 func TestMarshalGoTime(t *testing.T) {
@@ -321,4 +338,17 @@ func TestMarshalGoTime(t *testing.T) {
 	b, err := zson.Marshal(tm)
 	require.NoError(t, err)
 	assert.Equal(t, `2006-01-02T15:04:05.123Z`, b)
+}
+
+func TestMarshalDecoratedIPs(t *testing.T) {
+	m := zson.NewMarshaler()
+	// Make sure IPs don't get decorated with Go type and just
+	// appear as native Zed IPs.
+	m.Decorate(zson.StyleSimple)
+	b, err := m.Marshal(net.ParseIP("142.250.72.142"))
+	require.NoError(t, err)
+	assert.Equal(t, `142.250.72.142`, b)
+	b, err = m.Marshal(netip.MustParseAddr("142.250.72.142"))
+	require.NoError(t, err)
+	assert.Equal(t, `142.250.72.142`, b)
 }

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -333,13 +333,6 @@ func TestMarshalNetipAddr(t *testing.T) {
 	assert.Equal(t, before, after)
 }
 
-func TestMarshalGoTime(t *testing.T) {
-	tm, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05.123Z")
-	b, err := zson.Marshal(tm)
-	require.NoError(t, err)
-	assert.Equal(t, `2006-01-02T15:04:05.123Z`, b)
-}
-
 func TestMarshalDecoratedIPs(t *testing.T) {
 	m := zson.NewMarshaler()
 	// Make sure IPs don't get decorated with Go type and just
@@ -351,4 +344,11 @@ func TestMarshalDecoratedIPs(t *testing.T) {
 	b, err = m.Marshal(netip.MustParseAddr("142.250.72.142"))
 	require.NoError(t, err)
 	assert.Equal(t, `142.250.72.142`, b)
+}
+
+func TestMarshalGoTime(t *testing.T) {
+	tm, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05.123Z")
+	b, err := zson.Marshal(tm)
+	require.NoError(t, err)
+	assert.Equal(t, `2006-01-02T15:04:05.123Z`, b)
 }


### PR DESCRIPTION
This commit fixes bugs in the IP marshaling code where Go types
net.IP and netip.Addr were being decorated when they should just
convert to native Zed ip type.  Also, we added suport for unmarshaling
net.IP in addition to netip.Addr.  Test coverage was extended to
cover these use cases.