### PR TITLE
use PAT_TOKEN in .github/workflows/release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
       with:
         args: release --rm-dist
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
The goreleaser/goreleaser-action step in .github/workflows/release.yml
is configured (in .goreleaser.yaml) to push to the brimdata/homebrew-tap
repository.  This fails because it uses the GITHUB_TOKEN secret, which
can only push to the repository containing the workflow.  Use the
PAT_TOKEN secret instead.