### PR TITLE
change difference of Zed times to duration

### DIFF
--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -463,6 +463,10 @@ func (s *Subtract) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return ectx.NewValue(typ, zed.EncodeFloat64(v1-v2))
 	case zed.IsSigned(id):
 		v1, v2 := s.operands.ints()
+		if id == zed.IDTime {
+			// Return the difference of two times as a duration.
+			typ = zed.TypeDuration
+		}
 		return ectx.NewValue(typ, zed.EncodeInt(v1-v2))
 	case zed.IsNumber(id):
 		v1, v2 := s.operands.uints()

--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -395,6 +395,10 @@ func TestArithmetic(t *testing.T) {
 	testSuccessful(t, "f / 1.25", record, zfloat64(2.0))
 	testSuccessful(t, "5.0 / f", record, zfloat64(2.0))
 
+	// Difference of two times is a duration
+	testSuccessful(t, "a - b", "{a:2022-09-22T00:00:01Z,b:2022-09-22T00:00:00Z}",
+		*zed.NewDuration(nano.Second))
+
 	width := func(id int) int {
 		switch id {
 		case zed.IDInt8, zed.IDUint8:


### PR DESCRIPTION
The difference of two Zed time values is itself a time value.  Change it to be a duration value.

Closes #3142.