### PR TITLE
connection: Use default headers

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -60,9 +60,13 @@ func NewConnection() *Connection {
 // NewConnectionTo creates a new connection with the given useragent string
 // and a base URL derived from the hostURL argument.
 func NewConnectionTo(hostURL string) *Connection {
+	defaultHeader := http.Header{
+		"Accept":       []string{api.MediaTypeZNG},
+		"Content-Type": []string{api.MediaTypeZNG},
+	}
 	return &Connection{
 		client:        &http.Client{},
-		defaultHeader: http.Header{"Accept": []string{api.MediaTypeZNG}},
+		defaultHeader: defaultHeader,
 		hostURL:       hostURL,
 	}
 }

--- a/api/client/request.go
+++ b/api/client/request.go
@@ -51,8 +51,6 @@ func newRequest(ctx context.Context, host string, h http.Header) *Request {
 }
 
 func (r *Request) HTTPRequest() (*http.Request, error) {
-	r.Header.Set("Content-Type", api.MediaTypeZNG)
-	r.Header.Set("Accept", api.MediaTypeZNG)
 	body, err := r.getBody()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Do no set content-type and accept headers when creating a NewRequest, which can overwrite any changes to the headers on the request. Rely on default headers to ensure content-type and accept headers are populated by default.