### PR TITLE
python: extract package version from Git

### DIFF
--- a/python/zed/setup.py
+++ b/python/zed/setup.py
@@ -9,4 +9,6 @@ setuptools.setup(
     ],
     py_modules=['zed'],
     python_requires='>=3.3',
+    setup_requires=['setuptools_scm'],
+    use_scm_version={'root': '../..'},
 )

--- a/python/zed/setup.py
+++ b/python/zed/setup.py
@@ -10,5 +10,8 @@ setuptools.setup(
     py_modules=['zed'],
     python_requires='>=3.3',
     setup_requires=['setuptools_scm'],
-    use_scm_version={'root': '../..'},
+    use_scm_version={
+        'fallback_version': 'unknown',
+        'root': '../..',
+    },
 )

--- a/python/zed/setup.py
+++ b/python/zed/setup.py
@@ -13,5 +13,6 @@ setuptools.setup(
     use_scm_version={
         'fallback_version': 'unknown',
         'root': '../..',
+        'version_scheme': 'post-release',
     },
 )


### PR DESCRIPTION
The Python package in python/zed installs as version 0.0.0, which isn't
helpful for support purposes.  Use setuptools_scm to extract a
meaningful version from Git.

The version is available via pip and (with Python >= 3.8) via
"importlib.metadata.version('zed')".  It is not available as a module
property because the package contains just the single-file module in
zed.py, so there's currently nowhere for setuptools_scm to write a
_version.py file.

Closes #3869.