### PR TITLE
manage monitor command

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
@@ -31,9 +30,6 @@ func (l *EventsClient) Recv() (string, interface{}, error) {
 	var kind, data string
 	_, err := fmt.Fscanf(l.rc, "event: %s\ndata: %s\n\n\n", &kind, &data)
 	if err != nil {
-		if errors.Is(err, io.EOF) {
-			return "", nil, nil
-		}
 		return "", nil, err
 	}
 	var v interface{}

--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/brimdata/zed/cmd/zed/ls"
 	"github.com/brimdata/zed/cmd/zed/manage"
 	_ "github.com/brimdata/zed/cmd/zed/manage/compact"
+	_ "github.com/brimdata/zed/cmd/zed/manage/monitor"
 	"github.com/brimdata/zed/cmd/zed/merge"
 	"github.com/brimdata/zed/cmd/zed/query"
 	"github.com/brimdata/zed/cmd/zed/rename"

--- a/cmd/zed/manage/compact/command.go
+++ b/cmd/zed/manage/compact/command.go
@@ -3,16 +3,13 @@ package compact
 import (
 	"flag"
 	"fmt"
-	"os"
-	"time"
 
 	"github.com/brimdata/zed/cli/commitflags"
 	"github.com/brimdata/zed/cli/lakeflags"
 	"github.com/brimdata/zed/cmd/zed/manage"
-	"github.com/brimdata/zed/cmd/zed/manage/lakemanager"
+	"github.com/brimdata/zed/cmd/zed/manage/lakemanage"
 	"github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/pkg/charm"
-	"gopkg.in/yaml.v3"
 )
 
 var Cmd = &charm.Spec{
@@ -29,20 +26,13 @@ func init() {
 type Command struct {
 	*manage.Command
 	commitFlags commitflags.Flags
-	config      lakemanager.Config
+	manageFlags manage.Flags
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*manage.Command)}
 	c.commitFlags.SetFlags(f)
-	f.Func("config", "path of manage YAML config file", func(s string) error {
-		b, err := os.ReadFile(s)
-		if err != nil {
-			return err
-		}
-		return yaml.Unmarshal(b, &c.config)
-	})
-	f.DurationVar(&c.config.ColdThreshold, "coldthresh", time.Minute*5, "age at which objects are considered for compaction")
+	c.manageFlags.SetFlags(f)
 	return c, nil
 }
 
@@ -67,13 +57,14 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	r, err := lakemanager.NewPoolObjectIterator(ctx, lake, head, pool.Layout)
+	r, err := lakemanage.NewPoolObjectIterator(ctx, lake, head, pool.Layout)
 	if err != nil {
 		return err
 	}
-	ch := make(chan lakemanager.Run)
+	config := c.manageFlags.Config
+	ch := make(chan lakemanage.Run)
 	go func() {
-		err = lakemanager.Scan(ctx, r, pool, c.config.ColdThreshold, ch)
+		_, err = lakemanage.Scan(ctx, r, pool, config.ColdThreshold, ch)
 		close(ch)
 	}()
 	for run := range ch {
@@ -85,6 +76,6 @@ func (c *Command) Run(args []string) error {
 			fmt.Printf("%s compaction committed\n", commit)
 		}
 	}
-	// Make sure to return err from the lakemanager.Scan goroutine.
+	// Make sure to return err from the lakemanage.Scan goroutine.
 	return err
 }

--- a/cmd/zed/manage/flags.go
+++ b/cmd/zed/manage/flags.go
@@ -1,0 +1,25 @@
+package manage
+
+import (
+	"flag"
+	"os"
+	"time"
+
+	"github.com/brimdata/zed/cmd/zed/manage/lakemanage"
+	"gopkg.in/yaml.v3"
+)
+
+type Flags struct {
+	Config lakemanage.Config
+}
+
+func (f *Flags) SetFlags(fs *flag.FlagSet) {
+	fs.Func("config", "path of manage yaml config file", func(s string) error {
+		b, err := os.ReadFile(s)
+		if err != nil {
+			return err
+		}
+		return yaml.Unmarshal(b, &f.Config)
+	})
+	fs.DurationVar(&f.Config.ColdThreshold, "coldthresh", time.Minute*5, "age at which objects are considered for compaction")
+}

--- a/cmd/zed/manage/lakemanage/config.go
+++ b/cmd/zed/manage/lakemanage/config.go
@@ -1,4 +1,4 @@
-package lakemanager
+package lakemanage
 
 import "time"
 

--- a/cmd/zed/manage/lakemanage/monitor.go
+++ b/cmd/zed/manage/lakemanage/monitor.go
@@ -1,0 +1,213 @@
+package lakemanage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/brimdata/zed/api"
+	"github.com/brimdata/zed/api/client"
+	lakeapi "github.com/brimdata/zed/lake/api"
+	"github.com/brimdata/zed/lake/pools"
+	"github.com/brimdata/zed/lakeparse"
+	"github.com/segmentio/ksuid"
+	"go.uber.org/zap"
+)
+
+type monitor struct {
+	conn   *client.Connection
+	config Config
+	lake   lakeapi.Interface
+	logger *zap.Logger
+}
+
+func Monitor(ctx context.Context, conn *client.Connection, config Config, logger *zap.Logger) error {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	m := &monitor{
+		conn:   conn,
+		config: config,
+		lake:   lakeapi.NewRemoteLake(conn),
+		logger: logger,
+	}
+	timer := time.NewTimer(0)
+	defer func() {
+		if !timer.Stop() {
+			<-timer.C
+		}
+	}()
+	for {
+		switch err := m.run(ctx); {
+		case errors.Is(err, syscall.ECONNREFUSED):
+			m.logger.Info("cannot connect to lake, retrying in 5 seconds")
+		case err != nil:
+			return err
+		}
+		timer.Reset(time.Second * 5)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (m *monitor) run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	pools, err := lakeapi.GetPools(ctx, m.lake)
+	if err != nil {
+		return err
+	}
+	monitors := make(map[ksuid.KSUID]*poolMonitor)
+	for _, pool := range pools {
+		m.launchPool(ctx, pool, monitors)
+	}
+	return m.listen(ctx, monitors)
+}
+
+func (m *monitor) listen(ctx context.Context, monitors map[ksuid.KSUID]*poolMonitor) error {
+	ev, err := m.conn.SubscribeEvents(ctx)
+	if err != nil {
+		return err
+	}
+	defer ev.Close()
+	for {
+		kind, detail, err := ev.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				// Ignore EOF error from lost connection.
+				return nil
+			}
+			return err
+		}
+		switch kind {
+		case "pool-new":
+			ev := detail.(*api.EventPool)
+			pool, err := lakeapi.LookupPoolByID(ctx, m.lake, ev.PoolID)
+			if err != nil {
+				return err
+			}
+			m.launchPool(ctx, pool, monitors)
+		case "pool-delete":
+			ev := detail.(*api.EventPool)
+			if pm, ok := monitors[ev.PoolID]; ok {
+				pm.cancel()
+				delete(monitors, ev.PoolID)
+			}
+		case "branch-commit":
+			ev := detail.(*api.EventBranchCommit)
+			if pm, ok := monitors[ev.PoolID]; ok && pm.branch == ev.Branch {
+				pm.run()
+			}
+		case "branch-update", "branch-delete":
+			// Ignore these events.
+		default:
+			m.logger.Warn("unexpected event kind received", zap.String("kind", kind))
+		}
+	}
+}
+
+func (m *monitor) launchPool(ctx context.Context, pool *pools.Config, monitors map[ksuid.KSUID]*poolMonitor) {
+	if _, ok := monitors[pool.ID]; !ok {
+		// XXX For now only track main but this should be configurable and allow
+		// non-main branches as well as monitoring multiple branches.
+		pm := newPoolMonitor(ctx, pool, "main", m.lake, m.config, m.logger)
+		pm.run()
+		monitors[pool.ID] = pm
+	}
+}
+
+type poolMonitor struct {
+	branch  string
+	cancel  context.CancelFunc
+	config  Config
+	ctx     context.Context
+	logger  *zap.Logger
+	lake    lakeapi.Interface
+	pool    *pools.Config
+	running int32
+}
+
+func newPoolMonitor(ctx context.Context, pool *pools.Config, branch string, lk lakeapi.Interface, config Config, logger *zap.Logger) *poolMonitor {
+	ctx, cancel := context.WithCancel(ctx)
+	return &poolMonitor{
+		branch: branch,
+		cancel: cancel,
+		config: config,
+		ctx:    ctx,
+		lake:   lk,
+		pool:   pool,
+		logger: logger.Named("pool").With(
+			zap.String("name", pool.Name),
+			zap.Stringer("id", pool.ID),
+			zap.String("branch", branch),
+		),
+	}
+}
+
+func (p *poolMonitor) run() {
+	if !atomic.CompareAndSwapInt32(&p.running, 0, 1) {
+		return
+	}
+	go func() {
+		timer := time.NewTimer(0)
+		defer func() {
+			if !timer.Stop() {
+				<-timer.C
+			}
+			p.logger.Debug("exit")
+		}()
+		for p.ctx.Err() == nil {
+			next, err := p.scan()
+			if err != nil || next == nil {
+				if err != nil && !errors.Is(err, context.Canceled) {
+					p.logger.Error("scan error", zap.Error(err))
+				}
+				atomic.StoreInt32(&p.running, 0)
+				return
+			}
+			timer.Reset(time.Until(*next))
+			select {
+			case <-p.ctx.Done():
+			case <-timer.C:
+			}
+		}
+	}()
+}
+
+func (p *poolMonitor) scan() (*time.Time, error) {
+	p.logger.Debug("scan started")
+	head := lakeparse.Commitish{Pool: p.pool.Name, Branch: p.branch}
+	reader, err := NewPoolObjectIterator(p.ctx, p.lake, &head, p.pool.Layout)
+	if err != nil {
+		return nil, err
+	}
+	var nextcold *time.Time
+	ch := make(chan Run)
+	go func() {
+		nextcold, err = Scan(p.ctx, reader, p.pool, p.config.ColdThreshold, ch)
+		close(ch)
+	}()
+	var found int
+	var compacted int
+	for run := range ch {
+		found++
+		compacted += len(run.Objects)
+		commit, err := p.lake.Compact(p.ctx, p.pool.ID, head.Branch, run.ObjectIDs(), api.CommitMessage{})
+		if err != nil {
+			return nil, err
+		}
+		p.logger.Debug("compacted", zap.Stringer("commit", commit), zap.Int("objects_compacted", len(run.Objects)))
+	}
+	if compacted == 0 {
+		p.logger.Debug("scan completed", zap.Int("runs_found", found), zap.Int("objects_compacted", compacted))
+	} else {
+		p.logger.Info("scan completed", zap.Int("runs_found", found), zap.Int("objects_compacted", compacted))
+	}
+	return nextcold, err
+}

--- a/cmd/zed/manage/lakemanage/objectiterator.go
+++ b/cmd/zed/manage/lakemanage/objectiterator.go
@@ -1,4 +1,4 @@
-package lakemanager
+package lakemanage
 
 import (
 	"context"

--- a/cmd/zed/manage/lakemanage/run.go
+++ b/cmd/zed/manage/lakemanage/run.go
@@ -1,4 +1,4 @@
-package lakemanager
+package lakemanage
 
 import (
 	"github.com/brimdata/zed"

--- a/cmd/zed/manage/lakemanage/scan_test.go
+++ b/cmd/zed/manage/lakemanage/scan_test.go
@@ -1,4 +1,4 @@
-package lakemanager_test
+package lakemanage_test
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/cmd/zed/manage/lakemanager"
+	"github.com/brimdata/zed/cmd/zed/manage/lakemanage"
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/lake/pools"
 	"github.com/brimdata/zed/order"
@@ -60,15 +60,15 @@ func TestScan(t *testing.T) {
 	})
 }
 
-func testScan(t *testing.T, coldthresh time.Duration, pool *pools.Config, objects []testObj) []lakemanager.Run {
+func testScan(t *testing.T, coldthresh time.Duration, pool *pools.Config, objects []testObj) []lakemanage.Run {
 	reader := newTestObjectReader(objects, nil, coldthresh)
-	ch := make(chan lakemanager.Run)
+	ch := make(chan lakemanage.Run)
 	var err error
 	go func() {
-		err = lakemanager.Scan(context.Background(), reader, pool, coldthresh, ch)
+		_, err = lakemanage.Scan(context.Background(), reader, pool, coldthresh, ch)
 		close(ch)
 	}()
-	var runs []lakemanager.Run
+	var runs []lakemanage.Run
 	for run := range ch {
 		runs = append(runs, run)
 	}
@@ -82,7 +82,7 @@ type testObj struct {
 	size        int64
 }
 
-func newTestObjectReader(objs []testObj, pool *pools.Config, coldthresh time.Duration) lakemanager.ObjectIterator {
+func newTestObjectReader(objs []testObj, pool *pools.Config, coldthresh time.Duration) lakemanage.ObjectIterator {
 	var objects []*data.Object
 	for _, o := range objs {
 		ts := time.Now()

--- a/cmd/zed/manage/monitor/command.go
+++ b/cmd/zed/manage/monitor/command.go
@@ -1,0 +1,52 @@
+package manage
+
+import (
+	"flag"
+
+	"github.com/brimdata/zed/cli/commitflags"
+	"github.com/brimdata/zed/cmd/zed/manage"
+	"github.com/brimdata/zed/cmd/zed/manage/lakemanage"
+	"github.com/brimdata/zed/pkg/charm"
+	"go.uber.org/zap"
+)
+
+var Cmd = &charm.Spec{
+	Name:  "monitor",
+	Usage: "monitor",
+	Short: "monitor pools in a lake",
+	New:   New,
+}
+
+func init() {
+	manage.Cmd.Add(Cmd)
+}
+
+type Command struct {
+	*manage.Command
+	commitFlags commitflags.Flags
+	manageFlags manage.Flags
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*manage.Command)}
+	c.commitFlags.SetFlags(f)
+	c.manageFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	ctx, cleanup, err := c.Init()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	conn, err := c.LakeFlags.Connection()
+	if err != nil {
+		return err
+	}
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		return err
+	}
+	return lakemanage.Monitor(ctx, conn, c.manageFlags.Config, logger)
+}

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -85,6 +85,23 @@ func LookupPoolByName(ctx context.Context, api Interface, name string) (*pools.C
 	}
 }
 
+func GetPools(ctx context.Context, api Interface) ([]*pools.Config, error) {
+	b := newBuffer(pools.Config{})
+	q, err := api.Query(ctx, nil, "from :pools")
+	if err != nil {
+		return nil, err
+	}
+	defer q.Close()
+	if err := zio.Copy(b, zbuf.NoControl(q)); err != nil {
+		return nil, err
+	}
+	var pls []*pools.Config
+	for _, r := range b.results {
+		pls = append(pls, r.(*pools.Config))
+	}
+	return pls, nil
+}
+
 func LookupPoolByID(ctx context.Context, api Interface, id ksuid.KSUID) (*pools.Config, error) {
 	b := newBuffer(pools.Config{})
 	zed := fmt.Sprintf("from :pools | id == hex('%s')", idToHex(id))


### PR DESCRIPTION
Add zed manage monitor command- a long running process that monitors the
pools in a zed lake and executes opportunistic compactions as data is
loaded into the various pools.