### PR TITLE
runtime/exec: refactor newSeekFinder

### DIFF
--- a/runtime/exec/planner.go
+++ b/runtime/exec/planner.go
@@ -20,33 +20,27 @@ import (
 )
 
 type Planner struct {
-	ctx         context.Context
-	zctx        *zed.Context
-	pool        *lake.Pool
-	snap        commits.View
-	rangeFinder seekFinder
-	filter      zbuf.Filter
-	once        sync.Once
-	ch          chan meta.Partition
-	group       *errgroup.Group
-	progress    zbuf.Progress
+	ctx      context.Context
+	zctx     *zed.Context
+	pool     *lake.Pool
+	snap     commits.View
+	filter   zbuf.Filter
+	once     sync.Once
+	ch       chan meta.Partition
+	group    *errgroup.Group
+	progress zbuf.Progress
 }
 
 var _ from.Planner = (*Planner)(nil)
 
 func NewSortedPlanner(ctx context.Context, zctx *zed.Context, pool *lake.Pool, snap commits.View, filter zbuf.Filter) (*Planner, error) {
-	finder, err := newSeekFinder(pool, snap, filter)
-	if err != nil {
-		return nil, err
-	}
 	return &Planner{
-		ctx:         ctx,
-		zctx:        zctx,
-		pool:        pool,
-		rangeFinder: finder,
-		snap:        snap,
-		filter:      filter,
-		ch:          make(chan meta.Partition),
+		ctx:    ctx,
+		zctx:   zctx,
+		pool:   pool,
+		snap:   snap,
+		filter: filter,
+		ch:     make(chan meta.Partition),
 	}, nil
 }
 

--- a/runtime/exec/sorted.go
+++ b/runtime/exec/sorted.go
@@ -89,7 +89,6 @@ func newSeekFinder(pool *lake.Pool, snap commits.View, f zbuf.Filter) (seekFinde
 	if err != nil {
 		return nil, err
 	}
-	cmp := expr.NewValueCompareFn(pool.Layout.Order == order.Asc)
 	return func(ctx context.Context, o *data.Object) (seekindex.Range, error) {
 		rg := seekindex.Range{End: o.Size}
 		var indexSpan extent.Span
@@ -109,6 +108,7 @@ func newSeekFinder(pool *lake.Pool, snap commits.View, f zbuf.Filter) (seekFinde
 				}
 			}
 		}
+		cmp := expr.NewValueCompareFn(pool.Layout.Order == order.Asc)
 		span := extent.NewGeneric(o.First, o.Last, cmp)
 		if indexSpan != nil || cropped != nil && cropped.Eval(span.First(), span.Last()) {
 			// If there is an index optimization or the object's span is


### PR DESCRIPTION
newSeekFinder returns a closure, saving a little work at the cost of
some clarity.  Simplify by recasting it as a method,
Planner.objectRange.