### PR TITLE
update to actions/setup-go@v3 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,12 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
       - run: go mod download
       - run: make fmt
       - run: make tidy
@@ -28,10 +28,10 @@ jobs:
   test-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
       - run: go test -short ./...
       - run: mkdir dist -ea 0
       - run: go build -o dist ./cmd/...
@@ -39,9 +39,9 @@ jobs:
   output-check:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
       - run: make install
       - run: make output-check

--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -12,10 +12,10 @@ jobs:
   perf-compare:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.18'
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
     - name: Add zeek-cut to PATH
       run: |
         echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,12 @@ jobs:
   publish:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.18'
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
     - run: go mod download
     - run: make fmt
     - run: make tidy


### PR DESCRIPTION
This version lets us pull the Go version from go.mod, so do that.  And move it after actions/checkout so go.mod is available.