### PR TITLE
delete where: ensure missing values are kept

### DIFF
--- a/lake/ztests/delete-where-missing.yaml
+++ b/lake/ztests/delete-where-missing.yaml
@@ -1,0 +1,23 @@
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create -q test
+  zed use -q test
+  zed load -q in.zson
+  zed delete -q -where 'uid==C3UeSqaSOFRReHD68'
+  zed query -z 'count()'
+  zed delete -q -where 'uid=="C3UeSqaSOFRReHD68"'
+  zed query -z 'count()'
+
+inputs:
+  - name: in.zson
+    data: |
+      {ts:0,uid:"C3UeSqaSOFRReHD68"}
+      {ts:1,uid:null(string)}
+      {ts:2}
+
+outputs:
+  - name: stdout
+    data: |
+      {count:3(uint64)}
+      {count:2(uint64)}


### PR DESCRIPTION
Fix bug in delete where, where values that evaluated missing("error") on the filter expression where getting deleted.

Closes #4122