### PR TITLE
used "tagged union" for union terminology

### DIFF
--- a/complex.go
+++ b/complex.go
@@ -374,7 +374,7 @@ func (t *TypeUnion) TagOf(typ Type) int {
 }
 
 // Untag takes bytes of the reciever's type and returns the underlying value
-// as its types and bytes by removing the tag and determining that tag's
+// as its type and bytes by removing the tag and determining that tag's
 // type from the union.  Untag panics if the tag is invalid.
 func (t *TypeUnion) Untag(bytes zcode.Bytes) (Type, zcode.Bytes) {
 	if bytes == nil {

--- a/complex.go
+++ b/complex.go
@@ -359,7 +359,7 @@ func (t *TypeUnion) ID() int {
 // Type returns the type corresponding to tag.
 func (t *TypeUnion) Type(tag int) (Type, error) {
 	if tag < 0 || tag >= len(t.Types) {
-		return nil, ErrUnionSelector
+		return nil, ErrUnionTag
 	}
 	return t.Types[tag], nil
 }

--- a/complex.go
+++ b/complex.go
@@ -356,33 +356,33 @@ func (t *TypeUnion) ID() int {
 	return t.id
 }
 
-// Type returns the type corresponding to selector.
-func (t *TypeUnion) Type(selector int) (Type, error) {
-	if selector < 0 || selector >= len(t.Types) {
+// Type returns the type corresponding to tag.
+func (t *TypeUnion) Type(tag int) (Type, error) {
+	if tag < 0 || tag >= len(t.Types) {
 		return nil, ErrUnionSelector
 	}
-	return t.Types[selector], nil
+	return t.Types[tag], nil
 }
 
-// Selector returns the selector for typ in the union. If no type exists -1 is
+// TagOf returns the tag for typ in the union. If no type exists -1 is
 // returned.
-func (t *TypeUnion) Selector(typ Type) int {
+func (t *TypeUnion) TagOf(typ Type) int {
 	if s, ok := t.LUT[typ]; ok {
 		return s
 	}
 	return -1
 }
 
-// SplitZNG takes a zng encoding of a value of the receiver's union type and
-// returns the concrete type of the value, its selector, and the value encoding.
-// SplitZNG panics if the selector is invalid.
-func (t *TypeUnion) SplitZNG(zv zcode.Bytes) (Type, zcode.Bytes) {
-	if zv == nil {
+// Untag takes bytes of the reciever's type and returns the underlying value
+// as its types and bytes by removing the tag and determining that tag's
+// type from the union.  Untag panics if the tag is invalid.
+func (t *TypeUnion) Untag(bytes zcode.Bytes) (Type, zcode.Bytes) {
+	if bytes == nil {
 		return t, nil
 	}
-	it := zv.Iter()
-	selector := DecodeInt(it.Next())
-	inner, err := t.Type(int(selector))
+	it := bytes.Iter()
+	tag := DecodeInt(it.Next())
+	inner, err := t.Type(int(tag))
 	if err != nil {
 		panic(err)
 	}
@@ -393,14 +393,14 @@ func (t *TypeUnion) Kind() Kind {
 	return UnionKind
 }
 
-// BuildUnion appends to b a union described by selector and val.
-func BuildUnion(b *zcode.Builder, selector int, val zcode.Bytes) {
+// BuildUnion appends to b a union described by tag and val.
+func BuildUnion(b *zcode.Builder, tag int, val zcode.Bytes) {
 	if val == nil {
 		b.Append(nil)
 		return
 	}
 	b.BeginContainer()
-	b.Append(EncodeInt(int64(selector)))
+	b.Append(EncodeInt(int64(tag)))
 	b.Append(val)
 	b.EndContainer()
 }

--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -377,7 +377,7 @@ where the values are encoded as follows:
 | `set`    | normalized concatenation of elements    |
 | `record` | concatenation of elements               |
 | `map`    | concatenation of key and value elements |
-| `union`  | concatenation of selector and value     |
+| `union`  | concatenation of tag and value     |
 | `enum`   | position of enum element                |
 | `error`  | wrapped element                         |
 
@@ -391,7 +391,7 @@ sequence of bytes encoding each element's tag-counted value is
 lexicographically greater than that of the preceding element.
 
 A union value is encoded as a container with two elements. The first
-element, called the selector, is the `uvarint` encoding of the
+element, called the tag, is the `uvarint` encoding of the
 positional index determining the type of the value in reference to the
 union's list of defined types, and the second element is the value
 encoded according to that type.

--- a/docs/formats/zst.md
+++ b/docs/formats/zst.md
@@ -376,10 +376,10 @@ For an `<array_column>`, a length is read from its `lengths` segmap as an `int32
 and that many values are read from its the `values` sub-column,
 encoding the result as a ZNG array value.
 
-For a `<union_column>`, a value is read from its `selector` segmap
+For a `<union_column>`, a value is read from its `tags` segmap
 and that value is used to select the corresponding column stream
 `c0`, `c1`, etc.  The value read is then encoded as a ZNG union value
-using the same selector value within the union value.
+using the same tag within the union value.
 
 ## Examples
 

--- a/runtime/expr/agg/collect.go
+++ b/runtime/expr/agg/collect.go
@@ -44,7 +44,7 @@ func (c *Collect) Result(zctx *zed.Context) *zed.Value {
 	inner := innerType(zctx, c.values)
 	if union, ok := inner.(*zed.TypeUnion); ok {
 		for _, val := range c.values {
-			zed.BuildUnion(&b, union.Selector(val.Type), val.Bytes)
+			zed.BuildUnion(&b, union.TagOf(val.Type), val.Bytes)
 		}
 	} else {
 		for _, val := range c.values {

--- a/runtime/expr/agg/union.go
+++ b/runtime/expr/agg/union.go
@@ -73,7 +73,7 @@ func (u *Union) Result(zctx *zed.Context) *zed.Value {
 	for typ, m := range u.types {
 		for v := range m {
 			if union, ok := zed.TypeUnder(inner).(*zed.TypeUnion); ok {
-				zed.BuildUnion(&b, union.Selector(typ), []byte(v))
+				zed.BuildUnion(&b, union.TagOf(typ), []byte(v))
 			} else {
 				b.Append([]byte(v))
 			}
@@ -94,7 +94,7 @@ func (u *Union) ConsumeAsPartial(val *zed.Value) {
 		typ := styp.Type
 		b := it.Next()
 		if union, ok := zed.TypeUnder(typ).(*zed.TypeUnion); ok {
-			typ, b = union.SplitZNG(b)
+			typ, b = union.Untag(b)
 		}
 		u.update(typ, b)
 	}

--- a/runtime/expr/dot.go
+++ b/runtime/expr/dot.go
@@ -51,7 +51,7 @@ func ValueUnder(val *zed.Value) *zed.Value {
 		if !ok {
 			return &zed.Value{typ, bytes}
 		}
-		typ, bytes = union.SplitZNG(bytes)
+		typ, bytes = union.Untag(bytes)
 	}
 }
 

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -753,7 +753,7 @@ func indexMap(zctx *zed.Context, ectx Context, typ *zed.TypeMap, mapBytes zcode.
 
 func deunion(ectx Context, typ zed.Type, b zcode.Bytes) *zed.Value {
 	if union, ok := typ.(*zed.TypeUnion); ok {
-		typ, b = union.SplitZNG(b)
+		typ, b = union.Untag(b)
 	}
 	return ectx.NewValue(typ, b)
 }

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -96,7 +96,7 @@ func (n *Flatten) encode(cols []zed.Column, inner zed.Type, base field.Path, b z
 		union, _ := inner.(*zed.TypeUnion)
 		if union != nil {
 			n.BeginContainer()
-			n.Append(zed.EncodeInt(int64(union.Selector(typ))))
+			n.Append(zed.EncodeInt(int64(union.TagOf(typ))))
 		}
 		n.BeginContainer()
 		n.encodeKey(key)

--- a/runtime/expr/function/types.go
+++ b/runtime/expr/function/types.go
@@ -169,7 +169,7 @@ func (h *HasError) hasError(t zed.Type, b zcode.Bytes) (bool, bool) {
 			_, isErr := zed.TypeUnder(typ).(*zed.TypeError)
 			canCache = !canCache || isErr
 		}
-		if typ, b := typ.SplitZNG(b); b != nil {
+		if typ, b := typ.Untag(b); b != nil {
 			// Check mb is not nil to avoid infinite recursion.
 			var cc bool
 			hasErr, cc = h.hasError(typ, b)

--- a/runtime/expr/function/under.go
+++ b/runtime/expr/function/under.go
@@ -17,8 +17,7 @@ func (u *Under) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	case *zed.TypeError:
 		return ectx.NewValue(typ.Type, val.Bytes)
 	case *zed.TypeUnion:
-		t, bytes := typ.SplitZNG(val.Bytes)
-		return ectx.NewValue(t, bytes)
+		return ectx.NewValue(typ.Untag(val.Bytes))
 	case *zed.TypeOfType:
 		t, err := u.zctx.LookupByValue(val.Bytes)
 		if err != nil {

--- a/runtime/expr/function/unflatten.go
+++ b/runtime/expr/function/unflatten.go
@@ -69,7 +69,7 @@ func (u *Unflatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 
 func (u *Unflatten) parseElem(inner zed.Type, vb zcode.Bytes) (field.Path, zed.Type, zcode.Bytes, error) {
 	if union, ok := zed.TypeUnder(inner).(*zed.TypeUnion); ok {
-		inner, vb = union.SplitZNG(vb)
+		inner, vb = union.Untag(vb)
 	}
 	typ := zed.TypeRecordOf(inner)
 	if typ == nil || len(typ.Columns) != 2 {

--- a/runtime/expr/shaper_test.go
+++ b/runtime/expr/shaper_test.go
@@ -18,14 +18,14 @@ func TestBestUnionSelector(t *testing.T) {
 	u8named3, err := zctx.LookupTypeNamed("u8named3", u8)
 	require.NoError(t, err)
 
-	assert.Equal(t, -1, bestUnionSelector(u8, nil))
-	assert.Equal(t, -1, bestUnionSelector(u8, u8))
-	assert.Equal(t, -1, bestUnionSelector(zed.TypeUint16, zctx.LookupTypeUnion([]zed.Type{u8})))
+	assert.Equal(t, -1, bestUnionTag(u8, nil))
+	assert.Equal(t, -1, bestUnionTag(u8, u8))
+	assert.Equal(t, -1, bestUnionTag(zed.TypeUint16, zctx.LookupTypeUnion([]zed.Type{u8})))
 
 	test := func(expected, needle zed.Type, haystack []zed.Type) {
 		t.Helper()
 		union := zctx.LookupTypeUnion(haystack)
-		typ, err := union.Type(bestUnionSelector(needle, union))
+		typ, err := union.Type(bestUnionTag(needle, union))
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, typ)
 		}

--- a/runtime/expr/shaper_test.go
+++ b/runtime/expr/shaper_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBestUnionSelector(t *testing.T) {
+func TestBestUnionTag(t *testing.T) {
 	u8 := zed.TypeUint8
 	zctx := zed.NewContext()
 	u8named1, err := zctx.LookupTypeNamed("u8named1", u8)

--- a/runtime/expr/values.go
+++ b/runtime/expr/values.go
@@ -348,7 +348,7 @@ type collectionIter struct {
 
 func (c *collectionIter) appendNext(b *zcode.Builder) {
 	if union, ok := c.typ.(*zed.TypeUnion); ok {
-		zed.BuildUnion(b, union.Selector(c.types[0]), c.bytes[0])
+		zed.BuildUnion(b, union.TagOf(c.types[0]), c.bytes[0])
 	} else {
 		b.Append(c.bytes[0])
 	}

--- a/runtime/op/traverse/eval.go
+++ b/runtime/op/traverse/eval.go
@@ -108,7 +108,7 @@ func (e *Expr) makeUnionArray(ectx expr.Context, vals []zed.Value) *zed.Value {
 	union := e.zctx.LookupTypeUnion(utypes)
 	var b zcode.Builder
 	for _, val := range vals {
-		zed.BuildUnion(&b, union.Selector(val.Type), val.Bytes)
+		zed.BuildUnion(&b, union.TagOf(val.Type), val.Bytes)
 	}
 	return ectx.NewValue(e.zctx.LookupTypeArray(union), b.Bytes())
 }

--- a/type.go
+++ b/type.go
@@ -19,10 +19,10 @@ import (
 )
 
 var (
-	ErrNotArray      = errors.New("cannot index a non-array")
-	ErrIndex         = errors.New("array index out of bounds")
-	ErrUnionSelector = errors.New("union selector out of bounds")
-	ErrEnumIndex     = errors.New("enum index out of bounds")
+	ErrNotArray  = errors.New("cannot index a non-array")
+	ErrIndex     = errors.New("array index out of bounds")
+	ErrUnionTag  = errors.New("invalid union tag")
+	ErrEnumIndex = errors.New("enum index out of bounds")
 )
 
 // A Type is an interface presented by a zeek type.

--- a/walk.go
+++ b/walk.go
@@ -81,8 +81,8 @@ func walkUnion(typ *TypeUnion, body zcode.Bytes, visit Visitor) error {
 		return errors.New("union has empty body")
 	}
 	it := body.Iter()
-	selector := DecodeInt(it.Next())
-	inner, err := typ.Type(int(selector))
+	tag := DecodeInt(it.Next())
+	inner, err := typ.Type(int(tag))
 	if err != nil {
 		return err
 	}

--- a/zio/jsonio/builder.go
+++ b/zio/jsonio/builder.go
@@ -111,7 +111,7 @@ func (b *builder) endArray() {
 			if bytes := items[i].zb.Bytes().Body(); bytes == nil {
 				container.zb.Append(nil)
 			} else {
-				selector := union.Selector(items[i].typ)
+				selector := union.TagOf(items[i].typ)
 				zed.BuildUnion(&container.zb, selector, bytes)
 			}
 		}

--- a/zio/jsonio/builder.go
+++ b/zio/jsonio/builder.go
@@ -111,8 +111,8 @@ func (b *builder) endArray() {
 			if bytes := items[i].zb.Bytes().Body(); bytes == nil {
 				container.zb.Append(nil)
 			} else {
-				selector := union.TagOf(items[i].typ)
-				zed.BuildUnion(&container.zb, selector, bytes)
+				tag := union.TagOf(items[i].typ)
+				zed.BuildUnion(&container.zb, tag, bytes)
 			}
 		}
 	}

--- a/zio/jsonio/marshal.go
+++ b/zio/jsonio/marshal.go
@@ -51,7 +51,7 @@ func marshalAny(typ zed.Type, bytes zcode.Bytes) interface{} {
 	case *zed.TypeMap:
 		return marshalMap(typ, bytes)
 	case *zed.TypeUnion:
-		return marshalAny(typ.SplitZNG(bytes))
+		return marshalAny(typ.Untag(bytes))
 	case *zed.TypeEnum:
 		return marshalEnum(typ, bytes)
 	case *zed.TypeError:

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -193,8 +193,8 @@ func formatUnion(t *zed.TypeUnion, zv zcode.Bytes) string {
 	if zv == nil {
 		return FormatValue(zed.Null)
 	}
-	typ, iv := t.SplitZNG(zv)
-	s := strconv.FormatInt(int64(t.Selector(typ)), 10) + ":"
+	typ, iv := t.Untag(zv)
+	s := strconv.FormatInt(int64(t.TagOf(typ)), 10) + ":"
 	return s + formatAny(zed.NewValue(typ, iv), false)
 }
 

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -191,20 +191,20 @@ func (r *Reader) decodeUnion(builder *zcode.Builder, typ *zed.TypeUnion, body in
 	if len(tuple) != 2 {
 		return errors.New("ZJSON union value not an array of two elements")
 	}
-	selectorStr, ok := tuple[0].(string)
+	tagStr, ok := tuple[0].(string)
 	if !ok {
-		return errors.New("bad selector for ZJSON union value")
+		return errors.New("bad tag for ZJSON union value")
 	}
-	selector, err := strconv.Atoi(selectorStr)
+	tag, err := strconv.Atoi(tagStr)
 	if err != nil {
-		return fmt.Errorf("bad selector for ZJSON union value: %w", err)
+		return fmt.Errorf("bad tag for ZJSON union value: %w", err)
 	}
-	inner, err := typ.Type(selector)
+	inner, err := typ.Type(tag)
 	if err != nil {
-		return fmt.Errorf("bad selector for ZJSON union value: %w", err)
+		return fmt.Errorf("bad tag for ZJSON union value: %w", err)
 	}
 	builder.BeginContainer()
-	builder.Append(zed.EncodeInt(int64(selector)))
+	builder.Append(zed.EncodeInt(int64(tag)))
 	if err := r.decodeValue(builder, inner, tuple[1]); err != nil {
 		return err
 	}

--- a/zio/zjsonio/writer.go
+++ b/zio/zjsonio/writer.go
@@ -205,12 +205,12 @@ func (w *Writer) encodeUnion(zctx *zed.Context, union *zed.TypeUnion, bytes zcod
 	if bytes == nil {
 		return nil, nil
 	}
-	inner, b := union.SplitZNG(bytes)
+	inner, b := union.Untag(bytes)
 	val, err := w.encodeValue(zctx, inner, b)
 	if err != nil {
 		return nil, err
 	}
-	return []interface{}{strconv.Itoa(union.Selector(inner)), val}, nil
+	return []interface{}{strconv.Itoa(union.TagOf(inner)), val}, nil
 }
 
 func (w *Writer) encodePrimitive(zctx *zed.Context, typ zed.Type, v zcode.Bytes) (interface{}, error) {

--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -33,9 +33,9 @@ type (
 		Elements []Value
 	}
 	Union struct {
-		Type     zed.Type
-		Selector int
-		Value    Value
+		Type  zed.Type
+		Tag   int
+		Value Value
 	}
 	Enum struct {
 		Type zed.Type
@@ -187,7 +187,7 @@ func (a Analyzer) enterTypeDef(zctx *zed.Context, name string, typ zed.Type) (*z
 func (a Analyzer) convertAny(zctx *zed.Context, val astzed.Any, cast zed.Type) (Value, error) {
 	// If we're casting something to a union, then the thing inside needs to
 	// describe itself and we can convert the inner value to a union value when
-	// we know its type (so we can code the selector).
+	// we know its type (so we can code the tag).
 	if union, ok := zed.TypeUnder(cast).(*zed.TypeUnion); ok {
 		v, err := a.convertAny(zctx, val, nil)
 		if err != nil {
@@ -428,19 +428,19 @@ func (a Analyzer) convertSet(zctx *zed.Context, set *astzed.Set, cast zed.Type) 
 func (a Analyzer) convertUnion(zctx *zed.Context, v Value, union *zed.TypeUnion, cast zed.Type) (Value, error) {
 	valType := v.TypeOf()
 	if valType == zed.TypeNull {
-		// Set selector to -1 to signal to the builder to encode a null.
+		// Set tag to -1 to signal to the builder to encode a null.
 		return &Union{
-			Type:     cast,
-			Selector: -1,
-			Value:    v,
+			Type:  cast,
+			Tag:   -1,
+			Value: v,
 		}, nil
 	}
 	for k, typ := range union.Types {
 		if valType == typ {
 			return &Union{
-				Type:     cast,
-				Selector: k,
-				Value:    v,
+				Type:  cast,
+				Tag:   k,
+				Value: v,
 			}, nil
 		}
 	}

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -209,9 +209,9 @@ func buildMap(b *zcode.Builder, m *Map) error {
 }
 
 func buildUnion(b *zcode.Builder, union *Union) error {
-	if selector := union.Selector; selector >= 0 {
+	if tag := union.Tag; tag >= 0 {
 		b.BeginContainer()
-		b.Append(zed.EncodeInt(int64(union.Selector)))
+		b.Append(zed.EncodeInt(int64(tag)))
 		if err := buildValue(b, union.Value); err != nil {
 			return err
 		}

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -510,7 +510,7 @@ func (e *elemHelper) needsDecoration() bool {
 func (f *Formatter) formatUnion(indent int, union *zed.TypeUnion, bytes zcode.Bytes) error {
 	typ, bytes := union.Untag(bytes)
 	// XXX For now, we always decorate a union value so that
-	// we can determine the selector from the value's explicit type.
+	// we can determine the tag from the value's explicit type.
 	// We can later optimize this so we only print the decorator if its
 	// ambigous with another type (e.g., int8 and int16 vs a union of int8 and string).
 	// Let's do this after we have the parser working and capable of this

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -495,7 +495,7 @@ func (e *elemHelper) add(b zcode.Bytes) (zed.Type, zcode.Bytes) {
 		// set the type to null.
 		return zed.TypeNull, b
 	}
-	typ, b := e.union.SplitZNG(b)
+	typ, b := e.union.Untag(b)
 	if _, ok := e.seen[typ]; !ok {
 		e.seen[typ] = struct{}{}
 	}
@@ -508,7 +508,7 @@ func (e *elemHelper) needsDecoration() bool {
 }
 
 func (f *Formatter) formatUnion(indent int, union *zed.TypeUnion, bytes zcode.Bytes) error {
-	typ, bytes := union.SplitZNG(bytes)
+	typ, bytes := union.Untag(bytes)
 	// XXX For now, we always decorate a union value so that
 	// we can determine the selector from the value's explicit type.
 	// We can later optimize this so we only print the decorator if its


### PR DESCRIPTION
This commit is a cosmetic change that adopts the more conventional
terminology of tagged unions over the more obscure terms SplitZNG
and Selector.  No logic is changed; only names.