### PR TITLE
Link to README.md files, not directories

### DIFF
--- a/docs/language/README.md
+++ b/docs/language/README.md
@@ -3,5 +3,5 @@
 The language documents:
 * provide an [overview](overview.md) of the Zed language,
 * layout some [conventions](conventions.md) for the documenation, and
-* enumerate the [operators](operators), [functions](functions),
-and [aggregate functions](aggregates) in reference format.
+* enumerate the [operators](operators/README.md), [functions](functions/README.md),
+and [aggregate functions](aggregates/README.md) in reference format.


### PR DESCRIPTION
In testing a docs site deployment with Docusaurus configured with `trailingSlash: false`, I found these three links to directories rather than markdown files would break in that new config.