### PR TITLE
Add missing square bracket to unflatten doc

### DIFF
--- a/docs/language/functions/unflatten.md
+++ b/docs/language/functions/unflatten.md
@@ -6,7 +6,7 @@ record.
 ### Synopsis
 
 ```
-unflatten(val: [{key:string|[string],value:any}) -> record
+unflatten(val: [{key:string|[string],value:any}]) -> record
 ```
 ### Description
 The _unflatten_ function converts the key/value records in array `val` into


### PR DESCRIPTION
A community user spotted this error in the `unflatten()` doc.