### PR TITLE
runtime/expr: return error in newArrayOrSetStep

### DIFF
--- a/runtime/expr/shaper.go
+++ b/runtime/expr/shaper.go
@@ -392,7 +392,7 @@ func newRecordStep(zctx *zed.Context, in, out *zed.TypeRecord) (step, error) {
 func newArrayOrSetStep(zctx *zed.Context, op op, in, out zed.Type) (step, error) {
 	innerStep, err := newStep(zctx, in, out)
 	if err != nil {
-		return step{}, nil
+		return step{}, err
 	}
 	return step{op: op, children: []step{innerStep}}, nil
 }

--- a/runtime/expr/ztests/shape-cast-from-union.yaml
+++ b/runtime/expr/ztests/shape-cast-from-union.yaml
@@ -10,6 +10,7 @@ input: |
   {from:"one"((int64,string)),to:<string>}
   {from:[1,"one"],to:<[string]>}
   {from:[1,"one"],to:<[(int8,string)]>}
+  {from:[1,"one"],to:<[(int8,int16)]>}
   {from:{a:[1,"one"]},to:<{a:[string]}>}
   {from:{a:[1,"one"]},to:<{a:[(int8,string)]}>}
 
@@ -21,6 +22,7 @@ output: |
   error("createStep: incompatible types (int64,string) and (int8,string)")
   "one"
   ["1","one"]
-  [1(int8),"one"]
+  error("createStep: incompatible types (int64,string) and (int8,string)")
+  error("createStep: incompatible types (int64,string) and (int8,int16)")
   {a:["1","one"]}
-  {a:[1(int8),"one"]}
+  error("createStep: incompatible types (int64,string) and (int8,string)")


### PR DESCRIPTION
newArrayOrSetStep returns early if newStep fails but does not return the
newStep error.  This can result in a shaper with a bad copyOp step
(because the zero-value step is a copyOp with a fromIndex of 0), which
can lead step.build to return malformed zed.Values.  Fix by returning
the error.