### PR TITLE
Add = in "Named Types" doc examples

### DIFF
--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -536,7 +536,7 @@ name=type
 and create a binding between the indicated string `name` and the specified type.
 For example,
 ```
-type socket {addr:ip,port:port=uint16}
+type socket = {addr:ip,port:port=uint16}
 ```
 defines a named type `socket` that is a record with field `addr` of type `ip`
 and field `port` of type "port", where type "port" is a named type for type `uint16` .
@@ -603,7 +603,7 @@ is a superset of relational tables and
 the Zed language's type system can easily make this connection.
 As an example, consider this type definition for "employee":
 ```
-type employee {id:int64,first:string,last:string,job:string,salary:float64}
+type employee = {id:int64,first:string,last:string,job:string,salary:float64}
 ```
 In SQL, you might find the top five salaries by last name with
 ```


### PR DESCRIPTION
While scrubbing issue #3452, I noticed that these examples in the docs are out of sync with the implementation. I think I've heard talk of maybe dropping the `=` from the implementation, and if folks would rather hurry up and make that change, I'm fine with that. But if not, I figure we should fix the doc in the meantime. If dropping the `=` is still something we definitely wanna do, just say the word and I'll open an issue and include a note to make sure these examples get changed then.

Semi-related topic: It looks like there's excess parens in the [Enum Value](https://zed.brimdata.io/docs/next/formats/zson#246-enum-value) section of the ZSON spec. But per https://github.com/brimdata/zed/issues/3821#issuecomment-1247240361 it looks like the implementation currently chokes regardless. If everyone's in agreement that the spec is wrong here I'd be happy to push a fix for that as well.