### PR TITLE
move pkg/stringsearch.FieldNameFinder to runtime/expr

### DIFF
--- a/compiler/kernel/bufferfilter.go
+++ b/compiler/kernel/bufferfilter.go
@@ -66,7 +66,7 @@ func CompileBufferFilter(zctx *zed.Context, e dag.Expr) (*expr.BufferFilter, err
 			if left == nil {
 				return nil, nil
 			}
-			right := expr.NewFieldNameFinder(string(pattern))
+			right := expr.NewBufferFilterForFieldName(string(pattern))
 			return expr.NewOrBufferFilter(left, right), nil
 		}
 		left := expr.NewBufferFilterForStringCase(e.Text)

--- a/runtime/expr/bufferfilter.go
+++ b/runtime/expr/bufferfilter.go
@@ -22,7 +22,7 @@ type BufferFilter struct {
 	op    int
 	left  *BufferFilter
 	right *BufferFilter
-	fnf   *stringsearch.FieldNameFinder
+	fnf   *FieldNameFinder
 	cf    *stringsearch.CaseFinder
 	f     *stringsearch.Finder
 }
@@ -35,10 +35,10 @@ func NewOrBufferFilter(left, right *BufferFilter) *BufferFilter {
 	return &BufferFilter{op: opOr, left: left, right: right}
 }
 
-func NewFieldNameFinder(pattern string) *BufferFilter {
+func NewBufferFilterForFieldName(pattern string) *BufferFilter {
 	return &BufferFilter{
 		op:  opFieldNameFinder,
-		fnf: stringsearch.NewFieldNameFinder(pattern),
+		fnf: NewFieldNameFinder(pattern),
 	}
 }
 

--- a/runtime/expr/fieldnamefinder.go
+++ b/runtime/expr/fieldnamefinder.go
@@ -1,4 +1,4 @@
-package stringsearch
+package expr
 
 import (
 	"encoding/binary"
@@ -6,22 +6,23 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/byteconv"
+	"github.com/brimdata/zed/pkg/stringsearch"
 	"github.com/brimdata/zed/zcode"
 )
 
 type FieldNameFinder struct {
 	checkedIDs    big.Int
 	fieldNameIter FieldNameIter
-	caseFinder    *CaseFinder
+	caseFinder    *stringsearch.CaseFinder
 }
 
 func NewFieldNameFinder(pattern string) *FieldNameFinder {
-	return &FieldNameFinder{caseFinder: NewCaseFinder(pattern)}
+	return &FieldNameFinder{caseFinder: stringsearch.NewCaseFinder(pattern)}
 }
 
 // Find returns true if buf, which holds a sequence of ZNG value messages, might
 // contain a record with a field whose fully-qualified name (e.g., a.b.c)
-// matches the pattern. find also returns true if it encounters an error.
+// matches the pattern.  Find also returns true if it encounters an error.
 func (f *FieldNameFinder) Find(zctx *zed.Context, buf []byte) bool {
 	f.checkedIDs.SetInt64(0)
 	for len(buf) > 0 {

--- a/runtime/expr/fieldnamefinder_test.go
+++ b/runtime/expr/fieldnamefinder_test.go
@@ -1,4 +1,4 @@
-package stringsearch
+package expr
 
 import (
 	"testing"

--- a/runtime/expr/filter.go
+++ b/runtime/expr/filter.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/byteconv"
-	"github.com/brimdata/zed/pkg/stringsearch"
 	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zson"
 )
@@ -53,7 +52,7 @@ func (s *searchByPred) searchType(typ zed.Type) bool {
 	var match bool
 	recType := zed.TypeRecordOf(typ)
 	if recType != nil {
-		var nameIter stringsearch.FieldNameIter
+		var nameIter FieldNameIter
 		nameIter.Init(recType)
 		for !nameIter.Done() {
 			if s.pred(zed.NewValue(zed.TypeString, nameIter.Next())) {
@@ -192,7 +191,7 @@ func (s *searchString) searchType(typ zed.Type) bool {
 	var match bool
 	recType := zed.TypeRecordOf(typ)
 	if recType != nil {
-		var nameIter stringsearch.FieldNameIter
+		var nameIter FieldNameIter
 		nameIter.Init(recType)
 		for !nameIter.Done() {
 			if stringSearch(byteconv.UnsafeString(nameIter.Next()), s.term) {


### PR DESCRIPTION
pkg/stringsearch isn't a great home for FieldNameFinder, which isn't
concerned with general string seach.  Move it to runtime/expr, where
it's used.