### PR TITLE
fix union() for input comprising single union type

### DIFF
--- a/runtime/expr/agg/union.go
+++ b/runtime/expr/agg/union.go
@@ -64,19 +64,20 @@ func (u *Union) Result(zctx *zed.Context) *zed.Value {
 	for typ := range u.types {
 		types = append(types, typ)
 	}
-	types = zed.UniqueTypes(types)
-	inner := types[0]
-	if len(types) > 1 {
-		inner = zctx.LookupTypeUnion(types)
-	}
+	var inner zed.Type
 	var b zcode.Builder
-	for typ, m := range u.types {
-		for v := range m {
-			if union, ok := zed.TypeUnder(inner).(*zed.TypeUnion); ok {
+	if len(types) > 1 {
+		union := zctx.LookupTypeUnion(types)
+		inner = union
+		for typ, m := range u.types {
+			for v := range m {
 				zed.BuildUnion(&b, union.TagOf(typ), []byte(v))
-			} else {
-				b.Append([]byte(v))
 			}
+		}
+	} else {
+		inner = types[0]
+		for v := range u.types[inner] {
+			b.Append([]byte(v))
 		}
 	}
 	return zed.NewValue(zctx.LookupTypeSet(inner), zed.NormalizeSet(b.Bytes()))

--- a/runtime/expr/agg/ztests/union-single-union-type.yaml
+++ b/runtime/expr/agg/ztests/union-single-union-type.yaml
@@ -1,0 +1,8 @@
+zed: union(this) | yield union
+
+input: |
+  1((int64,string))
+  1((int64,string))
+
+output: |
+  |[1]|(|[(int64,string)]|)


### PR DESCRIPTION
The union() function emits a malformed value when its input comprises
values of a single union type.  Fix by calling zed.BuildUnion only if
we've seen multiple input types.

Closes #4057.