### PR TITLE
runtime/exec: fix concurrent map writes in newSeekFinder

### DIFF
--- a/runtime/exec/sorted.go
+++ b/runtime/exec/sorted.go
@@ -89,7 +89,6 @@ func newSeekFinder(pool *lake.Pool, snap commits.View, f zbuf.Filter) (seekFinde
 	if err != nil {
 		return nil, err
 	}
-	cmp := expr.NewValueCompareFn(pool.Layout.Order == order.Asc)
 	return func(ctx context.Context, o *data.Object) (seekindex.Range, error) {
 		rg := seekindex.Range{End: o.Size}
 		var indexSpan extent.Span
@@ -109,6 +108,7 @@ func newSeekFinder(pool *lake.Pool, snap commits.View, f zbuf.Filter) (seekFinde
 				}
 			}
 		}
+		cmp := expr.NewValueCompareFn(pool.Layout.Order == order.Asc)
 		span := extent.NewGeneric(o.First, o.Last, cmp)
 		if indexSpan != nil || cropped != nil && cropped.Eval(span.First(), span.Last()) {
 			// If there is an index optimization or the object's span is


### PR DESCRIPTION
newSeekFinder returns a closure containing a reference to a comparison
function from expr.NewValueCompareFn.  The comparison function isn't
safe for concurrent use, but because a lake may read objects in
parallel, the closure may be called concurrently, and thus the
comparison function too.  This causes crashes due to concurrent map
writes.  Fix by moving the call to expr.NewValueCompareFn into the
closure.

Closes #4055.