### PR TITLE
add "zed vector" command

### DIFF
--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/brimdata/zed/cmd/zed/serve"
 	"github.com/brimdata/zed/cmd/zed/use"
 	"github.com/brimdata/zed/cmd/zed/vacate"
+	"github.com/brimdata/zed/cmd/zed/vector"
 )
 
 func main() {
@@ -58,6 +59,7 @@ func main() {
 	zed.Add(serve.Cmd)
 	zed.Add(use.Cmd)
 	zed.Add(vacate.Cmd)
+	zed.Add(vector.Cmd)
 	zed.Add(dev.Cmd)
 	if err := root.Zed.ExecRoot(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/cmd/zed/vector/add.go
+++ b/cmd/zed/vector/add.go
@@ -1,0 +1,61 @@
+package vector
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/brimdata/zed/cli/commitflags"
+	"github.com/brimdata/zed/lakeparse"
+	"github.com/brimdata/zed/pkg/charm"
+)
+
+var add = &charm.Spec{
+	Name:  "add",
+	Usage: "add [options] id [id, ]",
+	Short: "create vectorized forms of one or more data objects",
+	Long: `
+The vector add command creates vector forms of one or more data objects specified
+by the indicated object IDs.
+`,
+	New: newAdd,
+}
+
+type addCommand struct {
+	*Command
+	commitFlags commitflags.Flags
+}
+
+func newAdd(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &addCommand{Command: parent.(*Command)}
+	c.commitFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *addCommand) Run(args []string) error {
+	ctx, cleanup, err := c.Init()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	ids, err := lakeparse.ParseIDs(args)
+	if err != nil {
+		return err
+	}
+	lake, err := c.LakeFlags.Open(ctx)
+	if err != nil {
+		return err
+	}
+	head, err := c.LakeFlags.HEAD()
+	if err != nil {
+		return err
+	}
+	poolID, err := lake.PoolID(ctx, head.Pool)
+	if err != nil {
+		return err
+	}
+	commit, err := lake.AddVectors(ctx, poolID, head.Branch, ids, c.commitFlags.CommitMessage())
+	if err == nil && !c.LakeFlags.Quiet {
+		fmt.Printf("%s vectors committed\n", commit)
+	}
+	return err
+}

--- a/cmd/zed/vector/add.go
+++ b/cmd/zed/vector/add.go
@@ -55,7 +55,7 @@ func (c *addCommand) Run(args []string) error {
 	}
 	commit, err := lake.AddVectors(ctx, poolID, head.Branch, ids, c.commitFlags.CommitMessage())
 	if err == nil && !c.LakeFlags.Quiet {
-		fmt.Printf("%s vectors committed\n", commit)
+		fmt.Printf("%s vectors added\n", commit)
 	}
 	return err
 }

--- a/cmd/zed/vector/command.go
+++ b/cmd/zed/vector/command.go
@@ -14,7 +14,8 @@ var Cmd = &charm.Spec{
 	Long: `
 The vector subcommands control the creation, management, and deletion
 of vectorized data in a Zed lake.
-`, New: New,
+`,
+	New: New,
 }
 
 func init() {

--- a/cmd/zed/vector/command.go
+++ b/cmd/zed/vector/command.go
@@ -1,0 +1,38 @@
+package vector
+
+import (
+	"flag"
+
+	"github.com/brimdata/zed/cmd/zed/root"
+	"github.com/brimdata/zed/pkg/charm"
+)
+
+var Cmd = &charm.Spec{
+	Name:  "vector",
+	Usage: "vector [subcommand]",
+	Short: "create and delete vectorized versions of lake data",
+	Long: `
+The vector subcommands control the creation, management, and deletion
+of vectorized data in a Zed lake.
+`, New: New,
+}
+
+func init() {
+	Cmd.Add(add)
+	Cmd.Add(del)
+}
+
+type Command struct {
+	*root.Command
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &Command{Command: parent.(*root.Command)}, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) == 0 {
+		return charm.NeedHelp
+	}
+	return charm.ErrNoRun
+}

--- a/cmd/zed/vector/delete.go
+++ b/cmd/zed/vector/delete.go
@@ -14,7 +14,7 @@ var del = &charm.Spec{
 	Usage: "delete [options] id [id, ]",
 	Short: "deleted vectors from one or more data objects",
 	Long: `
-The vector delete command deleted vectors from of one or more data objects specified
+The vector delete command deletes vectors from of one or more data objects specified
 by the indicated object IDs.  The references to the vectors is simply deleted
 in the commit history.  The vacate command may be used to delete the actual data.
 `,
@@ -56,7 +56,7 @@ func (c *deleteCommand) Run(args []string) error {
 	}
 	commit, err := lake.DeleteVectors(ctx, poolID, head.Branch, ids, c.commitFlags.CommitMessage())
 	if err == nil && !c.LakeFlags.Quiet {
-		fmt.Printf("%s vectors committed\n", commit)
+		fmt.Printf("%s vectors deleted\n", commit)
 	}
 	return err
 }

--- a/cmd/zed/vector/delete.go
+++ b/cmd/zed/vector/delete.go
@@ -1,0 +1,62 @@
+package vector
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/brimdata/zed/cli/commitflags"
+	"github.com/brimdata/zed/lakeparse"
+	"github.com/brimdata/zed/pkg/charm"
+)
+
+var del = &charm.Spec{
+	Name:  "delete",
+	Usage: "delete [options] id [id, ]",
+	Short: "deleted vectors from one or more data objects",
+	Long: `
+The vector delete command deleted vectors from of one or more data objects specified
+by the indicated object IDs.  The references to the vectors is simply deleted
+in the commit history.  The vacate command may be used to delete the actual data.
+`,
+	New: newDelete,
+}
+
+type deleteCommand struct {
+	*Command
+	commitFlags commitflags.Flags
+}
+
+func newDelete(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &deleteCommand{Command: parent.(*Command)}
+	c.commitFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *deleteCommand) Run(args []string) error {
+	ctx, cleanup, err := c.Init()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	ids, err := lakeparse.ParseIDs(args)
+	if err != nil {
+		return err
+	}
+	lake, err := c.LakeFlags.Open(ctx)
+	if err != nil {
+		return err
+	}
+	head, err := c.LakeFlags.HEAD()
+	if err != nil {
+		return err
+	}
+	poolID, err := lake.PoolID(ctx, head.Pool)
+	if err != nil {
+		return err
+	}
+	commit, err := lake.DeleteVectors(ctx, poolID, head.Branch, ids, c.commitFlags.CommitMessage())
+	if err == nil && !c.LakeFlags.Quiet {
+		fmt.Printf("%s vectors committed\n", commit)
+	}
+	return err
+}

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -41,6 +41,8 @@ type Interface interface {
 	DeleteIndexRules(context.Context, []ksuid.KSUID) ([]index.Rule, error)
 	ApplyIndexRules(ctx context.Context, rule string, pool ksuid.KSUID, branchName string, ids []ksuid.KSUID) (ksuid.KSUID, error)
 	UpdateIndex(ctx context.Context, names []string, pool ksuid.KSUID, branchName string) (ksuid.KSUID, error)
+	AddVectors(ctx context.Context, pool ksuid.KSUID, branch string, objects []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
+	DeleteVectors(ctx context.Context, pool ksuid.KSUID, branch string, objects []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
 }
 
 func OpenLake(ctx context.Context, u string) (Interface, error) {

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -231,3 +231,27 @@ func (l *local) UpdateIndex(ctx context.Context, names []string, poolID ksuid.KS
 	}
 	return branch.UpdateIndex(ctx, l.compiler, rules)
 }
+
+func (l *local) AddVectors(ctx context.Context, poolID ksuid.KSUID, branchName string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
+	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
+	if err != nil {
+		return ksuid.Nil, err
+	}
+	commitID, err := branch.AddVectors(ctx, ids, message.Author, message.Body)
+	if err != nil {
+		return ksuid.Nil, err
+	}
+	return commitID, nil
+}
+
+func (l *local) DeleteVectors(ctx context.Context, poolID ksuid.KSUID, branchName string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
+	_, branch, err := l.lookupBranch(ctx, poolID, branchName)
+	if err != nil {
+		return ksuid.Nil, err
+	}
+	commitID, err := branch.DeleteVectors(ctx, ids, message.Author, message.Body)
+	if err != nil {
+		return ksuid.Nil, err
+	}
+	return commitID, nil
+}

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -237,11 +237,7 @@ func (l *local) AddVectors(ctx context.Context, poolID ksuid.KSUID, branchName s
 	if err != nil {
 		return ksuid.Nil, err
 	}
-	commitID, err := branch.AddVectors(ctx, ids, message.Author, message.Body)
-	if err != nil {
-		return ksuid.Nil, err
-	}
-	return commitID, nil
+	return branch.AddVectors(ctx, ids, message.Author, message.Body)
 }
 
 func (l *local) DeleteVectors(ctx context.Context, poolID ksuid.KSUID, branchName string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
@@ -249,9 +245,5 @@ func (l *local) DeleteVectors(ctx context.Context, poolID ksuid.KSUID, branchNam
 	if err != nil {
 		return ksuid.Nil, err
 	}
-	commitID, err := branch.DeleteVectors(ctx, ids, message.Author, message.Body)
-	if err != nil {
-		return ksuid.Nil, err
-	}
-	return commitID, nil
+	return branch.DeleteVectors(ctx, ids, message.Author, message.Body)
 }

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -156,3 +156,11 @@ func (r *remote) UpdateIndex(ctx context.Context, rules []string, poolID ksuid.K
 	res, err := r.conn.UpdateIndex(ctx, poolID, branchName, rules)
 	return res.Commit, err
 }
+
+func (r *remote) AddVectors(ctx context.Context, pool ksuid.KSUID, branch string, objects []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
+	panic("TBD")
+}
+
+func (r *remote) DeleteVectors(ctx context.Context, poolID ksuid.KSUID, branchName string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
+	panic("TBD")
+}

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -556,3 +556,65 @@ func (b *Branch) indexObject(ctx context.Context, c runtime.Compiler, rules []in
 	}
 	return w.References(), err
 }
+
+func (b *Branch) AddVectors(ctx context.Context, ids []ksuid.KSUID, author, message string) (ksuid.KSUID, error) {
+	// XXX We should add some parallelism here to stream the next file while
+	// the CPU is chugging away on the current file.  See issue #4015.
+	for _, id := range ids {
+		if err := data.CreateVector(ctx, b.pool.engine, b.pool.DataPath, id); err != nil {
+			return ksuid.Nil, err
+		}
+	}
+	return b.commit(ctx, func(parent *branches.Config, retries int) (*commits.Object, error) {
+		snap, err := b.pool.commits.Snapshot(ctx, parent.Commit)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			if !snap.Exists(id) {
+				return nil, fmt.Errorf("non-existent object %s: vector add operation aborted", id)
+			}
+			if snap.HasVector(id) {
+				return nil, fmt.Errorf("vector exists for %s: vector add operation aborted", id)
+			}
+		}
+		if message == "" {
+			message = vectorMessage("add", ids)
+		}
+		return commits.NewAddVectorsObject(parent.Commit, author, message, ids, retries), nil
+	})
+}
+
+func (b *Branch) DeleteVectors(ctx context.Context, ids []ksuid.KSUID, author, message string) (ksuid.KSUID, error) {
+	if message == "" {
+		message = vectorMessage("delete", ids)
+	}
+	return b.commit(ctx, func(parent *branches.Config, retries int) (*commits.Object, error) {
+		snap, err := b.pool.commits.Snapshot(ctx, parent.Commit)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			if !snap.Exists(id) {
+				return nil, fmt.Errorf("non-existent object %s: vector delete operation aborted", id)
+			}
+			if !snap.HasVector(id) {
+				return nil, fmt.Errorf("vector %s does not exist: vector delete operation aborted", id)
+			}
+		}
+		return commits.NewDeleteVectorsObject(parent.Commit, author, message, ids, retries), nil
+	})
+}
+
+func vectorMessage(kind string, ids []ksuid.KSUID) string {
+	var b strings.Builder
+	b.WriteString("vector ")
+	b.WriteString(kind)
+	b.WriteString("\n\n")
+	for _, id := range ids {
+		b.WriteString("    ")
+		b.WriteString(id.String())
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -558,6 +558,9 @@ func (b *Branch) indexObject(ctx context.Context, c runtime.Compiler, rules []in
 }
 
 func (b *Branch) AddVectors(ctx context.Context, ids []ksuid.KSUID, author, message string) (ksuid.KSUID, error) {
+	if message == "" {
+		message = vectorMessage("add", ids)
+	}
 	// XXX We should add some parallelism here to stream the next file while
 	// the CPU is chugging away on the current file.  See issue #4015.
 	for _, id := range ids {
@@ -577,9 +580,6 @@ func (b *Branch) AddVectors(ctx context.Context, ids []ksuid.KSUID, author, mess
 			if snap.HasVector(id) {
 				return nil, fmt.Errorf("vector exists for %s: vector add operation aborted", id)
 			}
-		}
-		if message == "" {
-			message = vectorMessage("add", ids)
 		}
 		return commits.NewAddVectorsObject(parent.Commit, author, message, ids, retries), nil
 	})

--- a/lake/commits/actions.go
+++ b/lake/commits/actions.go
@@ -18,9 +18,11 @@ type Action interface {
 var ActionTypes = []interface{}{
 	Add{},
 	AddIndex{},
+	AddVector{},
 	index.AddRule{},
 	Delete{},
 	DeleteIndex{},
+	DeleteVector{},
 	index.DeleteRule{},
 	index.TypeRule{},
 	index.AggRule{},
@@ -106,5 +108,31 @@ func (d *DeleteIndex) String() string {
 }
 
 func (d *DeleteIndex) CommitID() ksuid.KSUID {
+	return d.Commit
+}
+
+type AddVector struct {
+	Commit ksuid.KSUID `zed:"commit"`
+	ID     ksuid.KSUID `zed:"id"`
+}
+
+func (a *AddVector) String() string {
+	return fmt.Sprintf("ADD_VECTOR %s", a.ID)
+}
+
+func (a *AddVector) CommitID() ksuid.KSUID {
+	return a.Commit
+}
+
+type DeleteVector struct {
+	Commit ksuid.KSUID `zed:"commit"`
+	ID     ksuid.KSUID `zed:"id"`
+}
+
+func (d *DeleteVector) String() string {
+	return fmt.Sprintf("DEL_VECTOR %s", d.ID)
+}
+
+func (d *DeleteVector) CommitID() ksuid.KSUID {
 	return d.Commit
 }

--- a/lake/commits/object.go
+++ b/lake/commits/object.go
@@ -64,6 +64,22 @@ func NewAddIndexesObject(parent ksuid.KSUID, author, message string, retries int
 	return o
 }
 
+func NewAddVectorsObject(parent ksuid.KSUID, author, message string, ids []ksuid.KSUID, retries int) *Object {
+	o := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
+	for _, id := range ids {
+		o.appendAddVector(id)
+	}
+	return o
+}
+
+func NewDeleteVectorsObject(parent ksuid.KSUID, author, message string, ids []ksuid.KSUID, retries int) *Object {
+	o := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
+	for _, id := range ids {
+		o.appendDeleteVector(id)
+	}
+	return o
+}
+
 func (o *Object) append(action Action) {
 	o.Actions = append(o.Actions, action)
 }
@@ -82,6 +98,14 @@ func (o *Object) appendAddIndex(i *index.Object) {
 
 func (o *Object) appendDeleteIndex(ruleID, id ksuid.KSUID) {
 	o.append(&DeleteIndex{Commit: o.Commit, RuleID: ruleID, ID: id})
+}
+
+func (o *Object) appendAddVector(id ksuid.KSUID) {
+	o.append(&AddVector{Commit: o.Commit, ID: id})
+}
+
+func (o *Object) appendDeleteVector(id ksuid.KSUID) {
+	o.append(&DeleteVector{Commit: o.Commit, ID: id})
 }
 
 func (o Object) Serialize() ([]byte, error) {

--- a/lake/commits/patch.go
+++ b/lake/commits/patch.go
@@ -57,10 +57,7 @@ func (p *Patch) LookupIndexObjectRules(id ksuid.KSUID) ([]index.Rule, error) {
 }
 
 func (p *Patch) HasVector(id ksuid.KSUID) bool {
-	if p.diff.HasVector(id) {
-		return true
-	}
-	return p.base.HasVector(id)
+	return p.diff.HasVector(id) || p.base.HasVector(id)
 }
 
 func (p *Patch) Select(span extent.Span, o order.Which) DataObjects {

--- a/lake/commits/snapshot.go
+++ b/lake/commits/snapshot.go
@@ -101,8 +101,7 @@ func (s *Snapshot) AddVector(id ksuid.KSUID) error {
 }
 
 func (s *Snapshot) DeleteVector(id ksuid.KSUID) error {
-	_, ok := s.vectors[id]
-	if !ok {
+	if _, ok := s.vectors[id]; !ok {
 		return fmt.Errorf("%s: delete of a non-present vector: %w", id, ErrWriteConflict)
 	}
 	delete(s.vectors, id)
@@ -288,13 +287,9 @@ func PlayAction(w Writeable, action Action) error {
 	case *DeleteIndex:
 		err = w.DeleteIndexObject(action.RuleID, action.ID)
 	case *AddVector:
-		if err := w.AddVector(action.ID); err != nil {
-			return err
-		}
+		err = w.AddVector(action.ID)
 	case *DeleteVector:
-		if err := w.DeleteVector(action.ID); err != nil {
-			return err
-		}
+		err = w.DeleteVector(action.ID)
 	case *Commit:
 		// ignore
 	default:
@@ -315,8 +310,7 @@ func Play(w Writeable, o *Object) error {
 
 func Vectors(view View) *Snapshot {
 	snap := NewSnapshot()
-	all := view.SelectAll()
-	for _, o := range all {
+	for _, o := range view.SelectAll() {
 		if view.HasVector(o.ID) {
 			snap.AddDataObject(o)
 		}

--- a/lake/data/vector.go
+++ b/lake/data/vector.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 
 	"github.com/brimdata/zed"
@@ -18,6 +19,10 @@ import (
 func CreateVector(ctx context.Context, engine storage.Engine, path *storage.URI, id ksuid.KSUID) error {
 	get, err := engine.Get(ctx, SequenceURI(path, id))
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// Make a cleaner error.
+			err = fmt.Errorf("object %s: does not exist", id)
+		}
 		return err
 	}
 	put, err := engine.Put(ctx, VectorURI(path, id))

--- a/lake/data/vector.go
+++ b/lake/data/vector.go
@@ -21,7 +21,7 @@ func CreateVector(ctx context.Context, engine storage.Engine, path *storage.URI,
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			// Make a cleaner error.
-			err = fmt.Errorf("object %s: does not exist", id)
+			err = fmt.Errorf("object %s: %w", id, fs.ErrNotExist)
 		}
 		return err
 	}

--- a/lake/ztests/vector.yaml
+++ b/lake/ztests/vector.yaml
@@ -1,0 +1,36 @@
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create -q POOL
+  zed use -q POOL
+  zed load -q in.zson
+  id=$(zed query -f text 'from POOL@main:objects | yield ksuid(id)')
+  zed vector add -q $id
+  zed query -Z 'from POOL@main:vectors | drop id'
+  echo ===
+  zed vector delete -q $id
+  zed query -Z 'from POOL@main:vectors | drop id'
+  echo ===
+
+inputs:
+  - name: in.zson
+    data: |
+      {x:1}
+      {s:"hello",a:[1,2,3]}
+      {s:"world",a:[3,4,5]}
+      {x:2}
+      {x:3,y:4}
+
+outputs:
+  - name: stdout
+    data: |
+      {
+          meta: {
+              first: null,
+              last: null,
+              count: 5 (uint64),
+              size: 72
+          } (=data.Meta)
+      }
+      ===
+      ===

--- a/runtime/exec/meta.go
+++ b/runtime/exec/meta.go
@@ -225,6 +225,21 @@ func NewCommitMetaPlanner(ctx context.Context, zctx *zed.Context, r *lake.Root, 
 			return nil, err
 		}
 		return newScannerScheduler(s), nil
+	case "vectors":
+		snap, err := p.Snapshot(ctx, commit)
+		if err != nil {
+			return nil, err
+		}
+		vectors := commits.Vectors(snap)
+		reader, err := objectReader(ctx, zctx, vectors, span, p.Layout.Order)
+		if err != nil {
+			return nil, err
+		}
+		s, err := zbuf.NewScanner(ctx, reader, filter)
+		if err != nil {
+			return nil, err
+		}
+		return newScannerScheduler(s), nil
 	default:
 		return nil, fmt.Errorf("unknown commit metadata type: %q", meta)
 	}


### PR DESCRIPTION
This commit adds a zed command for adding and deleting vectors by
attaching ZST files to data objects.  The presence of vectors is
tracked in the pool's journal and available to the snapshot.

This commit does not utilize the vectors in the query plan or
any scan as this will begin to be implemented in subsequent commits.