### PR TITLE
Fix ZSON doc Type Decorator examples

### DIFF
--- a/docs/formats/zson.md
+++ b/docs/formats/zson.md
@@ -52,11 +52,11 @@ For union values, multiple decorators might be
 required to distinguish the union-member type from the possible set of
 union types when there is ambiguity, as in
 ```
-123.0 (float32) ((int64,float32,float64))
+123. (float32) ((int64,float32,float64))
 ```
 In contrast, this union value is unambiguous:
 ```
-123.0 ((int64,float64))
+123. ((int64,float64))
 ```
 
 The syntax of a union value decorator is

--- a/docs/formats/zson.md
+++ b/docs/formats/zson.md
@@ -52,11 +52,11 @@ For union values, multiple decorators might be
 required to distinguish the union-member type from the possible set of
 union types when there is ambiguity, as in
 ```
-123 (float64) (int64,float64)
+123.0 (float32) ((int64,float32,float64))
 ```
 In contrast, this union value is unambiguous:
 ```
-123.0 (int64,float64)
+123.0 ((int64,float64))
 ```
 
 The syntax of a union value decorator is


### PR DESCRIPTION
These now work and come back the same when passed through `zq`.

```
$ zq -version
Version: v1.2.0-38-gd07901b2

$ echo '123.0 (float32) ((int64,float32,float64))' | zq -z -
123.(float32)((int64,float32,float64))

$ echo '123.0 ((int64,float64))' | zq -z -
123.((int64,float64))
```

Also, I paused briefly at this part:

---
<img width="726" alt="image" src="https://user-images.githubusercontent.com/5934157/187813216-3fbcdb12-aecf-47d8-8692-ae539dad7a10.png">

---

...and wondered if it needed the second set of parens inside the `[ ]`, but I don't think so. Since the rightmost `<type>` is a union type as the text says, it could come with its own set of extra parens, or lack them if it was a reference to a named type. Just figured I'd point it out.

Fixes #4056