### PR TITLE
fix "fork (=> ... => ...) | head" hang

### DIFF
--- a/runtime/op/router.go
+++ b/runtime/op/router.go
@@ -99,6 +99,9 @@ func (r *Router) sendEOS(err error) bool {
 	// catch any dones in progress.  This result in all routes
 	// being blocked.
 	for _, p := range r.routes {
+		if p.blocked {
+			continue
+		}
 		// XXX If we get done while trying to send an EOS, we need to
 		// ack the done and then send the EOS.  We treat it as if it
 		// happened before the EOS being sent.

--- a/runtime/ztests/issue-4013.yaml
+++ b/runtime/ztests/issue-4013.yaml
@@ -1,0 +1,14 @@
+# Make sure "fork (=> ... => ...) | head" with one leg that pulls until
+# EOS and one that does not works for an input containing multiple
+# batches.
+script: |
+  seq 1000 | zq -z 'fork (=> count() => pass) | head' -
+  echo ===
+  seq 1000 | zq -z 'fork (=> pass => count()) | head' -
+
+outputs:
+  - name: stdout
+    data: |
+      1
+      ===
+      1


### PR DESCRIPTION
"fork (=> ... => ...) | head" with one leg that pulls until EOS and one that does not will hang on an input containing multiple batches.  Fix in runtime/op/combine.Proc.propagateDone and runtime/op.Router.sendEOS.

Closes #4013.