### PR TITLE
lake/api: handle errors in remote.Load

### DIFF
--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -95,9 +95,12 @@ func (r *remote) RenamePool(ctx context.Context, pool ksuid.KSUID, name string) 
 func (r *remote) Load(ctx context.Context, _ *zed.Context, poolID ksuid.KSUID, branchName string, reader zio.Reader, commit api.CommitMessage) (ksuid.KSUID, error) {
 	pr, pw := io.Pipe()
 	go func() {
-		w := zngio.NewWriter(pw)
-		zio.CopyWithContext(ctx, w, reader)
-		w.Close()
+		w := zngio.NewWriter(zio.NopCloser(pw))
+		err := zio.CopyWithContext(ctx, w, reader)
+		if err2 := w.Close(); err == nil {
+			err = err2
+		}
+		pw.CloseWithError(err)
 	}()
 	res, err := r.conn.Load(ctx, poolID, branchName, pr, commit)
 	return res.Commit, err


### PR DESCRIPTION
The goroutine in remote.Load ignores errors.  Handle them by passing
them to io.PipeWriter.CloseWithError instead.