### PR TITLE
zio/zeekio: escape "(empty)" in output

### DIFF
--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -150,7 +150,9 @@ func formatString(t *zed.TypeOfString, zv zcode.Bytes, inContainer bool) string 
 	if bytes.Equal(zv, []byte{'-'}) {
 		return "\\x2d"
 	}
-
+	if string(zv) == "(empty)" {
+		return "\\x28empty)"
+	}
 	var out []byte
 	var start int
 	for i := 0; i < len(zv); {

--- a/zio/zeekio/ztests/zeek-format-test.yaml
+++ b/zio/zeekio/ztests/zeek-format-test.yaml
@@ -5,6 +5,8 @@ input: |
   {s:null(string)}
   {s:"-"}
   {s:"--"}
+  {s:""}
+  {s:"(empty)"}
   {s:"\\"}
   {s:"\n\t"}
   {s:"a,b"}
@@ -13,12 +15,15 @@ input: |
   {s:";"}
   {s:null(|[string]|)}
   {s:|[]|(|[string]|)}
+  {s:|[""]|}
+  {s:|["(empty)"]|}
   {s:|["abc","xyz"]|}
   {s:|["a,b"]|}
   {s:null([string])}
   {s:[]([string])}
-  {s:["abc","xyz"]}
   {s:[""]}
+  {s:["(empty)"]}
+  {s:["abc","xyz"]}
   {s:["a,b"]}
 
 output-flags: -f zeek
@@ -34,6 +39,8 @@ output: |
   -
   \x2d
   --
+  
+  \x28empty)
   \\
   \x0a\x09
   a,b
@@ -44,12 +51,15 @@ output: |
   #types	set[string]
   -
   (empty)
+  
+  \x28empty)
   abc,xyz
   a\x2cb
   #fields	s
   #types	vector[string]
   -
   (empty)
-  abc,xyz
   
+  \x28empty)
+  abc,xyz
   a\x2cb


### PR DESCRIPTION
When emitting the Zeek empty field value "(empty)" as a string value,
zio/zeekio.Writer fails to escape the first character, making it
impossible to distinguish an empty Zeek set[string] or vector[string]
from one containing the string "(empty)".  Fix that.

Closes #845.