### PR TITLE
Clean up summarize doc

### DIFF
--- a/docs/language/operators/summarize.md
+++ b/docs/language/operators/summarize.md
@@ -5,26 +5,29 @@
 ### Synopsis
 
 ```
-summarize [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>]] [by [<field>][:=<expr>] ...]
+summarize [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>] ...] [by [<field>][:=<expr>] ...]
 ```
 ### Description
 
-The `summarize` operator consumes all of its input, applies an aggregate function
+The `summarize` operator consumes all of its input, applies an [aggregate function](../aggregates/README.md)
 to each input value optionally organized with the group-by keys specified after
-the `by` keyword and at the end of input, and produces one or more aggregations
+the `by` keyword, and at the end of input produces one or more aggregations
 for each unique set of group-by key values.
 
-Each aggregate function may be optionally followed by a `where` clause, which
-indicates a Boolean expression that indicates, for each input value,
-whether to deliver it to that aggregate.
+The keyword `summarize` can be treated as an [implied operator](../overview.md#26-implied-operators)
+and hence may be omitted before an aggregate function call.
+
+Each aggregate function may be optionally followed by a [`where`](where.md) clause, which
+applies a Boolean expression that indicates, for each input value,
+whether to deliver it to that aggregate function.
 
 The output field names for each aggregate and each key are optional.  If omitted,
-a field name is inferred from each right-hand side, e.g, the output field for the `sum`
-aggregate function is simply `sum`.
+a field name is inferred from each right-hand side, e.g, the output field for the [`count`](../aggregates/count.md)
+aggregate function is simply `count`.
 
-A key may be either an expression or a field.  If the key field is omitted it,
+A key may be either an expression or a field.  If the key field is omitted,
 it is inferred from the expression, e.g., the field name for `by lower(s)`
-is `lower.`
+is `lower`.
 
 If the cardinality of group-by keys causes the memory footprint to exceed
 a limit, then each aggregate's partial results are spilled to temporary storage
@@ -34,7 +37,16 @@ to a cluster of workers in an adaptive shuffle, though this is not yet implement
 
 ### Examples
 
-Sum the input sequence:
+Average the input sequence:
+```mdtest-command
+echo '1 2 3 4' | zq -z 'summarize avg(this)' -
+```
+=>
+```mdtest-output
+{avg:2.5}
+```
+
+Sum the input sequence, leaving out the `summarize` keyword:
 ```mdtest-command
 echo '1 2 3 4' | zq -z 'sum(this)' -
 ```
@@ -54,7 +66,7 @@ echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'set:=union(
 {key:"foo",set:|[1,3]|}
 ```
 
-Use a where clause
+Use a `where` clause:
 ```mdtest-command
 echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'set:=union(v) where v > 1 by key:=k' - | sort
 ```

--- a/docs/language/operators/summarize.md
+++ b/docs/language/operators/summarize.md
@@ -14,8 +14,8 @@ to each input value optionally organized with the group-by keys specified after
 the `by` keyword, and at the end of input produces one or more aggregations
 for each unique set of group-by key values.
 
-The keyword `summarize` can be treated as an [implied operator](../overview.md#26-implied-operators)
-and hence may be omitted before an aggregate function call.
+The `summarize` keyword is optional since it is an
+[implied operator](../overview.md#26-implied-operators).
 
 Each aggregate function may be optionally followed by a [`where`](where.md) clause, which
 applies a Boolean expression that indicates, for each input value,

--- a/docs/language/operators/summarize.md
+++ b/docs/language/operators/summarize.md
@@ -5,7 +5,7 @@
 ### Synopsis
 
 ```
-summarize [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>] ...] [by [<field>][:=<expr>] ...]
+[summarize] [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>] ...] [by [<field>][:=<expr>] ...]
 ```
 ### Description
 

--- a/docs/language/operators/summarize.md
+++ b/docs/language/operators/summarize.md
@@ -22,8 +22,8 @@ applies a Boolean expression that indicates, for each input value,
 whether to deliver it to that aggregate function.
 
 The output field names for each aggregate and each key are optional.  If omitted,
-a field name is inferred from each right-hand side, e.g, the output field for the [`count`](../aggregates/count.md)
-aggregate function is simply `count`.
+a field name is inferred from each right-hand side, e.g, the output field for the
+[`count` aggregate function](../aggregates/count.md) is simply `count`.
 
 A key may be either an expression or a field.  If the key field is omitted,
 it is inferred from the expression, e.g., the field name for `by lower(s)`

--- a/docs/language/operators/summarize.md
+++ b/docs/language/operators/summarize.md
@@ -17,9 +17,10 @@ for each unique set of group-by key values.
 The `summarize` keyword is optional since it is an
 [implied operator](../overview.md#26-implied-operators).
 
-Each aggregate function may be optionally followed by a [`where`](where.md) clause, which
+Each aggregate function may be optionally followed by a `where` clause, which
 applies a Boolean expression that indicates, for each input value,
-whether to deliver it to that aggregate function.
+whether to deliver it to that aggregate. (`where` clauses are analogous
+to the [`where` operator](where.md).)
 
 The output field names for each aggregate and each key are optional.  If omitted,
 a field name is inferred from each right-hand side, e.g, the output field for the


### PR DESCRIPTION
In #3868, a community user helpfully let us know that the `summarize` doc may be confusing to new users because it made ample reference to the `sum` aggregate function while not making use of the explicit `summarize` keyword in the examples. I've tried to make this all clearer with the changes in this PR, and cleaned up a couple other things with the doc while I was in there.

Closes #3868