### PR TITLE
add support for marshaling mixed-type arrays

### DIFF
--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -514,10 +514,10 @@ func (m *MarshalZNGContext) encodeArrayBytes(arrayVal reflect.Value) (zed.Type, 
 }
 
 func (m *MarshalZNGContext) encodeArray(arrayVal reflect.Value) (zed.Type, error) {
-	arrayLen := arrayVal.Len()
 	push := m.Builder
 	m.Builder = *zcode.NewBuilder()
 	m.Builder.BeginContainer()
+	arrayLen := arrayVal.Len()
 	types := make([]zed.Type, 0, arrayLen)
 	typeMap := make(map[zed.Type]struct{})
 	for i := 0; i < arrayLen; i++ {
@@ -544,7 +544,7 @@ func (m *MarshalZNGContext) encodeArray(arrayVal reflect.Value) (zed.Type, error
 		innerType = types[0]
 		push.Append(m.Builder.Bytes().Body())
 	default:
-		unionTypes := make([]zed.Type, 0, len(types))
+		unionTypes := make([]zed.Type, 0, len(typeMap))
 		for typ := range typeMap {
 			unionTypes = append(unionTypes, typ)
 		}
@@ -553,7 +553,7 @@ func (m *MarshalZNGContext) encodeArray(arrayVal reflect.Value) (zed.Type, error
 		// so we can recode the array with tagged union elements.
 		// We throw out the array computed above and start over with
 		// an empty builder.
-		m.Builder = *zcode.NewBuilder()
+		m.Builder.Truncate()
 		m.Builder.BeginContainer()
 		for i, typ := range types {
 			m.Builder.BeginContainer()

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -262,8 +262,6 @@ type MessageThing struct {
 }
 
 func TestMixedTypeArrayOfStructWithInterface(t *testing.T) {
-	t.Skip() //BROKEN
-
 	input := []MessageThing{
 		{
 			Message: "hello",
@@ -298,6 +296,7 @@ func TestMixedTypeArrayOfStructWithInterface(t *testing.T) {
 	assert.Equal(t, `[[{Message:"hello",Thing:{MyColor:"red"}(=Plant)}(=MessageThing),{Message:"world",Thing:{MyColor:"blue"}(=Animal)}(=MessageThing)]]`, actual)
 
 	u := zson.NewUnmarshaler()
+	u.Bind(Plant{}, Animal{}, MessageThing{}, Thing(nil))
 	var out RecordWithInterfaceSlice
 	err = u.Unmarshal(actual, &out)
 	require.NoError(t, err)

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -222,6 +222,12 @@ func TestMixedTypeArray(t *testing.T) {
 	assert.Equal(t, trim(exp), trim(actual))
 	// Double check that all the proper typing made it into the implied union.
 	assert.Equal(t, `{X:"hello",S:[[{MyColor:"red"}(=Plant),{MyColor:"blue"}(=Animal)]]}(=RecordWithInterfaceSlice)`, actual)
+
+	u := zson.NewUnmarshaler()
+	var out RecordWithInterfaceSlice
+	err = u.Unmarshal(actual, &out)
+	require.NoError(t, err)
+	assert.Equal(t, *x, out)
 }
 
 type Foo struct {

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -192,11 +192,7 @@ type RecordWithInterfaceSlice struct {
 	S []Thing
 }
 
-func TestBug2575(t *testing.T) {
-	// Bug #2575 is preventing "-f lake" from working on transactions that
-	// have arrays of actions.Interface.  This test repros the problem.
-	// Skipping until #2575 is addressed.
-	t.Skip()
+func TestMixedTypeArray(t *testing.T) {
 	x := &RecordWithInterfaceSlice{
 		X: "hello",
 		S: []Thing{
@@ -223,7 +219,9 @@ func TestBug2575(t *testing.T) {
 	require.NoError(t, err)
 	actual, err := zson.FormatValue(recActual)
 	require.NoError(t, err)
-	assert.Equal(t, trim(exp), actual)
+	assert.Equal(t, trim(exp), trim(actual))
+	// Double check that all the proper typing made it into the implied union.
+	assert.Equal(t, `{X:"hello",S:[[{MyColor:"red"}(=Plant),{MyColor:"blue"}(=Animal)]]}(=RecordWithInterfaceSlice)`, actual)
 }
 
 type Foo struct {

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -220,7 +220,7 @@ func TestMixedTypeArrayInsideRecord(t *testing.T) {
 	require.NoError(t, err)
 	actual, err := zson.FormatValue(recActual)
 	require.NoError(t, err)
-	assert.Equal(t, trim(exp), trim(actual))
+	assert.Equal(t, exp, actual)
 	// Double check that all the proper typing made it into the implied union.
 	assert.Equal(t, `{X:"hello",S:[[{MyColor:"red"}(=Plant),{MyColor:"blue"}(=Animal)]]}(=RecordWithInterfaceSlice)`, actual)
 

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -193,6 +193,7 @@ type RecordWithInterfaceSlice struct {
 }
 
 func TestMixedTypeArrayInsideRecord(t *testing.T) {
+	t.Skip() //XXX broken
 	x := &RecordWithInterfaceSlice{
 		X: "hello",
 		S: []Thing{
@@ -224,14 +225,29 @@ func TestMixedTypeArrayInsideRecord(t *testing.T) {
 	assert.Equal(t, `{X:"hello",S:[[{MyColor:"red"}(=Plant),{MyColor:"blue"}(=Animal)]]}(=RecordWithInterfaceSlice)`, actual)
 
 	u := zson.NewUnmarshaler()
+	u.Bind(Animal{}, Plant{}, RecordWithInterfaceSlice{})
 	var out RecordWithInterfaceSlice
 	err = u.Unmarshal(actual, &out)
 	require.NoError(t, err)
 	assert.Equal(t, *x, out)
 }
 
-//XXX add simple test to unmarshal 1(int64,string) into Go int64
+type Bug struct {
+	S []Thing
+}
 
+func TestBug(t *testing.T) {
+	z := `{S:[{MyColor:"red"}(=Plant),{MyColor:"blue"}(=Animal)]}`
+
+	u := zson.NewUnmarshaler()
+	u.Bind(Animal{}, Plant{}, Bug{})
+	var out Bug
+	err := u.Unmarshal(z, &out)
+	require.NoError(t, err)
+	//assert.Equal(t, *x, out)
+}
+
+//XXX add simple test to unmarshal 1(int64,string) into Go int64
 //XXX add recursive test (where implied union is an array of unions of unions)
 // and a "combinatoric" test, where there are multiple interface values with
 // combos otherwise creating combinatoric problems but I think Zed solve this
@@ -246,6 +262,8 @@ type MessageThing struct {
 }
 
 func TestMixedTypeArrayOfStructWithInterface(t *testing.T) {
+	t.Skip() //BROKEN
+
 	input := []MessageThing{
 		{
 			Message: "hello",

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -249,7 +249,7 @@ func TestUnmarshalNull(t *testing.T) {
 		require.NoError(t, zson.UnmarshalZNG(val, &obj))
 		require.Nil(t, obj.Test)
 		val = zson.MustParseValue(zed.NewContext(), "{test: null(ip)}")
-		require.EqualError(t, zson.UnmarshalZNG(val, &obj), "cannot unmarshal Zed type \"ip\" into Go struct")
+		require.EqualError(t, zson.UnmarshalZNG(val, &obj), `cannot unmarshal Zed value "null(ip)" into Go struct`)
 	})
 }
 
@@ -474,7 +474,7 @@ func TestInterfaceUnmarshal(t *testing.T) {
 
 	var thingI interface{}
 	err = u.Unmarshal(zv, &thingI)
-	require.NoError(t, err)
+	require.NoError(t, err, zson.String(zv))
 	actualThing, ok := thingI.(*ZNGThing)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, t1, actualThing)
@@ -483,7 +483,7 @@ func TestInterfaceUnmarshal(t *testing.T) {
 	var genericThing interface{}
 	err = u2.Unmarshal(zv, &genericThing)
 	require.Error(t, err)
-	assert.Equal(t, "unmarshaling records into interface value requires type binding", err.Error())
+	assert.Equal(t, `unmarshaling records into interface value requires type binding`, err.Error())
 }
 
 func TestBindings(t *testing.T) {


### PR DESCRIPTION
This commit fixes a known bug where mixed-type arrays would be
erroneously marshaled into zng.  The fix is to detect when the
array has multiple types.  This is tricky because the type of
each element is only determined upon a recursive descent which
also builds the value.  So, we opportunistically go this route
with a temp builder and track all the types encountered.  If there
is more than one type, we throw  out the improperly built array
and recode it as an array of unions.

This could be made more efficient if we implemented a function
to recursively compute the Zed type of each Go value without
building the value.

Closes #2575