### PR TITLE
enable "go vet" unkeyed composite literals analyzer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 #PEG_DEP=peg
 
 vet:
-	@go vet -composites=false -stdmethods=false ./...
+	@go vet -stdmethods=false ./...
 
 fmt:
 	gofmt -s -w .

--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -321,7 +321,7 @@ func (c *Connection) Query(ctx context.Context, head *lakeparse.Commitish, src s
 
 func (c *Connection) Compact(ctx context.Context, poolID ksuid.KSUID, branchName string, objects []ksuid.KSUID, message api.CommitMessage) (api.CommitResponse, error) {
 	path := urlPath("pool", poolID.String(), "branch", branchName, "compact")
-	req := c.NewRequest(ctx, http.MethodPost, path, api.CompactRequest{objects})
+	req := c.NewRequest(ctx, http.MethodPost, path, api.CompactRequest{ObjectIDs: objects})
 	if err := encodeCommitMessage(req, message); err != nil {
 		return api.CommitResponse{}, err
 	}

--- a/api/queryio/client.go
+++ b/api/queryio/client.go
@@ -54,11 +54,11 @@ func (q *Query) Read() (*zed.Value, error) {
 func controlToError(ctrl interface{}) error {
 	switch ctrl := ctrl.(type) {
 	case *api.QueryChannelSet:
-		return &zbuf.Control{zbuf.SetChannel(ctrl.ChannelID)}
+		return &zbuf.Control{Message: zbuf.SetChannel(ctrl.ChannelID)}
 	case *api.QueryChannelEnd:
-		return &zbuf.Control{zbuf.EndChannel(ctrl.ChannelID)}
+		return &zbuf.Control{Message: zbuf.EndChannel(ctrl.ChannelID)}
 	case *api.QueryStats:
-		return &zbuf.Control{zbuf.Progress(ctrl.Progress)}
+		return &zbuf.Control{Message: zbuf.Progress(ctrl.Progress)}
 	case *api.QueryError:
 		return errors.New(ctrl.Error)
 	default:

--- a/api/queryio/writer.go
+++ b/api/queryio/writer.go
@@ -52,7 +52,7 @@ func NewWriter(w io.WriteCloser, format string, flusher http.Flusher, ctrl bool)
 func (w *Writer) WriteBatch(cid int, batch zbuf.Batch) error {
 	if w.cid != cid {
 		w.cid = cid
-		if err := w.WriteControl(api.QueryChannelSet{cid}); err != nil {
+		if err := w.WriteControl(api.QueryChannelSet{ChannelID: cid}); err != nil {
 			return err
 		}
 	}
@@ -61,7 +61,7 @@ func (w *Writer) WriteBatch(cid int, batch zbuf.Batch) error {
 }
 
 func (w *Writer) WhiteChannelEnd(channelID int) error {
-	return w.WriteControl(api.QueryChannelEnd{channelID})
+	return w.WriteControl(api.QueryChannelEnd{ChannelID: channelID})
 }
 
 func (w *Writer) WriteProgress(stats zbuf.Progress) error {
@@ -74,7 +74,7 @@ func (w *Writer) WriteProgress(stats zbuf.Progress) error {
 }
 
 func (w *Writer) WriteError(err error) {
-	w.WriteControl(api.QueryError{err.Error()})
+	w.WriteControl(api.QueryError{Error: err.Error()})
 }
 
 func (w *Writer) WriteControl(value interface{}) error {

--- a/api/queryio/zjson_test.go
+++ b/api/queryio/zjson_test.go
@@ -30,13 +30,13 @@ func TestZJSONWriter(t *testing.T) {
 `
 	var buf bytes.Buffer
 	w := queryio.NewZJSONWriter(&buf)
-	err := w.WriteControl(api.QueryChannelSet{1})
+	err := w.WriteControl(api.QueryChannelSet{ChannelID: 1})
 	require.NoError(t, err)
 	err = w.Write(mkRecord(t, record))
 	require.NoError(t, err)
-	err = w.WriteControl(api.QueryChannelEnd{1})
+	err = w.WriteControl(api.QueryChannelEnd{ChannelID: 1})
 	require.NoError(t, err)
-	err = w.WriteControl(api.QueryError{"test.err"})
+	err = w.WriteControl(api.QueryError{Error: "test.err"})
 	require.NoError(t, err)
 	assert.Equal(t, expected, "\n"+buf.String())
 }

--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -279,7 +279,7 @@ func (b *Builder) compileAssignment(node *dag.Assignment) (expr.Assignment, erro
 	if err != nil {
 		return expr.Assignment{}, fmt.Errorf("rhs of assigment expression: %w", err)
 	}
-	return expr.Assignment{lhs, rhs}, err
+	return expr.Assignment{LHS: lhs, RHS: rhs}, err
 }
 
 func shaperOps(name string) expr.ShaperTransform {
@@ -461,7 +461,7 @@ func (b *Builder) compileMapExpr(m *dag.MapExpr) (expr.Evaluator, error) {
 		if err != nil {
 			return nil, err
 		}
-		entries = append(entries, expr.Entry{key, val})
+		entries = append(entries, expr.Entry{Key: key, Val: val})
 	}
 	return expr.NewMapExpr(b.zctx(), entries), nil
 }

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -592,8 +592,8 @@ func (b *Builder) compileTrunk(trunk *dag.Trunk, parent zbuf.Puller) ([]zbuf.Pul
 }
 
 func (b *Builder) compileRange(src dag.Source, exprLower, exprUpper dag.Expr) (extent.Span, error) {
-	lower := &zed.Value{zed.TypeNull, nil}
-	upper := &zed.Value{zed.TypeNull, nil}
+	lower := zed.Null
+	upper := zed.Null
 	if exprLower != nil {
 		var err error
 		lower, err = b.evalAtCompileTime(exprLower)

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -78,7 +78,7 @@ func addRangeToPushdown(trunk *dag.Trunk, key field.Path) {
 		return
 	}
 	if trunk.Pushdown == nil {
-		trunk.Pushdown = &dag.Filter{"Filter", rangeExpr}
+		trunk.Pushdown = &dag.Filter{Kind: "Filter", Expr: rangeExpr}
 		return
 	}
 	filter := trunk.Pushdown.(*dag.Filter)
@@ -90,7 +90,7 @@ func convertRangeScan(source dag.Source, key field.Path) dag.Expr {
 	if !ok {
 		return nil
 	}
-	this := &dag.This{"This", key}
+	this := &dag.This{Kind: "This", Path: key}
 	var lower, upper dag.Expr
 	if p.ScanLower != nil {
 		lower = dag.NewBinaryExpr(">=", this, p.ScanLower)

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -218,7 +218,7 @@ func semExpr(scope *Scope, e ast.Expr) (dag.Expr, error) {
 			if err != nil {
 				return nil, err
 			}
-			entries = append(entries, dag.Entry{key, val})
+			entries = append(entries, dag.Entry{Key: key, Value: val})
 		}
 		return &dag.MapExpr{
 			Kind:    "MapExpr",
@@ -515,11 +515,11 @@ func semAssignment(scope *Scope, a ast.Assignment, summarize bool) (dag.Assignme
 				}
 			}
 		}
-		lhs = &dag.This{"This", path}
+		lhs = &dag.This{Kind: "This", Path: path}
 	} else if agg, ok := a.RHS.(*ast.Agg); ok {
-		lhs = &dag.This{"This", []string{agg.Name}}
+		lhs = &dag.This{Kind: "This", Path: []string{agg.Name}}
 	} else if v, ok := rhs.(*dag.Var); ok {
-		lhs = &dag.This{"This", []string{v.Name}}
+		lhs = &dag.This{Kind: "This", Path: []string{v.Name}}
 	} else {
 		lhs, err = semExpr(scope, a.RHS)
 		if err != nil {
@@ -544,7 +544,7 @@ func semAssignment(scope *Scope, a ast.Assignment, summarize bool) (dag.Assignme
 	if len(this.Path) == 0 {
 		return dag.Assignment{}, errors.New("cannot assign to 'this'")
 	}
-	return dag.Assignment{"Assignment", lhs, rhs}, nil
+	return dag.Assignment{Kind: "Assignment", LHS: lhs, RHS: rhs}, nil
 }
 
 func semFields(scope *Scope, exprs []ast.Expr) ([]dag.Expr, error) {

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -386,7 +386,7 @@ func semOp(ctx context.Context, scope *Scope, o ast.Op, ds *data.Source, head *l
 			Cases: cases,
 		}, nil
 	case *ast.Shape:
-		return &dag.Shape{"Shape"}, nil
+		return &dag.Shape{Kind: "Shape"}, nil
 	case *ast.Cut:
 		assignments, err := semAssignments(scope, o.Args, false)
 		if err != nil {
@@ -443,7 +443,7 @@ func semOp(ctx context.Context, scope *Scope, o ast.Op, ds *data.Source, head *l
 			Cflag: o.Cflag,
 		}, nil
 	case *ast.Pass:
-		return &dag.Pass{"Pass"}, nil
+		return &dag.Pass{Kind: "Pass"}, nil
 	case *ast.OpExpr:
 		return semOpExpr(scope, o.Expr)
 	case *ast.Search:
@@ -510,14 +510,14 @@ func semOp(ctx context.Context, scope *Scope, o ast.Op, ds *data.Source, head *l
 					return nil, fmt.Errorf("cannot rename %s to %s (differ in %s vs %s)", src, dst, src.Path[i], dst.Path[i])
 				}
 			}
-			assignments = append(assignments, dag.Assignment{"Assignment", dst, src})
+			assignments = append(assignments, dag.Assignment{Kind: "Assignment", LHS: dst, RHS: src})
 		}
 		return &dag.Rename{
 			Kind: "Rename",
 			Args: assignments,
 		}, nil
 	case *ast.Fuse:
-		return &dag.Fuse{"Fuse"}, nil
+		return &dag.Fuse{Kind: "Fuse"}, nil
 	case *ast.Join:
 		leftKey, err := semExpr(scope, o.LeftKey)
 		if err != nil {
@@ -769,7 +769,7 @@ func semCallOp(scope *Scope, call *ast.Call) (dag.Op, error) {
 			Aggs: []dag.Assignment{
 				{
 					Kind: "Assignment",
-					LHS:  &dag.This{"This", field.New(call.Name)},
+					LHS:  &dag.This{Kind: "This", Path: field.New(call.Name)},
 					RHS:  agg,
 				},
 			},

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -113,7 +113,7 @@ func convertSQLOp(scope *Scope, sql *ast.SQLExpr) (dag.Op, error) {
 		ops = append(ops, p)
 	}
 	if len(ops) == 0 {
-		ops = []dag.Op{&dag.Pass{"Pass"}}
+		ops = []dag.Op{&dag.Pass{Kind: "Pass"}}
 	}
 	return wrap(ops), nil
 }
@@ -314,8 +314,8 @@ func convertSQLJoin(scope *Scope, leftPath []dag.Op, sqlJoin ast.SQLJoin) ([]dag
 	}
 	alias := dag.Assignment{
 		Kind: "Assignment",
-		LHS:  &dag.This{"This", field.New(aliasID)},
-		RHS:  &dag.This{"This", field.New(aliasID)},
+		LHS:  &dag.This{Kind: "This", Path: field.New(aliasID)},
+		RHS:  &dag.This{Kind: "This", Path: field.New(aliasID)},
 	}
 	join := &dag.Join{
 		Kind:     "Join",

--- a/index/writer.go
+++ b/index/writer.go
@@ -344,9 +344,9 @@ func (w *indexWriter) addToParentIndex(key *zed.Value, offset int64) error {
 }
 
 func (w *indexWriter) writeIndexRecord(keys *zed.Value, offset int64) error {
-	col := []zed.Column{{w.base.childField, zed.TypeInt64}}
+	col := []zed.Column{{Name: w.base.childField, Type: zed.TypeInt64}}
 	val := zed.EncodeInt(offset)
-	rec, err := w.base.zctx.AddColumns(keys, col, []zed.Value{{zed.TypeInt64, val}})
+	rec, err := w.base.zctx.AddColumns(keys, col, []zed.Value{{Type: zed.TypeInt64, Bytes: val}})
 	if err != nil {
 		return err
 	}

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -101,7 +101,7 @@ func loadMessage(objects []data.Object) string {
 
 func loadMeta(zctx *zed.Context, meta string) (*zed.Value, error) {
 	if meta == "" {
-		return &zed.Value{zed.TypeNull, nil}, nil
+		return zed.Null, nil
 	}
 	zv, err := zson.ParseValue(zed.NewContext(), meta)
 	if err != nil {
@@ -286,7 +286,7 @@ func (b *Branch) buildMergeObject(ctx context.Context, parent *branches.Config, 
 	if err != nil {
 		return nil, fmt.Errorf("error merging %q into %q: %w", b.Name, parent.Name, err)
 	}
-	return diff.NewCommitObject(parent.Commit, retries, author, message, zed.Value{zed.TypeNull, nil}), nil
+	return diff.NewCommitObject(parent.Commit, retries, author, message, *zed.Null), nil
 }
 
 func commonAncestor(a, b []ksuid.KSUID) ksuid.KSUID {

--- a/lake/commits/object.go
+++ b/lake/commits/object.go
@@ -49,7 +49,7 @@ func NewAddsObject(parent ksuid.KSUID, retries int, author, message string, meta
 }
 
 func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, ids []ksuid.KSUID) *Object {
-	o := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
+	o := NewObject(parent, author, message, *zed.Null, retries)
 	for _, id := range ids {
 		o.appendDelete(id)
 	}
@@ -57,7 +57,7 @@ func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, i
 }
 
 func NewAddIndexesObject(parent ksuid.KSUID, author, message string, retries int, indexes []*index.Object) *Object {
-	o := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
+	o := NewObject(parent, author, message, *zed.Null, retries)
 	for _, index := range indexes {
 		o.appendAddIndex(index)
 	}
@@ -65,7 +65,7 @@ func NewAddIndexesObject(parent ksuid.KSUID, author, message string, retries int
 }
 
 func NewAddVectorsObject(parent ksuid.KSUID, author, message string, ids []ksuid.KSUID, retries int) *Object {
-	o := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
+	o := NewObject(parent, author, message, *zed.Null, retries)
 	for _, id := range ids {
 		o.appendAddVector(id)
 	}
@@ -73,7 +73,7 @@ func NewAddVectorsObject(parent ksuid.KSUID, author, message string, ids []ksuid
 }
 
 func NewDeleteVectorsObject(parent ksuid.KSUID, author, message string, ids []ksuid.KSUID, retries int) *Object {
-	o := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
+	o := NewObject(parent, author, message, *zed.Null, retries)
 	for _, id := range ids {
 		o.appendDeleteVector(id)
 	}

--- a/lake/commits/patch.go
+++ b/lake/commits/patch.go
@@ -185,7 +185,7 @@ func (p *Patch) NewCommitObject(parent ksuid.KSUID, retries int, author, message
 }
 
 func (p *Patch) Revert(tip *Snapshot, commit, parent ksuid.KSUID, retries int, author, message string) (*Object, error) {
-	object := NewObject(parent, author, message, zed.Value{zed.TypeNull, nil}, retries)
+	object := NewObject(parent, author, message, *zed.Null, retries)
 	// For each data object that is added in the patch and is also in the tip, we do a delete.
 	for _, dataObject := range p.diff.SelectAll() {
 		if Exists(tip, dataObject.ID) {

--- a/lake/seekindex/writer.go
+++ b/lake/seekindex/writer.go
@@ -36,9 +36,9 @@ func (w *Writer) Write(key zed.Value, count uint64, offset int64) error {
 	b.Append(zed.EncodeInt(offset))
 	if w.typ != key.Type {
 		var schema = []zed.Column{
-			{"key", key.Type},
-			{"count", zed.TypeUint64},
-			{"offset", zed.TypeInt64},
+			{Name: "key", Type: key.Type},
+			{Name: "count", Type: zed.TypeUint64},
+			{Name: "offset", Type: zed.TypeInt64},
 		}
 		w.recType = w.zctx.MustLookupTypeRecord(schema)
 		w.typ = key.Type

--- a/runtime/expr/agg/collect.go
+++ b/runtime/expr/agg/collect.go
@@ -23,7 +23,7 @@ func (c *Collect) Consume(val *zed.Value) {
 }
 
 func (c *Collect) update(val *zed.Value) {
-	c.values = append(c.values, zed.Value{val.Type, slices.Clone(val.Bytes)})
+	c.values = append(c.values, zed.Value{Type: val.Type, Bytes: slices.Clone(val.Bytes)})
 	c.size += len(val.Bytes)
 	for c.size > MaxValueSize {
 		// XXX See issue #1813.  For now we silently discard entries

--- a/runtime/expr/agg/math.go
+++ b/runtime/expr/agg/math.go
@@ -34,7 +34,7 @@ func (m *mathReducer) Result(zctx *zed.Context) *zed.Value {
 		if m.math == nil {
 			return zed.Null
 		}
-		return &zed.Value{Type: m.math.typ()}
+		return zed.NewValue(m.math.typ(), nil)
 	}
 	return m.math.result()
 }

--- a/runtime/expr/cutter.go
+++ b/runtime/expr/cutter.go
@@ -92,7 +92,7 @@ func (c *Cutter) Eval(ectx Context, in *zed.Value) *zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	rec := &zed.Value{c.lookupTypeRecord(types), bytes}
+	rec := zed.NewValue(c.lookupTypeRecord(types), bytes)
 	for _, d := range droppers {
 		rec = d.Eval(ectx, rec)
 	}

--- a/runtime/expr/dot.go
+++ b/runtime/expr/dot.go
@@ -49,7 +49,7 @@ func ValueUnder(val *zed.Value) *zed.Value {
 		typ = zed.TypeUnder(typ)
 		union, ok := typ.(*zed.TypeUnion)
 		if !ok {
-			return &zed.Value{typ, bytes}
+			return zed.NewValue(typ, bytes)
 		}
 		typ, bytes = union.Untag(bytes)
 	}

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -239,7 +239,7 @@ func newNumeric(lhs, rhs Evaluator) numeric {
 func enumify(val *zed.Value) *zed.Value {
 	// automatically convert an enum to its index value when coercing
 	if _, ok := val.Type.(*zed.TypeEnum); ok {
-		return &zed.Value{zed.TypeUint64, val.Bytes}
+		return zed.NewValue(zed.TypeUint64, val.Bytes)
 	}
 	return val
 }

--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -43,40 +43,40 @@ func runZTest(t *testing.T, e string, zt *ztest.ZTest) {
 }
 
 func zbool(b bool) zed.Value {
-	return zed.Value{zed.TypeBool, zed.EncodeBool(b)}
+	return zed.Value{Type: zed.TypeBool, Bytes: zed.EncodeBool(b)}
 }
 
 func zint32(v int32) zed.Value {
-	return zed.Value{zed.TypeInt32, zed.EncodeInt(int64(v))}
+	return zed.Value{Type: zed.TypeInt32, Bytes: zed.EncodeInt(int64(v))}
 }
 
 func zint64(v int64) zed.Value {
-	return zed.Value{zed.TypeInt64, zed.EncodeInt(v)}
+	return zed.Value{Type: zed.TypeInt64, Bytes: zed.EncodeInt(v)}
 }
 
 func zuint64(v uint64) zed.Value {
-	return zed.Value{zed.TypeUint64, zed.EncodeUint(v)}
+	return zed.Value{Type: zed.TypeUint64, Bytes: zed.EncodeUint(v)}
 }
 
 func zfloat32(f float32) zed.Value {
-	return zed.Value{zed.TypeFloat32, zed.EncodeFloat32(f)}
+	return zed.Value{Type: zed.TypeFloat32, Bytes: zed.EncodeFloat32(f)}
 }
 
 func zfloat64(f float64) zed.Value {
-	return zed.Value{zed.TypeFloat64, zed.EncodeFloat64(f)}
+	return zed.Value{Type: zed.TypeFloat64, Bytes: zed.EncodeFloat64(f)}
 }
 
 func zstring(s string) zed.Value {
-	return zed.Value{zed.TypeString, zed.EncodeString(s)}
+	return zed.Value{Type: zed.TypeString, Bytes: zed.EncodeString(s)}
 }
 
 func zip(t *testing.T, s string) zed.Value {
-	return zed.Value{zed.TypeIP, zed.EncodeIP(netip.MustParseAddr(s))}
+	return zed.Value{Type: zed.TypeIP, Bytes: zed.EncodeIP(netip.MustParseAddr(s))}
 }
 func znet(t *testing.T, s string) zed.Value {
 	_, net, err := net.ParseCIDR(s)
 	require.NoError(t, err)
-	return zed.Value{zed.TypeNet, zed.EncodeNet(net)}
+	return zed.Value{Type: zed.TypeNet, Bytes: zed.EncodeNet(net)}
 }
 
 func TestPrimitives(t *testing.T) {
@@ -455,9 +455,9 @@ func TestArithmetic(t *testing.T) {
 			w = w2
 		}
 		if sign {
-			return zed.Value{signed(w), zed.AppendInt(nil, int64(v))}
+			return zed.Value{Type: signed(w), Bytes: zed.AppendInt(nil, int64(v))}
 		}
-		return zed.Value{unsigned(w), zed.AppendUint(nil, v)}
+		return zed.Value{Type: unsigned(w), Bytes: zed.AppendUint(nil, v)}
 	}
 
 	var intTypes = []string{"int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"}
@@ -534,7 +534,7 @@ func TestConditional(t *testing.T) {
 
 func TestCasts(t *testing.T) {
 	// Test casts to byte
-	testSuccessful(t, "uint8(10)", "", zed.Value{zed.TypeUint8, zed.EncodeUint(10)})
+	testSuccessful(t, "uint8(10)", "", zed.Value{Type: zed.TypeUint8, Bytes: zed.EncodeUint(10)})
 	testSuccessful(t, "uint8(-1)", "", ZSON(`error("cannot cast -1 to type uint8")`))
 	testSuccessful(t, "uint8(300)", "", ZSON(`error("cannot cast 300 to type uint8")`))
 	testSuccessful(t, `uint8("foo")`, "", ZSON(`error("cannot cast \"foo\" to type uint8")`))
@@ -546,19 +546,19 @@ func TestCasts(t *testing.T) {
 	testSuccessful(t, `int16("foo")`, "", ZSON(`error("cannot cast \"foo\" to type int16")`))
 
 	// Test casts to uint16
-	testSuccessful(t, "uint16(10)", "", zed.Value{zed.TypeUint16, zed.EncodeUint(10)})
+	testSuccessful(t, "uint16(10)", "", zed.Value{Type: zed.TypeUint16, Bytes: zed.EncodeUint(10)})
 	testSuccessful(t, "uint16(-1)", "", ZSON(`error("cannot cast -1 to type uint16")`))
 	testSuccessful(t, "uint16(66000)", "", ZSON(`error("cannot cast 66000 to type uint16")`))
 	testSuccessful(t, `uint16("foo")`, "", ZSON(`error("cannot cast \"foo\" to type uint16")`))
 
 	// Test casts to int32
-	testSuccessful(t, "int32(10)", "", zed.Value{zed.TypeInt32, zed.EncodeInt(10)})
+	testSuccessful(t, "int32(10)", "", zed.Value{Type: zed.TypeInt32, Bytes: zed.EncodeInt(10)})
 	testSuccessful(t, "int32(-2200000000)", "", ZSON(`error("cannot cast -2200000000 to type int32")`))
 	testSuccessful(t, "int32(2200000000)", "", ZSON(`error("cannot cast 2200000000 to type int32")`))
 	testSuccessful(t, `int32("foo")`, "", ZSON(`error("cannot cast \"foo\" to type int32")`))
 
 	// Test casts to uint32
-	testSuccessful(t, "uint32(10)", "", zed.Value{zed.TypeUint32, zed.EncodeUint(10)})
+	testSuccessful(t, "uint32(10)", "", zed.Value{Type: zed.TypeUint32, Bytes: zed.EncodeUint(10)})
 	testSuccessful(t, "uint32(-1)", "", ZSON(`error("cannot cast -1 to type uint32")`))
 	testSuccessful(t, "uint32(4300000000)", "", ZSON(`error("cannot cast 4300000000 to type uint32")`))
 	testSuccessful(t, `uint32("foo")`, "", ZSON(`error("cannot cast \"foo\" to type uint32")`))

--- a/runtime/expr/function/ip.go
+++ b/runtime/expr/function/ip.go
@@ -55,7 +55,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	}
 	// XXX GC
 	netIP := net.IP(ip.AsSlice()).Mask(mask)
-	v := &net.IPNet{netIP, mask}
+	v := &net.IPNet{IP: netIP, Mask: mask}
 	return ctx.NewValue(zed.TypeNet, zed.EncodeNet(v))
 }
 

--- a/runtime/expr/functions_test.go
+++ b/runtime/expr/functions_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func zaddr(addr string) zed.Value {
-	return zed.Value{zed.TypeIP, zed.EncodeIP(netip.MustParseAddr(addr))}
+	return zed.Value{Type: zed.TypeIP, Bytes: zed.EncodeIP(netip.MustParseAddr(addr))}
 }
 
 func TestBadFunction(t *testing.T) {

--- a/runtime/expr/putter.go
+++ b/runtime/expr/putter.go
@@ -214,19 +214,19 @@ func (p *Putter) deriveRecordSteps(parentPath field.Path, inCols []zed.Column, v
 				container: zed.IsContainerType(vals[matchIndex].Type),
 				index:     matchIndex,
 			})
-			cols = append(cols, zed.Column{inCol.Name, vals[matchIndex].Type})
+			cols = append(cols, zed.Column{Name: inCol.Name, Type: vals[matchIndex].Type})
 		// input record field overwritten by nested assignment: recurse.
 		case len(path) < len(matchPath) && zed.IsRecordType(inCol.Type):
 			nestedStep, typ := p.deriveRecordSteps(path, zed.TypeRecordOf(inCol.Type).Columns, vals, clauses)
 			nestedStep.index = i
 			s.append(nestedStep)
-			cols = append(cols, zed.Column{inCol.Name, typ})
+			cols = append(cols, zed.Column{Name: inCol.Name, Type: typ})
 		// input non-record field overwritten by nested assignment(s): recurse.
 		case len(path) < len(matchPath) && !zed.IsRecordType(inCol.Type):
 			nestedStep, typ := p.deriveRecordSteps(path, []zed.Column{}, vals, clauses)
 			nestedStep.index = i
 			s.append(nestedStep)
-			cols = append(cols, zed.Column{inCol.Name, typ})
+			cols = append(cols, zed.Column{Name: inCol.Name, Type: typ})
 		default:
 			panic("put: internal error computing record steps")
 		}
@@ -249,13 +249,13 @@ func (p *Putter) deriveRecordSteps(parentPath field.Path, inCols []zed.Column, v
 					container: zed.IsContainerType(vals[i].Type),
 					index:     i,
 				})
-				cols = append(cols, zed.Column{cl.LHS[len(parentPath)], vals[i].Type})
+				cols = append(cols, zed.Column{Name: cl.LHS[len(parentPath)], Type: vals[i].Type})
 			// Appended and nest. For example, this would happen with "put b.c=1" applied to a record {"a": 1}.
 			case len(cl.LHS) > len(parentPath)+1:
 				path := append(parentPath, cl.LHS[len(parentPath)])
 				nestedStep, typ := p.deriveRecordSteps(path, []zed.Column{}, vals, clauses)
 				nestedStep.index = -1
-				cols = append(cols, zed.Column{cl.LHS[len(parentPath)], typ})
+				cols = append(cols, zed.Column{Name: cl.LHS[len(parentPath)], Type: typ})
 				s.append(nestedStep)
 			}
 		}

--- a/runtime/expr/values.go
+++ b/runtime/expr/values.go
@@ -109,11 +109,11 @@ func (r *recordSpreadExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 			for _, col := range typ.Columns {
 				c, ok := object[col.Name]
 				if ok {
-					c.value = zed.Value{col.Type, it.Next()}
+					c.value = zed.Value{Type: col.Type, Bytes: it.Next()}
 				} else {
 					c = column{
 						colno: len(object),
-						value: zed.Value{col.Type, it.Next()},
+						value: zed.Value{Type: col.Type, Bytes: it.Next()},
 					}
 				}
 				object[col.Name] = c
@@ -153,7 +153,7 @@ func (r *recordSpreadExpr) update(object map[string]column) {
 		return
 	}
 	for name, field := range object {
-		col := zed.Column{name, field.value.Type}
+		col := zed.Column{Name: name, Type: field.value.Type}
 		if r.columns[field.colno] != col {
 			r.invalidate(object)
 			return
@@ -171,7 +171,7 @@ func (r *recordSpreadExpr) invalidate(object map[string]column) {
 		r.bytes = r.bytes[:n]
 	}
 	for name, field := range object {
-		r.columns[field.colno] = zed.Column{name, field.value.Type}
+		r.columns[field.colno] = zed.Column{Name: name, Type: field.value.Type}
 		r.bytes[field.colno] = field.value.Bytes
 	}
 	r.cache = r.zctx.MustLookupTypeRecord(r.columns)

--- a/runtime/op/combine/combine.go
+++ b/runtime/op/combine/combine.go
@@ -178,7 +178,7 @@ func (p *puller) run() {
 		batch, err := p.Pull(false)
 		p.queue <- p
 		select {
-		case p.resultCh <- op.Result{batch, err}:
+		case p.resultCh <- op.Result{Batch: batch, Err: err}:
 			if err != nil {
 				return
 			}

--- a/runtime/op/join/join.go
+++ b/runtime/op/join/join.go
@@ -213,7 +213,7 @@ func (p *Proc) buildType(left, right *zed.TypeRecord) (*zed.TypeRecord, error) {
 		for k := 2; left.HasField(name); k++ {
 			name = fmt.Sprintf("%s_%d", c.Name, k)
 		}
-		cols = append(cols, zed.Column{name, c.Type})
+		cols = append(cols, zed.Column{Name: name, Type: c.Type})
 	}
 	return p.pctx.Zctx.LookupTypeRecord(cols)
 }

--- a/runtime/op/join/puller.go
+++ b/runtime/op/join/puller.go
@@ -28,7 +28,7 @@ func (p *puller) run() {
 	for {
 		batch, err := p.op.Pull(false)
 		select {
-		case p.ch <- op.Result{batch, err}:
+		case p.ch <- op.Result{Batch: batch, Err: err}:
 			if batch == nil || err != nil {
 				close(p.ch)
 				return

--- a/runtime/op/merge/merge.go
+++ b/runtime/op/merge/merge.go
@@ -196,7 +196,7 @@ func (p *puller) run() {
 	for {
 		batch, err := p.Pull(false)
 		select {
-		case p.resultCh <- op.Result{batch, err}:
+		case p.resultCh <- op.Result{Batch: batch, Err: err}:
 			if err != nil {
 				//XXX
 				return

--- a/runtime/op/shape/shaper.go
+++ b/runtime/op/shape/shaper.go
@@ -86,7 +86,7 @@ func (i *integer) check(zv zed.Value) {
 func (a *anchor) updateInts(rec *zed.Value) error {
 	it := rec.Bytes.Iter()
 	for k, c := range rec.Columns() {
-		zv := zed.Value{c.Type, it.Next()}
+		zv := zed.Value{Type: c.Type, Bytes: it.Next()}
 		a.integers[k].check(zv)
 	}
 	return nil

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -68,7 +68,7 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 	go func() {
 		for {
 			batch, err := flowgraph.Pull(false)
-			results <- op.Result{batch, err}
+			results <- op.Result{Batch: batch, Err: err}
 			if batch == nil || err != nil {
 				return
 			}

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -94,5 +94,5 @@ func formatValue(typ zed.Type, bytes zcode.Bytes) string {
 	if typ.ID() < zed.IDTypeComplex {
 		return zson.FormatPrimitive(zed.TypeUnder(typ), bytes)
 	}
-	return zson.String(zed.Value{typ, bytes})
+	return zson.String(zed.Value{Type: typ, Bytes: bytes})
 }

--- a/zio/parquetio/data.go
+++ b/zio/parquetio/data.go
@@ -59,7 +59,7 @@ func newData(typ zed.Type, zb zcode.Bytes) (interface{}, error) {
 	case *zed.TypeMap:
 		return newMapData(typ.KeyType, typ.ValType, zb)
 	case *zed.TypeError:
-		return []byte(zson.String(zed.Value{typ, zb})), nil
+		return []byte(zson.String(zed.Value{Type: typ, Bytes: zb})), nil
 	}
 	panic(fmt.Sprintf("unknown type %T", typ))
 }

--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -317,7 +317,7 @@ func (a Analyzer) convertFields(zctx *zed.Context, in []astzed.Field, cols []zed
 func lookupRecordType(zctx *zed.Context, fields []astzed.Field, vals []Value) (*zed.TypeRecord, error) {
 	columns := make([]zed.Column, 0, len(fields))
 	for k, f := range fields {
-		columns = append(columns, zed.Column{f.Name, vals[k].TypeOf()})
+		columns = append(columns, zed.Column{Name: f.Name, Type: vals[k].TypeOf()})
 	}
 	return zctx.LookupTypeRecord(columns)
 }
@@ -641,7 +641,7 @@ func (a Analyzer) convertTypeRecord(zctx *zed.Context, typ *astzed.TypeRecord) (
 		if err != nil {
 			return nil, err
 		}
-		columns = append(columns, zed.Column{f.Name, typ})
+		columns = append(columns, zed.Column{Name: f.Name, Type: typ})
 	}
 	return zctx.LookupTypeRecord(columns)
 }

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -157,7 +157,7 @@ func (m *MarshalZNGContext) MarshalCustom(names []string, fields []interface{}) 
 		if err != nil {
 			return nil, err
 		}
-		cols = append(cols, zed.Column{names[k], typ})
+		cols = append(cols, zed.Column{Name: names[k], Type: typ})
 	}
 	// XXX issue #1836
 	// Since this can be the inner loop here and nowhere else do we call
@@ -462,7 +462,7 @@ func (m *MarshalZNGContext) encodeRecord(sval reflect.Value) (zed.Type, error) {
 		if err != nil {
 			return nil, err
 		}
-		columns = append(columns, zed.Column{name, typ})
+		columns = append(columns, zed.Column{Name: name, Type: typ})
 	}
 	m.Builder.EndContainer()
 	return m.Context.LookupTypeRecord(columns)
@@ -598,7 +598,7 @@ func (m *MarshalZNGContext) lookupTypeRecord(structType reflect.Type) (zed.Type,
 		if err != nil {
 			return nil, err
 		}
-		columns = append(columns, zed.Column{name, fieldType})
+		columns = append(columns, zed.Column{Name: name, Type: fieldType})
 	}
 	return m.Context.LookupTypeRecord(columns)
 }

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -315,7 +315,7 @@ func TestZNGValueField(t *testing.T) {
 	// Include a Zed int64 inside a Go struct as a zed.Value field.
 	zngValueField := &ZNGValueField{
 		Name:  "test1",
-		Field: zed.Value{zed.TypeInt64, zed.EncodeInt(123)},
+		Field: zed.Value{Type: zed.TypeInt64, Bytes: zed.EncodeInt(123)},
 	}
 	m := zson.NewZNGMarshaler()
 	m.Decorate(zson.StyleSimple)

--- a/zson/parser-types.go
+++ b/zson/parser-types.go
@@ -71,12 +71,12 @@ func (p *Parser) matchTypeName() (astzed.Type, error) {
 		return p.matchTypeEnumBody()
 	}
 	if t := zed.LookupPrimitive(name); t != nil {
-		return &astzed.TypePrimitive{"TypePrimitive", name}, nil
+		return &astzed.TypePrimitive{Kind: "TypePrimitive", Name: name}, nil
 	}
 	// Wherever we have a type name, we can have a type def defining the
 	// type name.
 	if ok, err := l.match('='); !ok || err != nil {
-		return &astzed.TypeName{"TypeName", name}, nil
+		return &astzed.TypeName{Kind: "TypeName", Name: name}, nil
 	}
 	typ, err := p.parseType()
 	if err != nil {


### PR DESCRIPTION
Enable the analyzer when "make vet" is run, and fix all of its reports.