### PR TITLE
Fix anchor links between docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,9 +47,9 @@ across one or more [data pools](commands/zed.md#14-data-pools) with ACID commit 
 accessed via a [Git](https://git-scm.com/)-like API.
 * The [Zed language](language/README.md) is the system's dataflow language for performing
 queries, searches, analytics, transformations, or any of the above combined together.
-* A  [Zed query](language/README.md#1-introduction) is a Zed script that performs
+* A  [Zed query](language/overview.md#1-introduction) is a Zed script that performs
 search and/or analytics.
-* A [Zed shaper](language/README.md#9-shaping) is a Zed script that performs
+* A [Zed shaper](language/overview.md#9-shaping) is a Zed script that performs
 data transformation to _shape_
 the input data into the desired set of organizing Zed data types called "shapes",
 which are traditionally called _schemas_ in relational systems but are

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -32,7 +32,7 @@ sidebar_label: zed
 A Zed lake is a cloud-native arrangement of data, optimized for search,
 analytics, ETL, data discovery, and data preparation
 at scale based on data represented in accordance
-with the [Zed data model](../formats).
+with the [Zed data model](../formats/zed.md#zed-data-model).
 
 A lake is organized into a collection of data pools forming a single
 administrative domain.  The current implementation supports
@@ -52,7 +52,7 @@ A core theme of the Zed lake design is _ergonomics_.  Given the Git metaphor,
 our goal here is that the Zed lake tooling be as easy and familiar as Git is
 to a technical user.
 
-Since Zed lakes are built around the [Zed data model](../formats/zed.md),
+Since Zed lakes are built around the Zed data model,
 getting different kinds of data into and out of a lake is easy.
 There is no need to define schemas or tables and then fit
 semi-structured data into schemas before loading data into a lake.
@@ -245,7 +245,7 @@ As pool data is often comprised of Zed records (analogous to JSON objects),
 the pool key is typically a field of the stored records.
 When pool data is not structured as records/objects (e.g., scalar or arrays or other
 non-record types), then the pool key would typically be configured
-as the [special value `this`](../language/README.md#23-the-special-value-this).
+as the [special value `this`](../language/overview.md#23-the-special-value-this).
 
 Data can be efficiently scanned via ranges of values conforming to the pool key.
 
@@ -444,7 +444,7 @@ The `-orderby` option indicates the pool key that is used to sort
 the data in lake, which may be in ascending or descending order.
 
 If a pool key is not specified, then it defaults to
-the [special value `this`](../language/README.md#23-the-special-value-this).
+the [special value `this`](../language/overview.md#23-the-special-value-this).
 
 A newly created pool is initialized with a branch called `main`.
 

--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -88,7 +88,7 @@ emits
 ```mdtest-output
 2
 ```
-Note here that the query `1+1` [implies](../language/README.md#26-implied-operators)
+Note here that the query `1+1` [implies](../language/overview.md#26-implied-operators)
 `yield 1+1`.
 
 ## 2. Input Formats
@@ -351,7 +351,7 @@ If you are ever stumped about how the `zq` compiler is parsing your query,
 you can always run `zq -C` to compile and display your query in canonical form
 without running it.
 This can be especially handy when you are learning the language and
-[its shortcuts](../language/README.md#26-implied-operators).
+[its shortcuts](../language/overview.md#26-implied-operators).
 
 For example, this query
 ```mdtest-command
@@ -380,7 +380,7 @@ as soon as they happen and cause the `zq` process to exit.
 On the other hand,
 runtime errors resulting from the Zed query itself
 do not halt execution.  Instead, these error conditions produce
-[first-class Zed errors](../language/README.md#53-first-class-errors)
+[first-class Zed errors](../language/overview.md#53-first-class-errors)
 in the data output stream interleaved with any valid results.
 Such errors are easily queried with the
 [is_error function](../language/functions/is_error.md).
@@ -421,7 +421,7 @@ echo <values> | zq <query> -
 which is used throughout the [language documentation](../language/README.md)
 and [operator reference](../language/operators/README.md).
 
-The language documentation and [tutorials directory](../tutorials)
+The language documentation and [tutorials directory](../tutorials/README.md)
 have many examples, but here are a few more simple `zq` use cases.
 
 _Hello, world_
@@ -529,7 +529,7 @@ for sparse results, many frames are discarded without their uncompressed bytes
 having to be processed any further.
 
 While this pre-search technique results in very fast brute-force pattern matching,
-[search indexes](zed.md#search-indexes)
+[search indexes](zed.md#16-search-indexes)
 can also be created when Zed data is managed by a Zed lake
 thereby avoiding scans of data altogether as the index pinpoints the locations
 of specific values in the lake.
@@ -582,7 +582,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](../../zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/main/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install
@@ -698,7 +698,7 @@ However, the benefit of Zed is that no flattening is required.  And unlike `sqli
 performance techniques cannot be applied to the Zed model and this is precisely what the
 open-source Zed project intends to do.  As a first step, with a
 [Zed lake](zed.md), you can build type-flexible
-[search indexes](zed.md#search-indexes)
+[search indexes](zed.md#16-search-indexes)
 to scale searches across very large stores of Zed data.
 
 Stay tuned!

--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -275,7 +275,7 @@ embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
 the [Zealot JavaScript library](https://github.com/brimdata/brim/tree/main/packages/zealot)
-and the [Zed Python library](../../python/zed).
+and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between
 a human-readable form, a row-based binary form, and a row-based columnar form can

--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -43,7 +43,7 @@ Instead, file formats like Avro, ORC, and Parquet arose to represent tabular dat
 with an explicit schema followed by a sequence of values that conform to the schema.
 While Avro and Parquet schemas can also represent semi-structured data, all of the
 values in a given Avro or Parquet file must conform to the same schema.
-The [Iceberg specification](https://iceberg.apache.org/#spec/)
+The [Iceberg specification](https://iceberg.apache.org/spec/)
 defines data types and metadata schemas for how large relational tables can be
 managed as a collection of Avro, ORC, and/or Parquet files.
 

--- a/docs/language/aggregates/fuse.md
+++ b/docs/language/aggregates/fuse.md
@@ -8,7 +8,7 @@ fuse(any) -> type
 ```
 ### Description
 
-The _fuse_ aggregate function applies [type fusion](../README.md#type-fusion)
+The _fuse_ aggregate function applies [type fusion](../overview.md#10-type-fusion)
 to its input and returns the fused type.
 
 This aggregation is useful with group-by for data exploration and discovery  

--- a/docs/language/functions/grep.md
+++ b/docs/language/functions/grep.md
@@ -12,8 +12,8 @@ grep(<pattern> [, e: any]) -> bool
 The _grep_ function searches all of the strings in its input value `e`
 (or `this` if `e` is not given)
  using the `<pattern>` argument, which must be a
-[regular expression](../README.md#regular-expressions),
-[glob pattern](../README.md#globs), or string literal.
+[regular expression](../overview.md#711-regular-expressions),
+[glob pattern](../overview.md#712-globs), or string literal.
 If the pattern matches for any string, then the result is `true`.  Otherwise, it is `false`.
 
 > Note that string matches are case insensitive while regular expression

--- a/docs/language/functions/typename.md
+++ b/docs/language/functions/typename.md
@@ -5,12 +5,12 @@
 ### Synopsis
 
 ```
-typename(s: string) -> type
+typename(name: string) -> type
 ```
 ### Description
 
 The _typename_ function returns the [type](../../formats/zson.md#25-types) of the
-[named type](../../formats/zson.md#258-named-type) give by `name` if it exists.  Otherwise, `error("missing")` is returned.
+[named type](../../formats/zson.md#258-named-type) given by `name` if it exists.  Otherwise, `error("missing")` is returned.
 
 ### Examples
 

--- a/docs/language/functions/typename.md
+++ b/docs/language/functions/typename.md
@@ -9,8 +9,8 @@ typename(s: string) -> type
 ```
 ### Description
 
-The _typename_ function returns the [type](../../formats/zson.md#357-type-type) of the
-named type give by `name` if it exists.  Otherwise, `error("missing")` is returned.
+The _typename_ function returns the [type](../../formats/zson.md#25-types) of the
+[named type](../../formats/zson.md#258-named-type) give by `name` if it exists.  Otherwise, `error("missing")` is returned.
 
 ### Examples
 

--- a/docs/language/functions/typeof.md
+++ b/docs/language/functions/typeof.md
@@ -9,7 +9,7 @@ typeof(val: any) -> type
 ```
 ### Description
 
-The _typeof_ function returns the [type](../../formats/zson.md#357-type-type) of
+The _typeof_ function returns the [type](../../formats/zson.md#25-types) of
 its argument `val`.  Types in Zed are first class so the returned type is
 also a Zed value.  The type of a type is type `type`.
 

--- a/docs/language/operators/cut.md
+++ b/docs/language/operators/cut.md
@@ -10,7 +10,7 @@ cut <field>[:=<expr>] [, <field>[:=<expr>] ...]
 ### Description
 
 The `cut` operator extracts values from each input record in the
-form of one or more [field assignments](../README.md#field-assignments),
+form of one or more [field assignments](../overview.md#25-field-assignments),
 creating one field for each expression.  Unlike the `put` operator,
 which adds or modifies the fields of a record, `cut` retains only the
 fields enumerated, much like a SQL projection.
@@ -34,7 +34,7 @@ resulting in `error("missing")` for expressions that reference fields of `this`.
 
 Note that when the field references are all top level,
 `cut` is a special case of a yield with a
-[record literal](../README.md#record-literal) having the form:
+[record literal](../overview.md#6112-record-expressions) having the form:
 ```
 yield {<field>:<expr> [, <field>:<expr>...]}
 ```

--- a/docs/language/operators/put.md
+++ b/docs/language/operators/put.md
@@ -9,7 +9,7 @@ put <field>:=<expr> [, <field>:=<expr> ...]
 ### Description
 
 The `put` operator modifies its input with
-one or more [field assignments](../README.md#field-assignments).
+one or more [field assignments](../overview.md#25-field-assignments).
 Each expression is evaluated based on the input record
 and the result is either assigned to a new field of the input record if it does not
 exist, or the existing field is modified in its original location with the result.
@@ -23,7 +23,7 @@ a computed value cannot be referenced in another expression.  If you need
 to re-use a computed result, this can be done by chaining multiple `put` operators.
 
 The "put" keyword is optional since it is an
-[implied operators](../README.md#implied-operators).
+[implied operators](../overview.md#26-implied-operators).
 
 Each `<field>` expression must be a field reference expressed as a dotted path or one more
 constant index operations on `this`, e.g., `a.b`, `this["a"]["b"]`,
@@ -35,7 +35,7 @@ For any input value that is not a record, an error is emitted.
 
 Note that when the field references are all top level,
 `put` is a special case of a `yield` with a
-[record literal](../README.md#record-literal)
+[record literal](../overview.md#6112-record-expressions)
 using a spread operator of the form:
 ```
 yield {...this, <field>:<expr> [, <field>:<expr>...]}

--- a/docs/language/operators/search.md
+++ b/docs/language/operators/search.md
@@ -13,7 +13,7 @@ to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
 The "search" keyword may be omitted in which case `<sexpr>` follows
-the [search expression](../overview.md#search-expressions) syntax.
+the [search expression](../overview.md#7-search-expressions) syntax.
 
 When Zed queries are run interactively, it is convenient to be able to omit
 the "search" keyword, but when search filters appear in Zed source files,

--- a/docs/language/operators/search.md
+++ b/docs/language/operators/search.md
@@ -13,7 +13,7 @@ to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
 The "search" keyword may be omitted in which case `<sexpr>` follows
-the [search expression](../README.md#search-expressions) syntax.
+the [search expression](../overview.md#search-expressions) syntax.
 
 When Zed queries are run interactively, it is convenient to be able to omit
 the "search" keyword, but when search filters appear in Zed source files,

--- a/docs/language/operators/yield.md
+++ b/docs/language/operators/yield.md
@@ -12,10 +12,10 @@ yield <expr> [, <expr>...]
 The `yield` operator produces output values by evaluating one or more
 expressions on each input value and sending each result to the output
 in left-to-right order.  Each `<expr>` may be any valid
-[Zed expression](../README.md#expressions).
+[Zed expression](../overview.md#6-expressions).
 
 The _yield_ keyword may be omitted when `<expr>` is a
-[record literal](../README.md#record-literal).
+[record literal](../overview.md#6112-record-expressions).
 
 ### Examples
 

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](../../testdata/edu) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](../../testdata/edu/README.md#creation).
+[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md#creation).
 
 ## 3. Searching
 
@@ -277,7 +277,7 @@ produces
 ### 3.5 Predicate Search
 
 Search terms can also be include Boolean predicates adhering
-to Zed's [expression syntax](../language/README.md#6-expressions).
+to Zed's [expression syntax](../language/overview.md#6-expressions).
 
 In particular, a search result can be narrowed down
 to include only records that contain a
@@ -298,7 +298,7 @@ produces
 Because the right-hand-side value to which we were comparing was a string, it
 was necessary to wrap it in quotes. If this string were written as a keyword,
 it would have been interpreted as a field name as
-Zed [field references](../language/README.md#24-implied-field-references)
+Zed [field references](../language/overview.md#24-implied-field-references)
 look like keywords in the context of an expression.
 
 For example, to see the records in which the school and district name are the
@@ -398,7 +398,7 @@ This is performed with `in`.
 
 Since our sample data doesn't contain complex fields, we'll make one by
 using the [`union`](../language/aggregates/union.md) aggregate function to
-create a [`set`](../formats/zson.md#343-set-value)-typed
+create a [`set`](../formats/zson.md#243-set-value)-typed
 field called `Schools` that contains all unique school names per district. From
 these we'll find each set that contains a school named `Lincoln Elementary`, e.g.,
 ```mdtest-command dir=testdata/edu
@@ -465,7 +465,7 @@ produces
 ### 3.6 Boolean Logic
 
 Search terms can be combined with Boolean logic as detailed in
-the [Zed language documentation](../language/overview.md##73-boolean-logic).
+the [Zed language documentation](../language/overview.md#73-boolean-logic).
 
 In particular, search terms separated by blank space implies
 Boolean `and` between the concatenated terms.
@@ -865,7 +865,7 @@ Each aggregation is performed by an
 [aggregate function](../language/aggregates/README.md)
 that operates on batches of records to carry out a running computation over
 the values they contain.  The `summarize` keyword is optional as the operato
-can be [inferred from context](../language/README.md#26-implied-operators).
+can be [inferred from context](../language/overview.md#26-implied-operators).
 
 As with SQL, multiple aggregate functions may be invoked at the same time.
 For example, to simultaneously calculate the minimum, maximum, and average of
@@ -929,8 +929,8 @@ produces
 
 ### 5.4 Aggregate Functions
 
-This section depicts examples of variou
-[aggregate functions](../language/README.md#aggregate-functions)
+This section depicts examples of various
+[aggregate functions](../language/overview.md#610-aggregate-function-calls)
 operating over thes "schools data set".
 
 #### 5.4.1 [and](../language/aggregates/and.md)
@@ -1261,7 +1261,7 @@ San Francisco   San Francisco Unified                              454.368421052
 ...
 ```
 Instead of a simple field name, any of the comma-separated group-by elements
-can be any [Zed expression](../language/README.md#expressions), which may
+can be any [Zed expression](../language/overview.md#6-expressions), which may
 appear in the form of a field assignment `field:=expr`
 
 To see a count of how many school names of a particular character length
@@ -1346,7 +1346,7 @@ Here we'll find the counties with the most schools by using the
 [`count()`](../language/aggregates/count.md) aggregate function and piping its
 output to a `sort` in reverse order. Note that even though we didn't list a
 field name as an explicit argument, the `sort` operator did what we wanted
-because it found a field of the `uint64` [data type](../language/README.md#data-types),
+because it found a field of the `uint64` [data type](../language/overview.md#5-data-types),
 e.g.,
 ```mdtest-command dir=testdata/edu
 zq -z 'count() by County | sort -r' schools.zson

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -1004,13 +1004,13 @@ which produces an output like this:
 {reviewers:|["henridf","mccanne","mattnibs"]|}
 ...
 ```
-Note that the syntax `=> ( ... )` defines a lateral scope where any Zed subquery can
+Note that the syntax `=> ( ... )` defines a [lateral scope](../language/overview.md#81-lateral-scope) where any Zed subquery can
 run in isolation over the input values created from the sequence of values
 traversed by the outer `over`.
 
 But we need a "graph edge" between the requesting user and the reviewers.
 To do this, we need to reference the `user.login` from the top-level scope within the
-[lateral scope](../language/overview.md#81-lateral-scope).  This can be done by
+lateral scope.  This can be done by
 bringing that value into the scope using a `with` clause appended to the
 `over` expression and yielding a
 [record literal](../language/overview.md#6112-record-expressions) with the desired value:

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -58,7 +58,7 @@ and you get
 ```
 With `zq`, the mysterious `jq` value `.` is instead called
 the almost-as-mysterious value
-[`this`](../language/README.md#23-the-special-value-this) and you say:
+[`this`](../language/overview.md#23-the-special-value-this) and you say:
 ```mdtest-command
 echo '1 2 3' | zq -z 'this+1' -
 ```
@@ -95,7 +95,7 @@ expression `2` is evaluated for each input value, and the value `2`
 is produced each time, so three copies of `2` are emitted.
 
 In `zq` however, `2` by itself is interpreted as a search and is
-[shorthand for](../language/README.md#26-implied-operators) `search 2` so the command
+[shorthand for](../language/overview.md#26-implied-operators) `search 2` so the command
 ```mdtest-command
 echo '1 2 3' | zq -z 2 -
 ```
@@ -268,7 +268,7 @@ As is often the case with semi-structured systems, you deal with
 nested values all the time: in JSON, data is nested with objects and arrays,
 while in Zed, data is nested with "records" and arrays (as well as other complex types).
 
-[Record expressions](../language/README.md#6112-record-expressions)
+[Record expressions](../language/overview.md#6112-record-expressions)
 are rather flexible with `zq` and look a bit like JavaScript
 or `jq` syntax, e.g.,
 ```mdtest-command
@@ -370,7 +370,7 @@ produces
 ## Union Types
 
 One of the tricks `zq` uses to represent JSON data in its structured type system
-is [union types](../language/README.md#6116-union-values).
+is [union types](../language/overview.md#6116-union-values).
 Most of the time, you don't need to worry about unions
 but they show up from time to time.  Even when
 they show up, Zed just tries to "do the right thing" so you usually
@@ -922,7 +922,7 @@ DATE                 NUMBER TITLE
 2019-11-12T16:49:07Z PR #6  a few clarifications to the zson spec
 ...
 ```
-Note that we used [string interpolation](../language/README.md#6111-string-interpolation)
+Note that we used [string interpolation](../language/overview.md#6111-string-interpolation)
 to convert the field `number` into a string and format it with surrounding text.
 
 Instead of old PRs, we can get the latest list of PRs using the
@@ -988,7 +988,7 @@ in the graph and each set of reviewers is another node.
 
 So as a first step, let's figure out how to create each edge, where an edge
 is a relation between the requesting user and the set of reviewers.  We can
-create this in Zed with a ["lateral subquery"](../language/README.md#8-lateral-subqueries).
+create this in Zed with a ["lateral subquery"](../language/overview.md#8-lateral-subqueries).
 Instead of computing a set-union over all the reviewers across all PRs,
 we instead want to compute the set-union over the reviewers in each PR.
 We can do this as follows:
@@ -1010,10 +1010,10 @@ traversed by the outer `over`.
 
 But we need a "graph edge" between the requesting user and the reviewers.
 To do this, we need to reference the `user.login` from the top-level scope within the
-[lateral scope](../language/README.md#81-lateral-scope).  This can be done by
+[lateral scope](../language/overview.md#81-lateral-scope).  This can be done by
 bringing that value into the scope using a `with` clause appended to the
 `over` expression and yielding a
-[record literal](../language/README.md#6112-record-expressions) with the desired value:
+[record literal](../language/overview.md#6112-record-expressions) with the desired value:
 ```mdtest-command dir=docs/tutorials
 zq -z 'over requested_reviewers with user=user.login => ( reviewers:=union(login) | {user,reviewers}) | sort user,len(reviewers)' prs.zng
 ```


### PR DESCRIPTION
The new coverage from our markdown link checker automation described in #4004 finds broken links for missing anchor destinations within the same markdown doc, but it still doesn't catch broken links to anchors within _other_ docs. When clicked, those bad links still just successfully end up at the top-level page, which has made these difficult to catch/fix. But I've been working on getting the ruzickap/action-my-broken-link-checker Action (the same one already used on the brimdata.io web site) to check for broken links on the deployed docs site https://zed.brimdata.io/, and thankfully that _does_ pick up on such breakages. So here I'm trying to fix those back at the origin. I guess once these changes are approved/merged I'll want to backport this to the older versioned doc revs. Fun times!