### PR TITLE
service: Add back query ctrl flag

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -301,7 +301,7 @@ func (c *Connection) Query(ctx context.Context, head *lakeparse.Commitish, src s
 	if head != nil {
 		body.Head = *head
 	}
-	req := c.NewRequest(ctx, http.MethodPost, "/query", body)
+	req := c.NewRequest(ctx, http.MethodPost, "/query?ctrl=T", body)
 	res, err := c.Do(req)
 	var ae *api.Error
 	if errors.As(err, &ae) {

--- a/api/queryio/writer.go
+++ b/api/queryio/writer.go
@@ -10,6 +10,8 @@ import (
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/jsonio"
+	"github.com/brimdata/zed/zio/zjsonio"
+	"github.com/brimdata/zed/zio/zngio"
 )
 
 type controlWriter interface {
@@ -24,7 +26,7 @@ type Writer struct {
 	flusher http.Flusher
 }
 
-func NewWriter(w io.WriteCloser, format string, flusher http.Flusher) (*Writer, error) {
+func NewWriter(w io.WriteCloser, format string, flusher http.Flusher, ctrl bool) (*Writer, error) {
 	d := &Writer{
 		cid:     -1,
 		start:   nano.Now(),
@@ -33,9 +35,17 @@ func NewWriter(w io.WriteCloser, format string, flusher http.Flusher) (*Writer, 
 	var err error
 	switch format {
 	case "zng":
-		d.writer = NewZNGWriter(w)
+		if ctrl {
+			d.writer = NewZNGWriter(w)
+		} else {
+			d.writer = zngio.NewWriter(w)
+		}
 	case "zjson":
-		d.writer = NewZJSONWriter(w)
+		if ctrl {
+			d.writer = NewZJSONWriter(w)
+		} else {
+			d.writer = zjsonio.NewWriter(w)
+		}
 	case "json":
 		// A JSON response is always an array.
 		d.writer = jsonio.NewArrayWriter(w)

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -3,7 +3,6 @@ package service
 import (
 	"errors"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/brimdata/zed"
@@ -30,7 +29,7 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 	if !r.Unmarshal(w, &req) {
 		return
 	}
-	ctrl, ok := r.BoolFromQuery("ctrl")
+	ctrl, ok := r.BoolFromQuery("ctrl", w)
 	if !ok {
 		return
 	}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -30,13 +30,9 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 	if !r.Unmarshal(w, &req) {
 		return
 	}
-	var ctrl bool
-	if s := r.URL.Query().Get("ctrl"); s != "" {
-		var err error
-		if ctrl, err = strconv.ParseBool(s); err != nil {
-			w.Error(srverr.ErrInvalid("non-boolean value for \"ctrl\" query parameter: %q", s))
-			return
-		}
+	ctrl, ok := r.BoolFromQuery("ctrl")
+	if !ok {
+		return
 	}
 	// A note on error handling here.  If we get an error setting up
 	// before the query starts to run, we call w.Error() and return

--- a/service/ztests/curl-query-ctrl.yaml
+++ b/service/ztests/curl-query-ctrl.yaml
@@ -24,4 +24,4 @@ outputs:
       // control messages disabled
       {"type":{"kind":"record","id":30,"fields":[{"name":"ts","type":{"kind":"primitive","name":"int64"}}]},"value":["0"]}
       // invalid ctrl value
-      {"type":"Error","kind":"invalid operation","error":"non-boolean value for \"ctrl\" query parameter: \"Foo\""}
+      {"type":"Error","kind":"invalid operation","error":"invalid query param \"Foo\": strconv.ParseBool: parsing \"Foo\": invalid syntax"}

--- a/service/ztests/curl-query-ctrl.yaml
+++ b/service/ztests/curl-query-ctrl.yaml
@@ -1,0 +1,27 @@
+script: |
+  source service.sh
+  zed create -q test
+  echo '{ts:0}' | zed load -use test -q - 
+  echo // control messages enabled
+  curl -H "Accept: application/x-zjson" -d '{"query":"from test@main"}' $ZED_LAKE/query?ctrl=T \
+    | sed -E '/QueryStats/s/[0-9]{3,}/xxx/g' # for ZJSON
+  echo // control messages disabled
+  curl -H "Accept: application/x-zjson" -d '{"query":"from test@main"}' $ZED_LAKE/query?ctrl=F
+  echo // invalid ctrl value
+  curl -H "Accept: application/x-zjson" -d '{"query":"from test@main"}' $ZED_LAKE/query?ctrl=Foo
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      // control messages enabled
+      {"type":"QueryChannelSet","value":{"channel_id":0}}
+      {"type":{"kind":"record","id":30,"fields":[{"name":"ts","type":{"kind":"primitive","name":"int64"}}]},"value":["0"]}
+      {"type":"QueryChannelEnd","value":{"channel_id":0}}
+      {"type":"QueryStats","value":{"start_time":{"sec":xxx,"ns":xxx},"update_time":{"sec":xxx,"ns":xxx},"bytes_read":1,"bytes_matched":1,"records_read":1,"records_matched":1}}
+      // control messages disabled
+      {"type":{"kind":"record","id":30,"fields":[{"name":"ts","type":{"kind":"primitive","name":"int64"}}]},"value":["0"]}
+      // invalid ctrl value
+      {"type":"Error","kind":"invalid operation","error":"non-boolean value for \"ctrl\" query parameter: \"Foo\""}

--- a/service/ztests/drop.yaml
+++ b/service/ztests/drop.yaml
@@ -27,4 +27,4 @@ outputs:
       ===
       ===
       "p3": pool not found
-      Post "http://127.0.0.1:1/query": dial tcp 127.0.0.1:1: connect: connection refused
+      Post "http://127.0.0.1:1/query?ctrl=T": dial tcp 127.0.0.1:1: connect: connection refused


### PR DESCRIPTION
By default have the query endpoint return no control messages for
supporting formats (zng and zjson). If the query params ctrl is set to
true enable control messages. For the go client enable control messages
on queries by default.

Closes #3990