### PR TITLE
copy slice argument in zed.Context.LookupTypeEnum, LookupTypeUnion

### DIFF
--- a/context.go
+++ b/context.go
@@ -224,7 +224,8 @@ func (c *Context) LookupTypeUnion(types []Type) *TypeUnion {
 		tvPool.Put(tv)
 		return typ.(*TypeUnion)
 	}
-	typ := NewTypeUnion(c.nextIDWithLock(), types)
+	dup := make([]Type, 0, len(types))
+	typ := NewTypeUnion(c.nextIDWithLock(), append(dup, types...))
 	c.enterWithLock(*tv, typ)
 	return typ
 }
@@ -238,7 +239,8 @@ func (c *Context) LookupTypeEnum(symbols []string) *TypeEnum {
 		tvPool.Put(tv)
 		return typ.(*TypeEnum)
 	}
-	typ := NewTypeEnum(c.nextIDWithLock(), symbols)
+	dup := make([]string, 0, len(symbols))
+	typ := NewTypeEnum(c.nextIDWithLock(), append(dup, symbols...))
 	c.enterWithLock(*tv, typ)
 	return typ
 }

--- a/zio/jsonio/builder.go
+++ b/zio/jsonio/builder.go
@@ -102,10 +102,6 @@ func (b *builder) endArray() {
 		}
 	default:
 		union := b.zctx.LookupTypeUnion(b.types)
-		if &union.Types[0] == &b.types[0] {
-			// union now owns b.types, so don't reuse it.
-			b.types = nil
-		}
 		container.typ = b.zctx.LookupTypeArray(union)
 		for i := range items {
 			if bytes := items[i].zb.Bytes().Body(); bytes == nil {


### PR DESCRIPTION
zed.Context's LookupTypeEnum and LookupTypeUnion methods sometimes take
ownership of their slice argument.  This is error-prone.  It's also
inconsistent with LookupTypeRecord, which copies its slice argument when
necessary.  Change LookupTypeEnum and LookupTypeUnion so they also copy
their slice argument when necessary.