### PR TITLE
always update binding in zed.Context.LookupTypeNamed

### DIFF
--- a/context.go
+++ b/context.go
@@ -245,12 +245,16 @@ func (c *Context) LookupTypeEnum(symbols []string) *TypeEnum {
 	return typ
 }
 
+// LookupTypeDef returns the named type last bound to name by LookupTypeNamed.
+// It returns nil if name is unbound.
 func (c *Context) LookupTypeDef(name string) *TypeNamed {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.typedefs[name]
 }
 
+// LookupTypeNamed returns the named type for name and inner.  It also binds
+// name to that named type.
 func (c *Context) LookupTypeNamed(name string, inner Type) (*TypeNamed, error) {
 	tv := tvPool.Get().(*[]byte)
 	*tv = AppendTypeValue((*tv)[:0], &TypeNamed{Name: name, Type: inner})
@@ -258,6 +262,7 @@ func (c *Context) LookupTypeNamed(name string, inner Type) (*TypeNamed, error) {
 	defer c.mu.Unlock()
 	if typ, ok := c.toType[string(*tv)]; ok {
 		tvPool.Put(tv)
+		c.typedefs[name] = typ.(*TypeNamed)
 		return typ.(*TypeNamed), nil
 	}
 	typ := NewTypeNamed(c.nextIDWithLock(), name, inner)

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,27 @@
+package zed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextLookupTypeNamedAndLookupTypeDef(t *testing.T) {
+	zctx := NewContext()
+
+	assert.Nil(t, zctx.LookupTypeDef("x"))
+
+	named1, err := zctx.LookupTypeNamed("x", TypeNull)
+	require.NoError(t, err)
+	assert.Same(t, named1, zctx.LookupTypeDef("x"))
+
+	named2, err := zctx.LookupTypeNamed("x", TypeInt8)
+	require.NoError(t, err)
+	assert.Same(t, named2, zctx.LookupTypeDef("x"))
+
+	named3, err := zctx.LookupTypeNamed("x", TypeNull)
+	require.NoError(t, err)
+	assert.Same(t, named3, zctx.LookupTypeDef("x"))
+	assert.Same(t, named3, named1)
+}

--- a/zst/ztests/issue-4074.yaml
+++ b/zst/ztests/issue-4074.yaml
@@ -1,0 +1,13 @@
+script: |
+  zst create -o out.zst -
+  zq -z -i zst out.zst
+
+inputs:
+  - name: stdin
+    data: &stdin |
+      {a:{aa:0}}
+      {a:{aa:0},b:[{bb:0}]}
+
+outputs:
+  - name: stdout
+    data: *stdin


### PR DESCRIPTION
zed.Context.LookupTypeNamed updates the binding for its name argument when creating a new named typed but not when returning an existing one. This can cause Context.DecodeTypeValue to return a type that does not match its argument, as in #4074.  Fix that by always updating the binding.

Closes #4074.