### PR TITLE
Standardize on ubuntu-20.04 in Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -37,7 +37,7 @@ jobs:
       - run: go build -o dist ./cmd/...
       - run: go test -v ./mdtest
   output-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   markdown-link:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Extract branch name

--- a/.github/workflows/notify-docs-update.yaml
+++ b/.github/workflows/notify-docs-update.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Send dispatch event
       run: |

--- a/.github/workflows/notify-downstream-merge.yml
+++ b/.github/workflows/notify-downstream-merge.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         repo: [brim, brimcap]

--- a/.github/workflows/notify-main-failure.yaml
+++ b/.github/workflows/notify-main-failure.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   slackNotify:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Notify Brim HQ of failure on main
         uses: tiloio/slack-webhook-action@v1.1.2

--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   perf-compare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/setup-go@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - v*
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
As we recently went through for https://github.com/brimdata/brim/issues/2482, we should proactively deal with the planned phasing out of the `ubuntu-18.04` hosted Actions runners. As of the moment I'm putting up this PR, the Actions have been a mix of `ubuntu-18.04` and `ubuntu-latest`, the latter of which is a pointer to `ubuntu-20.04`. Therefore I've standardized across the board with an explicit `ubuntu-20.04`.