### PR TITLE
Add explicit leading dot in README link

### DIFF
--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -61,7 +61,7 @@ Also, it is at the whim of a JSON implementation whether
 or not the order of object keys is preserved.
 
 While JSON is well suited for data exchange of generic information, it is not
-so appropriate for a [super-structured data model](README.md#2-zed-a-super-structured-pattern)
+so appropriate for a [super-structured data model](./README.md#2-zed-a-super-structured-pattern)
 like Zed.  That said, JSON can be used as an encoding format for Zed by mapping Zed data
 onto a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Zed and, with the help of client


### PR DESCRIPTION
During my research into an alternate hosting platform for the docs site, I bumped into yet another flavor of broken link in the ZJSON format doc, tied to the text "a super-structured data model". Following the link from the page in its original GitHub home at https://github.com/brimdata/zed/blob/main/docs/formats/zjson.md, it goes to the right place. But if you follow the same link on the same page on the published docs site at https://zed.brimdata.io/docs/next/formats/zjson/, it goes to the wrong place. With the fix in this PR, the page in the test site at https://62fc192ae0abad15aea124c1--spiffy-gnome-8f2834.netlify.app/docs/next/formats/zjson/ goes to the correct place again.