### PR TITLE
allow 'cut a["b"]'

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -403,9 +403,8 @@ func semBinary(scope *Scope, e *ast.BinaryExpr) (dag.Expr, error) {
 	}, nil
 }
 
-//XXX this should work for any path not just this, e.g., this.x["@foo"]
 func isIndexOfThis(scope *Scope, lhs, rhs dag.Expr) *dag.This {
-	if this, ok := lhs.(*dag.This); ok && len(this.Path) == 0 {
+	if this, ok := lhs.(*dag.This); ok {
 		if s, ok := isStringConst(scope, rhs); ok {
 			this.Path = append(this.Path, s)
 			return this

--- a/docs/language/operators/cut.md
+++ b/docs/language/operators/cut.md
@@ -16,7 +16,7 @@ which adds or modifies the fields of a record, `cut` retains only the
 fields enumerated, much like a SQL projection.
 
 Each `<field>` expression must be a field reference expressed as a dotted path or sequence of
-constant index operations on `this`, e.g., `a.b` or `this["a"]["b"]`.
+constant index operations on `this`, e.g., `a.b` or `a["b"]`.
 
 Each right-hand side `<expr>` can be any Zed expression and is optional.
 

--- a/runtime/expr/dot.go
+++ b/runtime/expr/dot.go
@@ -61,7 +61,9 @@ func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if _, ok := val.Type.(*zed.TypeOfType); ok {
 		return d.evalTypeOfType(ectx, val.Bytes)
 	}
-
+	if typ, ok := val.Type.(*zed.TypeMap); ok {
+		return indexMap(d.zctx, ectx, typ, val.Bytes, zed.NewString(d.field))
+	}
 	recType, ok := val.Type.(*zed.TypeRecord)
 	if !ok {
 		return d.zctx.Missing()

--- a/runtime/expr/ztests/cut-nested.yaml
+++ b/runtime/expr/ztests/cut-nested.yaml
@@ -1,9 +1,9 @@
 script: |
   zq -z "cut rec.foo" nested1.zson
   echo ===
-  zq -z "cut rec.foo,rec.bar" nested1.zson
+  zq -z "cut rec.foo,rec['bar']" nested1.zson
   echo ===
-  zq -z "cut rec1.sub1.foo,rec1.sub2.bar,rec2.foo,foo" nested2.zson
+  zq -z "cut rec1.sub1.foo,rec1['sub2']['bar'],rec2.foo,foo" nested2.zson
 
 inputs:
   - name: nested1.zson


### PR DESCRIPTION
'cut a["b"]' produces an error in compiler/semantic.semAssignment because that function wants to use a["b"] as the assignment LHS, for which it requires a dag.This, but semExpr returns a dag.BinaryExpr for a["b"].  Remove the path-length restriction in isIndexOfThis so semExpr will return a dag.This.

This change triggers test failures that expose the lack of map support in runtime/expr.DotExpr.Eval, so add that.

Closes #3071.