### PR TITLE
Make implied operator docs consistent

### DIFF
--- a/docs/language/operators/put.md
+++ b/docs/language/operators/put.md
@@ -4,7 +4,7 @@
 
 ### Synopsis
 ```
-put <field>:=<expr> [, <field>:=<expr> ...]
+[put] <field>:=<expr> [, <field>:=<expr> ...]
 ```
 ### Description
 
@@ -22,8 +22,8 @@ computed first and then they are all written simultaneously.  As a result,
 a computed value cannot be referenced in another expression.  If you need
 to re-use a computed result, this can be done by chaining multiple `put` operators.
 
-The "put" keyword is optional since it is an
-[implied operators](../overview.md#26-implied-operators).
+The `put` keyword is optional since it is an
+[implied operator](../overview.md#26-implied-operators).
 
 Each `<field>` expression must be a field reference expressed as a dotted path or one more
 constant index operations on `this`, e.g., `a.b`, `this["a"]["b"]`,

--- a/docs/language/operators/search.md
+++ b/docs/language/operators/search.md
@@ -12,8 +12,8 @@ The `search` operator filters its input by applying a search expression `<sexpr>
 to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
-The "search" keyword may be omitted in which case `<sexpr>` follows
-the [search expression](../overview.md#7-search-expressions) syntax.
+The `search` keyword is optional since it is an
+[implied operator](../overview.md#26-implied-operators).
 
 When Zed queries are run interactively, it is convenient to be able to omit
 the "search" keyword, but when search filters appear in Zed source files,

--- a/docs/language/operators/where.md
+++ b/docs/language/operators/where.md
@@ -12,6 +12,9 @@ The `where` operator filters its input by applying a Boolean expression `<expr>`
 to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
+The `where` keyword is optional since it is an
+[implied operator](../overview.md#26-implied-operators).
+
 The "where" keyword requires a regular Zed expression and does not support
 [search expressions](../overview.md#7-search-expressions).  Use the
 [search operator](search.md) if you want search syntax.

--- a/docs/language/operators/yield.md
+++ b/docs/language/operators/yield.md
@@ -5,7 +5,7 @@
 ### Synopsis
 
 ```
-yield <expr> [, <expr>...]
+[yield] <expr> [, <expr>...]
 ```
 ### Description
 
@@ -14,8 +14,8 @@ expressions on each input value and sending each result to the output
 in left-to-right order.  Each `<expr>` may be any valid
 [Zed expression](../overview.md#6-expressions).
 
-The _yield_ keyword may be omitted when `<expr>` is a
-[record literal](../overview.md#6112-record-expressions).
+The `yield` keyword is optional since it is an
+[implied operator](../overview.md#26-implied-operators).
 
 ### Examples
 


### PR DESCRIPTION
While repurposing `put` docs as part of #4089, I noticed some inconsistency among how the different implied operators are described. With the changes here I make sure each is shown as optional with the `[ ]` in the synopsis and that their optional nature is described in brief terms since the hyperlinked "implied operators" section of the language overview doc is exhaustive.