### PR TITLE
simplify zst to use io.ReaderAt instead of storage.Seeker

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -111,3 +111,10 @@ type Seeker struct {
 func (s *Seeker) Read(b []byte) (int, error) {
 	return s.ReadSeeker.Read(b)
 }
+
+func IsSeekable(r Reader) bool {
+	// All of the Reader implementations are seekable except this one,
+	// which is used by stdin.
+	_, ok := r.(*nopReadAtCloser)
+	return !ok
+}

--- a/zio/zstio/ztests/stdin-error.yaml
+++ b/zio/zstio/ztests/stdin-error.yaml
@@ -1,0 +1,14 @@
+script: |
+  zq -f zst -o t.zst in.zson
+  ! cat t.zst | zq -i zst -
+
+inputs:
+  - name: in.zson
+    data: |
+      ["hello"(=bar),"world"(bar)]
+      {a:["hello"(=bar),"world"(bar)]}
+
+outputs:
+  - name: stderr
+    data: |
+      stdio:stdin: zst must be used with a seekable input

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -39,7 +39,7 @@ func NewCutter(zctx *zed.Context, path field.Path, object *Object) (*Cutter, err
 			// Field not in this record, keep going.
 			continue
 		}
-		reader, err := vector.NewFieldReader(*f, object.seeker)
+		reader, err := vector.NewFieldReader(*f, object.readerAt)
 		if err != nil {
 			return nil, err
 		}
@@ -54,7 +54,7 @@ func NewCutter(zctx *zed.Context, path field.Path, object *Object) (*Cutter, err
 	return &Cutter{
 		zctx:   zctx,
 		object: object,
-		root:   vector.NewInt64Reader(object.root, object.seeker),
+		root:   vector.NewInt64Reader(object.root, object.readerAt),
 		cuts:   cuts,
 	}, nil
 }

--- a/zst/object.go
+++ b/zst/object.go
@@ -85,7 +85,12 @@ func NewObjectFromPath(ctx context.Context, zctx *zed.Context, engine storage.En
 	if err != nil {
 		return nil, err
 	}
-	return NewObjectFromStorageReader(zctx, r)
+	object, err := NewObjectFromStorageReader(zctx, r)
+	if err != nil {
+		r.Close()
+		return nil, err
+	}
+	return object, nil
 }
 
 func (o *Object) Close() error {


### PR DESCRIPTION
This commit simplifies the zst package to use io.ReaderAt
throughout and get rid of storage.Seeker.  We also noticed
that the check in zstio for a seekable input did not work
and instead failed on the first call to ReadAt (which gives
an error for stdin).  We fixed this and added a test to
make sure stdin fails properly.