### PR TITLE
Use absolute URLs for ZNG-format GitHub test data

### DIFF
--- a/docs/tutorials/zed.md
+++ b/docs/tutorials/zed.md
@@ -68,7 +68,7 @@ prs <pool_id> key created_at order desc
 ```
 
 Let's add some pull request data I've prefetched from the GitHub API
-[here](github1.zng):
+[here](https://github.com/brimdata/zed/raw/main/docs/tutorials/github1.zng):
 
 ```bash
 $ zed load -use prs github1.zng
@@ -140,7 +140,7 @@ That's not a lot of data, so let's add some more.
 ## Adding additional data
 
 Additional data can be added to our pool by running `zed load` on our second
-[data set](github2.zng):
+[data set](https://github.com/brimdata/zed/raw/main/docs/tutorials/github2.zng):
 
 ```bash
 $ zed load github2.zng


### PR DESCRIPTION
https://github.com/brimdata/zed-docs-site/issues/26 describes how the URLs to ZNG test data in the Zed tutorial break after they make their way to the production docs site. I've since researched both of the possible fixes I described in that issue and in this PR have decided on the approach of using an absolute URL.

FWIW, I did test out the other proposed approach of just setting `trailingSlash: false` in the Docusaurus config. This seemed to work fine. However, there's no shortage of pages on the web such as [this StackOverflow thread](https://stackoverflow.com/questions/5948659/when-should-i-use-a-trailing-slash-in-my-url) where people argue passionately about their strong feelings on this topic, with the loudest voices seeming to come down on the side of having the trailing slashes. I don't know how strongly the Brim Dev team feels about it, but since the trailing slashes were there originally, I assume that reflects a preference.

Meanwhile, the open issue at https://github.com/facebook/docusaurus/issues/6282 gets into whether it's currently possible for Docusaurus to be smart enough to drop the trailing slash for file assets, and the short answer is effectively "no". Granted, it looks like we could hack their code and add `.zng` an additional extension to the set shown in https://github.com/facebook/docusaurus/issues/6282#issuecomment-1011120038, but this all seems kind of heavyweight for something that bites us in all of two URLs.

As I see it, linking directly to the raw file destination saves the user a click even if they should be looking at the docs while in GitHub, and then it has the follow-on benefit of Docusaurus leaving the link alone, so this fix is quick and clean.

You can see a working test version of the deployed fix at https://philrz.github.io/docs/next/tutorials/zed/

Fixes https://github.com/brimdata/zed-docs-site/issues/26