### PR TITLE
Point Zealot links at package directory in Brim repo

### DIFF
--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -274,7 +274,7 @@ values.
 embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
-the [Zealot JavaScript library](https://github.com/brimdata/zealot)
+the [Zealot JavaScript library](https://github.com/brimdata/brim/tree/main/packages/zealot)
 and the [Zed Python library](../../python/zed).
 
 Because all of the formats conform to the same Zed data model, conversions between

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -65,7 +65,7 @@ so appropriate for a [super-structured data model](README.md#2-zed-a-super-struc
 like Zed.  That said, JSON can be used as an encoding format for Zed by mapping Zed data
 onto a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Zed and, with the help of client
-libraries like [Zealot](https://github.com/brimdata/zealot),
+libraries like [Zealot](https://github.com/brimdata/brim/tree/main/packages/zealot),
 to manipulate the rich, structured Zed types that are implemented on top of
 the basic JavaScript types.
 


### PR DESCRIPTION
There's been some confusion about the standalone Zealot repo https://github.com/brimdata/zealot, which has been confirmed to be "old and outdated and not being used anywhere”. I'm about to downsize that repo to be just a README pointing at the correct location, which is the package directory https://github.com/brimdata/brim/tree/main/packages/zealot in the Brim repo. But I found these couple links in the Zed repo to fix as well.