### PR TITLE
remove undocumented fork operator behavior

### DIFF
--- a/compiler/ztests/from-fork.yaml
+++ b/compiler/ztests/from-fork.yaml
@@ -1,0 +1,13 @@
+script: |
+  zq -z 'from (file in.zson file in.zson ) | fork (=> count() => count())'
+
+inputs:
+  - name: in.zson
+    data: |
+      1
+
+outputs:
+  - name: stdout
+    data: |
+      {count:2(uint64)}
+      {count:2(uint64)}


### PR DESCRIPTION
The fork operator has undocumented behavior when it follows another fork operator ("fork (...) | fork (...)", a multi-leg from operator ("from (...) | fork (...)"), or a simple from operator with a pool pattern matching multiple pools ("from * | fork (...)").  In these cases, both operators must have the same number of legs, and the Nth leg of the first operator becomes the input to the Nth leg of the second operator.

This behavior is surprising and appears to be accidental (based on the implementation's history).  Remove it.

Closes #4085.