### PR TITLE
runtime/expr: incorporate error when shaper fails

### DIFF
--- a/runtime/expr/shaper.go
+++ b/runtime/expr/shaper.go
@@ -392,7 +392,7 @@ func newRecordStep(zctx *zed.Context, in, out *zed.TypeRecord) (step, error) {
 func newArrayOrSetStep(zctx *zed.Context, op op, in, out zed.Type) (step, error) {
 	innerStep, err := newStep(zctx, in, out)
 	if err != nil {
-		return step{}, nil
+		return step{}, err
 	}
 	return step{op: op, children: []step{innerStep}}, nil
 }

--- a/runtime/expr/shaper.go
+++ b/runtime/expr/shaper.go
@@ -450,10 +450,6 @@ func (s *step) buildArrayOrSet(zctx *zed.Context, ectx Context, op op, in zcode.
 		inner = s.uniqueTypes[0]
 	default:
 		union := zctx.LookupTypeUnion(s.uniqueTypes)
-		if &union.Types[0] == &s.uniqueTypes[0] {
-			// union now owns s.uniqueTypes, so don't reuse it.
-			s.uniqueTypes = nil
-		}
 		// Convert each container element to the union type.
 		b.TransformContainer(func(bytes zcode.Bytes) zcode.Bytes {
 			var b2 zcode.Builder

--- a/runtime/expr/ztests/shape-cast-array-to-set.yaml
+++ b/runtime/expr/ztests/shape-cast-array-to-set.yaml
@@ -6,9 +6,11 @@ input: |
   {a:[]([string]),b:[]([{b:string}])}
   {a:["1.1.1.1","2.2.2.2","2.2.2.2"],b:[{b:"1.1.1.1"},{b:"2.2.2.2"},{b:"2.2.2.2"}]}
   {a:[null(string),"1.1.1.1"],b:[null({b:string}),{b:null(string)},{b:"2.2.2.2"}]}
+  {a:[null,"1.1.1.1","2"],b:[{b:null},{b:"1.1.1.1"},{b:"2"}]}
 
 output: |
   {a:null(|[ip]|),b:null(|[{b:ip}]|)}
   {a:|[]|(|[ip]|),b:|[]|(|[{b:ip}]|)}
   {a:|[1.1.1.1,2.2.2.2]|,b:|[{b:1.1.1.1},{b:2.2.2.2}]|}
   {a:|[null(ip),1.1.1.1]|,b:|[null({b:ip}),{b:null(ip)},{b:2.2.2.2}]|}
+  {a:|[null,1.1.1.1,error("cannot cast \"2\" to type ip")]|,b:|[{b:null(ip)},{b:1.1.1.1},{b:error("cannot cast \"2\" to type ip")}]|}

--- a/runtime/expr/ztests/shape-cast-arrays.yaml
+++ b/runtime/expr/ztests/shape-cast-arrays.yaml
@@ -6,9 +6,11 @@ input: |
   {a:[]([string]),b:[]([{b:string}])}
   {a:["1.1.1.1","2.2.2.2"],b:[{b:"1.1.1.1"},{b:"2.2.2.2"}]}
   {a:[null(string),"1.1.1.1"],b:[null({b:string}),{b:null(string)},{b:"2.2.2.2"}]}
+  {a:[null,"1.1.1.1","2"],b:[{b:null},{b:"1.1.1.1"},{b:"2"}]}
 
 output: |
   {a:null([ip]),b:null([{b:ip}])}
   {a:[]([ip]),b:[]([{b:ip}])}
   {a:[1.1.1.1,2.2.2.2],b:[{b:1.1.1.1},{b:2.2.2.2}]}
   {a:[null(ip),1.1.1.1],b:[null({b:ip}),{b:null(ip)},{b:2.2.2.2}]}
+  {a:[null,1.1.1.1,error("cannot cast \"2\" to type ip")],b:[{b:null(ip)},{b:1.1.1.1},{b:error("cannot cast \"2\" to type ip")}]}

--- a/runtime/expr/ztests/shape-cast-from-union.yaml
+++ b/runtime/expr/ztests/shape-cast-from-union.yaml
@@ -10,6 +10,7 @@ input: |
   {from:"one"((int64,string)),to:<string>}
   {from:[1,"one"],to:<[string]>}
   {from:[1,"one"],to:<[(int8,string)]>}
+  {from:[1,"one"],to:<[(int8,int16)]>}
   {from:{a:[1,"one"]},to:<{a:[string]}>}
   {from:{a:[1,"one"]},to:<{a:[(int8,string)]}>}
 
@@ -21,6 +22,7 @@ output: |
   error("createStep: incompatible types (int64,string) and (int8,string)")
   "one"
   ["1","one"]
-  [1(int8),"one"]
+  error("createStep: incompatible types (int64,string) and (int8,string)")
+  error("createStep: incompatible types (int64,string) and (int8,int16)")
   {a:["1","one"]}
-  {a:[1(int8),"one"]}
+  error("createStep: incompatible types (int64,string) and (int8,string)")

--- a/runtime/expr/ztests/shape-cast-set-to-array.yaml
+++ b/runtime/expr/ztests/shape-cast-set-to-array.yaml
@@ -6,9 +6,11 @@ input: |
   {a:|[]|(|[string]|),b:|[]|(|[{b:string}]|)}
   {a:|["1.1.1.1","2.2.2.2"]|,b:|[{b:"1.1.1.1"},{b:"2.2.2.2"}]|}
   {a:|[null(string),"1.1.1.1"]|,b:|[null({b:string}),{b:null(string)},{b:"2.2.2.2"}]|}
+  {a:|[null,"1.1.1.1","2"]|,b:|[{b:null},{b:"1.1.1.1"},{b:"2"}]|}
 
 output: |
   {a:null([ip]),b:null([{b:ip}])}
   {a:[]([ip]),b:[]([{b:ip}])}
   {a:[1.1.1.1,2.2.2.2],b:[{b:1.1.1.1},{b:2.2.2.2}]}
   {a:[null(ip),1.1.1.1],b:[null({b:ip}),{b:null(ip)},{b:2.2.2.2}]}
+  {a:[null,error("cannot cast \"2\" to type ip"),1.1.1.1],b:[{b:error("cannot cast \"2\" to type ip")},{b:null(ip)},{b:1.1.1.1}]}

--- a/runtime/expr/ztests/shape-cast-sets.yaml
+++ b/runtime/expr/ztests/shape-cast-sets.yaml
@@ -6,9 +6,11 @@ input: |
   {a:|[]|(|[string]|),b:|[]|(|[{b:string}]|)}
   {a:|["1.1.1.1","2.2.2.2"]|,b:|[{b:"1.1.1.1"},{b:"2.2.2.2"}]|}
   {a:|[null(string),"1.1.1.1"]|,b:|[null({b:string}),{b:null(string)},{b:"2.2.2.2"}]|}
+  {a:|[null,"1.1.1.1","2"]|,b:|[{b:null},{b:"1.1.1.1"},{b:"2"}]|}
 
 output: |
   {a:null(|[ip]|),b:null(|[{b:ip}]|)}
   {a:|[]|(|[ip]|),b:|[]|(|[{b:ip}]|)}
   {a:|[1.1.1.1,2.2.2.2]|,b:|[{b:1.1.1.1},{b:2.2.2.2}]|}
   {a:|[null(ip),1.1.1.1]|,b:|[null({b:ip}),{b:null(ip)},{b:2.2.2.2}]|}
+  {a:|[null,1.1.1.1,error("cannot cast \"2\" to type ip")]|,b:|[{b:null(ip)},{b:1.1.1.1},{b:error("cannot cast \"2\" to type ip")}]|}

--- a/runtime/expr/ztests/shape-cast.yaml
+++ b/runtime/expr/ztests/shape-cast.yaml
@@ -11,4 +11,4 @@ input: |
 
 output: |
   {id:{orig_h:ff02::fb,orig_p:5353(port=uint16),resp_p:5353(port),resp_h:1.2.3.4},other:123.,id2:{orig_h:ff02::fb,orig_p:5353(port),resp_p:5353(port),resp_h:1.2.3.4}}
-  {id:error("cannot cast \"notanip\" to type ip"),other:123.,id2:error("cannot cast \"notanip\" to type ip")}
+  {id:{orig_h:ff02::fb,orig_p:5353(port=uint16),resp_p:5353(port),resp_h:error("cannot cast \"notanip\" to type ip")},other:123.,id2:{orig_h:ff02::fb,orig_p:5353(port),resp_p:5353(port),resp_h:error("cannot cast \"notanip\" to type ip")}}

--- a/runtime/expr/ztests/shape-string-time-err.yaml
+++ b/runtime/expr/ztests/shape-string-time-err.yaml
@@ -1,8 +1,8 @@
 zed: |
-  yield shape(<{f1:time}>)
+  yield shape(<{a:time}>)
 
 input: |
-  {f1:"WellWhatDoYouThinkOfThis",f2:"NotMuch"}
+  {a:"a",b:"b"}
 
 output: |
-  error("cannot cast \"WellWhatDoYouThinkOfThis\" to type time")
+  {a:error("cannot cast \"a\" to type time"),b:"b"}


### PR DESCRIPTION
When a shaper fails because a primitive cast returns an error, only that
error is returned.

    $ zq 'yield cast({a:"a"},<{a:ip}>)'
    error("cannot cast \"a\" to type ip")

Rework step.build et al. to incorporate such an error into the value
being built.

    $ zq 'yield cast({a:"a"},<{a:ip}>)'
    {a:error("cannot cast \"a\" to type ip")}

Closes #2710.

For #4052.

Depends on #4067.