### PR TITLE
fix bug in EncodeTypeValue to honor DFS order of named bindings

### DIFF
--- a/zed_test.go
+++ b/zed_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/parquetio"
+	"github.com/brimdata/zed/zson"
 	"github.com/brimdata/zed/ztest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -237,4 +239,19 @@ func findInputs(t *testing.T, dirs map[string]struct{}, script string, isValidIn
 		}
 	}
 	return out, nil
+}
+
+func TestTranslateNameConflictUnion(t *testing.T) {
+	// This test confirms that a union with complicated type renamig is properly
+	// decoded.  There was a bug where child typedefs would override the
+	// top level typedef in TranslateTypeValue so foo in the value below had
+	// two of the same union type instead of the two it should have had.
+	zctx := zed.NewContext()
+	val := zson.MustParseValue(zctx, `[{x:{y:63}}(=foo),{x:{abcdef:{x:{y:127}}(foo)}}(=foo)]`)
+	foreign := zed.NewContext()
+	twin, err := foreign.TranslateType(val.Type)
+	require.NoError(t, err)
+	union := twin.(*zed.TypeArray).Type.(*zed.TypeUnion)
+	assert.Equal(t, `foo={x:{abcdef:foo={x:{y:int64}}}}`, zson.String(union.Types[0]))
+	assert.Equal(t, `foo={x:{y:int64}}`, zson.String(union.Types[1]))
 }

--- a/zed_test.go
+++ b/zed_test.go
@@ -242,7 +242,7 @@ func findInputs(t *testing.T, dirs map[string]struct{}, script string, isValidIn
 }
 
 func TestTranslateNameConflictUnion(t *testing.T) {
-	// This test confirms that a union with complicated type renamig is properly
+	// This test confirms that a union with complicated type renaming is properly
 	// decoded.  There was a bug where child typedefs would override the
 	// top level typedef in TranslateTypeValue so foo in the value below had
 	// two of the same union type instead of the two it should have had.


### PR DESCRIPTION
This commit fixes a bug where a child typedef would override the
parent typedef violating the DFS ordering semantics of name bindings
that refer to the same name.  This fix is to simply update the
typedefs map after the child is traversed.