### PR TITLE
fix type context handling of named types

### DIFF
--- a/ztests/multiple-named-union.yaml
+++ b/ztests/multiple-named-union.yaml
@@ -1,0 +1,7 @@
+zed: yield this
+
+input: |
+  1(foo=int64)((foo=int64,foo=string))
+
+output: |
+  1(=foo)((foo,foo=string))


### PR DESCRIPTION
The type context looks up named types only by name when checking
for the previous existence of a named type.  This doesn't work
right because multipled named types with distinct inner types
should be able to coexist and the different instances should be
able to be returned upon lookup.

This commit fixes this bug by simply changing LookupTypeNamed
to behave like the other lookup methods instead of looking for
the name in the typedefs table.  LookupTypedef remains the same
as this returns the latest definition a named type.