### PR TITLE
Fix unmarshaling nulls into *zed.Value

### DIFF
--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -875,7 +875,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv *zed.Value, v reflect.Value) error {
 }
 
 // Adapted from:
-// https://github.com/golang/go/blob/master/src/encoding/json/decode.go#L426
+// https://github.com/golang/go/blob/46ab7a5c4f80d912f25b6b3e1044282a2a79df8b/src/encoding/json/decode.go#L426
 func indirect(v reflect.Value, zv *zed.Value) (ZNGUnmarshaler, reflect.Value) {
 	var nilptr reflect.Value
 	// If v is a named type and is addressable,

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -612,7 +612,6 @@ func TestZedValues(t *testing.T) {
 			val, err = zson.MarshalZNG(v)
 			require.NoError(t, err)
 			assert.Equal(t, s, zson.MustFormatValue(val))
-
 		})
 	}
 	var testptr struct {

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -602,3 +602,35 @@ func TestMultipleZedValues(t *testing.T) {
 	assert.Equal(t, "foo", string(foo.Bytes))
 	assert.Equal(t, "bar", string(bar.Bytes))
 }
+
+func TestZedValues(t *testing.T) {
+	test := func(t *testing.T, name, s string, v interface{}) {
+		t.Run(name, func(t *testing.T) {
+			val := zson.MustParseValue(zed.NewContext(), s)
+			err := zson.UnmarshalZNG(val, v)
+			require.NoError(t, err)
+			val, err = zson.MarshalZNG(v)
+			require.NoError(t, err)
+			assert.Equal(t, s, zson.MustFormatValue(val))
+
+		})
+	}
+	var testptr struct {
+		Value *zed.Value `zed:"value"`
+	}
+	t.Run("pointer", func(t *testing.T) {
+		test(t, "string", "{value:\"foo\"}", &testptr)
+		test(t, "typed-null", "{value:null(time)}", &testptr)
+		test(t, "null", "{value:null}", &testptr)
+		test(t, "record", "{value:{foo:1,bar:\"baz\"}}", &testptr)
+	})
+	var teststruct struct {
+		Value zed.Value `zed:"value"`
+	}
+	t.Run("struct", func(t *testing.T) {
+		test(t, "string", "{value:\"foo\"}", &teststruct)
+		test(t, "typed-null", "{value:null(time)}", &teststruct)
+		test(t, "null", "{value:null}", &teststruct)
+		test(t, "record", "{value:{foo:1,bar:\"baz\"}}", &teststruct)
+	})
+}


### PR DESCRIPTION
Fix an issue in zson.UnmarshalZNG where unmarshaling a null value into a
pointer of zed.Value would cause the pointer to get set to nil when it
should really be initialized as a (typed) null zed.Value.