### PR TITLE
first bits of vector cache for ZST objects

### DIFF
--- a/cmd/zed/dev/vcache/command.go
+++ b/cmd/zed/dev/vcache/command.go
@@ -1,0 +1,26 @@
+package vcache
+
+import (
+	"flag"
+
+	"github.com/brimdata/zed/cmd/zed/dev"
+	"github.com/brimdata/zed/cmd/zed/root"
+	"github.com/brimdata/zed/pkg/charm"
+)
+
+var Cmd = &charm.Spec{
+	Name:  "vcache",
+	Usage: "vcache sub-command [arguments...]",
+	Short: "run specified zst vector test",
+	Long: `
+vcache runs various tests of the vector cache as specified by its sub-command.`,
+	New: New,
+}
+
+func init() {
+	dev.Cmd.Add(Cmd)
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return parent.(*root.Command), nil
+}

--- a/cmd/zed/dev/vcache/copy/command.go
+++ b/cmd/zed/dev/vcache/copy/command.go
@@ -1,0 +1,75 @@
+package copy
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/brimdata/zed/cli/outputflags"
+	devvcache "github.com/brimdata/zed/cmd/zed/dev/vcache"
+	"github.com/brimdata/zed/cmd/zed/root"
+	"github.com/brimdata/zed/pkg/charm"
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/runtime/vcache"
+	"github.com/brimdata/zed/zio"
+	"github.com/segmentio/ksuid"
+)
+
+var Copy = &charm.Spec{
+	Name:  "copy",
+	Usage: "copy [flags] path",
+	Short: "read a ZST file and copy to the output through the vector cache",
+	Long: `
+The copy command reads ZST vectors from
+a ZST storage objects (local files or s3 objects) and outputs
+the reconstructed ZNG row data by exercising the vector cache.
+
+This command is most useful for testing the ZST vector cache.
+`,
+	New: newCommand,
+}
+
+func init() {
+	devvcache.Cmd.Add(Copy)
+}
+
+type Command struct {
+	*root.Command
+	outputFlags outputflags.Flags
+}
+
+func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	c.outputFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	ctx, cleanup, err := c.Init(&c.outputFlags)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if len(args) != 1 {
+		return errors.New("zst read: must be run with a single path argument")
+	}
+	uri, err := storage.ParseURI(args[0])
+	if err != nil {
+		return err
+	}
+	local := storage.NewLocalEngine()
+	cache := vcache.NewCache(local)
+	object, err := cache.Fetch(ctx, uri, ksuid.Nil)
+	if err != nil {
+		return err
+	}
+	defer object.Close()
+	writer, err := c.outputFlags.Open(ctx, local)
+	if err != nil {
+		return err
+	}
+	if err := zio.Copy(writer, object.NewReader()); err != nil {
+		writer.Close()
+		return err
+	}
+	return writer.Close()
+}

--- a/cmd/zed/dev/vcache/project/command.go
+++ b/cmd/zed/dev/vcache/project/command.go
@@ -1,0 +1,80 @@
+package read
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/brimdata/zed/cli/outputflags"
+	devvcache "github.com/brimdata/zed/cmd/zed/dev/vcache"
+	"github.com/brimdata/zed/cmd/zed/root"
+	"github.com/brimdata/zed/pkg/charm"
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/runtime/vcache"
+	"github.com/brimdata/zed/zio"
+	"github.com/segmentio/ksuid"
+)
+
+var Project = &charm.Spec{
+	Name:  "project",
+	Usage: "project [flags] field[,field...] path",
+	Short: "read a ZST file and run a projection as a test",
+	Long: `
+The project command reads ZST vectors from
+a ZST storage objects (local files or s3 objects) and outputs
+the reconstructed ZNG row data as a projection of one or more fields.
+
+This command is most useful for testing the ZST vector cache.
+`,
+	New: newCommand,
+}
+
+func init() {
+	devvcache.Cmd.Add(Project)
+}
+
+type Command struct {
+	*root.Command
+	outputFlags outputflags.Flags
+}
+
+func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	c.outputFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	ctx, cleanup, err := c.Init(&c.outputFlags)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if len(args) < 2 {
+		return errors.New("zst read: must be run with a single path argument followed by one or more fields")
+	}
+	uri, err := storage.ParseURI(args[0])
+	if err != nil {
+		return err
+	}
+	fields := args[1:]
+	local := storage.NewLocalEngine()
+	cache := vcache.NewCache(local)
+	object, err := cache.Fetch(ctx, uri, ksuid.Nil)
+	if err != nil {
+		return err
+	}
+	defer object.Close()
+	writer, err := c.outputFlags.Open(ctx, local)
+	if err != nil {
+		return err
+	}
+	projection, err := object.NewProjection(fields)
+	if err != nil {
+		return err
+	}
+	if err := zio.Copy(writer, projection); err != nil {
+		writer.Close()
+		return err
+	}
+	return writer.Close()
+}

--- a/cmd/zed/dev/vcache/project/command.go
+++ b/cmd/zed/dev/vcache/project/command.go
@@ -64,11 +64,11 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer object.Close()
-	writer, err := c.outputFlags.Open(ctx, local)
+	projection, err := object.NewProjection(fields)
 	if err != nil {
 		return err
 	}
-	projection, err := object.NewProjection(fields)
+	writer, err := c.outputFlags.Open(ctx, local)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -18,6 +18,8 @@ import (
 	_ "github.com/brimdata/zed/cmd/zed/dev/indexfile"
 	_ "github.com/brimdata/zed/cmd/zed/dev/indexfile/create"
 	_ "github.com/brimdata/zed/cmd/zed/dev/indexfile/lookup"
+	_ "github.com/brimdata/zed/cmd/zed/dev/vcache/copy"
+	_ "github.com/brimdata/zed/cmd/zed/dev/vcache/project"
 	"github.com/brimdata/zed/cmd/zed/drop"
 	"github.com/brimdata/zed/cmd/zed/index"
 	zedinit "github.com/brimdata/zed/cmd/zed/init"

--- a/runtime/vcache/array.go
+++ b/runtime/vcache/array.go
@@ -1,0 +1,54 @@
+package vcache
+
+import (
+	"io"
+
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zst"
+	"github.com/brimdata/zed/zst/vector"
+)
+
+type Array struct {
+	segmap  []vector.Segment
+	values  Vector
+	lengths []int32
+}
+
+func NewArray(array *vector.Array, r io.ReaderAt) (*Array, error) {
+	values, err := NewVector(array.Values, r)
+	if err != nil {
+		return nil, err
+	}
+	return &Array{
+		segmap: array.Lengths,
+		values: values,
+	}, nil
+}
+
+func (a *Array) NewIter(reader io.ReaderAt) (iterator, error) {
+	// The lengths vector is typically large and is loaded on demand.
+	if a.lengths == nil {
+		lengths, err := zst.ReadIntVector(a.segmap, reader)
+		if err != nil {
+			return nil, err
+		}
+		a.lengths = lengths
+	}
+	values, err := a.values.NewIter(reader)
+	if err != nil {
+		return nil, err
+	}
+	off := 0
+	return func(b *zcode.Builder) error {
+		b.BeginContainer()
+		len := a.lengths[off]
+		off++
+		for ; len > 0; len-- {
+			if err := values(b); err != nil {
+				return err
+			}
+		}
+		b.EndContainer()
+		return nil
+	}, nil
+}

--- a/runtime/vcache/cache.go
+++ b/runtime/vcache/cache.go
@@ -1,0 +1,39 @@
+package vcache
+
+import (
+	"context"
+
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/segmentio/ksuid"
+)
+
+type Cache struct {
+	engine storage.Engine
+	// objects is currently a simple map but we will turn this into an
+	// LRU cache sometime soon.  First step is object-level granularity, though
+	// we might want LRU inside of objects based on vectors.  We can do that
+	// later if measurements warrant it.  XXX note that we keep the storage
+	// reader open for every object and never close it.  We should timeout
+	// files and close them and then reopen them when needed to access
+	// vectors that haven't yet been loaded.
+	objects map[ksuid.KSUID]*Object
+}
+
+func NewCache(engine storage.Engine) *Cache {
+	return &Cache{
+		engine:  engine,
+		objects: make(map[ksuid.KSUID]*Object),
+	}
+}
+
+func (c *Cache) Fetch(ctx context.Context, uri *storage.URI, id ksuid.KSUID) (*Object, error) {
+	if object, ok := c.objects[id]; ok {
+		return object, nil
+	}
+	object, err := NewObject(ctx, c.engine, uri, id)
+	if err != nil {
+		return nil, err
+	}
+	c.objects[id] = object
+	return object, nil
+}

--- a/runtime/vcache/map.go
+++ b/runtime/vcache/map.go
@@ -1,0 +1,67 @@
+package vcache
+
+import (
+	"io"
+
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zst"
+	"github.com/brimdata/zed/zst/vector"
+)
+
+type Map struct {
+	segmap  []vector.Segment
+	keys    Vector
+	values  Vector
+	lengths []int32
+}
+
+func NewMap(m *vector.Map, r io.ReaderAt) (*Map, error) {
+	keys, err := NewVector(m.Keys, r)
+	if err != nil {
+		return nil, err
+	}
+	values, err := NewVector(m.Values, r)
+	if err != nil {
+		return nil, err
+	}
+	return &Map{
+		segmap: m.Lengths,
+		keys:   keys,
+		values: values,
+	}, nil
+}
+
+func (m *Map) NewIter(reader io.ReaderAt) (iterator, error) {
+	// The lengths vector is typically large and is loaded on demand.
+	if m.lengths == nil {
+		lengths, err := zst.ReadIntVector(m.segmap, reader)
+		if err != nil {
+			return nil, err
+		}
+		m.lengths = lengths
+	}
+	keys, err := m.keys.NewIter(reader)
+	if err != nil {
+		return nil, err
+	}
+	values, err := m.values.NewIter(reader)
+	if err != nil {
+		return nil, err
+	}
+	off := 0
+	return func(b *zcode.Builder) error {
+		len := m.lengths[off]
+		off++
+		b.BeginContainer()
+		for ; len > 0; len-- {
+			if err := keys(b); err != nil {
+				return err
+			}
+			if err := values(b); err != nil {
+				return err
+			}
+		}
+		b.EndContainer()
+		return nil
+	}, nil
+}

--- a/runtime/vcache/nulls.go
+++ b/runtime/vcache/nulls.go
@@ -1,0 +1,68 @@
+package vcache
+
+import (
+	"io"
+
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zst/vector"
+)
+
+type Nulls struct {
+	// The runs array encodes the run lengths of values and nulls in
+	// the same fashion as the ZST Nulls vector.
+	// This data structure provides a nice way to creator an iterator closure
+	// and (somewhat) efficiently build all the values that comprise a field
+	// into an zcode.Builder while allowing projections to intermix the calls
+	// to the iterator.  There's probably a better data structure for this
+	// but this is a prototype for now.
+	runs   []int
+	values Vector
+}
+
+func NewNulls(nulls *vector.Nulls, values Vector, r io.ReaderAt) (*Nulls, error) {
+	// The runlengths are typically small so we load them with the metadata
+	// and don't bother waiting for a reference.
+	runlens := vector.NewInt64Reader(nulls.Runs, r)
+	var runs []int
+	for {
+		run, err := runlens.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		runs = append(runs, int(run))
+	}
+	return &Nulls{
+		runs:   runs,
+		values: values,
+	}, nil
+}
+
+func (n *Nulls) NewIter(reader io.ReaderAt) (iterator, error) {
+	null := true
+	var run, off int
+	values, err := n.values.NewIter(reader)
+	if err != nil {
+		return nil, err
+	}
+	return func(b *zcode.Builder) error {
+		for run == 0 {
+			if off >= len(n.runs) {
+				//XXX this shouldn't happen... call panic?
+				b.Append(nil)
+				return nil
+			}
+			null = !null
+			run = n.runs[off]
+			off++
+		}
+		run--
+		if null {
+			b.Append(nil)
+			return nil
+		}
+		return values(b)
+	}, nil
+}

--- a/runtime/vcache/object.go
+++ b/runtime/vcache/object.go
@@ -1,0 +1,119 @@
+package vcache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zst"
+	"github.com/segmentio/ksuid"
+	"golang.org/x/sync/errgroup"
+)
+
+const MaxTypesPerObject = 2500
+
+// Object represents the collection of vectors that are loaded into
+// memory for a given data object as referenced by its ID.
+// An Object structure mirrors the metadata structures used in ZST but here
+// we support dynamic loading of vectors as they are needed and data and
+// metadata are all cached in memory.
+type Object struct {
+	id     ksuid.KSUID
+	uri    *storage.URI
+	engine storage.Engine
+	reader storage.Reader
+	// We keep a local context for each object since a new type context is created
+	// for each query and we need to map the ZST object context to the query
+	// context.  Of course, with Zed, this is very cheap.
+	local *zed.Context
+	// There is one vector per Zed type and the typeIDs array provides
+	// the sequence order of each vector to be accessed.  When
+	// ordering doesn't matter, the vectors can be traversed directly
+	// without an indirection through the typeIDs array.
+	vectors []Vector
+	types   []zed.Type
+	typeIDs []int32
+}
+
+// NewObject creates a new in-memory Object corresponding to a ZST object
+// residing in storage.  It loads the list of ZST root types (one per value
+// in the file) and the ZST metadata for vector reassembly.  This provides
+// the metadata needed to load vector chunks on demand only as they are
+// referenced.
+func NewObject(ctx context.Context, engine storage.Engine, uri *storage.URI, id ksuid.KSUID) (*Object, error) {
+	// XXX currently we open a storage.Reader for every object and never close it.
+	// We should either close after a timeout and reopen when needed or change the
+	// storage API to have a more reasonable semantics around the Put/Get not leaving
+	// a file descriptor open for every long Get.  Perhaps there should be another
+	// method for intermitted random access.
+	reader, err := engine.Get(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	zctx := zed.NewContext()
+	z, err := zst.NewObjectFromStorageReader(zctx, reader)
+	if err != nil {
+		return nil, err
+	}
+	typeIDs, metas, err := z.FetchMetaData()
+	if err != nil {
+		return nil, err
+	}
+	if len(metas) == 0 {
+		return nil, fmt.Errorf("empty ZST object: %s", uri)
+	}
+	if len(metas) > MaxTypesPerObject {
+		return nil, fmt.Errorf("too many types is ZST object: %s", uri)
+	}
+	types := make([]zed.Type, 0, len(metas))
+	for _, meta := range metas {
+		types = append(types, meta.Type(zctx))
+	}
+	var group errgroup.Group
+	group.SetLimit(-1)
+	vectors := make([]Vector, len(metas))
+	for k, meta := range metas {
+		which := k
+		this := meta
+		group.Go(func() error {
+			v, err := NewVector(this, reader)
+			if err != nil {
+				return err
+			}
+			vectors[which] = v
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return &Object{
+		id:      id,
+		uri:     uri,
+		engine:  engine,
+		reader:  reader,
+		local:   zctx,
+		vectors: vectors,
+		types:   types,
+		typeIDs: typeIDs,
+	}, nil
+}
+
+func (o *Object) Close() error {
+	if o.reader != nil {
+		return o.reader.Close()
+	}
+	return nil
+}
+
+func (o *Object) NewReader() *Reader {
+	return &Reader{
+		object: o,
+		iters:  make([]iterator, len(o.vectors)),
+	}
+}
+
+func (o *Object) NewProjection(fields []string) (*Projection, error) {
+	return NewProjection(o, fields)
+}

--- a/runtime/vcache/object.go
+++ b/runtime/vcache/object.go
@@ -56,7 +56,7 @@ func NewObject(ctx context.Context, engine storage.Engine, uri *storage.URI, id 
 	if err != nil {
 		return nil, err
 	}
-	typeIDs, metas, err := z.FetchMetaData()
+	typeIDs, metas, err := z.FetchMetadata()
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/vcache/primitive.go
+++ b/runtime/vcache/primitive.go
@@ -1,0 +1,46 @@
+package vcache
+
+import (
+	"io"
+
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zst/vector"
+)
+
+type Primitive struct {
+	meta  *vector.Primitive
+	bytes zcode.Bytes
+}
+
+func NewPrimitive(meta *vector.Primitive) (*Primitive, error) {
+	return &Primitive{meta: meta}, nil
+}
+
+func (p *Primitive) NewIter(r io.ReaderAt) (iterator, error) {
+	if p.bytes == nil {
+		// The ZST primitive columns are stored as one big
+		// list of Zed values.  So we can just read the data in
+		// all at once, compute the byte offsets of each value
+		// (for random access, not used yet).
+		var n int
+		for _, segment := range p.meta.Segmap {
+			n += int(segment.Length)
+		}
+		data := make([]byte, n)
+		off := 0
+		for _, segment := range p.meta.Segmap {
+			section := io.NewSectionReader(r, segment.Offset, int64(segment.Length))
+			if _, err := io.ReadFull(section, data[off:off+int(segment.Length)]); err != nil {
+				return nil, err
+
+			}
+			off += int(segment.Length)
+		}
+		p.bytes = data
+	}
+	it := zcode.Iter(p.bytes)
+	return func(b *zcode.Builder) error {
+		b.Append(it.Next())
+		return nil
+	}, nil
+}

--- a/runtime/vcache/projection.go
+++ b/runtime/vcache/projection.go
@@ -1,0 +1,134 @@
+package vcache
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zio"
+	"golang.org/x/sync/errgroup"
+)
+
+type Projection struct {
+	object  *Object
+	cuts    []*cut
+	off     int
+	builder zcode.Builder
+}
+
+type cut struct {
+	it  iterator
+	typ zed.Type
+}
+
+var _ zio.Reader = (*Projection)(nil)
+
+func NewProjection(o *Object, names []string) (*Projection, error) {
+	cuts, err := findCuts(o, names)
+	if err != nil {
+		return nil, err
+	}
+	return &Projection{
+		object: o,
+		cuts:   cuts,
+	}, nil
+}
+
+func (p *Projection) Read() (*zed.Value, error) {
+	o := p.object
+	var c *cut
+	for c == nil {
+		if p.off >= len(o.typeIDs) {
+			return nil, nil
+		}
+		id := o.typeIDs[p.off]
+		p.off++
+		c = p.cuts[id]
+	}
+	p.builder.Reset()
+	if err := c.it(&p.builder); err != nil {
+		return nil, err
+	}
+	return zed.NewValue(c.typ, p.builder.Bytes().Body()), nil
+}
+
+func findCuts(o *Object, names []string) ([]*cut, error) {
+	var dirty bool
+	cuts := make([]*cut, len(o.types))
+	var group errgroup.Group
+	group.SetLimit(-1)
+	// Loop through each type to determine if there is a cut and build
+	// a cut for that type.  The creation of all the iterators is done
+	// in parallel to avoid synchronous round trips to storage.
+	for k, typ := range o.types {
+		recType := zed.TypeRecordOf(typ)
+		if recType == nil {
+			continue
+		}
+		fields := Under(o.vectors[k]).(Record)
+		var actuals []string
+		for _, name := range names {
+			if _, ok := recType.ColumnOfField(name); !ok {
+				continue
+			}
+			actuals = append(actuals, name)
+		}
+		if len(actuals) == 0 {
+			continue
+		}
+		dirty = true
+		whichCut := k
+		group.Go(func() error {
+			c, err := newCut(o.local, recType, fields, actuals, o.reader)
+			cuts[whichCut] = c
+			return err
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	if !dirty {
+		return nil, fmt.Errorf("none of the specified fields were found: %s", strings.Join(names, ", "))
+	}
+	return cuts, nil
+}
+
+func newCut(zctx *zed.Context, typ *zed.TypeRecord, fields []Vector, actuals []string, reader storage.Reader) (*cut, error) {
+	var group errgroup.Group
+	group.SetLimit(-1)
+	iters := make([]iterator, len(actuals))
+	columns := make([]zed.Column, len(actuals))
+	for k, name := range actuals {
+		col, _ := typ.ColumnOfField(name)
+		columns[k] = typ.Columns[col]
+		which := k
+		group.Go(func() error {
+			it, err := fields[col].NewIter(reader)
+			if err != nil {
+				return err
+			}
+			iters[which] = it
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	outType, err := zctx.LookupTypeRecord(columns)
+	if err != nil {
+		return nil, err
+	}
+	project := func(b *zcode.Builder) error {
+		b.BeginContainer()
+		for _, it := range iters {
+			if err := it(b); err != nil {
+				return err
+			}
+		}
+		b.EndContainer()
+		return nil
+	}
+	return &cut{it: project, typ: outType}, nil
+}

--- a/runtime/vcache/reader.go
+++ b/runtime/vcache/reader.go
@@ -1,0 +1,39 @@
+package vcache
+
+import (
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zio"
+)
+
+type Reader struct {
+	object  *Object
+	iters   []iterator
+	off     int
+	builder zcode.Builder
+}
+
+var _ zio.Reader = (*Reader)(nil)
+
+func (r *Reader) Read() (*zed.Value, error) {
+	o := r.object
+	if r.off >= len(o.typeIDs) {
+		return nil, nil
+	}
+	id := o.typeIDs[r.off]
+	r.off++
+	it := r.iters[id]
+	if it == nil {
+		var err error
+		it, err = o.vectors[id].NewIter(o.reader)
+		if err != nil {
+			return nil, err
+		}
+		r.iters[id] = it
+	}
+	r.builder.Reset()
+	if err := it(&r.builder); err != nil {
+		return nil, err
+	}
+	return zed.NewValue(o.types[id], r.builder.Bytes().Body()), nil
+}

--- a/runtime/vcache/record.go
+++ b/runtime/vcache/record.go
@@ -1,0 +1,54 @@
+package vcache
+
+import (
+	"io"
+
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zst/vector"
+	"golang.org/x/sync/errgroup"
+)
+
+type Record []Vector
+
+func NewRecord(fields []vector.Field, r io.ReaderAt) (Record, error) {
+	record := make([]Vector, 0, len(fields))
+	for _, field := range fields {
+		v, err := NewVector(field.Values, r)
+		if err != nil {
+			return nil, err
+		}
+		record = append(record, v)
+	}
+	return record, nil
+}
+
+func (r Record) NewIter(reader io.ReaderAt) (iterator, error) {
+	fields := make([]iterator, len(r))
+	var group errgroup.Group
+	group.SetLimit(-1)
+	for k, f := range r {
+		which := k
+		field := f
+		group.Go(func() error {
+			it, err := field.NewIter(reader)
+			if err != nil {
+				return err
+			}
+			fields[which] = it
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return func(b *zcode.Builder) error {
+		b.BeginContainer()
+		for _, it := range fields {
+			if err := it(b); err != nil {
+				return err
+			}
+		}
+		b.EndContainer()
+		return nil
+	}, nil
+}

--- a/runtime/vcache/union.go
+++ b/runtime/vcache/union.go
@@ -1,0 +1,76 @@
+package vcache
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zst"
+	"github.com/brimdata/zed/zst/vector"
+	"golang.org/x/sync/errgroup"
+)
+
+type Union struct {
+	values []Vector
+	tags   []int32
+	segmap []vector.Segment
+}
+
+func NewUnion(union *vector.Union, r io.ReaderAt) (*Union, error) {
+	values := make([]Vector, 0, len(union.Values))
+	for _, val := range union.Values {
+		v, err := NewVector(val, r)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, v)
+	}
+	return &Union{
+		values: values,
+		segmap: union.Tags,
+	}, nil
+}
+
+func (u *Union) NewIter(reader io.ReaderAt) (iterator, error) {
+	if u.tags == nil {
+		tags, err := zst.ReadIntVector(u.segmap, reader)
+		if err != nil {
+			return nil, err
+		}
+		u.tags = tags
+	}
+	var group errgroup.Group
+	group.SetLimit(-1)
+	iters := make([]iterator, len(u.values))
+	for k, v := range u.values {
+		which := k
+		vals := v
+		group.Go(func() error {
+			it, err := vals.NewIter(reader)
+			if err != nil {
+				return err
+			}
+			iters[which] = it
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	off := 0
+	return func(b *zcode.Builder) error {
+		tag := u.tags[off]
+		off++
+		if tag < 0 || int(tag) >= len(iters) {
+			return fmt.Errorf("zst cache: bad union tag encountered %d of %d", tag, len(iters))
+		}
+		b.BeginContainer()
+		b.Append(zed.EncodeInt(int64(tag)))
+		if err := iters[tag](b); err != nil {
+			return err
+		}
+		b.EndContainer()
+		return nil
+	}, nil
+}

--- a/runtime/vcache/vector.go
+++ b/runtime/vcache/vector.go
@@ -1,0 +1,59 @@
+package vcache
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/brimdata/zed/zcode"
+	"github.com/brimdata/zed/zst/vector"
+)
+
+type iterator func(*zcode.Builder) error
+
+// Vector is the primary interface to in-memory sequences of Zed values
+// representing the ZST vector format.  As we implement additional optimizations
+// and various forms of pushdown, we will enhance this interface with
+// corresponding methods.
+type Vector interface {
+	NewIter(io.ReaderAt) (iterator, error)
+}
+
+// NewVector converts a ZST metadata reader to its equivalent vector cache
+// metadata manager.
+func NewVector(meta vector.Metadata, r io.ReaderAt) (Vector, error) {
+	switch meta := meta.(type) {
+	case *vector.Named:
+		return NewVector(meta.Values, r)
+	case *vector.Record:
+		return NewRecord(meta.Fields, r)
+	case *vector.Primitive:
+		return NewPrimitive(meta)
+	case *vector.Array:
+		return NewArray(meta, r)
+	case *vector.Set:
+		a := *(*vector.Array)(meta)
+		return NewArray(&a, r)
+	case *vector.Map:
+		return NewMap(meta, r)
+	case *vector.Union:
+		return NewUnion(meta, r)
+	case *vector.Nulls:
+		values, err := NewVector(meta.Values, r)
+		if err != nil {
+			return nil, err
+		}
+		return NewNulls(meta, values, r)
+	default:
+		return nil, fmt.Errorf("vector cache: type %T not supported", meta)
+	}
+}
+
+func Under(v Vector) Vector {
+	for {
+		if nulls, ok := v.(*Nulls); ok {
+			v = nulls.values
+			continue
+		}
+		return v
+	}
+}

--- a/runtime/vcache/ztests/array-copy.yaml
+++ b/runtime/vcache/ztests/array-copy.yaml
@@ -1,0 +1,16 @@
+# This test simply converts some ZSON to ZST then runs it through 
+# the vector cache to exercise the logic that builds values from 
+# cached vectors.
+script: |
+  zq -f zst -o test.zst -
+  zed dev vcache copy -z test.zst
+
+inputs:
+  - name: stdin
+    data: &input |
+      {a:[1,2]}
+      {a:[3]}
+
+outputs:
+  - name: stdout
+    data: *input

--- a/runtime/vcache/ztests/map-copy.yaml
+++ b/runtime/vcache/ztests/map-copy.yaml
@@ -1,0 +1,19 @@
+# This test simply converts some ZSON to ZST then runs it through 
+# the vector cache to exercise the logic that builds values from 
+# cached vectors.
+script: |
+  zq -f zst -o test.zst -
+  zed dev vcache copy -z test.zst
+
+inputs:
+  - name: stdin
+    data: &input |
+      {m:|{"foo":"bar","hello":"goodby"}|}
+      {m:|{"foo":"bar2","hello2":"goodby"}|}
+      {m:|{1:"goodbye","foo":null(string)}|}
+      {m:null(|{int64:string}|)}
+      {m:|{2:"goodbye","bar":null(string)}|}
+
+outputs:
+  - name: stdout
+    data: *input

--- a/runtime/vcache/ztests/named-copy.yaml
+++ b/runtime/vcache/ztests/named-copy.yaml
@@ -1,0 +1,14 @@
+script: |
+  zq -f zst -o test.zst -
+  zed dev vcache copy -z test.zst
+
+inputs:
+  - name: stdin
+    data: &input |
+      {x:1,y:4}(=foo)
+      {x:2,y:3}(=foo)
+      {x:3,y:2}(=foo)
+
+outputs:
+  - name: stdout
+    data: *input

--- a/runtime/vcache/ztests/projection.yaml
+++ b/runtime/vcache/ztests/projection.yaml
@@ -1,0 +1,42 @@
+script: |
+  zq -f zst -o test.zst -
+  zed dev vcache project -z test.zst x y z
+  echo ===
+  zed dev vcache project -z test.zst s
+  echo ===
+  zed dev vcache project -z test.zst x s
+  echo ===
+  zed dev vcache project -z test.zst s x
+
+inputs:
+  - name: stdin
+    data: |
+      {x:1,y:2,s:"foo"}
+      {x:3,y:4}
+      {x:3,y:4,s:"bar"}
+      {x:3,y:4}
+      {s:"baz"}
+
+outputs:
+  - name: stdout
+    data: |
+      {x:1,y:2}
+      {x:3,y:4}
+      {x:3,y:4}
+      {x:3,y:4}
+      ===
+      {s:"foo"}
+      {s:"bar"}
+      {s:"baz"}
+      ===
+      {x:1,s:"foo"}
+      {x:3}
+      {x:3,s:"bar"}
+      {x:3}
+      {s:"baz"}
+      ===
+      {s:"foo",x:1}
+      {x:3}
+      {s:"bar",x:3}
+      {x:3}
+      {s:"baz"}

--- a/runtime/vcache/ztests/record-copy.yaml
+++ b/runtime/vcache/ztests/record-copy.yaml
@@ -1,0 +1,17 @@
+# This test simply converts some ZSON to ZST then runs it through 
+# the vector cache to exercise the logic that builds values from 
+# cached vectors.
+script: |
+  zq -f zst -o test.zst -
+  zed dev vcache copy -z test.zst
+
+inputs:
+  - name: stdin
+    data: &input |
+      {x:1,y:4}
+      {x:2,y:3}
+      {x:3,y:2}
+
+outputs:
+  - name: stdout
+    data: *input

--- a/runtime/vcache/ztests/set-copy.yaml
+++ b/runtime/vcache/ztests/set-copy.yaml
@@ -1,0 +1,16 @@
+# This test simply converts some ZSON to ZST then runs it through 
+# the vector cache to exercise the logic that builds values from 
+# cached vectors.
+script: |
+  zq -f zst -o test.zst -
+  zed dev vcache copy -z test.zst
+
+inputs:
+  - name: stdin
+    data: &input |
+      {a:|[1,2]|}
+      {a:|[3]|}
+
+outputs:
+  - name: stdout
+    data: *input

--- a/runtime/vcache/ztests/union-copy.yaml
+++ b/runtime/vcache/ztests/union-copy.yaml
@@ -1,0 +1,16 @@
+# This test simply converts some ZSON to ZST then runs it through 
+# the vector cache to exercise the logic that builds values from 
+# cached vectors.
+script: |
+  zq -f zst -o test.zst -
+  zed dev vcache copy -z test.zst
+
+inputs:
+  - name: stdin
+    data: &input |
+      1((int64,string))
+      "foo"((int64,string))
+
+outputs:
+  - name: stdout
+    data: *input

--- a/zst/object.go
+++ b/zst/object.go
@@ -105,7 +105,7 @@ func (o *Object) IsEmpty() bool {
 	return o.sections == nil
 }
 
-func (o *Object) FetchMetaData() ([]int32, []vector.Metadata, error) {
+func (o *Object) FetchMetadata() ([]int32, []vector.Metadata, error) {
 	typeIDs, err := ReadIntVector(o.root, o.readerAt)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This commit provides the first most basic implementation of the vector cache for ZST objects.  The new "zed dev vcache" command is added to support some ztests for exercising the cache.  It is not yet wired into the query planner.

Currently, this code represents the "slow path" of the vector cache, which supports only simple projections of ZNG-seralized values.

An object is loaded into the cache by reading the ZST metadata and building a hierarchical data structure of the Zed types implemented in package vcache.  Each of the types implements the vcache.Vector interface.  Currently, the only method on Vector is NewIter() to create an iterator to enumerate the values represented by each vector. In future PRs, we will introduce many more methods on this inteface to push down searches, boolean logic, aggregate functions, and so forth. We will also introduce Go-native vectors at some point too so that the zcode deserialization does not have to be done when pushing down operations.

Vector data is not loaded into the cache until it is referenced.  This way a pattern of queries that operates on a limited set of fields will only load the needed fields into the cache.  The loading happens on demand right now when an iterator is created and care has been taken to perform all the vector loads from storage in parallel as to avoid sequential round-trips to slower storage layers like S3.

There is also a simple implementation of top-level field projections. In this case, a projection can be created from a list of top-level fields. This differs from the cut operator a bit as error("missing") are omitted, which should be okay for how we plan to wire this into the planner. Also, projections of dotted field references are not yet supported.

Currently, each object leaves its file open forever and memory is never freed from the cache.  In subsequent PRs, we will add a mechanism to age and close the files as well as LRU replacement policy to the cache with some sort of memory limit.