### PR TITLE
zio/jsonio: fix bug reading leading empty string

### DIFF
--- a/zio/jsonio/reader.go
+++ b/zio/jsonio/reader.go
@@ -22,6 +22,9 @@ func NewReader(zctx *zed.Context, r io.Reader) *Reader {
 		builder: builder{zctx: zctx},
 		// 64 KB gave the best performance when this was written.
 		lexer: jsonlexer.New(bufio.NewReaderSize(r, 64*1024)),
+		// Ensure handleToken never passes a nil buf to
+		// builder.pushPrimitiveItem.
+		buf: make([]byte, 0, 64),
 	}
 }
 

--- a/zio/jsonio/ztests/first-token-is-empty-string.yaml
+++ b/zio/jsonio/ztests/first-token-is-empty-string.yaml
@@ -1,0 +1,9 @@
+zed: '*'
+
+input-flags: -i json
+
+input: |
+  ""
+
+output: |
+  ""


### PR DESCRIPTION
The jsonio.Reader.Read incorrectly interprets a leading empty string
("") as a null string.  This happens because Reader.buf is nil on the
first call to Reader.handleToken and, when the first token is an empty
string, remains nil for the call to Reader.builder.pushPrimativeItem.
Fix by initializing Reader.buf with a non-nil value.

Closes #4053.